### PR TITLE
Add Cloudflare AI helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Before deploying, configure the following secrets in Cloudflare (via the dashboa
 - `GEMINI_API_KEY`
 - `тут_ваш_php_api_url_secret_name`
 - `тут_ваш_php_api_token_secret_name`
+- `CF_AI_TOKEN` – API token used for Cloudflare AI requests
+
+Optionally set `CF_ACCOUNT_ID` via `wrangler secret put` if it differs from the value in `wrangler.toml`. Ако липсва, работникът използва стойността от `wrangler.toml`.
 
 These names are referenced in `worker.js` and must exist for the worker to function.
 
@@ -138,6 +141,7 @@ Set the output as the value for `ADMIN_PASS_HASH`.
 ## Допълнителни функции
 - **Извънредно хранене** – бутонът "Добави извънредно хранене" в `code.html` отваря модалната форма `extra-meal-entry-form.html`. Логиката в `js/extraMealForm.js` изпраща данните към `/api/log-extra-meal` в `worker.js`.
 - **Изследвания** – POST заявки към `/api/uploadTestResult` и `/api/uploadIrisDiag` записват данни за проведени тестове или ирисова диагностика в KV и създават събитие за автоматична адаптация на плана.
+- **AI помощник** – POST заявка към `/api/aiHelper` изпраща последните логове на потребителя към Cloudflare AI и връща обобщение.
 
 - **Пример за запис в KV**
 

--- a/js/__tests__/aiHelper.test.js
+++ b/js/__tests__/aiHelper.test.js
@@ -1,0 +1,50 @@
+import { jest } from '@jest/globals';
+import { handleAiHelperRequest } from '../../worker.js';
+
+const originalFetch = global.fetch;
+
+describe('handleAiHelperRequest', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+  test('fails without userId', async () => {
+    const env = { USER_METADATA_KV: { get: jest.fn() } };
+    const request = { json: async () => ({}) };
+    const res = await handleAiHelperRequest(request, env);
+    expect(res.success).toBe(false);
+  });
+
+  test('returns AI response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { response: 'summary' } })
+    });
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn().mockResolvedValue('{"note":"ok"}')
+      },
+      CF_ACCOUNT_ID: 'acc',
+      CF_AI_TOKEN: 'token'
+    };
+    const request = { json: async () => ({ userId: 'u1', lookbackDays: 1 }) };
+    const res = await handleAiHelperRequest(request, env);
+    expect(res.success).toBe(true);
+    expect(res.aiResponse).toBe('summary');
+  });
+
+  test('handles AI error', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ errors: [{ message: 'bad' }] })
+    });
+    const env = {
+      USER_METADATA_KV: { get: jest.fn().mockResolvedValue('{}') },
+      CF_ACCOUNT_ID: 'acc',
+      CF_AI_TOKEN: 'token'
+    };
+    const request = { json: async () => ({ userId: 'u1' }) };
+    const res = await handleAiHelperRequest(request, env);
+    expect(res.success).toBe(false);
+  });
+});

--- a/js/config.js
+++ b/js/config.js
@@ -22,7 +22,8 @@ export const apiEndpoints = {
     recordFeedbackChat: `${workerBaseUrl}/api/recordFeedbackChat`,
     forgotPassword: `${workerBaseUrl}/api/forgotPassword`,
     getAchievements: `${workerBaseUrl}/api/getAchievements`,
-    generatePraise: `${workerBaseUrl}/api/generatePraise`
+    generatePraise: `${workerBaseUrl}/api/generatePraise`,
+    aiHelper: `${workerBaseUrl}/api/aiHelper`
 };
 
 export const generateId = (prefix = 'id') => `${prefix}-${Math.random().toString(36).substr(2, 9)}`;

--- a/worker.js
+++ b/worker.js
@@ -13,6 +13,8 @@
 const PHP_FILE_MANAGER_API_URL_SECRET_NAME = 'тут_ваш_php_api_url_secret_name';
 const PHP_API_STATIC_TOKEN_SECRET_NAME = 'тут_ваш_php_api_token_secret_name';
 const GEMINI_API_KEY_SECRET_NAME = 'GEMINI_API_KEY';
+const CF_AI_TOKEN_SECRET_NAME = 'CF_AI_TOKEN';
+const CF_ACCOUNT_ID_VAR_NAME = 'CF_ACCOUNT_ID';
 
 const GEMINI_API_URL_BASE = `https://generativelanguage.googleapis.com/v1beta/models/`;
 // Очаквани Bindings: RESOURCES_KV, USER_METADATA_KV
