### PR TITLE
Fix week panel closing and recs panel structure

### DIFF
--- a/code.html
+++ b/code.html
@@ -280,8 +280,10 @@
                                 <tr class="placeholder-row"><td colspan="6">Зареждане на седмичния план...</td></tr>
                             </tbody>
                         </table>
-                    </div>
-                    <div class="card" style="margin-top: var(--space-lg);">
+                    </div>  <!-- затваря .table-wrapper -->
+                </div>  <!-- затваря .container на week-panel -->
+            </section> <!-- затваря week-panel -->
+
             <!-- ======================================================================= -->
             <!-- ===================== RECOMMENDATIONS PANEL ========================= -->
             <!-- ======================================================================= -->


### PR DESCRIPTION
## Summary
- close `.container` и `section` на week-panel веднага след таблицата
- изнеси секцията с препоръки `recs-panel` извън week-panel
- гарантирай, че секцията „Допълнителни насоки“ използва id `additionalGuidelines`
- пусни Jest тестовете

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a581620608326854871a3225215b1