### PR TITLE
Fix env config and eslint setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,20 @@
 {
   "env": {
     "browser": true,
-    "es2021": true
+    "es2021": true,
+    "node": true,
+    "jest": true
   },
   "extends": "eslint:recommended",
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "rules": {}
+  "rules": {},
+  "overrides": [
+    {
+      "files": ["js/__tests__/*.js"],
+      "env": { "jest": true }
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ To set the token:
 1. Generate an API token with **Edit Cloudflare Workers** permissions.
 2. In your repository settings, create a GitHub secret named `CF_API_TOKEN` containing the token value.
 
-The worker configuration is stored in `wrangler.toml`. Update `account_id` with your Cloudflare account if needed.
+The worker configuration is stored in `wrangler.toml`. Update `account_id` with your Cloudflare account if needed. The file also contains
+placeholders for the `USER_METADATA_KV` namespace – replace `000000...` with the real KV IDs from your Cloudflare dashboard.
 
 ### Manual publish
 
@@ -103,6 +104,7 @@ The PHP helper scripts expect the following variables set in the server environm
 
 - `STATIC_TOKEN` – shared secret token used for authentication in `file_manager_api.php`.
 - `ADMIN_PASS_HASH` – bcrypt hash of the admin password for `login.php`.
+- `CF_API_TOKEN` – token used by `save-questions.php` to update the Cloudflare KV store.
 
 Example of generating a hash:
 

--- a/save-questions.php
+++ b/save-questions.php
@@ -1,9 +1,8 @@
 <?php
 header("Content-Type: application/json; charset=utf-8");
 
-// ----- ХАРДКОДНАТИ КОНФИГУРАЦИОННИ ПРОМЕНЛИВИ -----
-// !!! ВНИМАНИЕ: ХАРДКОДВАНЕТО НА API ТОКЕНИ Е РИСК ЗА СИГУРНОСТТА !!!
-$cloudflareApiToken = 'XIqmUGr4S3xT6FLsqPzIdN9IuG67ctXISGCzBZ3i'; // API Токен (Уверете се, че това е ТОКЕНЪТ, а не Namespace ID)
+// ----- Конфигурация чрез променливи на средата -----
+$cloudflareApiToken = getenv('CF_API_TOKEN');
 $cloudflareAccountId = 'c2015f4060e04bc3c414f78a9946668e'; // Cloudflare Account ID
 $kvNamespaceId = '8ebf65a6ed0a44e7b7d1b4bc6f24465e'; // Namespace ID за RESOURCES_KV
 $kvKeyName = 'question_definitions';
@@ -28,8 +27,8 @@ function respondAndExit($code, $success, $message) {
 
 // Проверка дали конфигурацията е попълнена (проста проверка)
 if (empty($cloudflareApiToken) || empty($cloudflareAccountId) || empty($kvNamespaceId)) {
-    error_log("save-questions.php: Липсва ХАРДКОДНАТА конфигурация за Cloudflare API.");
-    respondAndExit(500, false, "Грешка в сървърната конфигурация (API данни).");
+    error_log("save-questions.php: Липсва CF_API_TOKEN или друга конфигурация.");
+    respondAndExit(500, false, "Сървърът няма достъп до Cloudflare (липсва CF_API_TOKEN).");
 }
 
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,8 @@
 import { defineConfig } from 'vite';
-import { resolve } from 'path';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   base: './',

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,5 +11,5 @@ preview_id = "8ebf65a6ed0a44e7b7d1b4bc6f24465e"
 
 [[kv_namespaces]]
 binding = "USER_METADATA_KV"
-id = "00000000000000000000000000000000"
-preview_id = "00000000000000000000000000000000"
+id = "00000000000000000000000000000000"       # Replace with your real namespace ID
+preview_id = "00000000000000000000000000000000" # Replace with your preview namespace ID


### PR DESCRIPTION
## Summary
- load Cloudflare token from environment in `save-questions.php`
- document manual KV IDs and `CF_API_TOKEN` in README
- enable Node/Jest linting and add override for tests
- define `__dirname` for Vite config
- clarify placeholder IDs in `wrangler.toml`

## Testing
- `npm run lint` *(fails: 69 errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847a0fd43408326beec0b6d2cb68e27