### PR TITLE
Replace inline styles with CSS classes

### DIFF
--- a/code.html
+++ b/code.html
@@ -63,7 +63,7 @@
     <!-- ======================================================================= -->
     <!-- ============================ APP WRAPPER ============================== -->
     <!-- ======================================================================= -->
-    <div id="appWrapper" style="display: none;">
+    <div id="appWrapper" class="hidden">
 
         <!-- ========================== HEADER & MAIN MENU ========================= -->
         <header>
@@ -168,7 +168,7 @@
                             <svg class="icon arrow"><use href="#icon-chevron-right"></use></svg>
                         </div>
                         <div id="detailedAnalyticsContent" class="accordion-content" role="region">
-                            <div id="dashboardTextualAnalysis" style="margin-bottom: var(--space-lg);">
+                            <div id="dashboardTextualAnalysis" class="mb-lg">
                                 <p class="placeholder">Генериране на текстов анализ...</p>
                             </div>
                             <ul id="detailedAnalyticsList" class="detailed-metrics-list">
@@ -179,7 +179,7 @@
                     <!-- Край Акордеон детайлни показатели -->
 
                     <!-- Карта за история на напредъка -->
-                    <div class="card" id="progressHistoryCard" style="margin-top: var(--space-lg);">
+                    <div class="card mt-lg" id="progressHistoryCard">
                         <h4><svg class="icon" style="width: 1em; height: 1em; margin-right: 0.3em;"><use href="#icon-chart-line"></use></svg> История на Напредъка</h4>
                         <div class="chart-container">
                             <p class="placeholder">Зареждане на историята на напредъка...</p>
@@ -204,10 +204,10 @@
                             <div class="placeholder">Зареждане на тракера...</div>
                         </div>
 
-                        <button id="openExtraMealModalBtn" class="button-secondary" style="margin-bottom: 0.5rem; width: 100%;">🍽️ Добави извънредно хранене</button>
+                        <button id="openExtraMealModalBtn" class="button-secondary w-100" style="margin-bottom: 0.5rem;">🍽️ Добави извънредно хранене</button>
                         <button id="add-note-btn" class="button-secondary" aria-label="Добавяне или скриване на бележка за деня"></button>
                         <textarea id="daily-note" class="hidden" placeholder="Вашите бележки за деня..." rows="3" aria-label="Бележки за деня"></textarea>
-                        <button id="saveLogBtn" class="button-primary" style="margin-top: 1rem;">Запази Дневен Лог</button>
+                        <button id="saveLogBtn" class="button-primary mt-md">Запази Дневен Лог</button>
                     </div>
                     <!-- Край Дневен Лог -->
                 </div>
@@ -238,9 +238,9 @@
                             <p class="placeholder">Зареждане на съображенията...</p>
                         </div>
                     </div>
-                    <div class="card" style="margin-top: var(--space-lg);">
+                    <div class="card mt-lg">
                         <h3>⚙️ Инструменти за Индивидуализация</h3>
-                         <button id="triggerAdaptiveQuizBtn" class="button-secondary" style="width:100%;">Стартирай Въпросник за Актуализация на Плана</button>
+                         <button id="triggerAdaptiveQuizBtn" class="button-secondary w-100">Стартирай Въпросник за Актуализация на Плана</button>
                     </div>
                 </div>
             </section>
@@ -269,7 +269,7 @@
                             </tbody>
                         </table>
                     </div>
-                    <div class="card" style="margin-top: var(--space-lg);">
+                    <div class="card mt-lg">
                         <h4>🧭 Принципи и Фокус за Следващите Седмици</h4>
                         <div id="weeklyPrinciplesFocus" class="accordion-group">
                             <p class="placeholder">Зареждане на принципите...</p>
@@ -353,13 +353,13 @@
                 <button class="close-button" data-modal-close="welcomeScreenModal" aria-label="Затвори прозореца">
                     <svg class="icon" style="width: 1.2em; height: 1.2em;"><use href="#icon-close"></use></svg>
                 </button>
-                <h3 id="welcomeModalTitle" style="text-align:center;">Добре дошли в MyBody.Best!</h3>
+                <h3 id="welcomeModalTitle" class="text-center">Добре дошли в MyBody.Best!</h3>
                 <div id="welcomeModalBody">
