### PR TITLE
Implement user concerns summary

### DIFF
--- a/js/__tests__/principleAdjustmentSummary.test.js
+++ b/js/__tests__/principleAdjustmentSummary.test.js
@@ -50,3 +50,19 @@ describe('handlePrincipleAdjustment', () => {
     global.fetch = originalFetch;
   });
 });
+
+describe('createUserConcernsSummary', () => {
+  test('summarizes notes and extra meals', () => {
+    const logs = [
+      JSON.stringify({ note: 'Чувствам глад', extraMeals: [{}, {}] }),
+      null
+    ];
+    const chat = [
+      { role: 'user', parts: [{ text: 'Трудно ми е да спазвам плана' }] }
+    ];
+    const res = mod.createUserConcernsSummary(logs, chat);
+    expect(res).toContain('Чувствам');
+    expect(res).toContain('2');
+    expect(res).toContain('Трудно');
+  });
+});


### PR DESCRIPTION
## Summary
- generate user concerns summary from logs and chat
- insert the summary in principle adjustment prompt
- expose `createUserConcernsSummary` helper
- add unit test for concern summarization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e171db68c832697fefc2ddac6d252