### PR TITLE
Implement chat model selection

### DIFF
--- a/js/__tests__/handleChatRequestModel.test.js
+++ b/js/__tests__/handleChatRequestModel.test.js
@@ -1,0 +1,49 @@
+import { jest } from '@jest/globals';
+import { handleChatRequest } from '../../worker.js';
+
+describe('handleChatRequest model option', () => {
+  const baseEnv = {
+    USER_METADATA_KV: {
+      get: jest.fn(key => {
+        if (key.endsWith('_initial_answers')) return Promise.resolve('{"name":"U","goal":"gain"}');
+        if (key.endsWith('_final_plan')) return Promise.resolve(JSON.stringify({
+          profileSummary: 's',
+          caloriesMacros: { calories: 1800, protein_grams: 1, carbs_grams: 1, fat_grams: 1 },
+          allowedForbiddenFoods: { main_allowed_foods: [], main_forbidden_foods: [] },
+          hydrationCookingSupplements: { hydration_recommendations: { daily_liters: '2' }, cooking_methods: { recommended: [] }, supplement_suggestions: [] },
+          week1Menu: { sunday: [] }
+        }));
+        if (key.startsWith('plan_status_')) return Promise.resolve('ready');
+        if (key.endsWith('_chat_history')) return Promise.resolve('[]');
+        if (key.endsWith('_current_status')) return Promise.resolve('{}');
+        return Promise.resolve(null);
+      }),
+      put: jest.fn().mockResolvedValue(undefined)
+    },
+    RESOURCES_KV: {
+      get: jest.fn(key => {
+        if (key === 'recipe_data') return Promise.resolve('{}');
+        if (key === 'prompt_chat') return Promise.resolve('Say %%USER_MESSAGE%%');
+        if (key === 'model_chat') return Promise.resolve('base-model');
+        return Promise.resolve(null);
+      })
+    },
+    GEMINI_API_KEY: 'key'
+  };
+
+  afterEach(() => {
+    global.fetch && global.fetch.mockRestore();
+  });
+
+  test('uses provided model when present', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ candidates: [{ content: { parts: [{ text: 'hi' }] } }] })
+    });
+    const request = { json: async () => ({ userId: 'u1', message: 'm', model: 'override' }) };
+    const res = await handleChatRequest(request, { ...baseEnv });
+    expect(res.success).toBe(true);
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toContain('override');
+  });
+});

--- a/js/app.js
+++ b/js/app.js
@@ -730,17 +730,20 @@ export async function openPlanModificationChat() {
     if (!selectors.chatWidget?.classList.contains('visible')) toggleChatWidget();
     displayChatTypingIndicator(true);
     let prompt = planModificationPrompt;
+    let modelFromPrompt = null;
     try {
         const respPrompt = await fetch(`${apiEndpoints.getPlanModificationPrompt}?userId=${currentUserId}`);
         if (respPrompt.ok) {
             const dataPrompt = await respPrompt.json();
             if (dataPrompt && dataPrompt.prompt) prompt = dataPrompt.prompt;
+            if (dataPrompt && dataPrompt.model) modelFromPrompt = dataPrompt.model;
         }
     } catch (err) {
         console.warn('Failed to fetch plan modification prompt:', err);
     }
     try {
         const payload = { userId: currentUserId, message: prompt, history: chatHistory.slice(-10) };
+        if (modelFromPrompt) payload.model = modelFromPrompt;
         const resp = await fetch(apiEndpoints.chat, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- allow passing an optional model from plan modification prompt
- forward the optional model in `handleChatRequest`
- test that the backend uses the provided model

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850b9e2f2b08326adb2ea9050af779f