-                    <p style="text-align:center; font-size:1.5rem; margin-bottom:1rem;">🎉</p>
+                    <p class="text-center" style="font-size:1.5rem; margin-bottom:1rem;">🎉</p>
                     <p>Вашият персонализиран план е готов! Разгледайте секциите, за да се запознаете с него.</p>
                     <p>Не забравяйте да попълвате дневния си лог и да следите напредъка си. Успех!</p>
                 </div>
-                <button class="button-primary modal-close-btn" data-modal-close="welcomeScreenModal" style="margin-top: 1.5rem;">Разбрах, да започваме!</button>
+                <button class="button-primary modal-close-btn mt-lg" data-modal-close="welcomeScreenModal">Разбрах, да започваме!</button>
             </div>
         </div>
 
@@ -381,7 +381,7 @@
                 <button class="close-button" data-modal-close="infoModal" aria-label="Затвори прозореца">
                     <svg class="icon" style="width: 1.2em; height: 1.2em;"><use href="#icon-close"></use></svg>
                 </button>
-                <h4 id="infoModalTitle" style="text-align:center;">Информация</h4>
+                <h4 id="infoModalTitle" class="text-center">Информация</h4>
                 <div id="infoModalBody" style="white-space: pre-wrap; text-align: left;">...</div>
                 <button class="button-primary modal-close-btn" data-modal-close="infoModal">Затвори</button>
             </div>
@@ -393,11 +393,11 @@
                 <button class="close-button" data-modal-close="aiUpdateNotificationModal" aria-label="Затвори съобщението">
                     <svg class="icon" style="width: 1.2em; height: 1.2em;"><use href="#icon-close"></use></svg>
                 </button>
-                <h3 id="aiUpdateModalTitle" style="text-align:center;">📣 Информация за Актуализация</h3>
+                <h3 id="aiUpdateModalTitle" class="text-center">📣 Информация за Актуализация</h3>
                 <div id="aiUpdateModalBody" style="white-space: pre-wrap; text-align: left;">
                     <p class="placeholder">Зареждане на актуализации...</p>
                 </div>
-                <button class="button-primary modal-close-btn" data-modal-close="aiUpdateNotificationModal" style="margin-top: 1.5rem;">Разбрах</button>
+                <button class="button-primary modal-close-btn mt-lg" data-modal-close="aiUpdateNotificationModal">Разбрах</button>
             </div>
         </div>
 
@@ -517,7 +517,7 @@
                 <button class="close-button" data-modal-close="feedbackModal" aria-label="Затвори прозореца">
                     <svg class="icon" style="width: 1.2em; height: 1.2em;"><use href="#icon-close"></use></svg>
                 </button>
-                <h3 id="feedbackModalTitle" style="text-align:center;">Обратна Връзка</h3>
+                <h3 id="feedbackModalTitle" class="text-center">Обратна Връзка</h3>
                 <form id="feedbackForm" aria-labelledby="feedbackModalTitle">
                     <div>
                         <label for="feedbackType">Тип на обратната връзка:</label>
@@ -543,7 +543,7 @@
                             <option value="1">⭐ (Лошо)</option>
                         </select>
                     </div>
-                    <button type="submit" class="button-primary" style="margin-top: var(--space-lg); width:100%;">Изпрати</button>
+                    <button type="submit" class="button-primary mt-lg w-100">Изпрати</button>
                 </form>
             </div>
         </div>

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -290,6 +290,12 @@ body.dark-theme .button-icon-only:hover { background-color: rgba(255,255,255,0.0
   padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); border: 0;
 }
 .text-muted { color: var(--text-color-muted) !important; font-size: 0.9rem; }
