### PR TITLE
Handle load error in extraMealForm

### DIFF
--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -6,10 +6,17 @@ import { currentUserId } from './app.js'; // Accessing currentUserId from app.js
 
 let extraMealFormLoaded = false;
 let commonFoods = [];
+let commonFoodsErrorShown = false;
 fetch(new URL("../data/commonFoods.json", import.meta.url))
     .then(r => r.json())
     .then(d => { if (Array.isArray(d)) commonFoods = d; })
-    .catch(e => console.error("Failed to load foods", e));
+    .catch(e => {
+        console.error("Failed to load foods", e);
+        if (!commonFoodsErrorShown) {
+            showToast("Неуспешно зареждане на списъка с храни", true);
+            commonFoodsErrorShown = true;
+        }
+    });
 
 function initializeExtraMealFormLogic(formContainerElement) {
     const form = formContainerElement.querySelector('#extraMealEntryFormActual');


### PR DESCRIPTION
## Summary
- display a toast if loading commonFoods.json fails
- prevent duplicate error toasts

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f84bcf35c8326b0481f628f18b489