### PR TITLE
Add simple chat interface page

### DIFF
--- a/assistant.html
+++ b/assistant.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Чат Асистент</title>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="css/base_styles.css" rel="stylesheet">
+    <link href="css/components_styles.css" rel="stylesheet">
+    <link href="css/responsive_styles.css" rel="stylesheet">
+</head>
+<body>
+<svg style="position:absolute; width:0; height:0;" aria-hidden="true">
+    <symbol id="icon-send" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+        <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"></path>
+    </symbol>
+</svg>
+<div id="chat-widget" class="chat-widget visible" role="log" aria-live="polite">
+    <div class="chat-header">
+        <h4>💬 Cloudflare Асистент</h4>
+    </div>
+    <div id="chat-messages" class="chat-messages"></div>
+    <div class="chat-input-area">
+        <input type="text" id="userId" placeholder="User ID" style="max-width:120px;">
+        <textarea id="chat-input" placeholder="Вашето съобщение..." rows="2"></textarea>
+        <button id="chat-send" aria-label="Изпрати съобщение">
+            <svg class="icon"><use href="#icon-send"></use></svg>
+        </button>
+    </div>
+</div>
+<script type="module" src="js/assistantChat.js"></script>
+</body>
+</html>

--- a/js/assistantChat.js
+++ b/js/assistantChat.js
@@ -1,0 +1,48 @@
+const workerBaseUrl = window.location.hostname === 'localhost' ||
+      window.location.hostname.includes('replit') ||
+      window.location.hostname.includes('preview')
+      ? '/api'
+      : 'https://openapichatbot.radilov-k.workers.dev';
+
+const chatEndpoint = `${workerBaseUrl}/api/chat`;
+
+function addMessage(text, sender = 'bot', isError = false) {
+    const msg = document.createElement('div');
+    msg.className = `message ${sender}` + (isError ? ' error' : '');
+    msg.textContent = text;
+    document.getElementById('chat-messages').appendChild(msg);
+    const container = document.getElementById('chat-messages');
+    container.scrollTop = container.scrollHeight;
+}
+
+async function sendMessage() {
+    const userIdEl = document.getElementById('userId');
+    const inputEl = document.getElementById('chat-input');
+    const userId = userIdEl.value.trim();
+    const message = inputEl.value.trim();
+    if (!userId || !message) return;
+
+    addMessage(message, 'user');
+    inputEl.value = '';
+    inputEl.focus();
+
+    try {
+        const res = await fetch(chatEndpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ userId, message })
+        });
+        const data = await res.json();
+        if (res.ok && data.success) addMessage(data.reply, 'bot');
+        else addMessage(data.message || 'Грешка при заявката.', 'bot', true);
+    } catch (err) {
+        addMessage('Неуспешна връзка с Cloudflare Worker.', 'bot', true);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('chat-send').addEventListener('click', sendMessage);
+    document.getElementById('chat-input').addEventListener('keypress', e => {
+        if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
+    });
+});


### PR DESCRIPTION
## Summary
- add `assistant.html` with minimal chat widget
- implement `js/assistantChat.js` for sending messages to Cloudflare worker

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684bb3f730e08326a14abceff057fd83