### PR TITLE
Fix recommendations tab visibility and UI cues

### DIFF
--- a/css/layout_styles.css
+++ b/css/layout_styles.css
@@ -98,18 +98,30 @@ header h1 { color: var(--text-color-on-primary); margin: 0; font-size: clamp(1.3
 /* ==========================================================================
    4. ТАБОВЕ И ПАНЕЛИ
    ========================================================================== */
-nav.tabs { 
+nav.tabs {
   display: flex; flex-wrap: nowrap; background: var(--surface-background);
   box-shadow: var(--shadow-sm); border-bottom: 1px solid var(--border-color);
-  overflow-x: auto; 
+  overflow-x: auto;
   position: sticky;
-  top: var(--header-height); 
+  top: var(--header-height);
   z-index: 990;
-  height: var(--tabs-height); 
+  height: var(--tabs-height);
+  position: relative;
 }
 nav.tabs::-webkit-scrollbar { height: 4px; }
 nav.tabs::-webkit-scrollbar-track { background: transparent; }
 nav.tabs::-webkit-scrollbar-thumb { background-color: var(--accent-color); border-radius: 4px; }
+
+nav.tabs.has-overflow::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 30px;
+  height: 100%;
+  pointer-events: none;
+  background: linear-gradient(to left, var(--surface-background), transparent);
+}
 
 nav.tabs.styled-tabs .tab-btn {
   display: flex; 

--- a/js/app.js
+++ b/js/app.js
@@ -9,7 +9,7 @@ import {
     openModal, closeModal, openInfoModalWithDetails,
     toggleDailyNote,
     showTrackerTooltip, hideTrackerTooltip, handleTrackerTooltipShow, handleTrackerTooltipHide,
-    showLoading, showToast
+    showLoading, showToast, updateTabsOverflowIndicator
 } from './uiHandlers.js';
 import { populateUI } from './populateUI.js';
 // КОРЕКЦИЯ: Премахваме handleDelegatedClicks от импорта тук
@@ -97,6 +97,7 @@ function initializeApp() {
     try {
         if (isLocalDevelopment) console.log("initializeApp starting from app.js...");
         initializeSelectors();
+        updateTabsOverflowIndicator();
         showLoading(true, "Инициализация на таблото...");
         currentUserId = sessionStorage.getItem('userId');
 

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -18,7 +18,12 @@ export function populateUI() {
     try { populateDashboardLog(data.dailyLogs, data.currentStatus, data.initialData); } catch(e) { console.error("Error in populateDashboardLog:", e); }
     try { populateProfileTab(data.userName, data.initialData, data.currentStatus, data.initialAnswers); } catch(e) { console.error("Error in populateProfileTab:", e); }
     try { populateWeekPlanTab(data.planData?.week1Menu); } catch(e) { console.error("Error in populateWeekPlanTab:", e); }
-    try { populateRecsTab(data.planData, data.initialAnswers, data.planData?.currentPrinciples || data.planData?.principlesWeek2_4); } catch(e) { console.error("Error in populateRecsTab:", e); }
+    const guidelinesData =
+        data.planData?.currentPrinciples ||
+        data.planData?.principlesWeek2_4 ||
+        data.planData?.additionalGuidelines ||
+        data.additionalGuidelines;
+    try { populateRecsTab(data.planData, data.initialAnswers, guidelinesData); } catch(e) { console.error("Error in populateRecsTab:", e); }
     try { populateProgressHistory(data.dailyLogs, data.initialData); } catch(e) { console.error("Error in populateProgressHistory:", e); }
 }
 

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -84,6 +84,21 @@ export function activateTab(activeTabButton) {
     sessionStorage.setItem('activeTabId', activeTabButton.id);
 }
 
+export function updateTabsOverflowIndicator() {
+    if (!selectors.tabsContainer) return;
+    const nav = selectors.tabsContainer;
+
+    function refresh() {
+        const hasOverflow = nav.scrollWidth > nav.clientWidth + 1;
+        const atEnd = nav.scrollLeft >= nav.scrollWidth - nav.clientWidth - 1;
+        nav.classList.toggle('has-overflow', hasOverflow && !atEnd);
+    }
+
+    nav.addEventListener('scroll', refresh);
+    window.addEventListener('resize', refresh);
+    refresh();
+}
+
 export function handleTabKeydown(e) {
     const key = e.key; const currentTab = e.currentTarget;
     if(!selectors.tabButtons || selectors.tabButtons.length === 0) return;


### PR DESCRIPTION
## Summary
- ensure guidelines data is loaded from multiple possible fields
- add gradient indicator for horizontally scrollable tabs
- detect tab overflow and toggle indicator with JS
- call overflow check during app init

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2c3d50588326b18648712551657f