### PR TITLE
Add fallback messages when recommendations are missing

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -277,6 +277,17 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
         }
 
         populateUI();
+
+        const plan = fullDashboardData.planData;
+        const hasRecs = plan && (
+            (plan.allowedForbiddenFoods && Object.keys(plan.allowedForbiddenFoods).length > 0) ||
+            (plan.hydrationCookingSupplements && Object.keys(plan.hydrationCookingSupplements).length > 0) ||
+            (plan.psychologicalGuidance && Object.keys(plan.psychologicalGuidance).length > 0)
+        );
+        if (!hasRecs) {
+            showToast("Препоръките не са налични.", true);
+        }
+
         initializeAchievements(currentUserId);
         setupDynamicEventListeners();
 

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -484,6 +484,21 @@ function populateWeekPlanTab(week1Menu) {
 }
 
 function populateRecsTab(planData, initialAnswers, additionalGuidelines) {
+    if (!planData || (
+        (!planData.allowedForbiddenFoods || Object.keys(planData.allowedForbiddenFoods).length === 0) &&
+        (!planData.hydrationCookingSupplements || Object.keys(planData.hydrationCookingSupplements).length === 0) &&
+        (!planData.psychologicalGuidance || Object.keys(planData.psychologicalGuidance).length === 0)
+    )) {
+        console.warn("populateRecsTab: няма данни за показване");
+        if (selectors.recFoodAllowedContent) selectors.recFoodAllowedContent.innerHTML = '<p class="placeholder">Няма налични препоръки.</p>';
+        if (selectors.recFoodLimitContent) selectors.recFoodLimitContent.innerHTML = '<p class="placeholder">Няма налични препоръки.</p>';
+        if (selectors.recHydrationContent) selectors.recHydrationContent.innerHTML = '<p class="placeholder">Няма налични препоръки.</p>';
+        if (selectors.recCookingMethodsContent) selectors.recCookingMethodsContent.innerHTML = '<p class="placeholder">Няма налични препоръки.</p>';
+        if (selectors.recStrategiesContent) selectors.recStrategiesContent.innerHTML = '<div class="card placeholder"><p>Няма налични препоръки.</p></div>';
+        if (selectors.recSupplementsContent) selectors.recSupplementsContent.innerHTML = '<p class="placeholder">Няма налични препоръки.</p>';
+        if (selectors.additionalGuidelines) selectors.additionalGuidelines.innerHTML = '<div class="card placeholder"><p>Няма налични препоръки.</p></div>';
+        return;
+    }
     const { allowedForbiddenFoods, hydrationCookingSupplements, psychologicalGuidance } = planData || {};
     if (selectors.recFoodAllowedContent) {
         const placeholderEl = selectors.recFoodAllowedContent.querySelector('p.placeholder'); if (placeholderEl) placeholderEl.remove();


### PR DESCRIPTION
## Summary
- show toast when planData lacks recommendation sections
- guard `populateRecsTab` and insert placeholders if no plan data

## Testing
- `npm run lint` *(fails: 69 errors)*
- `npm test` *(fails: planModRequest.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684a433afc088326a741d3f63ade1d98