### PR TITLE
Improve analytics cards info

### DIFF
--- a/code.html
+++ b/code.html
@@ -163,6 +163,11 @@
                             </div>
                             <p id="healthProgressText" class="index-value">Изчисляване...</p>
                         </div>
+                        <div class="card index-card" id="streakCard">
+                            <h4>🔥 Поредица</h4>
+                            <div id="streakGrid" class="streak-grid"></div>
+                            <p id="streakCount" class="index-value">0</p>
+                        </div>
                     </div>
                     <!-- Край Основни Индекси -->
 
@@ -176,9 +181,9 @@
                             <div id="dashboardTextualAnalysis" style="margin-bottom: var(--space-lg);">
                                 <p class="placeholder">Генериране на текстов анализ...</p>
                             </div>
-                            <ul id="detailedAnalyticsList" class="detailed-metrics-list">
-                                <li class="placeholder">Зареждане на детайлните показатели...</li>
-                            </ul>
+                            <div id="analyticsCardsContainer" class="analytics-cards-grid">
+                                <p class="placeholder">Зареждане на детайлните показатели...</p>
+                            </div>
                         </div>
                     </div>
                     <!-- Край Акордеон детайлни показатели -->

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -102,6 +102,16 @@
   bottom: var(--space-lg); right: var(--space-lg);
   background-color: var(--fab-bg); color: var(--fab-icon);
 }
+#chat-fab.notification::after {
+  content: '';
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-danger);
+}
 #feedback-fab {
   bottom: var(--space-lg); left: var(--space-lg);
   background-color: var(--secondary-color); color: var(--text-color-on-secondary);

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -36,9 +36,90 @@
 }
 .index-card .index-value {
   font-size: 1.2rem; font-weight: 700; color: var(--primary-color);
-  text-align: center; 
-  margin-top: var(--space-sm); 
-  margin-bottom: var(--space-xs); 
+  text-align: center;
+  margin-top: var(--space-sm);
+  margin-bottom: var(--space-xs);
+}
+
+/* Streak Card */
+.streak-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  justify-items: center;
+  margin-bottom: var(--space-sm);
+}
+.streak-day {
+  width: 18px; height: 18px; border-radius: 50%; background: var(--border-color);
+}
+.streak-day.logged { background: var(--color-success); }
+
+/* Analytics Cards Grid */
+.analytics-cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-lg);
+}
+.analytics-card {
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  padding: var(--space-md);
+  box-shadow: var(--shadow-sm);
+}
+.analytics-card h5 {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-sm);
+  font-size: 1.05rem;
+}
+.analytics-card .mini-progress-bar {
+  background: var(--progress-gradient);
+  border-radius: var(--progress-bar-radius);
+  position: relative;
+  height: 0.5rem;
+  overflow: hidden;
+  margin-bottom: var(--space-sm);
+}
+.analytics-card .mini-progress-mask {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: auto;
+  background: var(--progress-bar-bg-empty);
+  transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  width: 100%;
+}
+.analytics-card { cursor: pointer; }
+.metric-current-text {
+  margin-bottom: var(--space-sm);
+  font-weight: 600;
+  color: var(--secondary-color);
+}
+.analytics-card-details {
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+}
+.analytics-card.open .analytics-card-details {
+  max-height: 500px;
+  opacity: 1;
+  margin-top: var(--space-sm);
+}
+
+/* Box with extra info for each metric */
+.metric-info-container {
+  background: var(--color-info-bg);
+  border-left: 4px solid var(--color-info);
+  padding: var(--space-sm);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-sm);
+}
+.metric-info-container .metric-period {
+  font-size: 0.85rem;
+  color: var(--text-color-muted);
 }
 
 /* Детайлни Показатели на Таблото - Корекции */
@@ -55,12 +136,6 @@
     margin-bottom: var(--space-lg); /* Увеличено разстояние */
 }
 .detailed-metric-item .metric-label { font-weight: 700; color: var(--primary-color); font-size: 1.15em; } /* Леко увеличен шрифт */
