### PR TITLE
Add event-based plan adaptation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ php -r "echo password_hash('yourPassword', PASSWORD_DEFAULT);"
 Set the output as the value for `ADMIN_PASS_HASH`.
 ## Допълнителни функции
 - **Извънредно хранене** – бутонът "Добави извънредно хранене" в `code.html` отваря модалната форма `extra-meal-entry-form.html`. Логиката в `js/extraMealForm.js` изпраща данните към `/api/log-extra-meal` в `worker.js`.
+- **Изследвания** – POST заявки към `/api/uploadTestResult` и `/api/uploadIrisDiag` записват данни за проведени тестове или ирисова диагностика и създават събитие за автоматична адаптация на плана.
 
 ## License
 

--- a/js/__tests__/userEvents.test.js
+++ b/js/__tests__/userEvents.test.js
@@ -1,0 +1,20 @@
+import { jest } from '@jest/globals';
+import { processPendingUserEvents } from '../../worker.js';
+
+describe('processPendingUserEvents', () => {
+  test('processes testResult event', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [{ name: 'event_testResult_u1' }] }),
+        get: jest.fn().mockResolvedValue(JSON.stringify({ type: 'testResult', userId: 'u1', payload: { value: 5 } })),
+        delete: jest.fn(),
+        put: jest.fn()
+      }
+    };
+    const ctx = { waitUntil: jest.fn() };
+    await processPendingUserEvents(env, ctx, 5);
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalled();
+    expect(env.USER_METADATA_KV.delete).toHaveBeenCalledWith('event_testResult_u1');
+  });
+});


### PR DESCRIPTION
## Summary
- support unified `event_<type>_<userId>` format via `createUserEvent`
- add handlers for `testResult` and `irisDiag` events
- expose `/api/uploadTestResult` and `/api/uploadIrisDiag` endpoints
- process payloads in `processPendingUserEvents`
- document new endpoints in README
- add unit test for event processing

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b1195a360832681b613447a9ff441