### PR TITLE
Add dependency install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Check the source code with ESLint:
 npm run lint
 ```
 
+### Инсталация на зависимости
+
+Преди да стартирате тестовете, инсталирайте необходимите зависимости:
+
+```bash
+npm ci
+```
+
 ### Test
 
 Run unit tests with Jest:


### PR DESCRIPTION
## Summary
- add a section in README for installing dependencies before testing

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684aca4caec48326a482661d72eab493