-.detailed-metric-item .info-btn-metric {
-    background: transparent; border: none; padding: var(--space-xs);
-    color: var(--icon-color-muted); cursor: pointer; line-height: 1;
-}
-.detailed-metric-item .info-btn-metric:hover { color: var(--primary-color); }
-.detailed-metric-item .info-btn-metric svg.icon { width: 1.3em; height: 1.3em; } /* Леко увеличена икона */
 
 .detailed-metric-item .metric-item-values {
     display: grid; 

--- a/index.html
+++ b/index.html
@@ -177,7 +177,11 @@
         const registerMessage = document.getElementById('register-message');
 
         // Базов URL на Worker-а
-        const workerBaseUrl = 'https://openapichatbot.radilov-k.workers.dev';
+        const isLocalDev = window.location.hostname === 'localhost' ||
+                           window.location.hostname.includes('replit') ||
+                           window.location.hostname.includes('preview');
+        const workerBaseUrl = isLocalDev ? '/api' :
+            'https://openapichatbot.radilov-k.workers.dev';
 
         // API Endpoints
         const loginEndpoint = `${workerBaseUrl}/api/login`;
@@ -276,7 +280,10 @@
 
             } catch (error) {
                 console.error('Login failed:', error);
-                showMessage(loginMessage, error.message, true);
+                const msg = error instanceof TypeError ?
+                    'Неуспешна връзка със сървъра. Проверете интернет връзката.' :
+                    error.message;
+                showMessage(loginMessage, msg, true);
                 loginButton.disabled = false;
                 loginButton.textContent = originalButtonText;
             }

--- a/js/__tests__/automatedChatFlag.test.js
+++ b/js/__tests__/automatedChatFlag.test.js
@@ -1,0 +1,17 @@
+import { shouldTriggerAutomatedFeedbackChat } from '../../worker.js';
+
+describe('shouldTriggerAutomatedFeedbackChat', () => {
+  const day = 24 * 60 * 60 * 1000;
+  test('triggers when update older than threshold and no chat', () => {
+    const now = Date.now();
+    expect(shouldTriggerAutomatedFeedbackChat(now - 4 * day, 0, now)).toBe(true);
+  });
+  test('does not trigger if chat already after update', () => {
+    const now = Date.now();
+    expect(shouldTriggerAutomatedFeedbackChat(now - 4 * day, now - 1 * day, now)).toBe(false);
+  });
+  test('does not trigger if update is recent', () => {
+    const now = Date.now();
+    expect(shouldTriggerAutomatedFeedbackChat(now - 1 * day, 0, now)).toBe(false);
+  });
+});

--- a/js/__tests__/swipeTabs.test.js
+++ b/js/__tests__/swipeTabs.test.js
@@ -1,0 +1,18 @@
+import { computeSwipeTargetIndex } from '../swipeUtils.js';
+
+describe('computeSwipeTargetIndex', () => {
+  test('swipe left moves to next tab', () => {
+    const idx = computeSwipeTargetIndex(0, -60, 50, 3);
+    expect(idx).toBe(1);
+  });
+
+  test('swipe right moves to previous tab', () => {
+    const idx = computeSwipeTargetIndex(1, 70, 50, 3);
+    expect(idx).toBe(0);
+  });
+
+  test('small move keeps same tab', () => {
+    const idx = computeSwipeTargetIndex(2, 10, 50, 3);
+    expect(idx).toBe(2);
+  });
+});

--- a/js/app.js
+++ b/js/app.js
@@ -17,7 +17,8 @@ import { setupStaticEventListeners, setupDynamicEventListeners } from './eventLi
 import { handleLogout as performLogout } from './auth.js';
 import {
     toggleChatWidget, closeChatWidget, displayMessage as displayChatMessage,
-    displayTypingIndicator as displayChatTypingIndicator, scrollToChatBottom
+    displayTypingIndicator as displayChatTypingIndicator, scrollToChatBottom,
+    setAutomatedChatPending
 } from './chat.js';
 import { openExtraMealModal } from './extraMealForm.js';
 import {
@@ -203,6 +204,11 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
                  headers: {'Content-Type': 'application/json'},
                  body: JSON.stringify({userId: currentUserId})
             }).catch(err => console.warn("Failed to acknowledge AI update:", err));
+        }
+
+        if (data.triggerAutomatedFeedbackChat) {
+            setAutomatedChatPending(true);
+            if (selectors.chatFab) selectors.chatFab.classList.add('notification');
         }
 
         populateUI();