@@ -120,6 +122,8 @@ export default {
                 responseBody = await handleGetAchievementsRequest(request, env);
             } else if (method === 'POST' && path === '/api/generatePraise') {
                 responseBody = await handleGeneratePraiseRequest(request, env);
+            } else if (method === 'POST' && path === '/api/aiHelper') {
+                responseBody = await handleAiHelperRequest(request, env);
             } else {
                 responseBody = { success: false, error: 'Not Found', message: 'Ресурсът не е намерен.' };
                 responseStatus = 404;
@@ -1155,6 +1159,42 @@ async function handleUploadIrisDiag(request, env) {
 }
 // ------------- END FUNCTION: handleUploadIrisDiag -------------
 
+// ------------- START FUNCTION: handleAiHelperRequest -------------
+async function handleAiHelperRequest(request, env) {
+    try {
+        const { userId, lookbackDays = 3, prompt = 'Обобщи следните логове' } = await request.json();
+        if (!userId) {
+            console.warn('AI_HELPER_ERROR: Missing userId.');
+            return { success: false, message: 'Липсва userId.', statusHint: 400 };
+        }
+
+        const days = Math.min(Math.max(parseInt(lookbackDays, 10) || 3, 1), 14);
+        const logKeys = [];
+        const today = new Date();
+        for (let i = 0; i < days; i++) {
+            const d = new Date(today); d.setDate(today.getDate() - i);
+            logKeys.push(`${userId}_log_${d.toISOString().split('T')[0]}`);
+        }
+        const logStrings = await Promise.all(logKeys.map(k => env.USER_METADATA_KV.get(k)));
+        const logs = logStrings.map((s, idx) => {
+            if (s) { const d = new Date(today); d.setDate(today.getDate() - idx); return { date: d.toISOString().split('T')[0], data: safeParseJson(s, {}) }; }
+            return null;
+        }).filter(Boolean);
+
+        const messages = [
+            { role: 'system', content: 'You are a friendly assistant that summarizes user logs in Bulgarian.' },
+            { role: 'user', content: `${prompt}:\n${JSON.stringify(logs)}` }
+        ];
+
+        const aiResp = await callCfAi('@cf/meta/llama-3-8b-instruct', messages, env);
+        return { success: true, aiResponse: aiResp };
+    } catch (error) {
+        console.error('Error in handleAiHelperRequest:', error.message, error.stack);
+        return { success: false, message: 'Грешка при извикване на Cloudflare AI.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleAiHelperRequest -------------
+
 
 // ------------- START BLOCK: PlanGenerationHeaderComment -------------
 // ===============================================
@@ -2164,6 +2204,31 @@ async function callGeminiAPI(prompt, apiKey, generationConfig = {}, safetySettin
 }
 // ------------- END FUNCTION: callGeminiAPI -------------
 
+// ------------- START FUNCTION: callCfAi -------------
+async function callCfAi(model, messages, env) {
+    const accountId = env[CF_ACCOUNT_ID_VAR_NAME] || env.accountId || env.ACCOUNT_ID;
+    const token = env[CF_AI_TOKEN_SECRET_NAME];
+    if (!accountId || !token) {
+        throw new Error('Missing Cloudflare AI credentials.');
+    }
+    const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}`;
+    const resp = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ messages })
+    });
+    const data = await resp.json();
+    if (!resp.ok) {
+        const msg = data?.errors?.[0]?.message || `HTTP ${resp.status}`;
+        throw new Error(`CF AI error: ${msg}`);
+    }
+    return data.result?.response || data;
+}
+// ------------- END FUNCTION: callCfAi -------------
+
 // ------------- START FUNCTION: calculateAnalyticsIndexes -------------
 async function calculateAnalyticsIndexes(userId, initialAnswers, finalPlan, logEntries = [], currentStatus = {}, env) {
     const userLogId = initialAnswers?.email || userId || 'calcAnalyticsUser'; // Enhanced logging ID
@@ -2694,4 +2759,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processPendingPlanModRequests, processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag };
+export { processPendingPlanModRequests, processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, callCfAi };


### PR DESCRIPTION
## Summary
- integrate Cloudflare AI into the worker
- expose new endpoint `/api/aiHelper`
- document new secret CF_AI_TOKEN
- update frontend configuration
- cover AI helper with tests
- restore fetch in tests and allow wrangler account fallback

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b69f0db848326a1275c4e745a5323