### PR TITLE
Resolve profile edit conflicts

### DIFF
--- a/js/profileEdit.js
+++ b/js/profileEdit.js
@@ -1,5 +1,14 @@
 import { safeParseFloat, safeGet } from './utils.js';
 
+// Apply saved theme so the page matches the dashboard
+(function applySavedTheme() {
+  const saved = localStorage.getItem('theme') || 'system';
+  const system = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  const theme = saved === 'system' ? system : saved;
+  document.body.classList.remove('light-theme', 'dark-theme');
+  document.body.classList.add(theme === 'dark' ? 'dark-theme' : 'light-theme');
+})();
+
 const form = document.getElementById('profileEditForm');
 
 if (form) {
@@ -9,6 +18,10 @@ if (form) {
       if (!res.ok) throw new Error('Server error');
       const data = await res.json();
       form.name.value = safeGet(data, 'name', '');
+      const age = safeParseFloat(safeGet(data, 'age'));
+      if (age !== null && age !== undefined) form.age.value = age;
+      const gender = safeGet(data, 'gender');
+      if (gender) form.gender.value = gender;
       const weight = safeParseFloat(safeGet(data, 'weight'));
       if (weight !== null && weight !== undefined) form.weight.value = weight;
       const height = safeParseFloat(safeGet(data, 'height'));
@@ -24,6 +37,8 @@ if (form) {
     e.preventDefault();
     const data = {
       name: form.name.value.trim(),
+      age: safeParseFloat(form.age.value),
+      gender: form.gender.value,
       weight: safeParseFloat(form.weight.value),
       height: safeParseFloat(form.height.value),
     };

--- a/profile-edit.html
+++ b/profile-edit.html
@@ -18,13 +18,26 @@
     <main class="container" style="padding-top: var(--space-lg);">
         <div class="card">
             <h2 style="margin-top:0">Лични Данни</h2>
-            <form id="profileEditForm">
+            <form id="profileEditForm" novalidate>
                 <div class="form-group">
                     <label for="name">Име</label>
                     <input id="name" name="name" type="text" required>
                 </div>
                 <div class="form-group">
-                    <label for="weight">Тегло (кг)</label>
+                    <label for="age">Възраст</label>
+                    <input id="age" name="age" type="number" min="0" step="1">
+                </div>
+                <div class="form-group">
+                    <label for="gender">Пол</label>
+                    <select id="gender" name="gender">
+                        <option value="">- Изберете -</option>
+                        <option value="male">Мъж</option>
+                        <option value="female">Жена</option>
+                        <option value="other">Друго</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="weight">Текущо тегло (кг)</label>
                     <input id="weight" name="weight" type="number" step="0.1">
                 </div>
                 <div class="form-group">


### PR DESCRIPTION
## Summary
- bring back age and gender fields in `profileEdit.js`
- add theme restoration on profile edit page
- include age and gender controls in `profile-edit.html`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422c0d84308326902b9da3326f012a