### PR TITLE
Add pending status update on planMod events

### DIFF
--- a/js/__tests__/createUserEvent.test.js
+++ b/js/__tests__/createUserEvent.test.js
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+import { createUserEvent } from '../../worker.js';
+
+describe('createUserEvent - planMod', () => {
+  test('sets status to pending when request accepted', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [] }),
+        get: jest.fn(),
+        put: jest.fn()
+      }
+    };
+    const res = await createUserEvent('planMod', 'u1', {}, env);
+    expect(res.success).toBe(true);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
+      expect.stringMatching(/^event_planMod_u1_/),
+      expect.any(String)
+    );
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
+      'plan_status_u1',
+      'pending',
+      { metadata: { status: 'pending' } }
+    );
+  });
+
+  test('does not change status when duplicate exists', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [{ name: 'event_planMod_u1_1' }] }),
+        get: jest.fn().mockResolvedValue('{"status":"pending"}'),
+        put: jest.fn()
+      }
+    };
+    const res = await createUserEvent('planMod', 'u1', {}, env);
+    expect(res.success).toBe(false);
+    expect(env.USER_METADATA_KV.put).not.toHaveBeenCalledWith(
+      'plan_status_u1',
+      'pending',
+      expect.anything()
+    );
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -2156,6 +2156,9 @@ async function createUserEvent(eventType, userId, payload, env) {
         payload
     };
     await env.USER_METADATA_KV.put(key, JSON.stringify(data));
+    if (eventType === 'planMod') {
+        await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'pending', { metadata: { status: 'pending' } });
+    }
     return { success: true };
 }
 // ------------- END FUNCTION: createUserEvent -------------


### PR DESCRIPTION
## Summary
- update `createUserEvent` to store `plan_status_<id>` as `pending` when new planMod event is created
- skip status update when duplicate planMod exists
- add unit tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850bdb335ec8326b3d4a7418e02b407