### PR TITLE
Fix dynamic plan-mod prompt

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -24,7 +24,8 @@ export const apiEndpoints = {
     forgotPassword: `${workerBaseUrl}/api/forgotPassword`,
     getAchievements: `${workerBaseUrl}/api/getAchievements`,
     generatePraise: `${workerBaseUrl}/api/generatePraise`,
-    aiHelper: `${workerBaseUrl}/api/aiHelper`
+    aiHelper: `${workerBaseUrl}/api/aiHelper`,
+    getPlanModificationPrompt: `${workerBaseUrl}/api/getPlanModificationPrompt`
 };
 
 // Cloudflare Account ID за използване в чат асистента


### PR DESCRIPTION
## Summary
- fetch plan modification prompt from backend
- call `pollPlanStatus` when plan modification is triggered
- show spinner while plan is being regenerated

## Testing
- `npm test`
- `npx eslint js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_6850ad6c49648326b70c7649c59fb062