### PR TITLE
Show plan modification progress

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -196,6 +196,17 @@ function initializeApp() {
     try {
         if (isLocalDevelopment) console.log("initializeApp starting from app.js...");
         initializeSelectors();
+        if (!document.getElementById('planModInProgressIcon') && selectors.triggerAdaptiveQuizBtn) {
+            const icon = document.createElement('svg');
+            icon.id = 'planModInProgressIcon';
+            icon.classList.add('icon', 'spinner', 'hidden');
+            icon.style.width = '24px';
+            icon.style.height = '24px';
+            icon.style.marginLeft = '0.5rem';
+            icon.innerHTML = '<use href="#icon-spinner"></use>';
+            selectors.triggerAdaptiveQuizBtn.insertAdjacentElement('afterend', icon);
+            selectors.planModInProgressIcon = icon;
+        }
         updateTabsOverflowIndicator();
         showLoading(true, "Инициализация на таблото...");
         currentUserId = sessionStorage.getItem('userId');
@@ -402,11 +413,15 @@ export function stopPlanStatusPolling() {
         planStatusTimeout = null;
     }
     window.removeEventListener('beforeunload', stopPlanStatusPolling);
+    if (selectors.planModInProgressIcon) selectors.planModInProgressIcon.classList.add('hidden');
+    if (selectors.triggerAdaptiveQuizBtn) selectors.triggerAdaptiveQuizBtn.classList.remove('hidden');
 }
 
 export function pollPlanStatus(intervalMs = 30000, maxDurationMs = 300000) {
     if (!currentUserId) return;
     stopPlanStatusPolling();
+    if (selectors.planModInProgressIcon) selectors.planModInProgressIcon.classList.remove('hidden');
+    if (selectors.triggerAdaptiveQuizBtn) selectors.triggerAdaptiveQuizBtn.classList.add('hidden');
     showPlanPendingState();
     showToast('Обновявам плана...', false, 3000);
 
@@ -418,11 +433,15 @@ export function pollPlanStatus(intervalMs = 30000, maxDurationMs = 300000) {
                 if (data.planStatus === 'ready') {
                     stopPlanStatusPolling();
                     if (selectors.planPendingState) selectors.planPendingState.classList.add('hidden');
+                    if (selectors.planModInProgressIcon) selectors.planModInProgressIcon.classList.add('hidden');
+                    if (selectors.triggerAdaptiveQuizBtn) selectors.triggerAdaptiveQuizBtn.classList.remove('hidden');
                     await loadDashboardData();
                     showToast('Планът е обновен.', false, 4000);
                 } else if (data.planStatus === 'error') {
                     stopPlanStatusPolling();
                     if (selectors.planPendingState) selectors.planPendingState.classList.add('hidden');
+                    if (selectors.planModInProgressIcon) selectors.planModInProgressIcon.classList.add('hidden');
+                    if (selectors.triggerAdaptiveQuizBtn) selectors.triggerAdaptiveQuizBtn.classList.remove('hidden');
                     showToast(`Грешка при обновяване: ${data.error || ''}`, true, 6000);
                 }
             }

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -28,6 +28,7 @@ export function initializeSelectors() {
         adaptiveQuizModal: 'adaptiveQuizWrapper',
         adaptiveQuizContainer: 'adaptiveQuizWrapper',
         triggerAdaptiveQuizBtn: 'triggerAdaptiveQuizBtn',
+        planModInProgressIcon: 'planModInProgressIcon',
         infoModal: 'infoModal', infoModalTitle: 'infoModalTitle', infoModalBody: 'infoModalBody',
         feedbackModal: 'feedbackModal',
         feedbackFab: 'feedback-fab',
@@ -55,7 +56,7 @@ export function initializeSelectors() {
         if (!selectors[key] || (key === 'tabButtons' && selectors[key].length === 0)) {
             const optionalOrDynamic = [
                 'menuClose', 'extraMealFormContainer', 'userAllergiesNote', 'userAllergiesList',
-                'feedbackForm', 'tooltipTracker', 'triggerAdaptiveQuizBtn',
+                'feedbackForm', 'tooltipTracker', 'triggerAdaptiveQuizBtn', 'planModInProgressIcon',
                 'streakGrid', 'streakCount', 'analyticsCardsContainer',
                 'goalCard', 'engagementCard', 'healthCard', 'streakCard'
             ];


### PR DESCRIPTION
## Summary
- create DOM element `planModInProgressIcon` next to adaptive quiz button
- expose new selector in `initializeSelectors`
- hide the quiz button and show spinner while polling plan status
- restore button and hide spinner when polling stops

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850a37b2d1c8326b0570294383876e4