### PR TITLE
Implement pending plan mod integration

### DIFF
--- a/js/__tests__/pendingPlanModIntegration.test.js
+++ b/js/__tests__/pendingPlanModIntegration.test.js
@@ -1,0 +1,62 @@
+import { jest } from '@jest/globals';
+import * as mod from '../../worker.js';
+
+const userId = 'u1';
+
+// Mock date for iso function if needed
+function iso(daysAgo = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  return d.toISOString().split('T')[0];
+}
+
+describe('processSingleUserPlan with pending modification', () => {
+  test('includes pending modification in prompt and clears key', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(key => {
+          if (key === `${userId}_initial_answers`) {
+            return Promise.resolve(JSON.stringify({ name: 'A', email: 'a@a.bg', goal: 'цел' }));
+          }
+          if (key === `${userId}_final_plan`) return Promise.resolve(null);
+          if (key === `${userId}_current_status`) return Promise.resolve(JSON.stringify({ weight: 70 }));
+          if (key === `pending_plan_mod_${userId}`) return Promise.resolve(JSON.stringify({ request: 'без яйца' }));
+          if (key.startsWith(`${userId}_log_`)) return Promise.resolve(null);
+          return Promise.resolve(null);
+        }),
+        put: jest.fn(),
+        delete: jest.fn(),
+      },
+      RESOURCES_KV: {
+        get: jest.fn(key => {
+          if (key === 'question_definitions') return '[]';
+          if (['base_diet_model','allowed_meal_combinations','eating_psychology'].includes(key)) return '';
+          if (key === 'recipe_data') return '{}';
+          if (key === 'model_plan_generation') return 'model';
+          if (key === 'prompt_unified_plan_generation_v2') return '{"profileSummary":"X","caloriesMacros":{},"week1Menu":{},"principlesWeek2_4":[],"detailedTargets":{}}';
+          return null;
+        })
+      },
+      GEMINI_API_KEY: 'key'
+    };
+
+    const originalFetch = global.fetch;
+    let sentPrompt = '';
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ candidates: [{ content: { parts: [{ text: '{"profileSummary":"ok","caloriesMacros":{},"week1Menu":{},"principlesWeek2_4":[],"detailedTargets":{}}' }] } }] })
+    });
+
+    await mod.processSingleUserPlan(userId, env);
+
+    if (global.fetch.mock.calls.length > 0) {
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      sentPrompt = body.contents[0].parts[0].text;
+    }
+
+    global.fetch = originalFetch;
+
+    expect(sentPrompt).toContain('без яйца');
+    expect(env.USER_METADATA_KV.delete).toHaveBeenCalledWith(`pending_plan_mod_${userId}`);
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -1262,12 +1262,19 @@ async function processSingleUserPlan(userId, env) {
         }
         console.log(`PROCESS_USER_PLAN (${userId}): Processing for email: ${initialAnswers.email || 'N/A'}`);
         const planBuilder = { profileSummary: null, caloriesMacros: null, week1Menu: null, principlesWeek2_4: [], additionalGuidelines: [], hydrationCookingSupplements: null, allowedForbiddenFoods: {}, psychologicalGuidance: null, detailedTargets: null, generationMetadata: { timestamp: '', modelUsed: null, errors: [] } };
