### PR TITLE
Fix adaptive quiz trigger

### DIFF
--- a/js/__tests__/adaptiveQuizTrigger.test.js
+++ b/js/__tests__/adaptiveQuizTrigger.test.js
@@ -1,0 +1,26 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let handleAdaptiveQuizBtnClick;
+
+beforeEach(async () => {
+  jest.resetModules();
+  global.fetch = jest.fn().mockResolvedValue({ json: async () => [] });
+  ({ handleAdaptiveQuizBtnClick } = await import('../eventListeners.js'));
+});
+
+describe('handleAdaptiveQuizBtnClick', () => {
+  test('does not trigger when quiz modal is visible', () => {
+    document.body.innerHTML = `<div id="adaptiveQuizWrapper" class="visible"></div>`;
+    const fn = jest.fn();
+    handleAdaptiveQuizBtnClick(fn);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test('triggers when quiz modal is hidden', () => {
+    document.body.innerHTML = `<div id="adaptiveQuizWrapper"></div>`;
+    const fn = jest.fn();
+    handleAdaptiveQuizBtnClick(fn);
+    expect(fn).toHaveBeenCalled();
+  });
+});

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -22,6 +22,12 @@ import { handleAchievementClick } from './achievements.js';
 let touchStartX = null;
 const SWIPE_THRESHOLD = 50;
 
+export function handleAdaptiveQuizBtnClick(triggerFn = _handleTriggerAdaptiveQuizClientSide) {
+    const modal = document.getElementById('adaptiveQuizWrapper');
+    if (modal && modal.classList.contains('visible')) return;
+    triggerFn();
+}
+
 
 export function setupStaticEventListeners() {
     if (selectors.menuToggle) selectors.menuToggle.addEventListener('click', toggleMenu);
@@ -50,7 +56,7 @@ export function setupStaticEventListeners() {
     if (selectors.addNoteBtn) selectors.addNoteBtn.addEventListener('click', toggleDailyNote);
     if (selectors.saveLogBtn) selectors.saveLogBtn.addEventListener('click', handleSaveLog);
     if (selectors.openExtraMealModalBtn) selectors.openExtraMealModalBtn.addEventListener('click', openExtraMealModal);
-    if (selectors.triggerAdaptiveQuizBtn) selectors.triggerAdaptiveQuizBtn.addEventListener('click', _handleTriggerAdaptiveQuizClientSide);
+    if (selectors.triggerAdaptiveQuizBtn) selectors.triggerAdaptiveQuizBtn.addEventListener('click', () => handleAdaptiveQuizBtnClick());
 
     if (selectors.goalCard) selectors.goalCard.addEventListener('click', () => openMainIndexInfo('goalProgress'));
     if (selectors.engagementCard) selectors.engagementCard.addEventListener('click', () => openMainIndexInfo('engagement'));


### PR DESCRIPTION
## Summary
- prevent multiple adaptive quiz openings by ignoring clicks when the quiz modal is already visible
- export helper `handleAdaptiveQuizBtnClick`
- add a small Jest test to verify this behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec8d8c4b88326a7773e836bb5ddf7