### PR TITLE
Add backend deployment workflow

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,24 @@
+name: Deploy PHP Backend
+
+on:
+  push:
+    paths:
+      - '**/*.php'
+      - 'questions.json'
+      - '.github/workflows/deploy-backend.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.BACKEND_SSH_KEY }}
+      - name: Sync backend files
+        run: |
+          rsync -avz --delete \
+            file_manager_api.php save-questions.php questions.json \
+            ${{ secrets.BACKEND_USERNAME }}@${{ secrets.BACKEND_HOST }}:${{ secrets.BACKEND_PATH }}

--- a/README.md
+++ b/README.md
@@ -222,6 +222,20 @@ php -r "echo password_hash('yourPassword', PASSWORD_DEFAULT);"
 ```
 
 Set the output as the value for `ADMIN_PASS_HASH`.
+
+### Deploying the PHP backend
+
+Changes to `file_manager_api.php`, `save-questions.php` or `questions.json` can
+be automatically uploaded to your server through the workflow
+`.github/workflows/deploy-backend.yml`.
+
+1. Create the secrets `BACKEND_HOST`, `BACKEND_USERNAME`, `BACKEND_SSH_KEY` and
+   `BACKEND_PATH` in your repository settings. The SSH key must allow rsync
+   access to the target directory.
+2. Push your modifications or trigger the workflow manually from the **Actions**
+   tab. The job runs `rsync` over SSH to keep the server in sync.
+
+This keeps the backend up to date without exposing credentials in the repository.
 ## Допълнителни функции
 - **Извънредно хранене** – бутонът "Добави извънредно хранене" в `code.html` отваря модалната форма `extra-meal-entry-form.html`. Логиката в `js/extraMealForm.js` изпраща данните към `/api/log-extra-meal` в `worker.js`.
 - **Изследвания** – POST заявки към `/api/uploadTestResult` и `/api/uploadIrisDiag` записват данни за проведени тестове или ирисова диагностика в KV и създават събитие за автоматична адаптация на плана.


### PR DESCRIPTION
## Summary
- sync PHP backend files to a server with a new deploy action
- document how to use the backend workflow

## Testing
- `npm test` *(fails: Jest is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c2a9892588326b9bc1338a2b21d58