+.text-center { text-align: center !important; }
+.w-100 { width: 100% !important; }
+.mt-sm { margin-top: var(--space-sm) !important; }
+.mt-md { margin-top: var(--space-md) !important; }
+.mt-lg { margin-top: var(--space-lg) !important; }
+.mb-lg { margin-bottom: var(--space-lg) !important; }
 .placeholder, .placeholder-row td {
   color: var(--text-color-muted); font-style: italic; text-align: center !important;
   padding: var(--space-lg) var(--space-md) !important;

--- a/css/extra_meal_form_styles.css
+++ b/css/extra_meal_form_styles.css
@@ -2,6 +2,27 @@
    11. СТИЛОВЕ ЗА ФОРМА ЗА ИЗВЪНРЕДНО ХРАНЕНЕ (Extra Meal Form)
    ========================================================================== */
 
+/* --- Общи елементи на wizard формата --- */
+#extraMealEntryModal .form-wizard-header {
+  margin-bottom: var(--space-lg);
+}
+
+#extraMealEntryModal .modal-form-title {
+  text-align: center;
+  margin-bottom: var(--space-md);
+}
+
+#extraMealEntryModal .radio-group-vertical {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+#extraMealEntryModal small.form-helper-text {
+  display: block;
+  margin-top: var(--space-xs);
+}
+
 /* --- Контейнер за Autocomplete --- */
 #extraMealEntryModal .autocomplete-container {
   position: relative;
@@ -91,7 +112,7 @@
 /* --- Заглавия на стъпките във формата --- */
 #extraMealEntryModal .form-step .step-title {
     font-size: 1.2em;
-    color: var(--secondary-color);
+    color: var(--primary-color);
     margin-bottom: var(--space-lg);
     padding-bottom: var(--space-sm);
     border-bottom: 1px solid var(--border-color-soft);
@@ -239,6 +260,9 @@
     width: 0%;
     transition: width 0.4s ease-in-out;
     border-radius: var(--radius-sm);
+}
+#extraMealEntryModal #stepProgressBar.start-width-20 {
+    width: 20%;
 }
 
 /* --- ВИЗУАЛНИ КАРТИ/БУТОНИ ЗА КОЛИЧЕСТВО (Стъпка 2) - С УВЕЛИЧЕН ШРИФТ --- */

--- a/extra-meal-entry-form.html
+++ b/extra-meal-entry-form.html
@@ -1,41 +1,41 @@
 <!-- extra-meal-entry-form.html -->
 <form id="extraMealEntryFormActual" aria-labelledby="extraMealModalFormTitle" novalidate>
-    <div class="form-wizard-header" style="margin-bottom: var(--space-lg);">
-        <h3 id="extraMealModalFormTitle" style="text-align:center; margin-bottom: var(--space-md);">Добавяне на Извънредно Хранене</h3>
+    <div class="form-wizard-header">
+        <h3 id="extraMealModalFormTitle" class="modal-form-title">Добавяне на Извънредно Хранене</h3>
         <div class="step-indicator-container">
-            <span class="step-indicator-label" style="display: block; font-size: 0.85em; color: var(--text-color-muted); margin-bottom: var(--space-xs); text-align: center;">Стъпка <span id="currentStepNumber">1</span> от <span id="totalStepNumber">5</span></span>
-            <div class="progress-bar-steps" style="width: 100%; height: 8px; background-color: var(--progress-bar-bg-empty); border-radius: var(--radius-sm); overflow: hidden; margin: 0 auto; max-width: 300px;">
-                <div id="stepProgressBar" style="height: 100%; background-color: var(--secondary-color); width: 20%; transition: width 0.4s ease-in-out; border-radius: var(--radius-sm);"></div>
+            <span class="step-indicator-label">Стъпка <span id="currentStepNumber">1</span> от <span id="totalStepNumber">5</span></span>
+            <div class="progress-bar-steps">
+                <div id="stepProgressBar" class="start-width-20"></div>
             </div>
         </div>
     </div>
 
     <!-- Стъпка 1: Описание на храната -->
     <div class="form-step active-step" data-step="1">
-        <h4 class="step-title" style="font-size: 1.1em; color: var(--primary-color); margin-bottom: var(--space-md); padding-bottom: var(--space-xs); border-bottom: 1px solid var(--border-color-soft);">
-            <span class="step-icon" style="margin-right: var(--space-sm); font-size: 1.1em;">🍽️</span>Описание на Храненето
+        <h4 class="step-title">
+            <span class="step-icon">🍽️</span>Описание на Храненето
         </h4>
         <div class="form-group"> <!-- Използваме общ клас за група от форма -->
             <label for="foodDescription">Какво консумирахте?</label>
