### PR TITLE
Remove index card height variable

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -52,7 +52,7 @@
 
   --progress-bar-bg-empty: #e9ecef;
   --progress-gradient: linear-gradient(to right, var(--color-danger), var(--color-warning), var(--color-success));
-  --progress-bar-height: 1rem; 
+  --progress-bar-height: 1rem;
   --progress-bar-radius: var(--radius-sm);
 
   --toast-bg: rgba(44, 62, 80, 0.95); --toast-text: #fff; --toast-radius: var(--radius-md);

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -7,10 +7,10 @@
   gap: var(--space-lg); margin-bottom: var(--space-lg);
 }
 .index-card {
-    display: flex; 
+    display: flex;
     flex-direction: column;
-    justify-content: space-around; 
-    min-height: 180px; 
+    justify-content: space-around;
+    min-height: 123px;
 }
 .index-card h4 {
   font-size: 1.1rem; 
@@ -51,7 +51,7 @@
 }
 
 #streakCard {
-  min-height: 120px;
+  min-height: 123px;
 }
 .streak-day { width: 18px; height: 18px; border-radius: 50%; background: var(--border-color); }
 .streak-day.logged { background: var(--color-success); }

--- a/css/responsive_styles.css
+++ b/css/responsive_styles.css
@@ -15,7 +15,7 @@
 
   .container { padding: var(--space-md); }
   .main-indexes { grid-template-columns: 1fr; }
-  .index-card { min-height: auto; padding: var(--space-md); } 
+  .index-card { min-height: 123px; padding: var(--space-md); }
   .index-card h4 { font-size: 1rem; margin-bottom: var(--space-xs); }
   .index-card .index-value { font-size: 1.1rem; }
 


### PR DESCRIPTION
## Summary
- revert README changes
- drop `--index-card-min-height` variable
- use fixed height for index cards in dashboard and responsive styles
- keep achievements container at the same height
- remove unused setup script

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848ed6f11e483269e76e18f8ecea2f3