### PR TITLE
Extend food preference parsing for planMod

### DIFF
--- a/js/__tests__/planModFoodPref.test.js
+++ b/js/__tests__/planModFoodPref.test.js
@@ -1,0 +1,54 @@
+import { jest } from '@jest/globals';
+import { processPendingUserEvents } from '../../worker.js';
+
+describe('planMod updates foodPreference', () => {
+  test('updates initial_answers and regenerates plan when vegan keyword present', async () => {
+    const initialAnswers = { name: 'Test', foodPreference: 'Нямам' };
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [{ name: 'event_planMod_u1_1' }] }),
+        get: jest.fn(key => {
+          if (key === 'event_planMod_u1_1') {
+            return Promise.resolve(JSON.stringify({ type: 'planMod', userId: 'u1', createdTimestamp: 1, payload: { description: 'Искам веган режим' } }));
+          }
+          if (key === 'u1_initial_answers') {
+            return Promise.resolve(JSON.stringify(initialAnswers));
+          }
+          return Promise.resolve(null);
+        }),
+        delete: jest.fn(),
+        put: jest.fn()
+      }
+    };
+    const ctx = { waitUntil: jest.fn() };
+    const count = await processPendingUserEvents(env, ctx, 5);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_initial_answers', JSON.stringify({ ...initialAnswers, foodPreference: 'Веган режим' }));
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
+    expect(count).toBe(1);
+  });
+
+  test('updates foodPreference when description contains "gluten free"', async () => {
+    const initialAnswers = { name: 'Test', foodPreference: 'Нямам' };
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [{ name: 'event_planMod_u2_1' }] }),
+        get: jest.fn(key => {
+          if (key === 'event_planMod_u2_1') {
+            return Promise.resolve(JSON.stringify({ type: 'planMod', userId: 'u2', createdTimestamp: 1, payload: { description: 'Prefer gluten free meals' } }));
+          }
+          if (key === 'u2_initial_answers') {
+            return Promise.resolve(JSON.stringify(initialAnswers));
+          }
+          return Promise.resolve(null);
+        }),
+        delete: jest.fn(),
+        put: jest.fn()
+      }
+    };
+    const ctx = { waitUntil: jest.fn() };
+    const count = await processPendingUserEvents(env, ctx, 5);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u2_initial_answers', JSON.stringify({ ...initialAnswers, foodPreference: 'Безглутенов режим' }));
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
+    expect(count).toBe(1);
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -2754,9 +2754,36 @@ async function handleIrisDiagEvent(userId, payload, env) {
     await processSingleUserPlan(userId, env);
 }
 
+function detectFoodPreferenceFromText(text) {
+    const t = typeof text === 'string' ? text.toLowerCase() : '';
+    if (t.includes('веган') || t.includes('vegan')) return 'Веган режим';
+    if (t.includes('вегетариан') || t.includes('vegetarian') || t.includes('без месо')) {
+        return 'Вегетариански режим';
+    }
+    if (t.includes('кето') || t.includes('кетоген') || t.includes('keto')) {
+        return 'Кетогенен режим';
+    }
+    if (t.includes('нисковъглехидрат') || t.includes('low carb')) {
+        return 'Нисковъглехидратен режим';
+    }
+    if (t.includes('без глутен') || t.includes('gluten free')) return 'Безглутенов режим';
+    if (t.includes('без млеч') || t.includes('dairy free')) return 'Безмлечен режим';
+    return null;
+}
+
 // ------------- START BLOCK: UserEventHandlers -------------
 const EVENT_HANDLERS = {
-    planMod: async (userId, env) => {
+    planMod: async (userId, env, payload) => {
+        const description = payload && payload.description ? String(payload.description) : '';
+        const newPref = detectFoodPreferenceFromText(description);
+        if (newPref) {
+            const iaStr = await env.USER_METADATA_KV.get(`${userId}_initial_answers`);
+            const ia = safeParseJson(iaStr, {});
+            if (Object.keys(ia).length > 0) {
+                ia.foodPreference = newPref;
+                await env.USER_METADATA_KV.put(`${userId}_initial_answers`, JSON.stringify(ia));
+            }
+        }
         await processSingleUserPlan(userId, env);
     },
     testResult: async (userId, env, payload) => {


### PR DESCRIPTION
## Summary
- expand detection of food preference keywords
- add test for gluten-free preference recognition

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68505f4e7018832696a4f27de5e8a6ac