### PR TITLE
Add modal transition delay constant

### DIFF
--- a/js/__tests__/modalQueue.test.js
+++ b/js/__tests__/modalQueue.test.js
@@ -14,6 +14,7 @@ beforeEach(async () => {
 });
 
 test('queued modals open sequentially', () => {
+  jest.useFakeTimers();
   openModal('firstModal');
   openModal('secondModal');
   const first = document.getElementById('firstModal');
@@ -21,5 +22,8 @@ test('queued modals open sequentially', () => {
   expect(first.classList.contains('visible')).toBe(true);
   expect(second.classList.contains('visible')).toBe(false);
   closeModal('firstModal');
+  expect(second.classList.contains('visible')).toBe(false);
+  jest.advanceTimersByTime(300);
   expect(second.classList.contains('visible')).toBe(true);
+  jest.useRealTimers();
 });

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -8,6 +8,9 @@ import {
 import { trackerInfoTexts, detailedMetricInfoTexts, mainIndexInfoTexts } from './uiElements.js';
 import { capitalizeFirstLetter, safeGet } from './utils.js';
 
+// Продължителност на анимацията при скриване/показване на модали
+const MODAL_TRANSITION_MS = 300;
+
 // Variable to hold the toast timeout ID, managed locally within this module
 let toastTimeoutUiHandlers;
 
@@ -136,11 +139,11 @@ export function closeModal(modalId) {
     const modal = document.getElementById(modalId); if (!modal) return;
     modal.classList.remove("visible"); modal.setAttribute("aria-hidden", "true");
     if (modalId === "adaptiveQuizWrapper") {
-        setTimeout(() => { modal.style.display = "none"; }, 300);
+        setTimeout(() => { modal.style.display = "none"; }, MODAL_TRANSITION_MS);
     }
     if (modalQueue.length > 0) {
         const next = modalQueue.shift();
-        openModalInternal(next);
+        setTimeout(() => openModalInternal(next), MODAL_TRANSITION_MS);
     }
 }
 


### PR DESCRIPTION
## Summary
- add `MODAL_TRANSITION_MS` constant
- wait for the transition before opening queued modals
- synchronise hiding of the adaptive quiz modal
- update unit test for queued modals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cf1ab37708326a847b69f94d32061