### PR TITLE
Add plan change evaluation

### DIFF
--- a/js/__tests__/evaluatePlanChange.test.js
+++ b/js/__tests__/evaluatePlanChange.test.js
@@ -1,0 +1,31 @@
+import { jest } from '@jest/globals';
+import { evaluatePlanChange } from '../../worker.js';
+
+function iso(daysAgo = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  return d.toISOString().split('T')[0];
+}
+
+describe('evaluatePlanChange', () => {
+  test('computes deviation from weight goal', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(key => {
+          if (key === 'u1_initial_answers') {
+            return Promise.resolve(JSON.stringify({ weight: 80, goal: 'отслабване', lossKg: 5 }));
+          }
+          if (key === `u1_log_${iso(0)}`) {
+            return Promise.resolve(JSON.stringify({ weight: 78 }));
+          }
+          if (key === 'u1_current_status') return Promise.resolve(null);
+          return Promise.resolve(null);
+        })
+      }
+    };
+    const res = await evaluatePlanChange('u1', {}, env);
+    expect(res.deviationPercent).toBe(4);
+    expect(res.explanation).toContain('78.0');
+    expect(res.explanation).toContain('75.0');
+  });
+});


### PR DESCRIPTION
## Summary
- add `evaluatePlanChange` for deviation calculations based on logs and the initial questionnaire
- integrate the new evaluation in chat-initiated and quiz-initiated plan modifications
- export `evaluatePlanChange`
- test evaluation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850a9f64ea083269d6ad69f994628a6