### PR TITLE
Introduce AI-powered achievement badges

### DIFF
--- a/code.html
+++ b/code.html
@@ -164,9 +164,8 @@
                             <p id="healthProgressText" class="index-value">Изчисляване...</p>
                         </div>
                         <div class="card index-card" id="streakCard">
-                            <h4>🔥 Поредица</h4>
+                            <h4>🏅 Моите успехи</h4>
                             <div id="streakGrid" class="streak-grid"></div>
-                            <p id="streakCount" class="index-value">0</p>
                         </div>
                     </div>
                     <!-- Край Основни Индекси -->
@@ -411,6 +410,22 @@
                     <p class="placeholder">Зареждане на актуализации...</p>
                 </div>
                 <button class="button-primary modal-close-btn" data-modal-close="aiUpdateNotificationModal" style="margin-top: 1.5rem;">Разбрах</button>
+            </div>
+        </div>
+
+        <!-- Achievement Modal -->
+        <div id="achievementModal" class="modal" role="dialog" aria-labelledby="achievementModalTitle" aria-modal="true" aria-hidden="true">
+            <div class="modal-content">
+                <button class="close-button" data-modal-close="achievementModal" aria-label="Затвори прозореца">
+                    <svg class="icon" style="width: 1.2em; height: 1.2em;"><use href="#icon-close"></use></svg>
+                </button>
+                <div class="achievement-emoji" aria-hidden="true">
+                    <span id="achievementMedalEmoji">🏅</span>
+                    <span class="achievement-confetti">🎉</span>
+                </div>
+                <h3 id="achievementModalTitle" style="text-align:center;">Поздравления!</h3>
+                <div id="achievementModalBody" style="white-space: pre-wrap; text-align: left;"></div>
+                <button class="button-primary modal-close-btn" data-modal-close="achievementModal" style="margin-top: 1.5rem;">Разбрах</button>
             </div>
         </div>
 

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -49,10 +49,49 @@
   justify-items: center;
   margin-bottom: var(--space-sm);
 }
-.streak-day {
-  width: 18px; height: 18px; border-radius: 50%; background: var(--border-color);
-}
+#streakCard { min-height: 120px; }
+.streak-day { width: 18px; height: 18px; border-radius: 50%; background: var(--border-color); }
 .streak-day.logged { background: var(--color-success); }
