### PR TITLE
Update plan summary handling

### DIFF
--- a/js/__tests__/planSummary.test.js
+++ b/js/__tests__/planSummary.test.js
@@ -36,4 +36,17 @@ describe('createPlanUpdateSummary', () => {
     expect(summary.changes.length).toBeGreaterThan(0);
     expect(summary.changes[0]).toContain('Няма съществени промени');
   });
+
+  test('handles principle objects correctly', () => {
+    const newPlan = {
+      principlesWeek2_4: [
+        { title: 'Заглавие', content: 'Съдържание' },
+        { title: 'Другo', content: 'Текст' }
+      ]
+    };
+    const summary = createPlanUpdateSummary(newPlan, {});
+    expect(summary.changes.length).toBe(2);
+    const total = summary.changes.join(' ');
+    expect(total).not.toContain('[object Object]');
+  });
 });

--- a/worker.js
+++ b/worker.js
@@ -1950,7 +1950,15 @@ function createPlanUpdateSummary(newPlan, oldPlan = {}) {
         ? principlesText.split('\n')
         : Array.isArray(principlesText) ? principlesText : [];
     principleLines.forEach(l => {
-        const t = String(l).replace(/^[-*]\s*/, '').trim();
+        let combined = '';
+        if (l && typeof l === 'object') {
+            const title = l.title ? String(l.title).trim() : '';
+            const content = l.content ? String(l.content).trim() : '';
+            combined = `${title} ${content}`.replace(/\s+/g, ' ').trim();
+        } else {
+            combined = String(l);
+        }
+        const t = combined.replace(/^[-*]\s*/, '').trim();
         if (t) changes.push(t);
     });
 


### PR DESCRIPTION
## Summary
- support principle objects when creating plan update summary
- add tests for object principles in summary generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ef1e0653883269e8c37d98d75e0d4