### PR TITLE
Show info modal when clicking main index cards

### DIFF
--- a/code.html
+++ b/code.html
@@ -136,7 +136,7 @@
                 <div class="container">
                     <!-- Основни Индекси -->
                     <div class="main-indexes">
-                        <div class="card index-card">
+                        <div class="card index-card" id="goalCard">
                             <h4>🎯 Напредък към Цел</h4>
                             <div class="progress-bar-container">
                                 <div id="goalProgressBar" class="progress-bar">
@@ -145,7 +145,7 @@
                             </div>
                             <p id="goalProgressText" class="index-value">Изчисляване...</p>
                         </div>
-                        <div class="card index-card">
+                        <div class="card index-card" id="engagementCard">
                             <h4>🔗 Ангажираност</h4>
                             <div class="progress-bar-container">
                                 <div id="engagementProgressBar" class="progress-bar">
@@ -154,7 +154,7 @@
                             </div>
                             <p id="engagementProgressText" class="index-value">Изчисляване...</p>
                         </div>
-                        <div class="card index-card">
+                        <div class="card index-card" id="healthCard">
                             <h4>❤️ Общо Здраве</h4>
                             <div class="progress-bar-container">
                                 <div id="healthProgressBar" class="progress-bar">

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -11,6 +11,7 @@
     flex-direction: column;
     justify-content: space-around;
     min-height: 123px;
+    cursor: pointer;
 }
 .index-card h4 {
   font-size: 1.1rem; 

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -3,7 +3,7 @@ import { selectors } from './uiElements.js';
 import {
     toggleMenu, closeMenu, handleOutsideMenuClick, handleMenuKeydown,
     toggleTheme, activateTab, handleTabKeydown, closeModal,
-    openInfoModalWithDetails, toggleDailyNote,
+    openInfoModalWithDetails, toggleDailyNote, openMainIndexInfo,
     handleTrackerTooltipShow, handleTrackerTooltipHide, showToast
 } from './uiHandlers.js';
 import { handleLogout } from './auth.js';
@@ -51,6 +51,11 @@ export function setupStaticEventListeners() {
     if (selectors.saveLogBtn) selectors.saveLogBtn.addEventListener('click', handleSaveLog);
     if (selectors.openExtraMealModalBtn) selectors.openExtraMealModalBtn.addEventListener('click', openExtraMealModal);
     if (selectors.triggerAdaptiveQuizBtn) selectors.triggerAdaptiveQuizBtn.addEventListener('click', _handleTriggerAdaptiveQuizClientSide);
+
+    if (selectors.goalCard) selectors.goalCard.addEventListener('click', () => openMainIndexInfo('goalProgress'));
+    if (selectors.engagementCard) selectors.engagementCard.addEventListener('click', () => openMainIndexInfo('engagement'));
+    if (selectors.healthCard) selectors.healthCard.addEventListener('click', () => openMainIndexInfo('overallHealth'));
+    if (selectors.streakCard) selectors.streakCard.addEventListener('click', () => openMainIndexInfo('successes'));
 
 
     if (selectors.detailedAnalyticsAccordion) {

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -13,6 +13,7 @@ export function initializeSelectors() {
         goalProgressBar: 'goalProgressBar', goalProgressMask: 'goalProgressMask', goalProgressText: 'goalProgressText',
         engagementProgressBar: 'engagementProgressBar', engagementProgressMask: 'engagementProgressMask', engagementProgressText: 'engagementProgressText',
         healthProgressBar: 'healthProgressBar', healthProgressMask: 'healthProgressMask', healthProgressText: 'healthProgressText',
+        goalCard: 'goalCard', engagementCard: 'engagementCard', healthCard: 'healthCard', streakCard: 'streakCard',
         detailedAnalyticsAccordion: 'detailedAnalyticsAccordion', detailedAnalyticsContent: 'detailedAnalyticsContent',
         dashboardTextualAnalysis: 'dashboardTextualAnalysis',
         dailyPlanTitle: 'dailyPlanTitle', dailyMealList: 'dailyMealList',
@@ -55,6 +56,7 @@ export function initializeSelectors() {
                 'menuClose', 'extraMealFormContainer', 'userAllergiesNote', 'userAllergiesList',
                 'feedbackForm', 'tooltipTracker', 'triggerAdaptiveQuizBtn',
                 'streakGrid', 'streakCount', 'analyticsCardsContainer',
+                'goalCard', 'engagementCard', 'healthCard', 'streakCard'
             ];
             if (!optionalOrDynamic.includes(key) && key !== 'adaptiveQuizModal' && key !== 'adaptiveQuizContainer') {
                 console.warn(`HTML element not found: ${key} (selector: '${selectorValue}')`);
@@ -135,4 +137,11 @@ export const detailedMetricInfoTexts = {
     meal_adherence_info: "Процентът на спазени планирани хранения. Високата стойност показва добро придържане към хранителната част на програмата.",
     log_consistency_info: "Колко редовно попълвате своя дневен лог. Редовното водене на дневник помага за осъзнатост и проследяване на напредъка.",
     emotional_eating_control_info: "Отчита способността ви да управлявате храненето, породено от емоции, а не от физически глад. Развиването на този контрол е важно за дългосрочен успех."
+};
+
+export const mainIndexInfoTexts = {
+    goalProgress: { title: "Напредък към Цел", text: "Индикаторът показва колко сте близо до зададената цел." },
+    engagement: { title: "Ангажираност", text: "Отразява колко редовно използвате програмата и попълвате дневника." },
+    overallHealth: { title: "Общо Здраве", text: "Комбинирана оценка на ключови показатели като сън, стрес и хранене." },
+    successes: { title: "Моите успехи", text: "Показва поредицата от дни и събрани постижения." }
 };

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -5,7 +5,7 @@ import {
     activeTooltip, // state from app.js that this module will modify
     setActiveTooltip // function from app.js to update activeTooltip state
 } from './app.js';
-import { trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
+import { trackerInfoTexts, detailedMetricInfoTexts, mainIndexInfoTexts } from './uiElements.js';
 import { capitalizeFirstLetter, safeGet } from './utils.js';
 
 // Variable to hold the toast timeout ID, managed locally within this module
@@ -145,6 +145,15 @@ export function openInfoModalWithDetails(key, type) {
             body += "\n\nСтойности:\n" + Object.values(metricInfo.levels).join("\n");
         }
     }
+    if (selectors.infoModalTitle) selectors.infoModalTitle.textContent = title;
+    if (selectors.infoModalBody) selectors.infoModalBody.innerHTML = String(body).replace(/\n/g, '<br>');
+    openModal('infoModal');
+}
+
+export function openMainIndexInfo(key) {
+    const info = mainIndexInfoTexts[key] || {};
+    const title = info.title || 'Информация';
+    const body = info.text || 'Няма налична информация.';
     if (selectors.infoModalTitle) selectors.infoModalTitle.textContent = title;
     if (selectors.infoModalBody) selectors.infoModalBody.innerHTML = String(body).replace(/\n/g, '<br>');
     openModal('infoModal');


### PR DESCRIPTION
## Summary
- make dashboard index cards clickable
- show pointer cursor for index cards
- add selector definitions and info text for each main index
- implement `openMainIndexInfo` helper and listeners for card clicks

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6848f9d6284c8326928b470fe2a052b9