### PR TITLE
Add event-driven plan modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ php -r "echo password_hash('yourPassword', PASSWORD_DEFAULT);"
 Set the output as the value for `ADMIN_PASS_HASH`.
 ## Допълнителни функции
 - **Извънредно хранене** – бутонът "Добави извънредно хранене" в `code.html` отваря модалната форма `extra-meal-entry-form.html`. Логиката в `js/extraMealForm.js` изпраща данните към `/api/log-extra-meal` в `worker.js`.
+- **Допълнителни насоки** – секцията с основни принципи се премести в таба „Съвети" и се визуализира като разгръщащ се контейнер с идентификатор `additionalGuidelines`.
+- **Динамична адаптация** – cron процесът в `worker.js` периодично проверява за събития в KV (напр. ключове `event_*`). Когато ботът предложи промяна, се записва както `_pending_plan_modification_request`, така и `event_planMod_<userId>`. Чрез `processPendingUserEvents` тези събития задействат автоматична адаптация на плана.
 
 ## License
 

--- a/code.html
+++ b/code.html
@@ -281,16 +281,9 @@
                                 <tr class="placeholder-row"><td colspan="6">Зареждане на седмичния план...</td></tr>
                             </tbody>
                         </table>
-                    </div>
-                    <div class="card" style="margin-top: var(--space-lg);">
-                        <h4>🧭 Принципи и Фокус за Следващите Седмици</h4>
-                        <div id="weeklyPrinciplesFocus" class="accordion-group">
-                            <p class="placeholder">Зареждане на принципите...</p>
-                        </div>
-                    </div>
-                </div>
-            </section>
-            <!-- ===================== END WEEKLY PLAN PANEL ======================= -->
+                    </div>  <!-- затваря .table-wrapper -->
+                </div>  <!-- затваря .container на week-panel -->
+            </section> <!-- затваря week-panel -->
 
             <!-- ======================================================================= -->
             <!-- ===================== RECOMMENDATIONS PANEL ========================= -->
@@ -349,6 +342,12 @@
                                 <svg class="icon prefix-icon"><use href="#icon-info"></use></svg>
                                 <span><strong>Важно:</strong> Винаги се консултирайте с лекар преди прием на нови хранителни добавки, особено ако имате съществуващи заболявания или приемате медикаменти.</span>
                             </div>
+                        </div>
+                    </div>
+                    <div class="recommendation-section">
+                        <h3>📖 Допълнителни насоки</h3>
+                        <div id="additionalGuidelines" class="accordion-group">
+                            <div class="card placeholder"><p>Зареждане на насоки...</p></div>
                         </div>
                     </div>
                 </div>

--- a/css/layout_styles.css
+++ b/css/layout_styles.css
@@ -98,18 +98,30 @@ header h1 { color: var(--text-color-on-primary); margin: 0; font-size: clamp(1.3
 /* ==========================================================================
    4. ТАБОВЕ И ПАНЕЛИ
    ========================================================================== */
-nav.tabs { 
+nav.tabs {
   display: flex; flex-wrap: nowrap; background: var(--surface-background);
   box-shadow: var(--shadow-sm); border-bottom: 1px solid var(--border-color);
-  overflow-x: auto; 
+  overflow-x: auto;
   position: sticky;
-  top: var(--header-height); 
+  top: var(--header-height);
   z-index: 990;
-  height: var(--tabs-height); 
+  height: var(--tabs-height);
+  position: relative;
 }
 nav.tabs::-webkit-scrollbar { height: 4px; }
 nav.tabs::-webkit-scrollbar-track { background: transparent; }
 nav.tabs::-webkit-scrollbar-thumb { background-color: var(--accent-color); border-radius: 4px; }
+
+nav.tabs.has-overflow::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 30px;
+  height: 100%;
+  pointer-events: none;
+  background: linear-gradient(to left, var(--surface-background), transparent);
+}
 
 nav.tabs.styled-tabs .tab-btn {
   display: flex; 

--- a/js/__tests__/planContent.test.js
+++ b/js/__tests__/planContent.test.js
@@ -1,0 +1,14 @@
+import { jest } from '@jest/globals';
+let planHasRecContent;
+beforeAll(async () => {
+  global.window = { location: { hostname: 'localhost' } };
+  global.document = { addEventListener: jest.fn() };
+  ({ planHasRecContent } = await import('../app.js'));
+});
+
+describe('planHasRecContent', () => {
+  test('returns true when only additionalGuidelines present', () => {
+    const plan = { additionalGuidelines: ['Tip 1', 'Tip 2'] };
+    expect(planHasRecContent(plan)).toBe(true);
+  });
+});

--- a/js/__tests__/planModRequest.test.js
+++ b/js/__tests__/planModRequest.test.js
@@ -1,0 +1,19 @@
+import { jest } from '@jest/globals';
+import { processPendingPlanModRequests } from '../../worker.js';
+
+describe('processPendingPlanModRequests', () => {
+  test('processes pending requests', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [{ name: 'u1_pending_plan_modification_request' }] }),
+        get: jest.fn().mockResolvedValue(JSON.stringify({ status: 'pending' })),
+        put: jest.fn()
+      }
+    };
+    const ctx = { waitUntil: jest.fn() };
+    const count = await processPendingPlanModRequests(env, ctx, 5);
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalled();
+    expect(count).toBe(1);
+  });
+});

