### PR TITLE
Add deployment validation script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,14 +4,16 @@ on:
   push:
     branches: [ main ]
 
-jobs:
-  publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Wrangler
-        run: npm install -g wrangler
-      - name: Publish
-        run: wrangler publish
-        env:
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+  jobs:
+    publish:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+        - name: Install Wrangler
+          run: npm install -g wrangler
+        - name: Validate configuration
+          run: node scripts/validate-wrangler.js
+        - name: Publish
+          run: wrangler publish
+          env:
+            CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ To set the token:
 
 The worker configuration is stored in `wrangler.toml`. Update `account_id` with your Cloudflare account if needed. The file also contains
 placeholders for the `USER_METADATA_KV` namespace – replace `000000...` with the real KV IDs from your Cloudflare dashboard.
+You can verify this setup locally by running:
+
+```bash
+node scripts/validate-wrangler.js
+```
+This script checks for placeholder values and for a provided `CF_API_TOKEN`.
 
 ### Manual publish
 

--- a/scripts/validate-wrangler.js
+++ b/scripts/validate-wrangler.js
@@ -1,0 +1,19 @@
+import fs from 'fs';
+
+try {
+  const toml = fs.readFileSync('wrangler.toml', 'utf8');
+  if (/00000000000000000000000000000000/.test(toml)) {
+    console.error('wrangler.toml съдържа стойности placeholder за KV namespace. Заменете ги с реални ID.');
+    process.exit(1);
+  }
+
+  if (!process.env.CF_API_TOKEN) {
+    console.error('Липсва променливата на средата CF_API_TOKEN.');
+    process.exit(1);
+  }
+
+  console.log('Конфигурацията изглежда валидна.');
+} catch (err) {
+  console.error('Грешка при проверка на wrangler.toml:', err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `validate-wrangler.js` to check for placeholder IDs and missing tokens
- run validation in GitHub deploy workflow
- document validation step in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b75ae57e08326845f9af8a525dd10