### PR TITLE
Fix wrangler KV command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,12 @@ This will upload the worker using the settings from `wrangler.toml`.
 Можете да управлявате съдържанието на KV директно през `wrangler`:
 
 ```bash
-wrangler kv:key put <ключ> "<стойност>" --binding=RESOURCES_KV
-wrangler kv:key get <ключ> --binding=RESOURCES_KV
-wrangler kv:key delete <ключ> --binding=RESOURCES_KV
+wrangler kv key put <ключ> "<стойност>" --binding=RESOURCES_KV
+wrangler kv key get <ключ> --binding=RESOURCES_KV
+wrangler kv key delete <ключ> --binding=RESOURCES_KV
 ```
+
+> За работа с тези команди трябва да имате зададен `CF_API_TOKEN` или да сте изпълнили `wrangler login`.
 
 Заменете `RESOURCES_KV` с `USER_METADATA_KV` при нужда. В директорията `scripts` има примерен Node скрипт `manage-kv.js`, който изпълнява същите операции:
 

--- a/scripts/manage-kv.js
+++ b/scripts/manage-kv.js
@@ -7,7 +7,7 @@ if (!['get', 'put', 'delete'].includes(action) || !key || (action === 'put' && !
   process.exit(1);
 }
 
-const args = ['kv:key', action, key];
+const args = ['kv', 'key', action, key];
 if (action === 'put') args.push(value);
 args.push('--binding', binding);
 


### PR DESCRIPTION
## Summary
- update README with new `wrangler kv key` syntax
- mention need for `CF_API_TOKEN` or `wrangler login`
- adjust `manage-kv.js` arguments

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b5f67122c8326b15b89bda7f81ca6