--- a/js/chat.js
+++ b/js/chat.js
@@ -1,12 +1,25 @@
 
 // chat.js - Логика за Чат
 import { selectors } from './uiElements.js';
-import { chatHistory } from './app.js'; // Accessing chatHistory from app.js
+import { chatHistory, currentUserId } from './app.js'; // Access chatHistory and userId
+import { apiEndpoints } from './config.js';
+
+export let automatedChatPending = false;
+export function setAutomatedChatPending(val) { automatedChatPending = val; }
 
 export function toggleChatWidget() {
     if (!selectors.chatWidget || !selectors.chatFab) return;
     const isVisible = selectors.chatWidget.classList.toggle('visible');
     selectors.chatFab.setAttribute('aria-expanded', isVisible.toString());
+    if (isVisible && automatedChatPending && currentUserId) {
+        selectors.chatFab.classList.remove('notification');
+        automatedChatPending = false;
+        fetch(apiEndpoints.recordFeedbackChat, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ userId: currentUserId })
+        }).catch(() => {});
+    }
     if (isVisible) {
         if(selectors.chatInput) selectors.chatInput.focus();
         if (selectors.chatMessages) {

--- a/js/config.js
+++ b/js/config.js
@@ -19,6 +19,7 @@ export const apiEndpoints = {
     getAdaptiveQuiz: `${workerBaseUrl}/api/getAdaptiveQuiz`,
     submitAdaptiveQuiz: `${workerBaseUrl}/api/submitAdaptiveQuiz`,
     acknowledgeAiUpdate: `${workerBaseUrl}/api/acknowledgeAiUpdate`,
+    recordFeedbackChat: `${workerBaseUrl}/api/recordFeedbackChat`,
     forgotPassword: `${workerBaseUrl}/api/forgotPassword`
 };
 

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -13,6 +13,7 @@ export function populateUI() {
     try { populateUserInfo(data.userName); } catch(e) { console.error("Error in populateUserInfo:", e); }
     try { populateDashboardMainIndexes(data.analytics?.current); } catch(e) { console.error("Error in populateDashboardMainIndexes:", e); }
     try { populateDashboardDetailedAnalytics(data.analytics); } catch(e) { console.error("Error in populateDashboardDetailedAnalytics:", e); }
+    try { populateDashboardStreak(data.analytics?.streak); } catch(e) { console.error("Error in populateDashboardStreak:", e); }
     try { populateDashboardDailyPlan(data.planData?.week1Menu, data.dailyLogs, data.recipeData); } catch(e) { console.error("Error in populateDashboardDailyPlan:", e); }
     try { populateDashboardLog(data.dailyLogs, data.currentStatus, data.initialData); } catch(e) { console.error("Error in populateDashboardLog:", e); }
     try { populateProfileTab(data.userName, data.initialData, data.currentStatus, data.initialAnswers); } catch(e) { console.error("Error in populateProfileTab:", e); }
@@ -60,15 +61,15 @@ function populateDashboardMainIndexes(currentAnalytics) {
 }
 
 function populateDashboardDetailedAnalytics(analyticsData) {
-    const list = selectors.detailedAnalyticsList;
+    const cardsContainer = selectors.analyticsCardsContainer;
     const accordionContent = selectors.detailedAnalyticsContent;
     const textualAnalysisContainer = selectors.dashboardTextualAnalysis;
 
-    if (!list || !accordionContent || !textualAnalysisContainer) {
+    if (!cardsContainer || !accordionContent || !textualAnalysisContainer) {
         console.warn("Detailed analytics elements for dashboard not found.");
         return;
     }
-    list.innerHTML = '';
+    cardsContainer.innerHTML = '';
     textualAnalysisContainer.innerHTML = '';
 
     const detailedMetrics = safeGet(analyticsData, 'detailed', []);
@@ -82,45 +83,84 @@ function populateDashboardDetailedAnalytics(analyticsData) {
 
     if (Array.isArray(detailedMetrics) && detailedMetrics.length > 0) {
         detailedMetrics.forEach(metric => {
-            const initialText = metric.initialValueText || 'Няма данни';
-            const expectedText = metric.expectedValueText || 'Не е зададена';
-            const currentText = metric.currentValueText || 'Няма данни';
+            const card = document.createElement('div');
+            card.className = 'analytics-card';
 
-            const li = document.createElement('li');
-            li.classList.add('detailed-metric-item');
+            const header = document.createElement('h5');
+            header.textContent = metric.label || 'Показател';
+            card.appendChild(header);
 
-            const formatValue = (value, typeClassSuffix) => {
-                if (value === 'N/A' || value === 'Няма данни' || value === 'Не е зададена' || value === null || value === undefined) {
-                    return `<span class="value-muted">${value === null || value === undefined ? 'Няма данни' : value}</span>`;
+            const progress = document.createElement('div');
+            progress.className = 'mini-progress-bar';
+            const mask = document.createElement('div');
+            mask.className = 'mini-progress-mask';
+            progress.appendChild(mask);
+            card.appendChild(progress);
+
+            const currentDiv = document.createElement('div');
+            currentDiv.className = 'metric-current-text';
+            currentDiv.textContent = metric.currentValueText || 'Няма данни';
+            card.appendChild(currentDiv);
+
+            const valuesDiv = document.createElement('div');
+            valuesDiv.className = 'metric-item-values';
+            const formatValue = (val, cls) => {
+                if (val === 'N/A' || val === 'Няма данни' || val === 'Не е зададена' || val === null || val === undefined) {
+                    return `<span class="value-muted">${val === null || val === undefined ? 'Няма данни' : val}</span>`;
                 }
-                return `<span class="value-${typeClassSuffix}">${value}</span>`;
+                return `<span class="value-${cls}">${val}</span>`;
             };
-
-            li.innerHTML = `
-                <div class="metric-item-header">
-                    <span class="metric-label">${metric.label || 'Неизвестен показател'}</span>
-                    <button class="button-icon-only info-btn-metric" data-info-key="${metric.infoTextKey || (metric.key ? metric.key + '_info' : generateId('info'))}" aria-label="Информация за ${metric.label || 'показател'}">
-                        <svg class="icon"><use href="#icon-info"/></svg>
-                    </button>
+            valuesDiv.innerHTML = `
+                <div class="metric-value-group">
+                    <span class="metric-value-label">Начална стойност:</span>
+                    ${formatValue(metric.initialValueText || 'Няма данни', 'initial')}
                 </div>
-                <div class="metric-item-values">
-                    <div class="metric-value-group">
-                        <span class="metric-value-label">Начална стойност:</span>
-                        ${formatValue(initialText, 'initial')}
-                    </div>
-                    <div class="metric-value-group">
-                        <span class="metric-value-label">Целева стойност:</span>
-                        ${formatValue(expectedText, 'expected')}
-                    </div>
-                    <div class="metric-value-group">
-                        <span class="metric-value-label">Текуща стойност:</span>
-                        ${formatValue(currentText, 'current')}
-                    </div>
+                <div class="metric-value-group">
+                    <span class="metric-value-label">Целева стойност:</span>
+                    ${formatValue(metric.expectedValueText || 'Не е зададена', 'expected')}
+                </div>
+                <div class="metric-value-group">
+                    <span class="metric-value-label">Текуща стойност:</span>
+                    ${formatValue(metric.currentValueText || 'Няма данни', 'current')}
                 </div>`;
-            list.appendChild(li);
+
+            const details = document.createElement('div');
+            details.className = 'analytics-card-details';
+            const infoContainer = document.createElement('div');
+            infoContainer.className = 'metric-info-container';
+            const infoText = detailedMetricInfoTexts[metric.infoTextKey || (metric.key ? metric.key + '_info' : '')] || metric.infoText || '';
+            if (infoText) {
+                const p = document.createElement('p');
+                p.className = 'metric-info';
+                p.textContent = infoText;
+                infoContainer.appendChild(p);
+            }
+            if (metric.periodDays !== undefined) {
+                const pPeriod = document.createElement('p');
+                pPeriod.className = 'metric-period';
+                pPeriod.textContent = metric.periodDays > 0
+                    ? `Период на изчисление: последните ${metric.periodDays} дни.`
+                    : 'Изчислено от последните налични данни.';
+                infoContainer.appendChild(pPeriod);
+            }
+            details.appendChild(infoContainer);
+            details.appendChild(valuesDiv);
+            card.appendChild(details);
+
+            card.addEventListener('click', () => {
+                card.classList.toggle('open');
+            });
+
+            if (!isNaN(metric.currentValueNumeric)) {
+                const value = Number(metric.currentValueNumeric);
+                const percent = value <= 5 ? ((value - 1) / 4) * 100 : Math.min(100, value);
+                mask.style.width = `${100 - percent}%`;
+            }
+
+            cardsContainer.appendChild(card);
         });
     } else {
-        list.innerHTML = '<li class="placeholder">Няма налични детайлни показатели за показване.</li>';
+        cardsContainer.innerHTML = '<p class="placeholder">Няма налични детайлни показатели за показване.</p>';
     }
 
     const accordionHeader = selectors.detailedAnalyticsAccordion?.querySelector('.accordion-header');
@@ -137,6 +177,19 @@ function populateDashboardDetailedAnalytics(analyticsData) {
             }
         }
     }
+}
+
+function populateDashboardStreak(streakData) {
+    if (!selectors.streakGrid || !selectors.streakCount) return;
+    selectors.streakGrid.innerHTML = '';
+    const days = streakData?.dailyStatusArray || [];
+    days.forEach(d => {
+        const el = document.createElement('div');
+        el.className = 'streak-day' + (d.logged ? ' logged' : '');
+        el.title = new Date(d.date).toLocaleDateString('bg-BG');
+        selectors.streakGrid.appendChild(el);
+    });
+    selectors.streakCount.textContent = streakData?.currentCount || 0;
 }
 
 function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {

--- a/js/swipeUtils.js
+++ b/js/swipeUtils.js
@@ -1,0 +1,4 @@
+export function computeSwipeTargetIndex(currentIndex, diffX, threshold, tabCount) {
+  if (Math.abs(diffX) < threshold) return currentIndex;
+  return diffX < 0 ? (currentIndex + 1) % tabCount : (currentIndex - 1 + tabCount) % tabCount;
+}

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -15,7 +15,6 @@ export function initializeSelectors() {
         healthProgressBar: 'healthProgressBar', healthProgressMask: 'healthProgressMask', healthProgressText: 'healthProgressText',
         detailedAnalyticsAccordion: 'detailedAnalyticsAccordion', detailedAnalyticsContent: 'detailedAnalyticsContent',
         dashboardTextualAnalysis: 'dashboardTextualAnalysis',
-        detailedAnalyticsList: 'detailedAnalyticsList',
         dailyPlanTitle: 'dailyPlanTitle', dailyMealList: 'dailyMealList',
         dailyTracker: 'dailyTracker', addNoteBtn: 'add-note-btn', dailyNote: 'daily-note', saveLogBtn: 'saveLogBtn', dailyLogDate: 'dailyLogDate',
         openExtraMealModalBtn: 'openExtraMealModalBtn',
@@ -33,6 +32,9 @@ export function initializeSelectors() {
         feedbackFab: 'feedback-fab',
         feedbackForm: 'feedbackForm',
         progressHistoryCard: 'progressHistoryCard',
+        streakGrid: 'streakGrid',
+        streakCount: 'streakCount',
+        analyticsCardsContainer: 'analyticsCardsContainer',
         tooltipTracker: 'tooltip-tracker',
         toast: 'toast', chatFab: 'chat-fab', chatWidget: 'chat-widget', chatClose: 'chat-close',
         chatMessages: 'chat-messages', chatInput: 'chat-input', chatSend: 'chat-send'
@@ -52,6 +54,7 @@ export function initializeSelectors() {
             const optionalOrDynamic = [
                 'menuClose', 'extraMealFormContainer', 'userAllergiesNote', 'userAllergiesList',
                 'feedbackForm', 'tooltipTracker', 'triggerAdaptiveQuizBtn',
+                'streakGrid', 'streakCount', 'analyticsCardsContainer',
             ];
             if (!optionalOrDynamic.includes(key) && key !== 'adaptiveQuizModal' && key !== 'adaptiveQuizContainer') {
                 console.warn(`HTML element not found: ${key} (selector: '${selectorValue}')`);


### PR DESCRIPTION
## Summary
- show analytics info in colored boxes with period explanation
- expose `periodDays` for each metric from worker
- add styles for info container

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68461dab07048326a09a4c3fd4abde72