### PR TITLE
Improve KV management script documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,41 @@ To set the token:
 
 The worker configuration is stored in `wrangler.toml`. Update `account_id` with your Cloudflare account if needed.
 
+### Manual publish
+
+For manual deployment run:
+
+```bash
+npx wrangler publish
+```
+
+This will upload the worker using the settings from `wrangler.toml`.
+
+### Работа с KV
+
+Можете да управлявате съдържанието на KV директно през `wrangler`:
+
+```bash
+wrangler kv:key put <ключ> "<стойност>" --binding=RESOURCES_KV
+wrangler kv:key get <ключ> --binding=RESOURCES_KV
+wrangler kv:key delete <ключ> --binding=RESOURCES_KV
+```
+
+Заменете `RESOURCES_KV` с `USER_METADATA_KV` при нужда. В директорията `scripts` има примерен Node скрипт `manage-kv.js`, който изпълнява същите операции:
+
+```bash
+node scripts/manage-kv.js put exampleKey "примерна стойност"
+node scripts/manage-kv.js get exampleKey
+node scripts/manage-kv.js delete exampleKey
+```
+Скриптът използва `npx wrangler`, така че не е нужна глобална инсталация.
+За директно изпълнение дайте права и извикайте:
+
+```bash
+chmod +x scripts/manage-kv.js
+./scripts/manage-kv.js put exampleKey "примерна стойност"
+```
+
 ### Required Worker Secrets
 
 Before deploying, configure the following secrets in Cloudflare (via the dashboard or `wrangler secret put`):

--- a/scripts/manage-kv.js
+++ b/scripts/manage-kv.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { spawnSync } from 'child_process';
+
+const [action, key, value, binding = 'RESOURCES_KV'] = process.argv.slice(2);
+
+if (!['get', 'put', 'delete'].includes(action) || !key || (action === 'put' && !value)) {
+  console.log('Usage: node scripts/manage-kv.js <get|put|delete> <key> [value] [binding]');
+  process.exit(1);
+}
+
+const args = ['kv:key', action, key];
+if (action === 'put') args.push(value);
+args.push('--binding', binding);
+
+// Използваме `npx`, за да работи без глобална инсталация на wrangler
+const result = spawnSync('npx', ['wrangler', ...args], { stdio: 'inherit' });
+
+if (result.error) {
+  console.error('Failed to run wrangler:', result.error);
+  process.exit(1);
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,3 +3,13 @@ account_id = "c2015f4060e04bc3c414f78a9946668e"
 workers_dev = true
 compatibility_date = "2025-06-06"
 main = "worker.js"
+
+[[kv_namespaces]]
+binding = "RESOURCES_KV"
+id = "8ebf65a6ed0a44e7b7d1b4bc6f24465e"
+preview_id = "8ebf65a6ed0a44e7b7d1b4bc6f24465e"
+
+[[kv_namespaces]]
+binding = "USER_METADATA_KV"
+id = "00000000000000000000000000000000"
+preview_id = "00000000000000000000000000000000"


### PR DESCRIPTION
## Summary
- allow `manage-kv.js` to invoke wrangler through `npx`
- add README note about giving execute permission

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684793e167588326ba89097018b95bdf