### PR TITLE
Implement plan status polling

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -1,11 +1,12 @@
 // auth.js - Аутентикация
 import { showToast } from './uiHandlers.js';
 import { selectors } from './uiElements.js';
-import { resetAppState } from './app.js'; // Function from app.js to clear state
+import { resetAppState, stopPlanStatusPolling } from './app.js'; // Function from app.js to clear state
 
 export function handleLogout() {
     sessionStorage.removeItem('userId');
     sessionStorage.removeItem('activeTabId'); // Also clear active tab
+    stopPlanStatusPolling();
     resetAppState(); // Call app.js to clear its global state variables
 
     showToast("Излизане от системата...", false, 1500);

--- a/js/config.js
+++ b/js/config.js
@@ -13,6 +13,7 @@ export const apiEndpoints = {
     dashboard: `${workerBaseUrl}/api/dashboardData`,
     log: `${workerBaseUrl}/api/log`,
     chat: `${workerBaseUrl}/api/chat`,
+    planStatus: `${workerBaseUrl}/api/planStatus`,
     logExtraMeal: `${workerBaseUrl}/api/log-extra-meal`,
     getProfile: `${workerBaseUrl}/api/getProfile`,
     updateProfile: `${workerBaseUrl}/api/updateProfile`,


### PR DESCRIPTION
## Summary
- add planStatus endpoint to config
- poll server for plan readiness and update dashboard when ready
- detect plan modification signal in chat replies
- stop polling on logout and page unload

## Testing
- `npm test` *(fails: canceled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684b7000f8688326b306cd7eca9b2513