--- a/js/__tests__/userEvents.test.js
+++ b/js/__tests__/userEvents.test.js
@@ -1,0 +1,19 @@
+import { jest } from '@jest/globals';
+import * as worker from '../../worker.js';
+
+describe('processPendingUserEvents', () => {
+  test('handles plan modification events', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [{ name: 'event_planMod_u1' }] }),
+        get: jest.fn().mockResolvedValue(JSON.stringify({ status: 'pending' })),
+        put: jest.fn()
+      }
+    };
+    const ctx = { waitUntil: jest.fn() };
+    const count = await worker.processPendingUserEvents(env, ctx, 5);
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalled();
+    expect(count).toBe(1);
+  });
+});

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -20,7 +20,7 @@ export function initializeSelectors() {
         dailyTracker: 'dailyTracker', addNoteBtn: 'add-note-btn', dailyNote: 'daily-note', saveLogBtn: 'saveLogBtn', dailyLogDate: 'dailyLogDate',
         openExtraMealModalBtn: 'openExtraMealModalBtn',
         profilePersonalData: 'profilePersonalData', profileGoals: 'profileGoals', profileConsiderations: 'profileConsiderations',
-        weeklyPlanTbody: 'weeklyPlanTbody', weeklyPrinciplesFocus: 'weeklyPrinciplesFocus',
+        weeklyPlanTbody: 'weeklyPlanTbody', additionalGuidelines: 'additionalGuidelines',
         recFoodAllowedContent: 'recFoodAllowedContent', recFoodLimitContent: 'recFoodLimitContent', userAllergiesNote: 'userAllergiesNote',
         userAllergiesList: 'userAllergiesList', recHydrationContent: 'recHydrationContent', recCookingMethodsContent: 'recCookingMethodsContent',
         recStrategiesContent: 'recStrategiesContent', recSupplementsContent: 'recSupplementsContent',

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -84,6 +84,21 @@ export function activateTab(activeTabButton) {
     sessionStorage.setItem('activeTabId', activeTabButton.id);
 }
 
+export function updateTabsOverflowIndicator() {
+    if (!selectors.tabsContainer) return;
+    const nav = selectors.tabsContainer;
+
+    function refresh() {
+        const hasOverflow = nav.scrollWidth > nav.clientWidth + 1;
+        const atEnd = nav.scrollLeft >= nav.scrollWidth - nav.clientWidth - 1;
+        nav.classList.toggle('has-overflow', hasOverflow && !atEnd);
+    }
+
+    nav.addEventListener('scroll', refresh);
+    window.addEventListener('resize', refresh);
+    refresh();
+}
+
 export function handleTabKeydown(e) {
     const key = e.key; const currentTab = e.currentTarget;
     if(!selectors.tabButtons || selectors.tabButtons.length === 0) return;

--- a/worker.js
+++ b/worker.js
@@ -1,4 +1,4 @@
-// Cloudflare Worker Script (index.js) - Версия 2.2 (Интегрирана, с подобрения по TODO, добавени адаптивни въпросници и log-extra-meal)
+// Cloudflare Worker Script (index.js) - Версия 2.3 (събитийно-ориентирани корекции и адаптивни въпросници)
 // Включва:
 // - Пълна логика за Адаптивен Въпросник: генериране, подаване, анализ на отговори. (Запазена и подобрена от v2.1)
 // - Актуализиран handlePrincipleAdjustment с по-детайлни данни от въпросник. (Запазено от v2.1)
@@ -148,6 +148,7 @@ export default {
         let processedUsersForPlan = 0;
         let processedUsersForPrinciples = 0;
         let processedUsersForAdaptiveQuiz = 0;
+        let processedUserEvents = 0;
         const MAX_PROCESS_PER_RUN_PLAN_GEN = 1;
         const MAX_PROCESS_PER_RUN_PRINCIPLES = 2;
         const MAX_PROCESS_PER_RUN_ADAPTIVE_QUIZ = 3;
@@ -188,6 +189,7 @@ export default {
             }
             if (processedUsersForPlan === 0) console.log("[CRON-PlanGen] No pending users for plan generation.");
 
+            processedUserEvents = await processPendingUserEvents(env, ctx);
             // --- Потребители с готов план ---
             const listResultReadyPlans = await env.USER_METADATA_KV.list({ prefix: "plan_status_" });
             const usersWithReadyPlan = [];
@@ -286,7 +288,7 @@ export default {
         } catch(error) {
             console.error("[CRON] Error during scheduled execution:", error.message, error.stack);
         }
-        console.log(`[CRON] Trigger finished. PlanGen: ${processedUsersForPlan}, Principles: ${processedUsersForPrinciples}, AdaptiveQuiz: ${processedUsersForAdaptiveQuiz}`);
+        console.log(`[CRON] Trigger finished. PlanGen: ${processedUsersForPlan}, Principles: ${processedUsersForPrinciples}, AdaptiveQuiz: ${processedUsersForAdaptiveQuiz}, Events: ${processedUserEvents}`);
     }
     // ------------- END FUNCTION: scheduled -------------
 };
@@ -485,13 +487,14 @@ async function handleDashboardDataRequest(request, env) {
             console.error(`DASHBOARD_DATA (${userId}): Plan status is 'error'. Error: ${errorMsg}`);
             return { ...baseResponse, success: false, message: `Възникна грешка при генерирането на Вашия план: ${errorMsg ? errorMsg.split('\n')[0] : 'Неизвестна грешка.'}`, planData: null, analytics: null, statusHint: 500 };
         }
+        const logTimestamp = new Date().toISOString();
         if (!finalPlanStr) {
-            console.warn(`DASHBOARD_DATA (${userId}): Plan status is '${actualPlanStatus}' but final_plan is missing.`);
+            console.warn(`DASHBOARD_DATA (${userId}) [${logTimestamp}]: Plan status '${actualPlanStatus}' but final_plan is missing. Snippet: ${String(finalPlanStr).slice(0,200)}`);
             return { ...baseResponse, success: false, message: 'Планът Ви не е наличен в системата, въпреки че статусът показва готовност. Моля, свържете се с поддръжка.', statusHint: 404, planData: null, analytics: null };
         }
         const finalPlan = safeParseJson(finalPlanStr, {});
         if (Object.keys(finalPlan).length === 0 && finalPlanStr) { // finalPlanStr ensures it wasn't null initially
-            console.error(`DASHBOARD_DATA (${userId}): Failed to parse final_plan JSON.`);
+            console.error(`DASHBOARD_DATA (${userId}) [${logTimestamp}]: Failed to parse final_plan JSON. Status: '${actualPlanStatus}'. Snippet: ${finalPlanStr.slice(0,200)}`);
             return { ...baseResponse, success: false, message: 'Грешка при зареждане на данните на Вашия план.', statusHint: 500, planData: null, analytics: null };
         }
         
@@ -709,8 +712,29 @@ async function handleChatRequest(request, env) {
         const populatedPrompt = populatePrompt(chatPromptTpl,r);
         const geminiRespRaw = await callGeminiAPI(populatedPrompt,geminiKey,{temperature:0.7,maxOutputTokens:800},[],chatModel); // Increased tokens slightly
         
-        let respToUser = geminiRespRaw.trim(); let planModReq=null; const sig='[PLAN_MODIFICATION_REQUEST]'; const sigIdx=respToUser.lastIndexOf(sig);
-        if(sigIdx!==-1){planModReq=respToUser.substring(sigIdx+sig.length).trim(); respToUser=respToUser.substring(0,sigIdx).trim(); console.log(`CHAT_INFO (${userId}): Plan modification signal detected: "${planModReq}"`); try{const reqKey=`${userId}_pending_plan_modification_request`; const reqData={timestamp:Date.now(),request_description:planModReq,original_user_message:message,status:'pending'}; await env.USER_METADATA_KV.put(reqKey,JSON.stringify(reqData));}catch(kvErr){console.error(`CHAT_ERROR (${userId}): Failed save pending modification request:`,kvErr);}}
+        let respToUser = geminiRespRaw.trim();
+        let planModReq = null;
+        const sig = '[PLAN_MODIFICATION_REQUEST]';
+        const sigIdx = respToUser.lastIndexOf(sig);
+        if (sigIdx !== -1) {
+            planModReq = respToUser.substring(sigIdx + sig.length).trim();
+            respToUser = respToUser.substring(0, sigIdx).trim();
+            console.log(`CHAT_INFO (${userId}): Plan modification signal detected: "${planModReq}"`);
+            try {
+                const reqKey = `${userId}_pending_plan_modification_request`;
+                const reqData = {
+                    timestamp: Date.now(),
+                    request_description: planModReq,
+                    original_user_message: message,
+                    status: 'pending'
+                };
+                await env.USER_METADATA_KV.put(reqKey, JSON.stringify(reqData));
+                const eventKey = `event_planMod_${userId}`;
+                await env.USER_METADATA_KV.put(eventKey, JSON.stringify({ status: 'pending', description: planModReq, createdTimestamp: Date.now() }));
+            } catch (kvErr) {
+                console.error(`CHAT_ERROR (${userId}): Failed save pending modification request:`, kvErr);
+            }
+        }
         
         storedChatHistory.push({role:'model',parts:[{text:respToUser}]});
         if(storedChatHistory.length>MAX_CHAT_HISTORY_MESSAGES) storedChatHistory=storedChatHistory.slice(-MAX_CHAT_HISTORY_MESSAGES);
@@ -1124,7 +1148,7 @@ async function processSingleUserPlan(userId, env) {
             throw new Error(`Parsed initial answers are empty for ${userId}.`);
         }
         console.log(`PROCESS_USER_PLAN (${userId}): Processing for email: ${initialAnswers.email || 'N/A'}`);
-        const planBuilder = { profileSummary: null, caloriesMacros: null, week1Menu: null, principlesWeek2_4: [], hydrationCookingSupplements: null, allowedForbiddenFoods: {}, psychologicalGuidance: null, detailedTargets: null, generationMetadata: { timestamp: '', modelUsed: null, errors: [] } };
+        const planBuilder = { profileSummary: null, caloriesMacros: null, week1Menu: null, principlesWeek2_4: [], additionalGuidelines: [], hydrationCookingSupplements: null, allowedForbiddenFoods: {}, psychologicalGuidance: null, detailedTargets: null, generationMetadata: { timestamp: '', modelUsed: null, errors: [] } };
         const [ questionsJsonString, baseDietModelContent, allowedMealCombinationsContent, eatingPsychologyContent, recipeDataStr, geminiApiKey, planModelName, unifiedPromptTemplate ] = await Promise.all([
             env.RESOURCES_KV.get('question_definitions'), env.RESOURCES_KV.get('base_diet_model'),
             env.RESOURCES_KV.get('allowed_meal_combinations'), env.RESOURCES_KV.get('eating_psychology'),
@@ -2538,6 +2562,70 @@ async function sendTxtBackupToPhp(userId, answers, env) {
 }
 // ------------- END FUNCTION: sendTxtBackupToPhp -------------
 
+// ------------- START FUNCTION: processPendingPlanModRequests -------------
+// Обхожда стария формат на заявки `_pending_plan_modification_request`.
+// След обработка извиква `processSingleUserPlan` за съответния потребител.
+async function processPendingPlanModRequests(env, ctx, maxToProcess = 2) {
+    const list = await env.USER_METADATA_KV.list();
+    const pendingKeys = list.keys.filter(k => k.name.endsWith('_pending_plan_modification_request'));
+    let processed = 0;
+    for (const key of pendingKeys) {
+        if (processed >= maxToProcess) break;
+        const reqStr = await env.USER_METADATA_KV.get(key.name);
+        const reqData = safeParseJson(reqStr, {});
+        if (reqData && reqData.status === 'pending') {
+            const userId = key.name.replace('_pending_plan_modification_request', '');
+            ctx.waitUntil(processSingleUserPlan(userId, env));
+            reqData.status = 'processed';
+            reqData.processedTimestamp = Date.now();
+            await env.USER_METADATA_KV.put(key.name, JSON.stringify(reqData));
+            processed++;
+        }
+    }
+    if (processed > 0) console.log(`[CRON-PlanMod] Processed ${processed} modification request(s).`);
+    else console.log('[CRON-PlanMod] No pending modification requests.');
+    return processed;
+}
+// ------------- END FUNCTION: processPendingPlanModRequests -------------
+
+// ------------- START FUNCTION: processPendingUserEvents -------------
+// Централизирано обработва всички събития с префикс `event_` в KV.
+// Това позволява лесно разширяване с нови видове тригери.
+async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
+    let processed = await processPendingPlanModRequests(env, ctx, maxToProcess);
+    if (processed >= maxToProcess) return processed;
+    const list = await env.USER_METADATA_KV.list({ prefix: "event_" });
+    for (const key of list.keys) {
+        if (processed >= maxToProcess) break;
+        const parts = key.name.split("_");
+        const prefix = parts.shift();
+        const eventType = parts.shift();
+        const userId = parts.join("_");
+        if (prefix !== "event" || !userId) continue;
+        const eventStr = await env.USER_METADATA_KV.get(key.name);
+        const eventData = safeParseJson(eventStr, {});
+        if (!eventData || eventData.status !== "pending") continue;
+        switch(eventType) {
+            case "planMod":
+                ctx.waitUntil(processSingleUserPlan(userId, env));
+                break;
+            case "testResult":
+            case "irisDiag":
+                // Future event types
+                break;
+            default:
+                console.log(`[CRON-UserEvent] Unknown event type ${eventType} for user ${userId}`);
+        }
+        eventData.status = "processed";
+        eventData.processedTimestamp = Date.now();
+        await env.USER_METADATA_KV.put(key.name, JSON.stringify(eventData));
+        processed++;
+    }
+    if (processed > 0) console.log(`[CRON-UserEvent] Processed ${processed} event(s).`);
+    else console.log('[CRON-UserEvent] No pending events.');
+    return processed;
+}
+// ------------- END FUNCTION: processPendingUserEvents -------------
 // ------------- START FUNCTION: shouldTriggerAutomatedFeedbackChat -------------
 function shouldTriggerAutomatedFeedbackChat(lastUpdateTs, lastChatTs, currentTime = Date.now()) {
     if (!lastUpdateTs) return false;
@@ -2548,4 +2636,4 @@ function shouldTriggerAutomatedFeedbackChat(lastUpdateTs, lastChatTs, currentTim
 }
 // ------------- END FUNCTION: shouldTriggerAutomatedFeedbackChat -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, handleRecordFeedbackChatRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest };
+export { processPendingUserEvents, processPendingPlanModRequests, processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, handleRecordFeedbackChatRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest };


### PR DESCRIPTION
## Summary
- create `event_planMod_<userId>` when chat suggests plan changes
- check pending plan events in `processPendingUserEvents`
- move principles into "Допълнителни насоки" section in recommendations tab
- show overflow indicator for tabs when needed
- hide debug logs
- clarify worker event handler comments
- bump worker version

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498cbc7b488326ab2b184f5d326bdc