### PR TITLE
Handle AI update acknowledgment on info modal close

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -333,20 +333,6 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
             if (selectors.infoModalTitle) selectors.infoModalTitle.textContent = normalizeText(title) || 'Информация';
             if (selectors.infoModalBody) selectors.infoModalBody.innerHTML = summaryHtml || '<p>Няма детайли.</p>';
             openModal('infoModal');
-            try {
-                const ackResp = await fetch(apiEndpoints.acknowledgeAiUpdate, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ userId: currentUserId })
-                });
-                if (!ackResp.ok) {
-                    const msg = await ackResp.text().catch(() => '');
-                    throw new Error(msg || `Status ${ackResp.status}`);
-                }
-            } catch (err) {
-                console.error('Failed to acknowledge AI update:', err);
-                showToast('Проблем при потвърждаване на AI обновлението.', true, 5000);
-            }
         }
 
         if (data.triggerAutomatedFeedbackChat) {


### PR DESCRIPTION
## Summary
- remove acknowledgeAiUpdate fetch from app.js
- send acknowledgement when closing infoModal in eventListeners

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f70e852188326812796f1a6d094e3