### PR TITLE
Handle multiple planMod events

### DIFF
--- a/js/__tests__/planModRequest.test.js
+++ b/js/__tests__/planModRequest.test.js
@@ -5,8 +5,8 @@ describe('processPendingUserEvents - planMod', () => {
   test('processes planMod event', async () => {
     const env = {
       USER_METADATA_KV: {
-        list: jest.fn().mockResolvedValue({ keys: [{ name: 'event_planMod_u1' }] }),
-        get: jest.fn().mockResolvedValue(JSON.stringify({ type: 'planMod', userId: 'u1', payload: {} })),
+        list: jest.fn().mockResolvedValue({ keys: [{ name: 'event_planMod_u1_1' }] }),
+        get: jest.fn().mockResolvedValue(JSON.stringify({ type: 'planMod', userId: 'u1', createdTimestamp: 1, payload: {} })),
         delete: jest.fn(),
         put: jest.fn()
       }
@@ -14,7 +14,35 @@ describe('processPendingUserEvents - planMod', () => {
     const ctx = { waitUntil: jest.fn() };
     const count = await processPendingUserEvents(env, ctx, 5);
     expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
-    expect(env.USER_METADATA_KV.delete).toHaveBeenCalledWith('event_planMod_u1');
+    expect(env.USER_METADATA_KV.delete).toHaveBeenCalledWith('event_planMod_u1_1');
     expect(count).toBe(1);
+  });
+
+  test('processes two planMod events for same user', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [
+          { name: 'event_planMod_u1_1' },
+          { name: 'event_planMod_u1_2' }
+        ] }),
+        get: jest.fn(key => {
+          if (key === 'event_planMod_u1_1') {
+            return Promise.resolve(JSON.stringify({ type: 'planMod', userId: 'u1', createdTimestamp: 1, payload: { a: 1 } }));
+          }
+          if (key === 'event_planMod_u1_2') {
+            return Promise.resolve(JSON.stringify({ type: 'planMod', userId: 'u1', createdTimestamp: 2, payload: { b: 2 } }));
+          }
+          return Promise.resolve('');
+        }),
+        delete: jest.fn(),
+        put: jest.fn()
+      }
+    };
+    const ctx = { waitUntil: jest.fn() };
+    const count = await processPendingUserEvents(env, ctx, 5);
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(2);
+    expect(env.USER_METADATA_KV.delete.mock.calls[0][0]).toBe('event_planMod_u1_1');
+    expect(env.USER_METADATA_KV.delete.mock.calls[1][0]).toBe('event_planMod_u1_2');
+    expect(count).toBe(2);
   });
 });

--- a/js/__tests__/userEvents.test.js
+++ b/js/__tests__/userEvents.test.js
@@ -5,8 +5,8 @@ describe('processPendingUserEvents', () => {
   test('processes testResult event', async () => {
     const env = {
       USER_METADATA_KV: {
-        list: jest.fn().mockResolvedValue({ keys: [{ name: 'event_testResult_u1' }] }),
-        get: jest.fn().mockResolvedValue(JSON.stringify({ type: 'testResult', userId: 'u1', payload: { value: 5 } })),
+        list: jest.fn().mockResolvedValue({ keys: [{ name: 'event_testResult_u1_1' }] }),
+        get: jest.fn().mockResolvedValue(JSON.stringify({ type: 'testResult', userId: 'u1', createdTimestamp: 1, payload: { value: 5 } })),
         delete: jest.fn(),
         put: jest.fn()
       }
@@ -15,6 +15,6 @@ describe('processPendingUserEvents', () => {
     await processPendingUserEvents(env, ctx, 5);
     expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
     expect(env.USER_METADATA_KV.put).toHaveBeenCalled();
-    expect(env.USER_METADATA_KV.delete).toHaveBeenCalledWith('event_testResult_u1');
+    expect(env.USER_METADATA_KV.delete).toHaveBeenCalledWith('event_testResult_u1_1');
   });
 });


### PR DESCRIPTION
## Summary
- generate unique key in `createUserEvent`
- sort pending user events by creation timestamp and process limited amount
- test new behaviour for multiple `planMod` events
- update existing tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ef2b4343483268c9bc71da63ed1e2