### PR TITLE
Ensure adaptive plan summary always shows explanation

### DIFF
--- a/js/__tests__/planSummary.test.js
+++ b/js/__tests__/planSummary.test.js
@@ -11,4 +11,11 @@ describe('createPlanUpdateSummary', () => {
     expect(summary.changes[0]).toContain('1800');
     expect(summary.changes.length).toBeGreaterThan(0);
   });
+
+  test('adds explanation when there are no changes', () => {
+    const newPlan = {};
+    const summary = createPlanUpdateSummary(newPlan, {});
+    expect(summary.changes.length).toBeGreaterThan(0);
+    expect(summary.changes[0]).toContain('Няма съществени промени');
+  });
 });

--- a/js/app.js
+++ b/js/app.js
@@ -313,8 +313,12 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
             const { title, introduction, changes, encouragement } = data.aiUpdateSummary;
             let summaryHtml = `<h3>${title || 'Важни Актуализации'}</h3>`;
             if (introduction) summaryHtml += `<p>${introduction.replace(/\n/g, '<br>')}</p>`;
-            if (changes && Array.isArray(changes) && changes.length > 0) {
-                summaryHtml += `<ul>${changes.map(ch => `<li>${String(ch).replace(/\n/g, '<br>')}</li>`).join('')}</ul>`;
+            if (changes && Array.isArray(changes)) {
+                if (changes.length > 0) {
+                    summaryHtml += `<ul>${changes.map(ch => `<li>${String(ch).replace(/\n/g, '<br>')}</li>`).join('')}</ul>`;
+                } else {
+                    summaryHtml += '<p>Няма съществени промени – планът е обновен без значителни разлики.</p>';
+                }
             }
             if (encouragement) summaryHtml += `<p>${encouragement.replace(/\n/g, '<br>')}</p>`;
 

--- a/worker.js
+++ b/worker.js
@@ -1954,6 +1954,10 @@ function createPlanUpdateSummary(newPlan, oldPlan = {}) {
         if (t) changes.push(t);
     });
 
+    if (changes.length === 0) {
+        changes.push('Няма съществени промени – планът е обновен без значителни разлики.');
+    }
+
     return {
         title: 'Обновен персонализиран план',
         introduction: 'Вашият план беше генериран отново. Ето няколко основни акцента:',


### PR DESCRIPTION
## Summary
- add fallback message in `createPlanUpdateSummary`
- show fallback message in app UI when summary has no changes
- test coverage for empty summary case

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e241f8ff48326b14ce37710531c96