### PR TITLE
Add clear chat button

### DIFF
--- a/assistant.html
+++ b/assistant.html
@@ -18,6 +18,7 @@
 <div id="chat-widget" class="chat-widget visible" role="log" aria-live="polite">
     <div class="chat-header">
         <h4>💬 Cloudflare Асистент</h4>
+        <button id="chat-clear" class="chat-clear-btn" aria-label="Изчисти чата">🗑</button>
     </div>
     <p style="margin:0.5rem 1rem;">Тук можете директно да давате инструкции към AI worker-а, който управлява целия бекенд.</p>
     <div id="chat-messages" class="chat-messages"></div>

--- a/code.html
+++ b/code.html
@@ -594,9 +594,12 @@
         <div id="chat-widget" class="chat-widget" role="log" aria-live="polite">
             <div class="chat-header">
                 <h4>💬 Чат с Асистент</h4>
-                <button id="chat-close" class="chat-close-btn" aria-label="Затвори чата">
-                    <svg class="icon"><use href="#icon-close"></use></svg>
-                </button>
+                <div class="chat-actions">
+                    <button id="chat-clear" class="chat-clear-btn" aria-label="Изчисти чата">🗑</button>
+                    <button id="chat-close" class="chat-close-btn" aria-label="Затвори чата">
+                        <svg class="icon"><use href="#icon-close"></use></svg>
+                    </button>
+                </div>
             </div>
             <div id="chat-messages" class="chat-messages">
                 <!-- Messages will be added here by JS -->

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -152,11 +152,22 @@
 }
 .chat-header h4 { margin: 0; font-size: 1.1rem; color: var(--chat-header-text); display: flex; align-items: center; }
 .chat-header h4 .emoji { margin-right: var(--space-sm); font-size: 1em; } 
-.chat-close-btn {
-  font-size: 1.5rem; color: var(--chat-header-text); padding: var(--space-xs);
-  line-height: 1; background: none; border: none; cursor: pointer; opacity: 0.8;
+.chat-header .chat-actions { display: flex; gap: var(--space-xs); align-items: center; }
+.chat-close-btn,
+.chat-clear-btn {
+  font-size: 1.5rem;
+  color: var(--chat-header-text);
+  padding: var(--space-xs);
+  line-height: 1;
+  background: none;
+  border: none;
+  cursor: pointer;
+  opacity: 0.8;
 }
-.chat-close-btn:hover { opacity: 1; }
+.chat-close-btn:hover,
+.chat-clear-btn:hover {
+  opacity: 1;
+}
 .chat-messages {
   flex-grow: 1; overflow-y: auto; padding: var(--space-md);
   display: flex; flex-direction: column; gap: var(--space-sm);

--- a/css/responsive_styles.css
+++ b/css/responsive_styles.css
@@ -171,7 +171,8 @@
    .chat-header h4 { font-size: 1rem; }
    .chat-header h4 .emoji { font-size: 0.9em; margin-right: var(--space-xs); }
    /* .chat-close-btn svg.icon { width: 20px; height: 20px; } */ /* This is a general icon, should be sized by its context or font-size */
-   .chat-close-btn { font-size: 1.3rem; /* Adjust size of close button itself */ }
+   .chat-close-btn,
+   .chat-clear-btn { font-size: 1.3rem; /* Adjust size of header buttons */ }
 
 
    .chat-messages { padding: var(--space-sm); gap: var(--space-xs); }

--- a/js/assistantChat.js
+++ b/js/assistantChat.js
@@ -13,6 +13,12 @@ function scrollChatToBottom() {
     container.scrollTop = container.scrollHeight;
 }
 
+function clearChat() {
+    document.getElementById('chat-messages').innerHTML = '';
+    chatHistory.length = 0;
+    sessionStorage.removeItem('chatHistory');
+}
+
 function addMessage(text, sender = 'bot', isError = false) {
     const msg = document.createElement('div');
     msg.className = `message ${sender}` + (isError ? ' error' : '');
@@ -106,4 +112,5 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('chat-input').addEventListener('keypress', e => {
         if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
     });
+    document.getElementById('chat-clear').addEventListener('click', clearChat);
 });

--- a/js/chat.js
+++ b/js/chat.js
@@ -43,6 +43,12 @@ export function closeChatWidget() {
     if (selectors.chatFab) selectors.chatFab.focus();
 }
 
+export function clearChat() {
+    if (!selectors.chatMessages) return;
+    selectors.chatMessages.innerHTML = '';
+    chatHistory.length = 0;
+}
+
 export function displayMessage(text, sender = 'bot', isError = false) {
     if (!selectors.chatMessages) return;
     const messageDiv = document.createElement('div');

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -15,7 +15,7 @@ import {
     _handleTriggerAdaptiveQuizClientSide, // from app.js
     todaysMealCompletionStatus, activeTooltip // from app.js
 } from './app.js';
-import { toggleChatWidget, closeChatWidget } from './chat.js';
+import { toggleChatWidget, closeChatWidget, clearChat } from './chat.js';
 import { computeSwipeTargetIndex } from './swipeUtils.js';
 import { handleAchievementClick } from './achievements.js';
 
@@ -105,6 +105,7 @@ export function setupStaticEventListeners() {
     });
     if (selectors.chatFab) selectors.chatFab.addEventListener('click', toggleChatWidget);
     if (selectors.chatClose) selectors.chatClose.addEventListener('click', closeChatWidget);
+    if (selectors.chatClear) selectors.chatClear.addEventListener('click', clearChat);
     if (selectors.chatSend) selectors.chatSend.addEventListener('click', handleChatSend);
     if (selectors.chatInput) selectors.chatInput.addEventListener('keypress', handleChatInputKeypress);
 

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -38,6 +38,7 @@ export function initializeSelectors() {
         analyticsCardsContainer: 'analyticsCardsContainer',
         tooltipTracker: 'tooltip-tracker',
         toast: 'toast', chatFab: 'chat-fab', chatWidget: 'chat-widget', chatClose: 'chat-close',
+        chatClear: 'chat-clear',
         chatMessages: 'chat-messages', chatInput: 'chat-input', chatSend: 'chat-send'
     };
     let missingCriticalCount = 0;


### PR DESCRIPTION
## Summary
- add clear chat button in assistant page and dashboard chat widget
- style new button in CSS
- wire up clear chat functionality in JS
- include event listener and UI selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cc2665a848326a23fd04d00e74732