### PR TITLE
Add AI plan update summary support

### DIFF
--- a/js/__tests__/planSummary.test.js
+++ b/js/__tests__/planSummary.test.js
@@ -1,0 +1,14 @@
+import { createPlanUpdateSummary } from '../../worker.js';
+
+describe('createPlanUpdateSummary', () => {
+  test('creates summary from new plan', () => {
+    const newPlan = {
+      caloriesMacros: { calories: 1800 },
+      principlesWeek2_4: 'Принцип 1\nПринцип 2\nПринцип 3'
+    };
+    const summary = createPlanUpdateSummary(newPlan, {});
+    expect(summary.title).toBeDefined();
+    expect(summary.changes[0]).toContain('1800');
+    expect(summary.changes.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- build plan update summary on new plan generation
- expose helper `createPlanUpdateSummary`
- expose summary via dashboard endpoint
- test summary generator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e0afe9dec83268a962374f7030028