### PR TITLE
Enhance assistant chat and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,23 @@ php -r "echo password_hash('yourPassword', PASSWORD_DEFAULT);"
 ```
 
 Set the output as the value for `ADMIN_PASS_HASH`.
+
+### Chat Assistant
+
+The standalone page `assistant.html` allows you to send direct commands to the worker.
+Open the file in a browser, enter your message and it will call the `/api/chat` endpoint.
+The Cloudflare account ID is filled automatically from `config.js`.
+
+Example test request with `curl`:
+
+```bash
+curl https://api.cloudflare.com/client/v4/accounts/<CF_ACCOUNT_ID>/ai/run/@cf/meta/llama-2-7b-chat-fp16 \
+  -H "Authorization: Bearer <CF_AI_TOKEN>" \
+  -H "Content-Type: application/json" \
+  --data '{"messages":[{"role":"user","content":"Здравей"}]}'
+```
+
+Replace the placeholders with your own values and keep the token secret.
 ## Допълнителни функции
 - **Извънредно хранене** – бутонът "Добави извънредно хранене" в `code.html` отваря модалната форма `extra-meal-entry-form.html`. Логиката в `js/extraMealForm.js` изпраща данните към `/api/log-extra-meal` в `worker.js`.
 - **Изследвания** – POST заявки към `/api/uploadTestResult` и `/api/uploadIrisDiag` записват данни за проведени тестове или ирисова диагностика в KV и създават събитие за автоматична адаптация на плана.

--- a/js/app.js
+++ b/js/app.js
@@ -284,7 +284,9 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
             const serverMsg = data.message || rawText || `${response.status} ${response.statusText}`;
             throw new Error(`Грешка от сървъра: ${serverMsg}`);
         }
-        console.log('Received planData', data.planData);
+        if (isLocalDevelopment) {
+            console.log('Received planData', data.planData);
+        }
         if (!data.success) throw new Error(data.message || 'Неуспешно зареждане на данни от сървъра.');
 
         if (isLocalDevelopment) console.log("Data received from worker:", data);

--- a/js/assistantChat.js
+++ b/js/assistantChat.js
@@ -2,6 +2,10 @@ import { apiEndpoints, cloudflareAccountId } from './config.js';
 
 const chatEndpoint = apiEndpoints.chat;
 const chatHistory = [];
+
+function saveHistory() {
+    sessionStorage.setItem('chatHistory', JSON.stringify(chatHistory));
+}
 let typingEl = null;
 
 function scrollChatToBottom() {
@@ -43,6 +47,7 @@ async function sendMessage() {
 
     addMessage(message, 'user');
     chatHistory.push({ text: message, sender: 'user', isError: false });
+    saveHistory();
     inputEl.value = '';
     inputEl.focus();
     showTyping();
@@ -57,15 +62,18 @@ async function sendMessage() {
         if (res.ok && data.success) {
             addMessage(data.reply, 'bot');
             chatHistory.push({ text: data.reply, sender: 'bot', isError: false });
+            saveHistory();
         } else {
             const msg = data.message || 'Грешка при заявката.';
             addMessage(msg, 'bot', true);
             chatHistory.push({ text: msg, sender: 'bot', isError: true });
+            saveHistory();
         }
     } catch (err) {
         const msg = 'Неуспешна връзка с Cloudflare Worker.';
         addMessage(msg, 'bot', true);
         chatHistory.push({ text: msg, sender: 'bot', isError: true });
+        saveHistory();
     } finally {
         hideTyping();
     }
@@ -82,6 +90,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
     userIdInput.value = savedId;
     userIdInput.disabled = true;
+
+    const storedHistory = sessionStorage.getItem('chatHistory');
+    if (storedHistory) {
+        try {
+            const parsed = JSON.parse(storedHistory);
+            parsed.forEach(h => {
+                addMessage(h.text, h.sender, h.isError);
+                chatHistory.push(h);
+            });
+        } catch { /* ignore parse errors */ }
+    }
 
     document.getElementById('chat-send').addEventListener('click', sendMessage);
     document.getElementById('chat-input').addEventListener('keypress', e => {

--- a/js/config.js
+++ b/js/config.js
@@ -28,6 +28,6 @@ export const apiEndpoints = {
 };
 
 // Cloudflare Account ID за използване в чат асистента
-export const cloudflareAccountId = 'c2015f4060e04bc3c414f78a9946668e';
+export const cloudflareAccountId = window.CF_ACCOUNT_ID || 'c2015f4060e04bc3c414f78a9946668e';
 
 export const generateId = (prefix = 'id') => `${prefix}-${Math.random().toString(36).substr(2, 9)}`;

--- a/save-questions.php
+++ b/save-questions.php
@@ -3,8 +3,8 @@ header("Content-Type: application/json; charset=utf-8");
 
 // ----- Конфигурация чрез променливи на средата -----
 $cloudflareApiToken = getenv('CF_API_TOKEN');
-$cloudflareAccountId = 'c2015f4060e04bc3c414f78a9946668e'; // Cloudflare Account ID
-$kvNamespaceId = '8ebf65a6ed0a44e7b7d1b4bc6f24465e'; // Namespace ID за RESOURCES_KV
+$cloudflareAccountId = getenv('CF_ACCOUNT_ID') ?: 'c2015f4060e04bc3c414f78a9946668e';
+$kvNamespaceId = getenv('RESOURCES_KV_ID') ?: '8ebf65a6ed0a44e7b7d1b4bc6f24465e';
 $kvKeyName = 'question_definitions';
 // -----------------------------------------------------
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -24,6 +24,7 @@ export default defineConfig({
         extraMealEntry: resolve(__dirname, 'extra-meal-entry-form.html'),
         adaptiveQuizTemplate: resolve(__dirname, 'adaptive_quiz_template.html'),
         profileEdit: resolve(__dirname, 'profile-edit.html'),
+        assistant: resolve(__dirname, 'assistant.html'),
       },
     },
   },


### PR DESCRIPTION
## Summary
- keep chat history in sessionStorage for assistant.html
- allow overriding Cloudflare Account ID via `window.CF_ACCOUNT_ID`
- include `assistant.html` in the Vite build
- hide planData log outside development
- read Cloudflare IDs from environment in `save-questions.php`
- document assistant chat usage

## Testing
- `npm ci`
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684cab4b187c8326ae1a23908341f4fc