### PR TITLE
Auto-fill assistant chat with Cloudflare ID

### DIFF
--- a/assistant.html
+++ b/assistant.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Чат Асистент</title>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="css/base_styles.css" rel="stylesheet">
+    <link href="css/components_styles.css" rel="stylesheet">
+    <link href="css/responsive_styles.css" rel="stylesheet">
+</head>
+<body>
+<svg style="position:absolute; width:0; height:0;" aria-hidden="true">
+    <symbol id="icon-send" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+        <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"></path>
+    </symbol>
+</svg>
+<div id="chat-widget" class="chat-widget visible" role="log" aria-live="polite">
+    <div class="chat-header">
+        <h4>💬 Cloudflare Асистент</h4>
+    </div>
+    <p style="margin:0.5rem 1rem;">Тук можете директно да давате инструкции към AI worker-а, който управлява целия бекенд.</p>
+    <div id="chat-messages" class="chat-messages"></div>
+    <div class="chat-input-area">
+        <input type="text" id="userId" placeholder="Вашият ID" style="max-width:120px;">
+        <small id="id-note" style="margin-left:0.5rem;">ID се попълва автоматично (Cloudflare Account ID) и се запазва за текущата сесия.</small>
+        <textarea id="chat-input" placeholder="Вашето съобщение..." rows="2"></textarea>
+        <button id="chat-send" aria-label="Изпрати съобщение">
+            <svg class="icon"><use href="#icon-send"></use></svg>
+        </button>
+    </div>
+</div>
+<script type="module" src="js/assistantChat.js"></script>
+</body>
+</html>

--- a/js/assistantChat.js
+++ b/js/assistantChat.js
@@ -1,0 +1,90 @@
+import { apiEndpoints, cloudflareAccountId } from './config.js';
+
+const chatEndpoint = apiEndpoints.chat;
+const chatHistory = [];
+let typingEl = null;
+
+function scrollChatToBottom() {
+    const container = document.getElementById('chat-messages');
+    container.scrollTop = container.scrollHeight;
+}
+
+function addMessage(text, sender = 'bot', isError = false) {
+    const msg = document.createElement('div');
+    msg.className = `message ${sender}` + (isError ? ' error' : '');
+    msg.textContent = text;
+    document.getElementById('chat-messages').appendChild(msg);
+    scrollChatToBottom();
+}
+
+function showTyping() {
+    if (!typingEl) {
+        typingEl = document.createElement('div');
+        typingEl.className = 'typing-indicator';
+        typingEl.textContent = 'Асистентът пише...';
+        document.getElementById('chat-messages').appendChild(typingEl);
+        scrollChatToBottom();
+    }
+}
+
+function hideTyping() {
+    if (typingEl) {
+        typingEl.remove();
+        typingEl = null;
+    }
+}
+
+async function sendMessage() {
+    const userIdEl = document.getElementById('userId');
+    const inputEl = document.getElementById('chat-input');
+    const userId = userIdEl.value.trim();
+    const message = inputEl.value.trim();
+    if (!userId || !message) return;
+
+    addMessage(message, 'user');
+    chatHistory.push({ text: message, sender: 'user', isError: false });
+    inputEl.value = '';
+    inputEl.focus();
+    showTyping();
+
+    try {
+        const res = await fetch(chatEndpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ userId, message, history: chatHistory.slice(-10) })
+        });
+        const data = await res.json();
+        if (res.ok && data.success) {
+            addMessage(data.reply, 'bot');
+            chatHistory.push({ text: data.reply, sender: 'bot', isError: false });
+        } else {
+            const msg = data.message || 'Грешка при заявката.';
+            addMessage(msg, 'bot', true);
+            chatHistory.push({ text: msg, sender: 'bot', isError: true });
+        }
+    } catch (err) {
+        const msg = 'Неуспешна връзка с Cloudflare Worker.';
+        addMessage(msg, 'bot', true);
+        chatHistory.push({ text: msg, sender: 'bot', isError: true });
+    } finally {
+        hideTyping();
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const userIdInput = document.getElementById('userId');
+    let savedId = sessionStorage.getItem('userId');
+
+    if (!savedId) {
+        savedId = cloudflareAccountId;
+        sessionStorage.setItem('userId', savedId);
+    }
+
+    userIdInput.value = savedId;
+    userIdInput.disabled = true;
+
+    document.getElementById('chat-send').addEventListener('click', sendMessage);
+    document.getElementById('chat-input').addEventListener('keypress', e => {
+        if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
+    });
+});

--- a/js/config.js
+++ b/js/config.js
@@ -27,4 +27,7 @@ export const apiEndpoints = {
     aiHelper: `${workerBaseUrl}/api/aiHelper`
 };
 
+// Cloudflare Account ID за използване в чат асистента
+export const cloudflareAccountId = 'c2015f4060e04bc3c414f78a9946668e';
+
 export const generateId = (prefix = 'id') => `${prefix}-${Math.random().toString(36).substr(2, 9)}`;


### PR DESCRIPTION
## Summary
- add `cloudflareAccountId` constant in config
- use that ID in `assistantChat.js`
- clarify note about auto-filled ID in chat page

## Testing
- `npm run lint`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684bb3f730e08326a14abceff057fd83