### PR TITLE
Dynamic plan prompt and button rename

### DIFF
--- a/code.html
+++ b/code.html
@@ -249,7 +249,7 @@
                     </div>
                     <div class="card" style="margin-top: var(--space-lg);">
                         <h3>⚙️ Инструменти за Индивидуализация</h3>
-                        <button id="triggerAdaptiveQuizBtn" class="button-secondary" style="width:100%;">Въведи промени</button>
+                        <button id="planModificationBtn" class="button-secondary" style="width:100%;">Въведи промени</button>
                     </div>
                     <div class="card" style="margin-top: var(--space-lg);">
                         <a href="profile-edit.html" class="button" style="width:100%;">Редактирай Профила</a>

--- a/js/config.js
+++ b/js/config.js
@@ -24,7 +24,8 @@ export const apiEndpoints = {
     forgotPassword: `${workerBaseUrl}/api/forgotPassword`,
     getAchievements: `${workerBaseUrl}/api/getAchievements`,
     generatePraise: `${workerBaseUrl}/api/generatePraise`,
-    aiHelper: `${workerBaseUrl}/api/aiHelper`
+    aiHelper: `${workerBaseUrl}/api/aiHelper`,
+    getPlanModificationPrompt: `${workerBaseUrl}/api/getPlanModificationPrompt`
 };
 
 // Cloudflare Account ID за използване в чат асистента

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -75,7 +75,7 @@ export function setupStaticEventListeners() {
     if (selectors.addNoteBtn) selectors.addNoteBtn.addEventListener('click', toggleDailyNote);
     if (selectors.saveLogBtn) selectors.saveLogBtn.addEventListener('click', handleSaveLog);
     if (selectors.openExtraMealModalBtn) selectors.openExtraMealModalBtn.addEventListener('click', openExtraMealModal);
-    if (selectors.triggerAdaptiveQuizBtn) selectors.triggerAdaptiveQuizBtn.addEventListener('click', openPlanModificationChat);
+    if (selectors.planModificationBtn) selectors.planModificationBtn.addEventListener('click', openPlanModificationChat);
 
     if (selectors.goalCard) selectors.goalCard.addEventListener('click', () => openMainIndexInfo('goalProgress'));
     if (selectors.engagementCard) selectors.engagementCard.addEventListener('click', () => openMainIndexInfo('engagement'));

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -27,7 +27,7 @@ export function initializeSelectors() {
         welcomeScreenModal: 'welcomeScreenModal', extraMealEntryModal: 'extraMealEntryModal', extraMealFormContainer: 'extraMealFormContainer',
         adaptiveQuizModal: 'adaptiveQuizWrapper',
         adaptiveQuizContainer: 'adaptiveQuizWrapper',
-        triggerAdaptiveQuizBtn: 'triggerAdaptiveQuizBtn',
+        planModificationBtn: 'planModificationBtn',
         planModInProgressIcon: 'planModInProgressIcon',
         infoModal: 'infoModal', infoModalTitle: 'infoModalTitle', infoModalBody: 'infoModalBody',
         feedbackModal: 'feedbackModal',
@@ -56,7 +56,7 @@ export function initializeSelectors() {
         if (!selectors[key] || (key === 'tabButtons' && selectors[key].length === 0)) {
             const optionalOrDynamic = [
                 'menuClose', 'extraMealFormContainer', 'userAllergiesNote', 'userAllergiesList',
-                'feedbackForm', 'tooltipTracker', 'triggerAdaptiveQuizBtn', 'planModInProgressIcon',
+                'feedbackForm', 'tooltipTracker', 'planModificationBtn', 'planModInProgressIcon',
                 'streakGrid', 'streakCount', 'analyticsCardsContainer',
                 'goalCard', 'engagementCard', 'healthCard', 'streakCard'
             ];


### PR DESCRIPTION
## Summary
- add `getPlanModificationPrompt` endpoint in config
- update `openPlanModificationChat` to fetch dynamic prompt
- rename the adaptive quiz button to `planModificationBtn`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850afdca2c0832697605fef10de6f0d