-            <div class="autocomplete-container" style="position: relative;">
+            <div class="autocomplete-container">
                 <textarea id="foodDescription" name="foodDescription" rows="3" placeholder="Въведете текст..." required aria-required="true" aria-describedby="foodDescriptionHelp"></textarea> <!-- Няма нужда от form-control, ако е глобално стилизиран textarea -->
-                <div id="foodSuggestionsDropdown" class="autocomplete-suggestions hidden" role="listbox" style="position: absolute; background-color: var(--surface-background); border: 1px solid var(--input-border-color); border-top: none; z-index: 1050; width: 100%; max-height: 150px; overflow-y: auto; box-shadow: var(--shadow-sm); border-bottom-left-radius: var(--radius-md); border-bottom-right-radius: var(--radius-md);">
+                <div id="foodSuggestionsDropdown" class="autocomplete-suggestions hidden" role="listbox">
                     <!-- Предложенията ще се добавят от JS -->
                 </div>
             </div>
-            <small id="foodDescriptionHelp" class="text-muted" style="display: block; margin-top: var(--space-xs);">✔ 1 храна/напитка на запис.
+            <small id="foodDescriptionHelp" class="text-muted form-helper-text">✔ 1 храна/напитка на запис.
             ➡ Завърши и стартирай нова форма за следващата.</small>
         </div>
     </div>
 
     <!-- Стъпка 2: Количество и Време -->
-    <div class="form-step" data-step="2" style="display: none;">
-        <h4 class="step-title" style="font-size: 1.1em; color: var(--primary-color); margin-bottom: var(--space-md); padding-bottom: var(--space-xs); border-bottom: 1px solid var(--border-color-soft);">
-            <span class="step-icon" style="margin-right: var(--space-sm); font-size: 1.1em;">⚖️</span>Количество и Време
+    <div class="form-step hidden" data-step="2">
+        <h4 class="step-title">
+            <span class="step-icon">⚖️</span>Количество и Време
         </h4>
         <fieldset class="form-group">
             <legend id="quantityLegend">Приблизително количество:</legend>
-            <div id="quantityCardGroup" class="quantity-card-selector-grid" role="radiogroup" aria-labelledby="quantityLegend" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: var(--space-sm); margin-bottom: var(--space-md);">
+            <div id="quantityCardGroup" class="quantity-card-selector-grid" role="radiogroup" aria-labelledby="quantityLegend">
                 <!-- Карти за количество (структурата е запазена, но стиловете ще дойдат от extra_meal_form_styles.css) -->
                 <label class="quantity-card-option">
                     <input type="radio" name="quantityEstimateVisual" value="не_посочено_в_стъпка_2" checked>
@@ -71,9 +71,9 @@
                 </label>
             </div>
         </fieldset>
-        <input type="text" id="quantityCustom" name="quantityCustom" class="hidden" style="margin-top: var(--space-sm);" placeholder="Напр. 100гр, 2 с.л., специфично количество" aria-label="Уточнение за количество">
+        <input type="text" id="quantityCustom" name="quantityCustom" class="hidden form-control-small-margin" placeholder="Напр. 100гр, 2 с.л., специфично количество" aria-label="Уточнение за количество">
 
-        <div class="form-group" style="margin-top: var(--space-md);">
+        <div class="form-group mt-md">
             <label for="mealTimeSelect">Кога го консумирахте?</label>
             <select id="mealTimeSelect" name="mealTimeSelect" autocomplete="off">
                 <option value="now" selected>Току-що</option>
@@ -83,58 +83,58 @@
                 <option value="specific_time">По-рано днес (посочете точно)</option>
                 <option value="yesterday_specific_time">Вчера (посочете точно)</option>
             </select>
-            <input type="datetime-local" id="mealTimeSpecific" name="mealTimeSpecific" class="hidden" style="margin-top: var(--space-sm);" aria-label="Конкретно време на консумация">
+            <input type="datetime-local" id="mealTimeSpecific" name="mealTimeSpecific" class="hidden form-control-small-margin" aria-label="Конкретно време на консумация">
         </div>
     </div>
 
     <!-- Стъпка 3: Причина -->