+
+/* Achievement Medals */
+.achievement-medal {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--secondary-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-color-on-secondary);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.3s ease;
+}
+.achievement-medal.new { animation: pop-in 0.6s ease; }
+
+.achievement-emoji {
+  font-size: 3rem;
+  text-align: center;
+  margin-bottom: var(--space-sm);
+  animation: pop-in 0.6s ease;
+}
+.achievement-confetti {
+  display: block;
+  font-size: 1.5rem;
+  margin-top: -0.2em;
+  animation: fade-slide 0.8s ease;
+}
+
+@keyframes fade-slide {
+  0% { opacity: 0; transform: translateY(-10px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes pop-in {
+  0% { transform: scale(0); }
+  80% { transform: scale(1.2); }
+  100% { transform: scale(1); }
+}
 
 /* Analytics Cards Grid */
 .analytics-cards-grid {

--- a/js/achievements.js
+++ b/js/achievements.js
@@ -1,0 +1,104 @@
+// achievements.js - управление на похвали и медали
+import { selectors } from './uiElements.js';
+import { openModal } from './uiHandlers.js';
+import { apiEndpoints } from './config.js';
+
+const medalEmojis = ['🥇','🥈','🥉','🏅','🎖️','🏆','🏵️'];
+
+let achievements = [];
+let currentUserId = null;
+
+export async function initializeAchievements(userId) {
+    currentUserId = userId || null;
+    achievements = JSON.parse(localStorage.getItem('achievements') || '[]');
+    if (currentUserId) {
+        try {
+            const res = await fetch(`${apiEndpoints.getAchievements}?userId=${currentUserId}`);
+            const data = await res.json();
+            if (res.ok && data.success && Array.isArray(data.achievements)) {
+                achievements = data.achievements;
+                saveAchievements();
+            }
+        } catch (err) { console.warn('Неуспешно зареждане на постижения:', err); }
+    }
+    ensureEmojis();
+    renderAchievements();
+
+    const last = achievements.length > 0 ? achievements[achievements.length - 1] : null;
+    const diffDays = last ? (Date.now() - last.date) / (1000 * 60 * 60 * 24) : Infinity;
+    if (diffDays >= 3 && currentUserId) {
+        fetchPraiseAndCreate(currentUserId);
+    }
+}
+
+function saveAchievements() {
+    localStorage.setItem('achievements', JSON.stringify(achievements));
+}
+
+function ensureEmojis() {
+    achievements.forEach((a, idx) => {
+        if (!a.emoji) a.emoji = medalEmojis[idx % medalEmojis.length];
+    });
+    saveAchievements();
+}
+
+function updateAchievementModal(emoji, title, message) {
+    const body = document.getElementById('achievementModalBody');
+    const modalTitle = document.getElementById('achievementModalTitle');
+    const medalSpan = document.getElementById('achievementMedalEmoji');
+    if (body) body.textContent = message;
+    if (modalTitle) modalTitle.textContent = title;
+    if (medalSpan) medalSpan.textContent = emoji;
+    openModal('achievementModal');
+}
+
+function renderAchievements(newIndex = -1) {
+    if (!selectors.streakGrid) return;
+    selectors.streakGrid.innerHTML = '';
+    achievements.forEach((a, index) => {
+        const el = document.createElement('div');
+        el.className = 'achievement-medal';
+        if (index === newIndex) el.classList.add('new');
+        el.textContent = a.emoji || medalEmojis[index % medalEmojis.length];
+        el.dataset.index = index;
+        el.setAttribute('role', 'button');
+        el.setAttribute('tabindex', '0');
+        el.setAttribute('aria-label', a.title || 'Успех');
+        selectors.streakGrid.appendChild(el);
+    });
+}
+
+export function createAchievement(title, message) {
+    const emoji = medalEmojis[achievements.length % medalEmojis.length];
+    achievements.push({ date: Date.now(), title, message, emoji });
+    if (achievements.length > 7) achievements.shift();
+    saveAchievements();
+    renderAchievements(achievements.length - 1);
+    updateAchievementModal(emoji, title, message);
+    localStorage.setItem('lastPraiseDate', String(Date.now()));
+}
+
+export function handleAchievementClick(e) {
+    const medal = e.target.closest('.achievement-medal');
+    if (!medal) return;
+    const index = parseInt(medal.dataset.index, 10);
+    const ach = achievements[index];
+    if (!ach) return;
+    updateAchievementModal(ach.emoji || medalEmojis[index % medalEmojis.length], ach.title, ach.message);
+}
+
+async function fetchPraiseAndCreate(userId) {
+    try {
+        const response = await fetch(apiEndpoints.generatePraise, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ userId })
+        });
+        const data = await response.json();
+        if (response.ok && data.success && data.title && data.message) {
+            createAchievement(data.title, data.message);
+        }
+    } catch (err) {
+        console.warn('Грешка при извличане на похвала:', err);
+    }
+}

--- a/js/app.js
+++ b/js/app.js
@@ -21,6 +21,7 @@ import {
     setAutomatedChatPending
 } from './chat.js';
 import { openExtraMealModal } from './extraMealForm.js';
+import { initializeAchievements } from './achievements.js';
 import {
     openAdaptiveQuizModal as _openAdaptiveQuizModal,
     renderCurrentQuizQuestion,
@@ -155,6 +156,7 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
             if(selectors.appWrapper) selectors.appWrapper.style.display = 'block';
 
             populateUI();
+            initializeAchievements(currentUserId);
             setupDynamicEventListeners();
 
             const activeTabId = sessionStorage.getItem('activeTabId') || selectors.tabButtons[0]?.id;
@@ -221,6 +223,7 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
         }
 
         populateUI();
+        initializeAchievements(currentUserId);
         setupDynamicEventListeners();
 
         const activeTabId = sessionStorage.getItem('activeTabId') || selectors.tabButtons[0]?.id;
@@ -336,6 +339,7 @@ export async function handleSaveLog() { // Exported for eventListeners.js
             }
         }
         populateUI();
