### PR TITLE
Fix achievement click behavior

### DIFF
--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -55,7 +55,10 @@ export function setupStaticEventListeners() {
     if (selectors.goalCard) selectors.goalCard.addEventListener('click', () => openMainIndexInfo('goalProgress'));
     if (selectors.engagementCard) selectors.engagementCard.addEventListener('click', () => openMainIndexInfo('engagement'));
     if (selectors.healthCard) selectors.healthCard.addEventListener('click', () => openMainIndexInfo('overallHealth'));
-    if (selectors.streakCard) selectors.streakCard.addEventListener('click', () => openMainIndexInfo('successes'));
+    if (selectors.streakCard) selectors.streakCard.addEventListener('click', (e) => {
+        if (e.target.closest('.achievement-medal')) return;
+        openMainIndexInfo('successes');
+    });
 
 
     if (selectors.detailedAnalyticsAccordion) {


### PR DESCRIPTION
## Summary
- prevent index info modal opening when clicking an achievement medal

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68495d13689c8326966201e8bf2ab8d1