-        const [ questionsJsonString, baseDietModelContent, allowedMealCombinationsContent, eatingPsychologyContent, recipeDataStr, geminiApiKey, planModelName, unifiedPromptTemplate ] = await Promise.all([
+        const [ questionsJsonString, baseDietModelContent, allowedMealCombinationsContent, eatingPsychologyContent, recipeDataStr, geminiApiKey, planModelName, unifiedPromptTemplate, pendingPlanModStr ] = await Promise.all([
             env.RESOURCES_KV.get('question_definitions'), env.RESOURCES_KV.get('base_diet_model'),
             env.RESOURCES_KV.get('allowed_meal_combinations'), env.RESOURCES_KV.get('eating_psychology'),
             env.RESOURCES_KV.get('recipe_data'), env[GEMINI_API_KEY_SECRET_NAME],
-            env.RESOURCES_KV.get('model_plan_generation'), env.RESOURCES_KV.get('prompt_unified_plan_generation_v2')
+            env.RESOURCES_KV.get('model_plan_generation'), env.RESOURCES_KV.get('prompt_unified_plan_generation_v2'),
+            env.USER_METADATA_KV.get(`pending_plan_mod_${userId}`)
         ]);
+        const pendingPlanModData = safeParseJson(pendingPlanModStr, pendingPlanModStr);
+        let pendingPlanModText = '';
+        if (pendingPlanModData) {
+            if (typeof pendingPlanModData === 'string') pendingPlanModText = pendingPlanModData;
+            else pendingPlanModText = JSON.stringify(pendingPlanModData);
+        }
         if (!geminiApiKey) {
             console.error(`PROCESS_USER_PLAN_ERROR (${userId}): CRITICAL: Gemini API Key secret not found or empty.`);
             throw new Error("CRITICAL: Gemini API Key secret not found or empty.");
@@ -1345,10 +1352,14 @@ async function processSingleUserPlan(userId, env) {
             '%%AVG_ENERGY_LAST_7_DAYS%%': avgEnergy !== 'N/A' ? `${avgEnergy}/5` : 'N/A'
         };
         const populatedUnifiedPrompt = populatePrompt(unifiedPromptTemplate, replacements);
+        let finalPrompt = populatedUnifiedPrompt;
+        if (pendingPlanModText) {
+            finalPrompt += `\n\n[PLAN_MODIFICATION]\n${pendingPlanModText}`;
+        }
         let generatedPlanObject = null; let rawResponseFromGemini = "";
         try {
-            console.log(`PROCESS_USER_PLAN (${userId}): Calling Gemini for unified plan. Prompt length: ${populatedUnifiedPrompt.length}`);
-            rawResponseFromGemini = await callGeminiAPI(populatedUnifiedPrompt, geminiApiKey, { temperature: 0.1, maxOutputTokens: 20000 }, [], planModelName); // maxOutputTokens: 8192 for gemini-pro, check model limits
+            console.log(`PROCESS_USER_PLAN (${userId}): Calling Gemini for unified plan. Prompt length: ${finalPrompt.length}`);
+            rawResponseFromGemini = await callGeminiAPI(finalPrompt, geminiApiKey, { temperature: 0.1, maxOutputTokens: 20000 }, [], planModelName); // maxOutputTokens: 8192 for gemini-pro, check model limits
             const cleanedJson = cleanGeminiJson(rawResponseFromGemini);
             generatedPlanObject = safeParseJson(cleanedJson);
             if (!generatedPlanObject || !generatedPlanObject.profileSummary || !generatedPlanObject.week1Menu || !generatedPlanObject.principlesWeek2_4 || !generatedPlanObject.detailedTargets) {
@@ -1378,6 +1389,7 @@ async function processSingleUserPlan(userId, env) {
         } else {
             await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'ready', { metadata: { status: 'ready' } });
             await env.USER_METADATA_KV.delete(`${userId}_processing_error`); // Изтриваме евентуална стара грешка
+            await env.USER_METADATA_KV.delete(`pending_plan_mod_${userId}`);
             await env.USER_METADATA_KV.put(`${userId}_last_significant_update_ts`, Date.now().toString());
             const summary = createPlanUpdateSummary(planBuilder, previousPlan);
             await env.USER_METADATA_KV.put(`${userId}_ai_update_pending_ack`, JSON.stringify(summary));
@@ -2156,6 +2168,13 @@ async function createUserEvent(eventType, userId, payload, env) {
         payload
     };
     await env.USER_METADATA_KV.put(key, JSON.stringify(data));
+    if (eventType === 'planMod') {
+        try {
+            await env.USER_METADATA_KV.put(`pending_plan_mod_${userId}`, JSON.stringify(payload || {}));
+        } catch (err) {
+            console.error(`EVENT_SAVE_PENDING_MOD_ERROR (${userId}):`, err);
+        }
+    }
     return { success: true };
 }
 // ------------- END FUNCTION: createUserEvent -------------


### PR DESCRIPTION
## Summary
- store plan modification event payload in `pending_plan_mod_<userId>`
- apply pending modifications when generating a plan and delete the key after success
- test that pending modification text is injected into the prompt

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850bc45221483268e2a3521ec95a002