-    <div class="form-step" data-step="3" style="display: none;">
-        <h4 class="step-title" style="font-size: 1.1em; color: var(--primary-color); margin-bottom: var(--space-md); padding-bottom: var(--space-xs); border-bottom: 1px solid var(--border-color-soft);">
-            <span class="step-icon" style="margin-right: var(--space-sm); font-size: 1.1em;">🤔</span>Причина за Храненето
+    <div class="form-step hidden" data-step="3">
+        <h4 class="step-title">
+            <span class="step-icon">🤔</span>Причина за Храненето
         </h4>
         <fieldset class="form-group">
             <legend>Основна причина:</legend>
-            <div class="radio-group-vertical" style="display: flex; flex-direction: column; gap: var(--space-sm);">
+            <div class="radio-group-vertical">
                 <!-- Стилът за .radio-group-vertical и label вътре ще дойде от extra_meal_form_styles.css -->
-                <label><input type="radio" name="reasonPrimary" value="глад" checked> <span class="emoji-icon" style="margin-right: var(--space-xs); font-size: 1.1em;">😋</span> Истински физически глад</label>
-                <label><input type="radio" name="reasonPrimary" value="craving"> <span class="emoji-icon" style="margin-right: var(--space-xs); font-size: 1.1em;">🤩</span> Силно желание (craving)</label>
-                <label><input type="radio" name="reasonPrimary" value="социално"> <span class="emoji-icon" style="margin-right: var(--space-xs); font-size: 1.1em;">🎉</span> Социално събитие / почерпка</label>
-                <label><input type="radio" name="reasonPrimary" value="емоция_стрес"> <span class="emoji-icon" style="margin-right: var(--space-xs); font-size: 1.1em;">😥</span> Стрес / Тъга / Емоционално</label>
-                <label><input type="radio" name="reasonPrimary" value="емоция_радост"> <span class="emoji-icon" style="margin-right: var(--space-xs); font-size: 1.1em;">🥳</span> Радост / Награда (емоционално)</label>
-                <label><input type="radio" name="reasonPrimary" value="скука"> <span class="emoji-icon" style="margin-right: var(--space-xs); font-size: 1.1em;">🥱</span> Скука / От навик</label>
-                <label><input type="radio" name="reasonPrimary" value="нямах_планирана"> <span class="emoji-icon" style="margin-right: var(--space-xs); font-size: 1.1em;">🤷</span> Нямах планирана храна</label>
-                <label><input type="radio" name="reasonPrimary" value="other_reason"> <span class="emoji-icon" style="margin-right: var(--space-xs); font-size: 1.1em;">❓</span> Друга причина</label>
+                <label><input type="radio" name="reasonPrimary" value="глад" checked> <span class="emoji-icon">😋</span> Истински физически глад</label>
+                <label><input type="radio" name="reasonPrimary" value="craving"> <span class="emoji-icon">🤩</span> Силно желание (craving)</label>
+                <label><input type="radio" name="reasonPrimary" value="социално"> <span class="emoji-icon">🎉</span> Социално събитие / почерпка</label>
+                <label><input type="radio" name="reasonPrimary" value="емоция_стрес"> <span class="emoji-icon">😥</span> Стрес / Тъга / Емоционално</label>
+                <label><input type="radio" name="reasonPrimary" value="емоция_радост"> <span class="emoji-icon">🥳</span> Радост / Награда (емоционално)</label>
+                <label><input type="radio" name="reasonPrimary" value="скука"> <span class="emoji-icon">🥱</span> Скука / От навик</label>
+                <label><input type="radio" name="reasonPrimary" value="нямах_планирана"> <span class="emoji-icon">🤷</span> Нямах планирана храна</label>
+                <label><input type="radio" name="reasonPrimary" value="other_reason"> <span class="emoji-icon">❓</span> Друга причина</label>
             </div>
-            <input type="text" id="reasonOtherText" name="reasonOtherText" class="hidden" style="margin-top: var(--space-sm);" placeholder="Моля, уточнете причината" aria-label="Уточнение за причина">
+            <input type="text" id="reasonOtherText" name="reasonOtherText" class="hidden form-control-small-margin" placeholder="Моля, уточнете причината" aria-label="Уточнение за причина">
         </fieldset>
     </div>
 
     <!-- Стъпка 4: Усещане и Влияние -->
