### PR TITLE
Fix npm proxy warning during tests

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+loglevel=error

--- a/README.md
+++ b/README.md
@@ -54,20 +54,22 @@ npm ci # или npm install
 Run unit tests with Jest:
 
 ```bash
-npm test         # изпълнява "npx jest"
+npm test         # изпълнява "scripts/test.sh" и Jest
 # или стартирайте директно
 npx jest
 ```
-If your environment defines `HTTP_PROXY`, `HTTPS_PROXY` or directly sets
-`npm_config_http_proxy`/`npm_config_https_proxy`, remove these variables before
-running `npm test` to avoid warnings. Например временно изключване може да се
-направи със следните команди:
+`npm test` автоматично изключва HTTP/HTTPS proxy променливите, така че не е
+необходимо ръчно да ги премахвате. Ако стартирате `npx jest` директно и срещате
+предупреждение "Unknown env config \"http-proxy\"", временно можете да ги
+изключите със следните команди:
 
 ```bash
 unset HTTP_PROXY HTTPS_PROXY npm_config_http_proxy npm_config_https_proxy
 npm config delete proxy
 npm config delete https-proxy
 ```
+Предупреждението може напълно да се скрие чрез файла `.npmrc`, който задава
+`loglevel=error` и е включен в репозиторито.
 Тези стъпки намаляват предупрежденията и потенциално ускоряват старта на
 тестовете.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "start": "vite preview",
     "lint": "eslint .",
-    "test": "npm_config_http_proxy='' npm_config_https_proxy='' NODE_OPTIONS=--experimental-vm-modules npx jest",
+    "test": "sh ./scripts/test.sh",
     "docs": "typedoc"
   },
   "keywords": [],

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Unset proxy environment variables to avoid npm warnings
+unset npm_config_http_proxy npm_config_https_proxy HTTP_PROXY HTTPS_PROXY
+
+# Run Jest with experimental VM modules
+NODE_OPTIONS=--experimental-vm-modules npx jest "$@"


### PR DESCRIPTION
## Summary
- add test script to clear proxy env vars
- suppress npm warnings with `.npmrc`
- update docs to explain the proxy handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b9356a3588326af7bce33e56eabae