### PR TITLE
Add API proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Run the Vite dev server which provides hot reload:
 npm run dev
 ```
 
+API requests to paths starting with `/api` are automatically proxied to
+`https://openapichatbot.radilov-k.workers.dev` when running the dev server.
+
 The application will be available at `http://localhost:5173` by default.
 
 ### Build

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,15 @@ import { resolve } from 'path';
 
 export default defineConfig({
   base: './',
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://openapichatbot.radilov-k.workers.dev',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- set up dev server proxy for /api requests
- document proxy usage in development setup instructions

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_684204d26e94832688d8bf00f6c4c0ef