+        initializeAchievements(currentUserId);
         showToast(result.message || "Логът е запазен!", false);
     } catch (error) {
         showToast(`Грешка при запис на лог: ${error.message}`, true);

--- a/js/config.js
+++ b/js/config.js
@@ -20,7 +20,9 @@ export const apiEndpoints = {
     submitAdaptiveQuiz: `${workerBaseUrl}/api/submitAdaptiveQuiz`,
     acknowledgeAiUpdate: `${workerBaseUrl}/api/acknowledgeAiUpdate`,
     recordFeedbackChat: `${workerBaseUrl}/api/recordFeedbackChat`,
-    forgotPassword: `${workerBaseUrl}/api/forgotPassword`
+    forgotPassword: `${workerBaseUrl}/api/forgotPassword`,
+    getAchievements: `${workerBaseUrl}/api/getAchievements`,
+    generatePraise: `${workerBaseUrl}/api/generatePraise`
 };
 
 export const generateId = (prefix = 'id') => `${prefix}-${Math.random().toString(36).substr(2, 9)}`;

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -17,6 +17,7 @@ import {
 } from './app.js';
 import { toggleChatWidget, closeChatWidget } from './chat.js';
 import { computeSwipeTargetIndex } from './swipeUtils.js';
+import { handleAchievementClick } from './achievements.js';
 
 let touchStartX = null;
 const SWIPE_THRESHOLD = 50;
@@ -215,5 +216,12 @@ function handleDelegatedClicks(event) {
                 if (sValue <= selectedValue) s.classList.add('filled', `level-${sValue}`);
             });
         }
