### PR TITLE
Fix tips availability check and add final_plan logging

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -139,6 +139,30 @@ function createTestData() {
     };
 }
 
+function planHasRecContent(plan) {
+    if (!plan) return false;
+    const aff = plan.allowedForbiddenFoods || {};
+    const hcs = plan.hydrationCookingSupplements || {};
+    const psych = plan.psychologicalGuidance || {};
+
+    const foodArrays = ['main_allowed_foods', 'main_forbidden_foods', 'detailed_allowed_suggestions', 'detailed_limit_suggestions', 'dressing_flavoring_ideas'];
+    const hasFoodData = foodArrays.some(key => Array.isArray(aff[key]) && aff[key].length > 0);
+
+    const hyd = hcs.hydration_recommendations || {};
+    const hasHydrationData = hyd.daily_liters ||
+        ['tips', 'suitable_drinks', 'unsuitable_drinks'].some(k => Array.isArray(hyd[k]) && hyd[k].length > 0);
+
+    const cook = hcs.cooking_methods || {};
+    const hasCookingData = ['recommended', 'limit_or_avoid'].some(k => Array.isArray(cook[k]) && cook[k].length > 0) || cook.fat_usage_tip;
+
+    const hasSuppData = Array.isArray(hcs.supplement_suggestions) && hcs.supplement_suggestions.length > 0;
+
+    const hasPsychData = ['coping_strategies', 'motivational_messages'].some(k => Array.isArray(psych[k]) && psych[k].length > 0) ||
+        psych.habit_building_tip || psych.self_compassion_reminder;
+
+    return hasFoodData || hasHydrationData || hasCookingData || hasSuppData || hasPsychData;
+}
+
 // ==========================================================================
 // ИНИЦИАЛИЗАЦИЯ НА ПРИЛОЖЕНИЕТО
 // ==========================================================================
@@ -279,11 +303,7 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
         populateUI();
 
         const plan = fullDashboardData.planData;
-        const hasRecs = plan && (
-            (plan.allowedForbiddenFoods && Object.keys(plan.allowedForbiddenFoods).length > 0) ||
-            (plan.hydrationCookingSupplements && Object.keys(plan.hydrationCookingSupplements).length > 0) ||
-            (plan.psychologicalGuidance && Object.keys(plan.psychologicalGuidance).length > 0)
-        );
+        const hasRecs = planHasRecContent(plan);
         if (!hasRecs) {
             showToast("Препоръките не са налични.", true);
         }

--- a/worker.js
+++ b/worker.js
@@ -487,13 +487,14 @@ async function handleDashboardDataRequest(request, env) {
             console.error(`DASHBOARD_DATA (${userId}): Plan status is 'error'. Error: ${errorMsg}`);
             return { ...baseResponse, success: false, message: `Възникна грешка при генерирането на Вашия план: ${errorMsg ? errorMsg.split('\n')[0] : 'Неизвестна грешка.'}`, planData: null, analytics: null, statusHint: 500 };
         }
+        const logTimestamp = new Date().toISOString();
         if (!finalPlanStr) {
-            console.warn(`DASHBOARD_DATA (${userId}): Plan status is '${actualPlanStatus}' but final_plan is missing.`);
+            console.warn(`DASHBOARD_DATA (${userId}) [${logTimestamp}]: Plan status '${actualPlanStatus}' but final_plan is missing. Snippet: ${String(finalPlanStr).slice(0,200)}`);
             return { ...baseResponse, success: false, message: 'Планът Ви не е наличен в системата, въпреки че статусът показва готовност. Моля, свържете се с поддръжка.', statusHint: 404, planData: null, analytics: null };
         }
         const finalPlan = safeParseJson(finalPlanStr, {});
         if (Object.keys(finalPlan).length === 0 && finalPlanStr) { // finalPlanStr ensures it wasn't null initially
-            console.error(`DASHBOARD_DATA (${userId}): Failed to parse final_plan JSON.`);
+            console.error(`DASHBOARD_DATA (${userId}) [${logTimestamp}]: Failed to parse final_plan JSON. Status: '${actualPlanStatus}'. Snippet: ${finalPlanStr.slice(0,200)}`);
             return { ...baseResponse, success: false, message: 'Грешка при зареждане на данните на Вашия план.', statusHint: 500, planData: null, analytics: null };
         }
         


### PR DESCRIPTION
## Summary
- check plan data deeper to decide if recommendations exist
- warn in worker logs when `final_plan` missing or invalid

## Testing
- `npm test` *(fails: Cannot assign to read only property 'processSingleUserPlan')*

------
https://chatgpt.com/codex/tasks/task_e_684a4756e1a88326ab17aa40d00cf02d