### PR TITLE
Fix npm proxy warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "start": "vite preview",
     "lint": "eslint .",
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest",
+    "test": "npm_config_http_proxy='' npm_config_https_proxy='' NODE_OPTIONS=--experimental-vm-modules npx jest",
     "docs": "typedoc"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- avoid `npm warn Unknown env config "http-proxy"` by clearing proxy vars in test

## Testing
- `npm test -- -w=1`

------
https://chatgpt.com/codex/tasks/task_e_684b874873ac8326a1b53c419f6b9e0e