### PR TITLE
Fix build to include all HTML pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,17 @@
 import { defineConfig } from 'vite';
+import { resolve } from 'path';
 
 export default defineConfig({
   base: './',
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        code: resolve(__dirname, 'code.html'),
+        forgotPassword: resolve(__dirname, 'forgot-password.html'),
+        extraMealEntry: resolve(__dirname, 'extra-meal-entry-form.html'),
+        adaptiveQuizTemplate: resolve(__dirname, 'adaptive_quiz_template.html'),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- add rollup input entries to Vite config so pages like `code.html` and `forgot-password.html` are built

## Testing
- `npm run build`
- `npm run lint` *(fails: many lint errors)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684200b751f08326aa28448aec67be2d