### PR TITLE
Remove outdated principles KV

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -164,7 +164,7 @@ function planHasRecContent(plan) {
     const hasPsychData = ['coping_strategies', 'motivational_messages'].some(k => Array.isArray(psych[k]) && psych[k].length > 0) ||
         psych.habit_building_tip || psych.self_compassion_reminder;
 
-    const guidelineFields = [plan.currentPrinciples, plan.principlesWeek2_4, plan.additionalGuidelines];
+    const guidelineFields = [plan.principlesWeek2_4, plan.additionalGuidelines];
     const hasGuidelineData = guidelineFields.some(g => {
         if (Array.isArray(g)) return g.length > 0;
         return typeof g === 'string' && g.trim() !== '';

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -19,7 +19,6 @@ export function populateUI() {
     try { populateProfileTab(data.userName, data.initialData, data.currentStatus, data.initialAnswers); } catch(e) { console.error("Error in populateProfileTab:", e); }
     try { populateWeekPlanTab(data.planData?.week1Menu); } catch(e) { console.error("Error in populateWeekPlanTab:", e); }
     const guidelinesData =
-        data.planData?.currentPrinciples ||
         data.planData?.principlesWeek2_4 ||
         data.planData?.additionalGuidelines ||
         data.additionalGuidelines;


### PR DESCRIPTION
## Summary
- drop usage of `_current_principles` KV and related timestamp
- rely on `principlesWeek2_4` from the stored plan in worker
- simplify dashboard and chat logic
- update client scripts to use the final plan principles

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cc7ecf56883269307609521daedea