### PR TITLE
Add streak count display

### DIFF
--- a/code.html
+++ b/code.html
@@ -166,6 +166,7 @@
                         <div class="card index-card" id="streakCard">
                             <h4>🏅 Моите успехи</h4>
                             <div id="streakGrid" class="streak-grid"></div>
+                            <p id="streakCount" class="index-value">0</p>
                         </div>
                     </div>
                     <!-- Край Основни Индекси -->

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -52,9 +52,7 @@
 }
 
 #streakCard {
-t0bwx1-codex/сравняване-на-височината-на-контейнера
   min-height: 123px;
- main
 }
 .streak-day { width: 18px; height: 18px; border-radius: 50%; background: var(--border-color); }
 .streak-day.logged { background: var(--color-success); }


### PR DESCRIPTION
## Summary
- show number of achievements in dashboard
- clean invalid CSS for streak card

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest` *(fails to run due to ESM parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a06ecf2c0832686339c9ddd263cc9