### PR TITLE
Добавен маршрут '/'

### DIFF
--- a/js/__tests__/rootRoute.test.js
+++ b/js/__tests__/rootRoute.test.js
@@ -1,0 +1,14 @@
+import worker from '../../worker.js';
+
+describe('root route', () => {
+  test('responds with usage message', async () => {
+    const req = new Request('https://example.com/', {
+      method: 'GET',
+      headers: { Origin: 'http://localhost:5173' }
+    });
+    const res = await worker.fetch(req, {}, {});
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.message).toBe('Използвайте /api/<endpoint>');
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -124,6 +124,8 @@ export default {
                 responseBody = await handleGeneratePraiseRequest(request, env);
             } else if (method === 'POST' && path === '/api/aiHelper') {
                 responseBody = await handleAiHelperRequest(request, env);
+            } else if (method === 'GET' && path === '/') {
+                responseBody = { message: 'Използвайте /api/<endpoint>' };
             } else {
                 responseBody = { success: false, error: 'Not Found', message: 'Ресурсът не е намерен.' };
                 responseStatus = 404;


### PR DESCRIPTION
## Summary
- return a short message for GET `/`
- test the new root route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e15a268c083268b404fbf38e20176