-    <div class="form-step" data-step="4" style="display: none;">
-        <h4 class="step-title" style="font-size: 1.1em; color: var(--primary-color); margin-bottom: var(--space-md); padding-bottom: var(--space-xs); border-bottom: 1px solid var(--border-color-soft);">
-            <span class="step-icon" style="margin-right: var(--space-sm); font-size: 1.1em;">💭</span>Усещане и Влияние
+    <div class="form-step hidden" data-step="4">
+        <h4 class="step-title">
+            <span class="step-icon">💭</span>Усещане и Влияние
         </h4>
         <fieldset class="form-group">
             <legend>Как се почувствахте след това?</legend>
-            <div class="radio-group-icons" style="display: flex; flex-wrap: wrap; gap: var(--space-sm); margin-bottom: var(--space-md);">
+            <div class="radio-group-icons">
                 <!-- Стилът за .icon-radio-label ще дойде от extra_meal_form_styles.css -->
-                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="ситост_доволство" checked> <span class="emoji-icon" style="margin-right: var(--space-xs);">😊</span> <span class="icon-radio-text">Заситен/а</span></label>
-                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="още_глад"> <span class="emoji-icon" style="margin-right: var(--space-xs);">😕</span> <span class="icon-radio-text">Гладен/а</span></label>
-                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="преядох_тежко"> <span class="emoji-icon" style="margin-right: var(--space-xs);">🤢</span> <span class="icon-radio-text">Тежко ми е</span></label>
-                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="виновен_съжаление"> <span class="emoji-icon" style="margin-right: var(--space-xs);">😥</span> <span class="icon-radio-text">Виновен/а</span></label>
-                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="без_особена_промяна"> <span class="emoji-icon" style="margin-right: var(--space-xs);">😐</span> <span class="icon-radio-text">Без промяна</span></label>
-                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="енергичен"> <span class="emoji-icon" style="margin-right: var(--space-xs);">⚡</span> <span class="icon-radio-text">Енергичен/а</span></label>
-                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="отпаднал_сънлив"> <span class="emoji-icon" style="margin-right: var(--space-xs);">😴</span> <span class="icon-radio-text">Отпаднал/а</span></label>
+                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="ситост_доволство" checked> <span class="emoji-icon">😊</span> <span class="icon-radio-text">Заситен/а</span></label>
+                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="още_глад"> <span class="emoji-icon">😕</span> <span class="icon-radio-text">Гладен/а</span></label>
+                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="преядох_тежко"> <span class="emoji-icon">🤢</span> <span class="icon-radio-text">Тежко ми е</span></label>
+                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="виновен_съжаление"> <span class="emoji-icon">😥</span> <span class="icon-radio-text">Виновен/а</span></label>
+                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="без_особена_промяна"> <span class="emoji-icon">😐</span> <span class="icon-radio-text">Без промяна</span></label>
+                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="енергичен"> <span class="emoji-icon">⚡</span> <span class="icon-radio-text">Енергичен/а</span></label>
+                <label class="icon-radio-label"><input type="radio" name="feelingAfter" value="отпаднал_сънлив"> <span class="emoji-icon">😴</span> <span class="icon-radio-text">Отпаднал/а</span></label>
             </div>
         </fieldset>
         <fieldset class="form-group">
             <legend>Замести ли планирано хранене?</legend>
-            <div class="radio-group-vertical" style="display: flex; flex-direction: column; gap: var(--space-sm);">
+            <div class="radio-group-vertical">
                 <label><input type="radio" name="replacedPlanned" value="не" checked> Не, беше допълнително</label>
                 <label><input type="radio" name="replacedPlanned" value="да_напълно"> Да, напълно го замести</label>
                 <label><input type="radio" name="replacedPlanned" value="да_частично"> Да, частично (хапнах по-малко от планираното)</label>
             </div>
-            <select id="skippedMeal" name="skippedMeal" class="hidden" style="margin-top: var(--space-sm);" autocomplete="off" aria-label="Избор на засегнато хранене">
+            <select id="skippedMeal" name="skippedMeal" class="hidden form-control-small-margin" autocomplete="off" aria-label="Избор на засегнато хранене">
                 <option value="">-- Кое хранене беше засегнато? --</option>
                 <option value="закуска">Закуска</option>
                 <option value="междинно1">Междинна закуска 1</option>
@@ -147,26 +147,26 @@
     </div>
 
     <!-- Стъпка 5: Потвърждение -->
