### PR TITLE
Resolve profile edit conflicts

### DIFF
--- a/js/profileEdit.js
+++ b/js/profileEdit.js
@@ -1,5 +1,14 @@
 import { safeParseFloat, safeGet } from './utils.js';
 
+// Apply saved theme so the page matches the dashboard
+(function applySavedTheme() {
+  const saved = localStorage.getItem('theme') || 'system';
+  const system = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  const theme = saved === 'system' ? system : saved;
+  document.body.classList.remove('light-theme', 'dark-theme');
+  document.body.classList.add(theme === 'dark' ? 'dark-theme' : 'light-theme');
+})();
+
 const form = document.getElementById('profileEditForm');
 
 if (form) {
@@ -9,8 +18,8 @@ if (form) {
       if (!res.ok) throw new Error('Server error');
       const data = await res.json();
       form.name.value = safeGet(data, 'name', '');
-      const weight = safeParseFloat(safeGet(data, 'weight'));
-      if (weight !== null && weight !== undefined) form.weight.value = weight;
+      const age = safeParseFloat(safeGet(data, 'age'));
+      if (age !== null && age !== undefined) form.age.value = age;
       const height = safeParseFloat(safeGet(data, 'height'));
       if (height !== null && height !== undefined) form.height.value = height;
     } catch (err) {
@@ -24,7 +33,7 @@ if (form) {
     e.preventDefault();
     const data = {
       name: form.name.value.trim(),
-      weight: safeParseFloat(form.weight.value),
+      age: safeParseFloat(form.age.value),
       height: safeParseFloat(form.height.value),
     };
     try {

--- a/profile-edit.html
+++ b/profile-edit.html
@@ -15,23 +15,23 @@
         <h1 id="headerTitle">Редакция на Профил</h1>
         <a href="code.html" class="button-secondary">← Назад</a>
     </header>
-    <main class="container" style="padding-top: var(--space-lg);">
+    <main class="container" style="padding-top: var(--space-lg); max-width: 500px;">
         <div class="card">
             <h2 style="margin-top:0">Лични Данни</h2>
-            <form id="profileEditForm">
+            <form id="profileEditForm" novalidate>
                 <div class="form-group">
                     <label for="name">Име</label>
                     <input id="name" name="name" type="text" required>
                 </div>
                 <div class="form-group">
-                    <label for="weight">Тегло (кг)</label>
-                    <input id="weight" name="weight" type="number" step="0.1">
+                    <label for="age">Възраст</label>
+                    <input id="age" name="age" type="number" min="0" step="1">
                 </div>
                 <div class="form-group">
                     <label for="height">Височина (см)</label>
                     <input id="height" name="height" type="number" step="1">
                 </div>
-                <button type="submit" class="button" style="width:100%">Запази</button>
+                <button type="submit" class="button">Запази</button>
             </form>
         </div>
     </main>


### PR DESCRIPTION
## Summary
- bring back age field and theme restoration on profile edit
- simplify profile form by removing gender and weight fields
- narrow the profile edit form for a cleaner look

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422c0d84308326902b9da3326f012a