### PR TITLE
Fix Cloudflare deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,17 @@ on:
         - uses: actions/checkout@v3
         - name: Install Wrangler
           run: npm install -g wrangler
+        - name: Prepare wrangler.toml
+          run: node scripts/prepare-wrangler.js
+          env:
+            USER_METADATA_KV_ID: ${{ secrets.USER_METADATA_KV_ID }}
+            USER_METADATA_KV_PREVIEW_ID: ${{ secrets.USER_METADATA_KV_PREVIEW_ID }}
         - name: Validate configuration
           run: node scripts/validate-wrangler.js
+          env:
+            USER_METADATA_KV_ID: ${{ secrets.USER_METADATA_KV_ID }}
+            USER_METADATA_KV_PREVIEW_ID: ${{ secrets.USER_METADATA_KV_PREVIEW_ID }}
+            CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
         - name: Publish
           run: wrangler publish
           env:

--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ To set the token:
 1. Generate an API token with **Edit Cloudflare Workers** permissions.
 2. In your repository settings, create a GitHub secret named `CF_API_TOKEN` containing the token value.
 
-The worker configuration is stored in `wrangler.toml`. Update `account_id` with your Cloudflare account if needed. The file also contains
-placeholders for the `USER_METADATA_KV` namespace – replace `000000...` with the real KV IDs from your Cloudflare dashboard.
+The worker configuration is stored in `wrangler.toml`. Update `account_id` with your Cloudflare account if needed. For the `USER_METADATA_KV` namespace the file expects the environment variables `USER_METADATA_KV_ID` and `USER_METADATA_KV_PREVIEW_ID`. Configure them as GitHub secrets so the workflow can substitute the correct IDs before publishing.
 You can verify this setup locally by running:
 
 ```bash

--- a/scripts/prepare-wrangler.js
+++ b/scripts/prepare-wrangler.js
@@ -1,0 +1,18 @@
+import fs from 'fs';
+
+const { USER_METADATA_KV_ID, USER_METADATA_KV_PREVIEW_ID } = process.env;
+
+if (USER_METADATA_KV_ID && USER_METADATA_KV_PREVIEW_ID) {
+  try {
+    let toml = fs.readFileSync('wrangler.toml', 'utf8');
+    toml = toml.replace('${USER_METADATA_KV_ID}', USER_METADATA_KV_ID)
+               .replace('${USER_METADATA_KV_PREVIEW_ID}', USER_METADATA_KV_PREVIEW_ID);
+    fs.writeFileSync('wrangler.toml', toml);
+    console.log('wrangler.toml updated with KV namespace IDs from environment');
+  } catch (err) {
+    console.error('Failed to update wrangler.toml:', err.message);
+    process.exit(1);
+  }
+} else {
+  console.log('KV ID environment variables not provided; using existing values');
+}

--- a/scripts/validate-wrangler.js
+++ b/scripts/validate-wrangler.js
@@ -2,8 +2,16 @@ import fs from 'fs';
 
 try {
   const toml = fs.readFileSync('wrangler.toml', 'utf8');
+
+  if (/\$\{USER_METADATA_KV_ID\}/.test(toml) || /\$\{USER_METADATA_KV_PREVIEW_ID\}/.test(toml)) {
+    if (!process.env.USER_METADATA_KV_ID || !process.env.USER_METADATA_KV_PREVIEW_ID) {
+      console.error('Липсват USER_METADATA_KV_ID или USER_METADATA_KV_PREVIEW_ID като променливи на средата.');
+      process.exit(1);
+    }
+  }
+
   if (/00000000000000000000000000000000/.test(toml)) {
-    console.error('wrangler.toml съдържа стойности placeholder за KV namespace. Заменете ги с реални ID.');
+    console.error('wrangler.toml съдържа стойности placeholder за KV namespace. Заменете ги с реални ID или използвайте env променливи.');
     process.exit(1);
   }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,5 +11,5 @@ preview_id = "8ebf65a6ed0a44e7b7d1b4bc6f24465e"
 
 [[kv_namespaces]]
 binding = "USER_METADATA_KV"
-id = "00000000000000000000000000000000"       # Replace with your real namespace ID
-preview_id = "00000000000000000000000000000000" # Replace with your preview namespace ID
+id = "${USER_METADATA_KV_ID}"
+preview_id = "${USER_METADATA_KV_PREVIEW_ID}"


### PR DESCRIPTION
## Summary
- use environment variables for USER_METADATA KV IDs
- add prepare-wrangler script and hook into CI
- enhance validation to check env vars
- document env vars in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b8ada6aa08326b9892e75fef2a09b