### PR TITLE
Update planMod event status

### DIFF
--- a/js/__tests__/createUserEvent.test.js
+++ b/js/__tests__/createUserEvent.test.js
@@ -1,0 +1,39 @@
+import { jest } from '@jest/globals';
+import { createUserEvent } from '../../worker.js';
+
+describe('createUserEvent planMod status', () => {
+  test('sets status to pending when no existing request', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [] }),
+        get: jest.fn(),
+        put: jest.fn()
+      }
+    };
+    const res = await createUserEvent('planMod', 'u1', { change: 'something' }, env);
+    expect(res.success).toBe(true);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
+      expect.stringMatching(/^event_planMod_u1_/), expect.any(String)
+    );
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
+      'pending_plan_mod_u1', JSON.stringify({ change: 'something' })
+    );
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
+      'plan_status_u1', 'pending', { metadata: { status: 'pending' } }
+    );
+  });
+
+  test('does not update status when request already pending', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [{ name: 'event_planMod_u1_old' }] }),
+        get: jest.fn().mockResolvedValue(JSON.stringify({ status: 'pending' })),
+        put: jest.fn()
+      }
+    };
+    const res = await createUserEvent('planMod', 'u1', { change: 'again' }, env);
+    expect(res.success).toBe(false);
+    const statusCalls = env.USER_METADATA_KV.put.mock.calls.filter(c => c[0] === 'plan_status_u1');
+    expect(statusCalls.length).toBe(0);
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -2173,6 +2173,7 @@ async function createUserEvent(eventType, userId, payload, env) {
     if (eventType === 'planMod') {
         try {
             await env.USER_METADATA_KV.put(`pending_plan_mod_${userId}`, JSON.stringify(payload || {}));
+            await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'pending', { metadata:{status:'pending'} });
         } catch (err) {
             console.error(`EVENT_SAVE_PENDING_MOD_ERROR (${userId}):`, err);
         }


### PR DESCRIPTION
## Summary
- set plan status to `pending` when a new `planMod` event is created
- add unit tests for `createUserEvent` plan modification flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850bec48da48326a6841f62cbc2c75d