### PR TITLE
Fix chat marker handling

### DIFF
--- a/js/__tests__/stripPlanModSignature.test.js
+++ b/js/__tests__/stripPlanModSignature.test.js
@@ -1,0 +1,14 @@
+import { jest } from '@jest/globals';
+
+let stripPlanModSignature;
+
+beforeAll(async () => {
+  global.window = { location: { hostname: 'localhost' } };
+  global.document = { addEventListener: jest.fn() };
+  ({ stripPlanModSignature } = await import('../app.js'));
+});
+
+test('handles multiple plan mod markers', () => {
+  const reply = 'a [PLAN_MODIFICATION_REQUEST] b [PLAN_MODIFICATION_REQUEST] c';
+  expect(stripPlanModSignature(reply)).toBe('a [PLAN_MODIFICATION_REQUEST] b');
+});

--- a/js/app.js
+++ b/js/app.js
@@ -707,6 +707,12 @@ export async function _handleTriggerAdaptiveQuizClientSide() { // Exported for e
 // ==========================================================================
 // ЧАТ ФУНКЦИИ (API комуникация и управление на историята)
 // ==========================================================================
+
+export function stripPlanModSignature(reply) {
+    const sig = '[PLAN_MODIFICATION_REQUEST]';
+    const idx = reply.lastIndexOf(sig);
+    return idx !== -1 ? reply.substring(0, idx).trim() : reply;
+}
 export async function handleChatSend() { // Exported for eventListeners.js
     if (!selectors.chatInput || !selectors.chatSend) return;
     const messageText = selectors.chatInput.value.trim();
@@ -726,11 +732,12 @@ export async function handleChatSend() { // Exported for eventListeners.js
         if (!response.ok || !result.success) throw new Error(result.message || `HTTP ${response.status}`);
 
         let botReply = result.reply || '';
-        const sig = '[PLAN_MODIFICATION_REQUEST]';
-        const sigIdx = botReply.indexOf(sig);
-        if (sigIdx !== -1) {
-            botReply = botReply.substring(0, sigIdx).trim();
+        const cleaned = stripPlanModSignature(botReply);
+        if (cleaned !== botReply) {
+            botReply = cleaned;
             pollPlanStatus();
+        } else {
+            botReply = cleaned;
         }
 
         displayChatMessage(botReply, 'bot'); // from chat.js


### PR DESCRIPTION
## Summary
- ensure chat answer marker uses last occurrence
- add helper `stripPlanModSignature`
- test for repeated marker trimming

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e3b5db3d883268e2918040f6b8d7f