### PR TITLE
Update Node instructions and jest script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A simple static web application for tracking nutrition and workouts.
 
 ## Development Setup
 
-1. Install [Node.js](https://nodejs.org/) (version 14 or later).
-2. Install dependencies:
+1. Install [Node.js](https://nodejs.org/) (version 18 or later).
+2. Install dependencies (Jest is included as a dev dependency):
 
 ```bash
 npm install
@@ -42,10 +42,11 @@ npm run lint
 
 ### Инсталация на зависимости
 
-Преди да стартирате тестовете, инсталирайте необходимите зависимости:
+Преди да стартирате тестовете, инсталирайте необходимите зависимости, за да бъде
+достъпен Jest:
 
 ```bash
-npm ci
+npm ci # или npm install
 ```
 
 ### Test
@@ -53,7 +54,9 @@ npm ci
 Run unit tests with Jest:
 
 ```bash
-npm test
+npm test         # изпълнява "npx jest"
+# или стартирайте директно
+npx jest
 ```
 
 ### Generate Documentation

--- a/package.json
+++ b/package.json
@@ -8,13 +8,16 @@
     "build": "vite build",
     "start": "vite preview",
     "lint": "eslint .",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest",
     "docs": "typedoc"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "devDependencies": {
     "eslint": "^8.57.1",
     "globals": "^16.2.0",


### PR DESCRIPTION
## Summary
- clarify Node >=18 requirement in README
- describe installing dependencies so Jest is available
- show how to run tests with `npm test` or `npx jest`
- add `engines` field in package.json and use `npx jest` in test script

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b302199c88326b8b5126bbfd37156