### PR TITLE
Add skipInit to toggleChatWidget and reset chat for plan changes

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -16,7 +16,8 @@ import { populateUI } from './populateUI.js';
 import { setupStaticEventListeners, setupDynamicEventListeners } from './eventListeners.js';
 import { handleLogout as performLogout } from './auth.js';
 import {
-    toggleChatWidget, closeChatWidget, displayMessage as displayChatMessage,
+    toggleChatWidget, closeChatWidget, clearChat,
+    displayMessage as displayChatMessage,
     displayTypingIndicator as displayChatTypingIndicator, scrollToChatBottom,
     setAutomatedChatPending
 } from './chat.js';
@@ -731,7 +732,8 @@ export async function _handleTriggerAdaptiveQuizClientSide() { // Exported for e
 export async function openPlanModificationChat(userIdOverride = null) {
     const uid = userIdOverride || currentUserId;
     if (!uid) { showToast('Моля, влезте първо.', true); return; }
-    if (!selectors.chatWidget?.classList.contains('visible')) toggleChatWidget();
+    clearChat();
+    if (!selectors.chatWidget?.classList.contains('visible')) toggleChatWidget(true);
     displayChatTypingIndicator(true);
     let promptOverride = null;
     let modelFromPrompt = null;

--- a/js/chat.js
+++ b/js/chat.js
@@ -8,7 +8,7 @@ import { escapeHtml } from './utils.js';
 export let automatedChatPending = false;
 export function setAutomatedChatPending(val) { automatedChatPending = val; }
 
-export function toggleChatWidget() {
+export function toggleChatWidget(skipInit = false) {
     if (!selectors.chatWidget || !selectors.chatFab) return;
     const isVisible = selectors.chatWidget.classList.toggle('visible');
     selectors.chatFab.setAttribute('aria-expanded', isVisible.toString());
@@ -24,7 +24,7 @@ export function toggleChatWidget() {
     if (isVisible) {
         if(selectors.chatInput) selectors.chatInput.focus();
         if (selectors.chatMessages) {
-            if (chatHistory.length === 0 && selectors.chatMessages.children.length === 0) {
+            if (!skipInit && chatHistory.length === 0 && selectors.chatMessages.children.length === 0) {
                  const initialBotMessage = "Здравейте! Аз съм вашият виртуален асистент MyBody.Best. Как мога да ви помогна днес?";
                  displayMessage(initialBotMessage, 'bot');
                  chatHistory.push({ text: initialBotMessage, sender: 'bot', isError: false });

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -141,7 +141,7 @@ export function setupStaticEventListeners() {
             if (activeTooltip) handleTrackerTooltipHide(); // Call hide from uiHandlers
         }
     });
-    if (selectors.chatFab) selectors.chatFab.addEventListener('click', toggleChatWidget);
+    if (selectors.chatFab) selectors.chatFab.addEventListener('click', () => toggleChatWidget());
     if (selectors.chatClose) selectors.chatClose.addEventListener('click', closeChatWidget);
     if (selectors.chatClear) selectors.chatClear.addEventListener('click', clearChat);
     if (selectors.chatSend) selectors.chatSend.addEventListener('click', handleChatSend);


### PR DESCRIPTION
## Summary
- allow passing a flag to `toggleChatWidget` to skip showing the initial bot message
- call this new option in `openPlanModificationChat`
- clear chat history before asking for plan modifications
- prevent click events from passing through to `toggleChatWidget`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851be093d148326b22d55c8a782c73e