-    <div class="form-step" data-step="5" style="display: none;">
-        <h4 class="step-title" style="font-size: 1.1em; color: var(--primary-color); margin-bottom: var(--space-md); padding-bottom: var(--space-xs); border-bottom: 1px solid var(--border-color-soft);">
-            <span class="step-icon" style="margin-right: var(--space-sm); font-size: 1.1em;">✅</span>Преглед и Потвърждение
+    <div class="form-step hidden" data-step="5">
+        <h4 class="step-title">
+            <span class="step-icon">✅</span>Преглед и Потвърждение
         </h4>
-        <div id="extraMealSummary" class="summary-box" style="background-color: var(--metric-value-group-bg-initial); padding: var(--space-md); border-radius: var(--radius-md); border: 1px solid var(--border-color); margin-bottom: var(--space-lg); font-size: 0.9em;">
-            <p style="margin-bottom: var(--space-sm); color: var(--text-color-secondary); font-weight: 500;">Моля, прегледайте въведената информация:</p>
-            <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Храна:</strong> <span data-summary="foodDescription"></span></div>
-            <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Количество:</strong> <span data-summary="quantityEstimate"></span></div>
-            <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Време:</strong> <span data-summary="mealTimeSelect"></span></div>
-            <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Причина:</strong> <span data-summary="reasonPrimary"></span></div>
-            <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Усещане:</strong> <span data-summary="feelingAfter"></span></div>
-            <div style="padding: var(--space-xs) 0;"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Замести планирано:</strong> <span data-summary="replacedPlanned"></span></div>
+        <div id="extraMealSummary" class="summary-box">
+            <p>Моля, прегледайте въведената информация:</p>
+            <div><strong>Храна:</strong> <span data-summary="foodDescription"></span></div>
+            <div><strong>Количество:</strong> <span data-summary="quantityEstimate"></span></div>
+            <div><strong>Време:</strong> <span data-summary="mealTimeSelect"></span></div>
+            <div><strong>Причина:</strong> <span data-summary="reasonPrimary"></span></div>
+            <div><strong>Усещане:</strong> <span data-summary="feelingAfter"></span></div>
+            <div><strong>Замести планирано:</strong> <span data-summary="replacedPlanned"></span></div>
         </div>
     </div>
 
     <!-- Навигация между стъпките -->
-    <div class="form-wizard-navigation" style="margin-top: var(--space-lg); display: flex; justify-content: space-between; align-items: center; gap: var(--space-sm); border-top: 1px solid var(--border-color-soft); padding-top: var(--space-lg);">
-        <button type="button" id="emPrevStepBtn" class="button button-secondary" style="flex-grow: 1;">Предишна</button> <!-- Добавен клас button -->
-        <button type="button" id="emCancelBtn" class="button button-secondary modal-close-btn-form" style="flex-grow: 1; background-color: var(--text-color-muted); color: var(--text-color-on-primary);">Отказ</button> <!-- Добавен клас button -->
-        <button type="button" id="emNextStepBtn" class="button button-primary" style="flex-grow: 1;">Следваща</button> <!-- Добавен клас button -->
-        <button type="submit" id="emSubmitBtn" class="button button-primary" style="flex-grow: 1;">Запази</button> <!-- Добавен клас button -->
+    <div class="form-wizard-navigation">
+        <button type="button" id="emPrevStepBtn" class="button button-secondary">Предишна</button> <!-- Добавен клас button -->
+        <button type="button" id="emCancelBtn" class="button button-secondary modal-close-btn-form">Отказ</button> <!-- Добавен клас button -->
+        <button type="button" id="emNextStepBtn" class="button button-primary">Следваща</button> <!-- Добавен клас button -->
+        <button type="submit" id="emSubmitBtn" class="button button-primary">Запази</button> <!-- Добавен клас button -->
     </div>
 </form>


### PR DESCRIPTION
## Summary
- added utility classes for spacing, width, and alignment
- added shared styles for the extra meal form
- changed step title color and added progress bar helper class
- removed inline styles from extra-meal-entry-form.html
- updated code.html to use new utility classes

## Testing
- `grep -n "style=" extra-meal-entry-form.html` (no results)
- `grep -n "style=" code.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6841e5640ed483269252e2315c5b5f9f