+    }
+
+    const medal = target.closest('.achievement-medal');
+    if (medal) {
+        event.stopPropagation();
+        handleAchievementClick(event);
+        return;
     }
 }

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -33,7 +33,6 @@ export function initializeSelectors() {
         feedbackForm: 'feedbackForm',
         progressHistoryCard: 'progressHistoryCard',
         streakGrid: 'streakGrid',
-        streakCount: 'streakCount',
         analyticsCardsContainer: 'analyticsCardsContainer',
         tooltipTracker: 'tooltip-tracker',
         toast: 'toast', chatFab: 'chat-fab', chatWidget: 'chat-widget', chatClose: 'chat-close',
@@ -54,7 +53,7 @@ export function initializeSelectors() {
             const optionalOrDynamic = [
                 'menuClose', 'extraMealFormContainer', 'userAllergiesNote', 'userAllergiesList',
                 'feedbackForm', 'tooltipTracker', 'triggerAdaptiveQuizBtn',
-                'streakGrid', 'streakCount', 'analyticsCardsContainer',
+                'streakGrid', 'analyticsCardsContainer',
             ];
             if (!optionalOrDynamic.includes(key) && key !== 'adaptiveQuizModal' && key !== 'adaptiveQuizContainer') {
                 console.warn(`HTML element not found: ${key} (selector: '${selectorValue}')`);

--- a/worker.js
+++ b/worker.js
@@ -32,6 +32,7 @@ const ADAPTIVE_QUIZ_LOW_ENGAGEMENT_DAYS = 7;
 const ADAPTIVE_QUIZ_ANSWERS_LOOKBACK_DAYS = 35; // Колко назад да търсим отговори от въпросник за контекст
 const PREVIOUS_QUIZZES_FOR_CONTEXT_COUNT = 2; // Брой предишни въпросници за контекст при генериране на нов
 const AUTOMATED_FEEDBACK_TRIGGER_DAYS = 3; // След толкова дни предлагаме автоматичен чат
+const PRAISE_INTERVAL_DAYS = 3; // Интервал за нова похвала/значка
 // ------------- END BLOCK: GlobalConstantsAndBindings -------------
 
 // ------------- START BLOCK: MainWorkerExport -------------
@@ -111,6 +112,10 @@ export default {
                 responseBody = await handleAcknowledgeAiUpdateRequest(request, env);
             } else if (method === 'POST' && path === '/api/recordFeedbackChat') {
                 responseBody = await handleRecordFeedbackChatRequest(request, env);
+            } else if (method === 'GET' && path === '/api/getAchievements') {
+                responseBody = await handleGetAchievementsRequest(request, env);
+            } else if (method === 'POST' && path === '/api/generatePraise') {
+                responseBody = await handleGeneratePraiseRequest(request, env);
             } else {
                 responseBody = { success: false, error: 'Not Found', message: 'Ресурсът не е намерен.' };
                 responseStatus = 404;
@@ -964,6 +969,137 @@ async function handleRecordFeedbackChatRequest(request, env) {
     }
 }
 // ------------- END FUNCTION: handleRecordFeedbackChatRequest -------------
+
+// ------------- START FUNCTION: handleGetAchievementsRequest -------------
+async function handleGetAchievementsRequest(request, env) {
+    try {
+        const url = new URL(request.url);
+        const userId = url.searchParams.get('userId');
+        if (!userId) return { success: false, message: 'Липсва ID на потребител.', statusHint: 400 };
+        const achStr = await env.USER_METADATA_KV.get(`${userId}_achievements`);
+        const achievements = safeParseJson(achStr, []);
+        return { success: true, achievements };
+    } catch (error) {
+        console.error('Error in handleGetAchievementsRequest:', error.message, error.stack);
+        return { success: false, message: 'Грешка при зареждане на постижения.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleGetAchievementsRequest -------------
+
+// ------------- START FUNCTION: handleGeneratePraiseRequest -------------
+async function handleGeneratePraiseRequest(request, env) {
+    try {
+        const { userId } = await request.json();
+        if (!userId) return { success: false, message: 'Липсва ID на потребител.', statusHint: 400 };
+
+        const now = Date.now();
+        const lastTsStr = await env.USER_METADATA_KV.get(`${userId}_last_praise_ts`);
+        const achStr = await env.USER_METADATA_KV.get(`${userId}_achievements`);
+        const achievements = safeParseJson(achStr, []);
+
+        if (!lastTsStr && achievements.length === 0) {
+            const title = 'Първа стъпка';
+            const message = 'Ти направи нещо, което мнозина отлагат с месеци, години, а други въобще не започват — реши да направиш първата крачка към твоето по-добро АЗ.\nОттук нататък ние сме част от твоята кауза и стъпките, които правиш с нашата подкрепа ще донесат резултат\nСамото присъствие тук вече те отличава!';
+            const newAch = { date: now, title, message };
+            achievements.push(newAch);
+            await env.USER_METADATA_KV.put(`${userId}_achievements`, JSON.stringify(achievements));
+            await env.USER_METADATA_KV.put(`${userId}_last_praise_ts`, now.toString());
+            return { success: true, title, message };
+        }
+
+        if (lastTsStr && now - parseInt(lastTsStr, 10) < PRAISE_INTERVAL_DAYS * 86400000) {
+            const lastAch = achievements[achievements.length - 1] || null;
+            return { success: true, alreadyGenerated: true, ...(lastAch || {}) };
+        }
+
+        const initialAnswersStr = await env.USER_METADATA_KV.get(`${userId}_initial_answers`);
+        const initialAnswers = safeParseJson(initialAnswersStr, {});
+
+        const logKeys = [];
+        const today = new Date();
+        for (let i = 0; i < PRAISE_INTERVAL_DAYS; i++) {
+            const d = new Date(today); d.setDate(today.getDate() - i);
+            logKeys.push(`${userId}_log_${d.toISOString().split('T')[0]}`);
+        }
+        const logStrings = await Promise.all(logKeys.map(k => env.USER_METADATA_KV.get(k)));
+        const logs = logStrings.map((ls, idx) => {
+            if (ls) { const d = new Date(today); d.setDate(today.getDate() - idx); return { date: d.toISOString().split('T')[0], data: safeParseJson(ls, {}) }; }
+            return null;
+        }).filter(Boolean);
+
+        const avgMetric = (key) => {
+            let sum = 0, count = 0;
+            logs.forEach(l => { const v = parseFloat(l.data[key]); if (!isNaN(v)) { sum += v; count++; } });
+            return count > 0 ? (sum / count).toFixed(1) : 'N/A';
+        };
+
+        const mealAdh = () => {
+            let total = 0, done = 0;
+            logs.forEach(l => {
+                const cs = l.data.completedMealsStatus || {};
+                const vals = Object.values(cs);
+                done += vals.filter(v => v === true).length;
+                total += vals.length;
+            });
+            return total > 0 ? Math.round((done / total) * 100) : 0;
+        };
+
+        const promptTpl = await env.RESOURCES_KV.get('prompt_praise_generation');
+        const geminiKey = env[GEMINI_API_KEY_SECRET_NAME];
+        const model = await env.RESOURCES_KV.get('model_chat') || await env.RESOURCES_KV.get('model_plan_generation');
+
+        let title = 'Браво!';
+        let message = 'Продължавай в същия дух!';
+
+        if (promptTpl && geminiKey && model) {
+            const replacements = {
+                '%%име%%': initialAnswers.name || 'Клиент',
+                '%%възраст%%': initialAnswers.age || 'N/A',
+                '%%формулировка_на_целта%%': initialAnswers.goal || 'N/A',
+                '%%извлечени_от_въпросника_ключови_моменти_като_mainChallenge_стрес_ниво_мотивационни_проблеми_или_синтезиран_кратък_психо_портрет_ако_има%%': initialAnswers.mainChallenge || '',
+                '%%брой_попълнени_дни%%': logs.length,
+                '%%общо_дни_в_периода%%': PRAISE_INTERVAL_DAYS,
+                '%%средна_енергия_за_периода%%': avgMetric('energy'),
+                '%%средна_енергия_предходен_период%%': 'N/A',
+                '%%средно_настроение_за_периода%%': avgMetric('mood'),
+                '%%средно_настроение_предходен_период%%': 'N/A',
+                '%%средна_хидратация_за_периода%%': avgMetric('hydration'),
+                '%%процент_придържане_към_хран_план_за_периода%%': mealAdh(),
+                '%%процент_придържане_предходен_период%%': 'N/A',
+                '%%средно_качество_сън_за_периода%%': avgMetric('sleep_quality'),
+                '%%цитат1_от_бележка_или_чат%%': logs[0]?.data?.note || '',
+                '%%цитат2_от_бележка_или_чат%%': logs[1]?.data?.note || '',
+                '%%заглавие_постижение_N-1%%': '',
+                '%%заглавие_постижение_N-2%%': ''
+            };
+            const populated = populatePrompt(promptTpl, replacements);
+            try {
+                const raw = await callGeminiAPI(populated, geminiKey, { temperature: 0.6, maxOutputTokens: 400 }, [], model);
+                const cleaned = cleanGeminiJson(raw);
+                const parsed = safeParseJson(cleaned, null);
+                if (parsed && parsed.title && parsed.message) {
+                    title = parsed.title; message = parsed.message;
+                } else {
+                    message = cleaned;
+                }
+            } catch (err) {
+                console.error('Praise generation AI error:', err.message);
+            }
+        }
+
+        const newAch = { date: now, title, message };
+        achievements.push(newAch);
+        if (achievements.length > 7) achievements.shift();
+        await env.USER_METADATA_KV.put(`${userId}_achievements`, JSON.stringify(achievements));
+        await env.USER_METADATA_KV.put(`${userId}_last_praise_ts`, now.toString());
+
+        return { success: true, title, message };
+    } catch (error) {
+        console.error('Error in handleGeneratePraiseRequest:', error.message, error.stack);
+        return { success: false, message: 'Грешка при генериране на похвала.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleGeneratePraiseRequest -------------
 
 
 // ------------- START BLOCK: PlanGenerationHeaderComment -------------
@@ -2412,4 +2548,4 @@ function shouldTriggerAutomatedFeedbackChat(lastUpdateTs, lastChatTs, currentTim
 }
 // ------------- END FUNCTION: shouldTriggerAutomatedFeedbackChat -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, handleRecordFeedbackChatRequest };
+export { handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, handleRecordFeedbackChatRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest };


### PR DESCRIPTION
## Summary
- replace "Поредица" card with "Моите успехи" in `code.html`
- add achievement modal and medal animations
- implement `achievements.js` with 3‑day AI praise logic
- expose `/api/getAchievements` and `/api/generatePraise` in worker
- improve accessibility of achievement badges

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848d01965008326b9e64f2b2dc9cc18