### PR TITLE
feat: expand plan summary

### DIFF
--- a/js/__tests__/planSummary.test.js
+++ b/js/__tests__/planSummary.test.js
@@ -1,7 +1,7 @@
 import { createPlanUpdateSummary } from '../../worker.js';
 
 describe('createPlanUpdateSummary', () => {
-  test('creates summary from new plan', () => {
+  test('creates summary from new plan without truncating short text', () => {
     const newPlan = {
       caloriesMacros: { calories: 1800 },
       principlesWeek2_4: 'Принцип 1\nПринцип 2\nПринцип 3'
@@ -9,7 +9,25 @@ describe('createPlanUpdateSummary', () => {
     const summary = createPlanUpdateSummary(newPlan, {});
     expect(summary.title).toBeDefined();
     expect(summary.changes[0]).toContain('1800');
-    expect(summary.changes.length).toBeGreaterThan(0);
+    expect(summary.changes.length).toBe(4);
+  });
+
+  test('limits number of changes when text is long', () => {
+    const longLine = 'Много дълъг принцип който увеличава дължината на текста';
+    const newPlan = {
+      caloriesMacros: { calories: 1800 },
+      principlesWeek2_4: Array(6).fill(longLine).join('\n')
+    };
+    const summary = createPlanUpdateSummary(newPlan, {});
+    expect(summary.changes.length).toBe(5);
+  });
+
+  test('shows all short changes when there are many', () => {
+    const newPlan = {
+      principlesWeek2_4: 'A\nB\nC\nD\nE\nF'
+    };
+    const summary = createPlanUpdateSummary(newPlan, {});
+    expect(summary.changes.length).toBe(6);
   });
 
   test('adds explanation when there are no changes', () => {

--- a/worker.js
+++ b/worker.js
@@ -1958,10 +1958,14 @@ function createPlanUpdateSummary(newPlan, oldPlan = {}) {
         changes.push('Няма съществени промени – планът е обновен без значителни разлики.');
     }
 
+    const MAX_CHANGES = 5;
+    const totalLength = changes.reduce((sum, ch) => sum + ch.length, 0);
+    const finalChanges = totalLength <= 120 ? changes : changes.slice(0, MAX_CHANGES);
+
     return {
         title: 'Обновен персонализиран план',
         introduction: 'Вашият план беше генериран отново. Ето няколко основни акцента:',
-        changes: changes.slice(0, 3),
+        changes: finalChanges,
         encouragement: 'Разгледайте плана и следвайте препоръките!'
     };
 }


### PR DESCRIPTION
## Summary
- include up to five changes in plan summary
- drop truncation for short text
- extend plan summary tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec8db36b083268a8ef61eaebaa5fc