### PR TITLE
Adjust streak card height

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -51,7 +51,7 @@
 }
 
 #streakCard {
-  min-height: 120px;
+  min-height: 180px;
 }
 .streak-day { width: 18px; height: 18px; border-radius: 50%; background: var(--border-color); }
 .streak-day.logged { background: var(--color-success); }


### PR DESCRIPTION
## Summary
- make streak card same height as other index cards

## Testing
- `npm test`
- `npm run lint` *(fails: show existing repo issues)*

------
https://chatgpt.com/codex/tasks/task_e_6848ed6f11e483269e76e18f8ecea2f3