### PR TITLE
Add spinner on chat button for plan updates

### DIFF
--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -124,6 +124,19 @@
   border-radius: 50%;
   background: var(--color-danger);
 }
+#chat-fab.planmod-processing::after {
+  content: '';
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 3px solid var(--accent-color);
+  border-top-color: transparent;
+  border-left-color: transparent;
+  animation: spin 1s linear infinite;
+}
 #feedback-fab {
   bottom: var(--space-lg); left: var(--space-lg);
   background-color: var(--secondary-color); color: var(--text-color-on-secondary);

--- a/js/app.js
+++ b/js/app.js
@@ -415,6 +415,7 @@ export function stopPlanStatusPolling() {
     window.removeEventListener('beforeunload', stopPlanStatusPolling);
     if (selectors.planModInProgressIcon) selectors.planModInProgressIcon.classList.add('hidden');
     if (selectors.planModificationBtn) selectors.planModificationBtn.classList.remove('hidden');
+    if (selectors.chatFab) selectors.chatFab.classList.remove('planmod-processing');
 }
 
 export function pollPlanStatus(intervalMs = 30000, maxDurationMs = 300000) {
@@ -422,6 +423,7 @@ export function pollPlanStatus(intervalMs = 30000, maxDurationMs = 300000) {
     stopPlanStatusPolling();
     if (selectors.planModInProgressIcon) selectors.planModInProgressIcon.classList.remove('hidden');
     if (selectors.planModificationBtn) selectors.planModificationBtn.classList.add('hidden');
+    if (selectors.chatFab) selectors.chatFab.classList.add('planmod-processing');
     showPlanPendingState();
     showToast('Обновявам плана...', false, 3000);
 


### PR DESCRIPTION
## Summary
- show spinner badge over chat button while plan modifications are being processed

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850b481c3448326aca8bd0e05d92720