### PR TITLE
Reset state on quiz submit error

### DIFF
--- a/js/__tests__/submitQuizErrorReset.test.js
+++ b/js/__tests__/submitQuizErrorReset.test.js
@@ -1,0 +1,27 @@
+import { jest } from '@jest/globals';
+let app;
+let consoleErrorMock;
+
+beforeEach(async () => {
+  jest.resetModules();
+  global.window = { location: { hostname: 'localhost' } };
+  global.document = { addEventListener: jest.fn() };
+  consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {});
+  app = await import('../app.js');
+});
+
+afterEach(() => {
+  consoleErrorMock.mockRestore();
+});
+
+test('resets state when quiz submission fails', async () => {
+  app.setCurrentQuizData({ quizId: 'q1', questions: [] });
+  app.setUserQuizAnswers({ q1: 'answer' });
+  app.setCurrentQuestionIndex(3);
+
+  await app._handleSubmitQuizAnswersClientSide();
+
+  expect(app.currentQuizData).toBeNull();
+  expect(app.userQuizAnswers).toEqual({});
+  expect(app.currentQuestionIndex).toBe(0);
+});

--- a/js/app.js
+++ b/js/app.js
@@ -694,6 +694,9 @@ export async function _handleSubmitQuizAnswersClientSide() {
     } catch (error) {
         console.error("Error submitting quiz answers:", error);
         showToast(`Грешка при подаване на въпросника: ${error.message}`, true);
+        setCurrentQuizData(null);
+        setUserQuizAnswers({});
+        setCurrentQuestionIndex(0);
     } finally {
         showLoading(false);
     }


### PR DESCRIPTION
## Summary
- reset quiz state in `_handleSubmitQuizAnswersClientSide` on error
- add test covering the error path for submitting the quiz

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec8dd8598832699dc4acc82957497