### PR TITLE
Switch AI helper to generative model

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Set the output as the value for `ADMIN_PASS_HASH`.
 - **Извънредно хранене** – бутонът "Добави извънредно хранене" в `code.html` отваря модалната форма `extra-meal-entry-form.html`. Логиката в `js/extraMealForm.js` изпраща данните към `/api/log-extra-meal` в `worker.js`.
 - **Изследвания** – POST заявки към `/api/uploadTestResult` и `/api/uploadIrisDiag` записват данни за проведени тестове или ирисова диагностика в KV и създават събитие за автоматична адаптация на плана.
 - **Промяна на план** – когато в чата се открие заявка за модификация, в KV се записва ключ `event_planMod_<userId>`. Планираната Cron задача извиква `processPendingUserEvents`, който обработва тези събития и стартира ново генериране на плана.
-- **AI помощник** – POST заявка към `/api/aiHelper` изпраща последните логове на потребителя към модела `@cf/baai/bge-m3` в Cloudflare AI.
+- **AI помощник** – POST заявка към `/api/aiHelper` изпраща последните логове на потребителя към модела `@cf/meta/llama-3-8b-instruct` в Cloudflare AI и връща текстово обобщение.
 
 - **Пример за запис в KV**
 

--- a/js/__tests__/aiHelper.test.js
+++ b/js/__tests__/aiHelper.test.js
@@ -30,6 +30,12 @@ describe('handleAiHelperRequest', () => {
     const res = await handleAiHelperRequest(request, env);
     expect(res.success).toBe(true);
     expect(res.aiResponse).toBe('summary');
+    const expectedUrl =
+      'https://api.cloudflare.com/client/v4/accounts/acc/ai/run/@cf/meta/llama-3-8b-instruct';
+    expect(global.fetch).toHaveBeenCalledWith(
+      expectedUrl,
+      expect.objectContaining({ method: 'POST' })
+    );
   });
 
   test('handles AI error', async () => {

--- a/worker.js
+++ b/worker.js
@@ -1180,7 +1180,14 @@ async function handleAiHelperRequest(request, env) {
         }).filter(Boolean);
 
         const textInput = `${prompt}:\n${JSON.stringify(logs)}`;
-        const aiResp = await callCfAi('@cf/baai/bge-m3', { text: textInput }, env);
+        const aiResp = await callCfAi(
+            '@cf/meta/llama-3-8b-instruct',
+            {
+                messages: [{ role: 'user', content: textInput }],
+                stream: false
+            },
+            env
+        );
         return { success: true, aiResponse: aiResp };
     } catch (error) {
         console.error('Error in handleAiHelperRequest:', error.message, error.stack);


### PR DESCRIPTION
## Summary
- use @cf/meta/llama-3-8b-instruct to generate AI helper summaries
- note the new model in README
- expect fetch call to use the new model in aiHelper tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b84d1758c832693f9967766cb37c3