### PR TITLE
Improve achievements display

### DIFF
--- a/code.html
+++ b/code.html
@@ -166,7 +166,6 @@
                         <div class="card index-card" id="streakCard">
                             <h4>🏅 Моите успехи</h4>
                             <div id="streakGrid" class="streak-grid"></div>
-                            <p id="streakCount" class="index-value">0</p>
                         </div>
                     </div>
                     <!-- Край Основни Индекси -->
@@ -420,6 +419,7 @@
                 <button class="close-button" data-modal-close="achievementModal" aria-label="Затвори прозореца">
                     <svg class="icon" style="width: 1.2em; height: 1.2em;"><use href="#icon-close"></use></svg>
                 </button>
+                <div id="achievementModalEmoji" class="achievement-emoji" aria-hidden="true"></div>
                 <h3 id="achievementModalTitle" style="text-align:center;">Поздравления!</h3>
                 <div id="achievementModalBody" style="white-space: pre-wrap; text-align: left;"></div>
                 <button class="button-primary modal-close-btn" data-modal-close="achievementModal" style="margin-top: 1.5rem;">Разбрах</button>

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -70,6 +70,18 @@
   z-index: 10; 
 }
 .modal-content .close-button:hover { color: var(--text-color-primary); }
+.achievement-emoji {
+  font-size: 3rem;
+  text-align: center;
+  animation: celebrate 0.8s ease-out;
+  margin-bottom: var(--space-sm);
+}
+
+@keyframes celebrate {
+  0% { transform: scale(0); opacity: 0; }
+  70% { transform: scale(1.2); opacity: 1; }
+  100% { transform: scale(1); }
+}
 #extraMealFormContainer .placeholder-form-loading {
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   min-height: 150px; color: var(--text-color-muted);

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -49,6 +49,10 @@
   justify-items: center;
   margin-bottom: var(--space-sm);
 }
+
+#streakCard {
+  min-height: 120px;
+}
 .streak-day { width: 18px; height: 18px; border-radius: 50%; background: var(--border-color); }
 .streak-day.logged { background: var(--color-success); }
 

--- a/js/achievements.js
+++ b/js/achievements.js
@@ -3,6 +3,8 @@ import { selectors } from './uiElements.js';
 import { openModal } from './uiHandlers.js';
 import { apiEndpoints } from './config.js';
 
+const medalEmojis = ['🥇', '🥈', '🥉', '🏆', '🎖️', '🏅'];
+
 let achievements = [];
 let currentUserId = null;
 
@@ -39,7 +41,7 @@ function renderAchievements(newIndex = -1) {
         const el = document.createElement('div');
         el.className = 'achievement-medal';
         if (index === newIndex) el.classList.add('new');
-        el.textContent = '🏅';
+        el.textContent = a.emoji || '🏅';
         el.dataset.index = index;
         selectors.streakGrid.appendChild(el);
     });
@@ -47,14 +49,17 @@ function renderAchievements(newIndex = -1) {
 }
 
 export function createAchievement(title, message) {
-    achievements.push({ date: Date.now(), title, message });
+    const emoji = medalEmojis[achievements.length % medalEmojis.length];
+    achievements.push({ date: Date.now(), title, message, emoji });
     if (achievements.length > 7) achievements.shift();
     saveAchievements();
     renderAchievements(achievements.length - 1);
     const body = document.getElementById('achievementModalBody');
     const modalTitle = document.getElementById('achievementModalTitle');
+    const emojiEl = document.getElementById('achievementModalEmoji');
     if (body) body.textContent = message;
     if (modalTitle) modalTitle.textContent = title;
+    if (emojiEl) emojiEl.textContent = emoji;
     openModal('achievementModal');
     localStorage.setItem('lastPraiseDate', String(Date.now()));
 }
@@ -67,8 +72,10 @@ export function handleAchievementClick(e) {
     if (!ach) return;
     const body = document.getElementById('achievementModalBody');
     const modalTitle = document.getElementById('achievementModalTitle');
+    const emojiEl = document.getElementById('achievementModalEmoji');
     if (body) body.textContent = ach.message;
     if (modalTitle) modalTitle.textContent = ach.title;
+    if (emojiEl) emojiEl.textContent = ach.emoji || '🏅';
     openModal('achievementModal');
 }
 

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -180,7 +180,7 @@ function populateDashboardDetailedAnalytics(analyticsData) {
 }
 
 function populateDashboardStreak(streakData) {
-    if (!selectors.streakGrid || !selectors.streakCount) return;
+    if (!selectors.streakGrid) return;
     selectors.streakGrid.innerHTML = '';
     const days = streakData?.dailyStatusArray || [];
     days.forEach(d => {
@@ -189,7 +189,7 @@ function populateDashboardStreak(streakData) {
         el.title = new Date(d.date).toLocaleDateString('bg-BG');
         selectors.streakGrid.appendChild(el);
     });
-    selectors.streakCount.textContent = streakData?.currentCount || 0;
+    if (selectors.streakCount) selectors.streakCount.textContent = streakData?.currentCount || 0;
 }
 
 function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {


### PR DESCRIPTION
## Summary
- trim the My Achievements card to save space
- enhance the medal popup with emoji and celebration animation
- vary the medal icons for visual distinction
- avoid mandatory streak counter element

## Testing
- `npm install`
- `npm run lint` *(fails: 69 errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848e6a3f8788326a4bf0af37b280af5