### PR TITLE
Implement escapeHtml helper and sanitize UI outputs

### DIFF
--- a/js/__tests__/utils.test.js
+++ b/js/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import { safeGet, safeParseFloat, capitalizeFirstLetter } from '../utils.js';
+import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml } from '../utils.js';
 
 describe('utils', () => {
   test('safeGet returns nested value', () => {
@@ -23,5 +23,16 @@ describe('utils', () => {
   test('capitalizeFirstLetter works', () => {
     expect(capitalizeFirstLetter('hello')).toBe('Hello');
     expect(capitalizeFirstLetter('')).toBe('');
+  });
+
+  test('escapeHtml replaces special characters', () => {
+    const input = '<div class="test">O\'Reilly & "Co"</div>';
+    const expected = '&lt;div class=&quot;test&quot;&gt;O&#39;Reilly &amp; &quot;Co&quot;&lt;/div&gt;';
+    expect(escapeHtml(input)).toBe(expected);
+  });
+
+  test('escapeHtml handles null and undefined', () => {
+    expect(escapeHtml(null)).toBe('');
+    expect(escapeHtml(undefined)).toBe('');
   });
 });

--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,6 @@
 // app.js - Основен Файл на Приложението
 import { isLocalDevelopment, workerBaseUrl, apiEndpoints, generateId } from './config.js';
-import { safeGet, safeParseFloat, capitalizeFirstLetter } from './utils.js';
+import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml } from './utils.js';
 import { selectors, initializeSelectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
 import {
     toggleMenu, closeMenu, handleOutsideMenuClick, handleMenuKeydown,
@@ -320,15 +320,15 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
         if (data.aiUpdateSummary) {
             const { title, introduction, changes, encouragement } = data.aiUpdateSummary;
             let summaryHtml = '';
-            if (introduction) summaryHtml += `<p>${normalizeText(introduction).replace(/\n/g, '<br>')}</p>`;
+            if (introduction) summaryHtml += `<p>${escapeHtml(normalizeText(introduction)).replace(/\n/g, '<br>')}</p>`;
             if (changes && Array.isArray(changes)) {
                 if (changes.length > 0) {
-                    summaryHtml += `<ul>${changes.map(ch => `<li>${normalizeText(ch).replace(/\n/g, '<br>')}</li>`).join('')}</ul>`;
+                    summaryHtml += `<ul>${changes.map(ch => `<li>${escapeHtml(normalizeText(ch)).replace(/\n/g, '<br>')}</li>`).join('')}</ul>`;
                 } else {
                     summaryHtml += '<p>Няма съществени промени – планът е обновен без значителни разлики.</p>';
                 }
             }
-            if (encouragement) summaryHtml += `<p>${normalizeText(encouragement).replace(/\n/g, '<br>')}</p>`;
+            if (encouragement) summaryHtml += `<p>${escapeHtml(normalizeText(encouragement)).replace(/\n/g, '<br>')}</p>`;
 
             if (selectors.infoModalTitle) selectors.infoModalTitle.textContent = normalizeText(title) || 'Информация';
             if (selectors.infoModalBody) selectors.infoModalBody.innerHTML = summaryHtml || '<p>Няма детайли.</p>';

--- a/js/chat.js
+++ b/js/chat.js
@@ -3,6 +3,7 @@
 import { selectors } from './uiElements.js';
 import { chatHistory, currentUserId } from './app.js'; // Access chatHistory and userId
 import { apiEndpoints } from './config.js';
+import { escapeHtml } from './utils.js';
 
 export let automatedChatPending = false;
 export function setAutomatedChatPending(val) { automatedChatPending = val; }
@@ -54,6 +55,7 @@ export function displayMessage(text, sender = 'bot', isError = false) {
     const messageDiv = document.createElement('div');
     messageDiv.classList.add('message', sender);
     if (isError) messageDiv.classList.add('error');
+    text = escapeHtml(text);
     text = text.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>').replace(/\*(.*?)\*/g, '<em>$1</em>');
     messageDiv.innerHTML = text.replace(/\n/g, '<br>');
     selectors.chatMessages.appendChild(messageDiv); scrollToChatBottom();

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,6 +1,6 @@
 // populateUI.js - Попълване на UI с данни
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
-import { safeGet, safeParseFloat, capitalizeFirstLetter } from './utils.js';
+import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml } from './utils.js';
 import { generateId } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, planHasRecContent } from './app.js';
 import { showToast, openModal, closeModal } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
@@ -80,7 +80,7 @@ function populateDashboardDetailedAnalytics(analyticsData) {
     const textualAnalysis = safeGet(analyticsData, 'textualAnalysis');
 
     if (textualAnalysis) {
-        textualAnalysisContainer.innerHTML = `<p>${textualAnalysis.replace(/\n/g, "<br>")}</p>`;
+        textualAnalysisContainer.innerHTML = `<p>${escapeHtml(textualAnalysis).replace(/\n/g, "<br>")}</p>`;
     } else {
         textualAnalysisContainer.innerHTML = '<p class="placeholder">Текстовият анализ се генерира или не е наличен...</p>';
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -37,3 +37,13 @@ export const capitalizeFirstLetter = (string) => {
     if (!string || typeof string !== 'string') return '';
     return string.charAt(0).toUpperCase() + string.slice(1);
 };
+
+export const escapeHtml = (text) => {
+    if (text === undefined || text === null) return '';
+    return String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+};


### PR DESCRIPTION
## Summary
- add `escapeHtml` to utils
- sanitize chat messages and analytics text
- sanitize AI summaries displayed in info modal
- test escapeHtml

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ece348b0883269bc77e046d0a4678