### PR TITLE
use env vars for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ Before deploying, configure the following secrets in Cloudflare (via the dashboa
 - `тут_ваш_php_api_token_secret_name`
 
 These names are referenced in `worker.js` and must exist for the worker to function.
+
+### PHP API Environment Variables
+
+The PHP helper scripts expect the following variables set in the server environment:
+
+- `STATIC_TOKEN` – shared secret token used for authentication in `file_manager_api.php`.
+- `ADMIN_PASS_HASH` – bcrypt hash of the admin password for `login.php`.
+
+Example of generating a hash:
+
+```bash
+php -r "echo password_hash('yourPassword', PASSWORD_DEFAULT);"
+```
+
+Set the output as the value for `ADMIN_PASS_HASH`.
 ## Допълнителни функции
 - **Извънредно хранене** – бутонът "Добави извънредно хранене" в `code.html` отваря модалната форма `extra-meal-entry-form.html`. Логиката в `js/extraMealForm.js` изпраща данните към `/api/log-extra-meal` в `worker.js`.
 

--- a/file_manager_api.php
+++ b/file_manager_api.php
@@ -3,7 +3,15 @@
 
 // Конфигурация
 define('UPLOADS_DIR', __DIR__ . '/user_profiles/'); // ОСТАВА БЕЗ ПРОМЯНА
-define('STATIC_TOKEN', 'FXW29QFHZ3M70VDUFN1FSLG6WVI9UOF1'); // API ключ за удостоверяване
+// Статичният токен вече се подава чрез променлива на средата
+$envToken = getenv('STATIC_TOKEN');
+if ($envToken === false) {
+    error_log('STATIC_TOKEN environment variable not set');
+    http_response_code(500);
+    echo json_encode(['error' => 'Server configuration error']);
+    exit;
+}
+define('STATIC_TOKEN', $envToken); // API ключ за удостоверяване
 
 // Задаване на CORS заглавки
 header("Access-Control-Allow-Origin: *"); // Може да се ограничи до твоя Worker или домейни

--- a/homeo.html
+++ b/homeo.html
@@ -521,7 +521,8 @@
 <!-- /.container --><script>
         // --- Конфигурация ---
         const API_URL = 'file_manager_api.php'; // Поставете правилния път до вашия PHP API скрипт
-        const API_TOKEN = 'FXW29QFHZ3M70VDUFN1FSLG6WVI9UOF1'; // Вашият статичен API ключ
+        // Токенът вече може да се подава чрез глобална променлива
+        const API_TOKEN = window.FILE_API_TOKEN || '';
 
         // --- Елементи от DOM ---
         const form = document.getElementById('homeopathy-questionnaire');

--- a/login.php
+++ b/login.php
@@ -14,9 +14,15 @@ if (!$data || !isset($data['password'])) {
     exit;
 }
 
-define('ADMIN_PASS', 'admin123');
+// Очакваме хеш на паролата в променлива на средата
+$adminHash = getenv('ADMIN_PASS_HASH');
+if ($adminHash === false) {
+    error_log('ADMIN_PASS_HASH env not set');
+    echo json_encode(["success"=>false, "message"=>"Server configuration error"]);
+    exit;
+}
 
-if ($data['password'] === ADMIN_PASS) {
+if (password_verify($data['password'], $adminHash)) {
     $_SESSION['isAdmin'] = true;
     echo json_encode(["success"=>true, "message"=>"Logged in"]);
 } else {

--- a/quest.html
+++ b/quest.html
@@ -717,7 +717,7 @@
 
   const phpFileManagerUrl = "http://mybody.best/wp-content/uploads/file_manager_api.php";
   const workerSubmitUrl = "https://openapichatbot.radilov-k.workers.dev/api/submitQuestionnaire";
-  const phpApiToken = "FXW29QFHZ3M70VDUFN1FSLG6WVI9UOF1";
+  const phpApiToken = window.FILE_API_TOKEN || "";
 
    // Преместваме ги извън функцията, за да са достъпни, ако е нужно
    const questionMapping = {


### PR DESCRIPTION
## Summary
- load STATIC_TOKEN from environment in `file_manager_api.php`
- verify admin password via hash from env var in `login.php`
- read API token from `window.FILE_API_TOKEN` in `homeo.html` and `quest.html`
- document PHP environment variables in `README.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842e997e2dc8326994c272e6994c839