### PR TITLE
Add plan modification chat modal

### DIFF
--- a/code.html
+++ b/code.html
@@ -17,6 +17,7 @@
     <link href="css/recommendations_panel_styles.css" rel="stylesheet">
     <link href="css/adaptive_quiz_styles.css" rel="stylesheet">
     <link href="css/extra_meal_form_styles.css" rel="stylesheet">
+    <link href="css/plan_mod_chat_styles.css" rel="stylesheet">
     <link href="css/responsive_styles.css" rel="stylesheet">
     <!-- Chart.js - зарежда се в края на body за по-добра производителност -->
 </head>
@@ -571,6 +572,28 @@
                 </form>
             </div>
         </div>
+
+        <!-- Plan Modification Chat Modal -->
+        <div id="planModChatModal" class="modal" role="dialog" aria-labelledby="planModChatTitle" aria-modal="true" aria-hidden="true">
+            <div class="modal-content plan-mod-chat-content">
+                <div class="plan-mod-chat-header">
+                    <h4 id="planModChatTitle">💬 Промяна на план</h4>
+                    <div class="chat-actions">
+                        <button id="planModChatClear" class="plan-mod-chat-clear" aria-label="Изчисти чата">🗑</button>
+                        <button id="planModChatClose" class="plan-mod-chat-close" aria-label="Затвори чата">
+                            <svg class="icon"><use href="#icon-close"></use></svg>
+                        </button>
+                    </div>
+                </div>
+                <div id="planModChatMessages" class="plan-mod-chat-messages"></div>
+                <div class="plan-mod-chat-input-area">
+                    <textarea id="planModChatInput" placeholder="Вашето съобщение..." rows="2" aria-label="Поле за въвеждане на съобщение"></textarea>
+                    <button id="planModChatSend" aria-label="Изпрати съобщение">
+                        <svg class="icon"><use href="#icon-send"></use></svg>
+                    </button>
+                </div>
+            </div>
+        </div>
         <!-- ======================= END MODAL WINDOWS =========================== -->
 
         <!-- ======================================================================= -->
@@ -620,6 +643,7 @@
 
     <!-- Коригирана JavaScript Връзка -->
     <script type="module" src="js/app.js" defer></script>
+    <script type="module" src="js/planModChat.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
 </body>
 </html>

--- a/css/plan_mod_chat_styles.css
+++ b/css/plan_mod_chat_styles.css
@@ -1,0 +1,100 @@
+.plan-mod-chat-content {
+  background: var(--chat-widget-bg);
+  padding: 0;
+  border-radius: var(--radius-lg);
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+}
+.plan-mod-chat-header {
+  background-color: var(--chat-header-bg);
+  color: var(--chat-header-text);
+  padding: var(--space-sm) var(--space-md);
+  border-top-left-radius: var(--radius-lg);
+  border-top-right-radius: var(--radius-lg);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.plan-mod-chat-header h4 { margin: 0; font-size: 1.1rem; }
+.plan-mod-chat-header .chat-actions { display: flex; gap: var(--space-xs); align-items: center; }
+.plan-mod-chat-messages {
+  flex-grow: 1;
+  overflow-y: auto;
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+.plan-mod-chat-messages .message {
+  padding: 0.7rem 1.1rem;
+  border-radius: 1.2rem;
+  max-width: 85%;
+  word-wrap: break-word;
+  line-height: 1.5;
+  font-size: var(--chat-font-size);
+}
+.plan-mod-chat-messages .message.user {
+  background-color: var(--chat-message-user-bg);
+  align-self: flex-end;
+  border-bottom-right-radius: var(--radius-sm);
+  color: var(--text-color-primary);
+}
+.plan-mod-chat-messages .message.bot {
+  background-color: var(--chat-message-bot-bg);
+  align-self: flex-start;
+  border-bottom-left-radius: var(--radius-sm);
+  color: var(--text-color-primary);
+}
+.plan-mod-chat-messages .message.error {
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger);
+  align-self: center;
+  max-width: 95%;
+}
+.plan-mod-chat-messages .typing-indicator {
+  font-style: italic;
+  color: var(--text-color-muted);
+  align-self: flex-start;
+  padding: 0.4rem 1rem;
+  font-size: calc(var(--chat-font-size) * 0.9);
+}
+.plan-mod-chat-input-area {
+  display: flex;
+  padding: var(--space-sm);
+  border-top: 1px solid var(--border-color);
+  gap: var(--space-sm);
+  background: var(--surface-background);
+  border-bottom-left-radius: var(--radius-lg);
+  border-bottom-right-radius: var(--radius-lg);
+}
+#planModChatInput {
+  flex-grow: 1;
+  resize: none;
+  border: 1px solid var(--input-border-color);
+  border-radius: var(--radius-round);
+  padding: 0.7rem 1.1rem;
+  background: var(--chat-input-field-bg);
+  color: var(--text-color-primary);
+  font-size: var(--chat-font-size);
+  max-height: 90px;
+  overflow-y: auto;
+}
+#planModChatSend {
+  background-color: var(--primary-color);
+  color: var(--fab-icon);
+  border-radius: var(--radius-round);
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  padding: 0;
+}
+#planModChatSend svg { width: 20px; height: 20px; }
+#planModChatSend:hover { background-color: var(--secondary-color); }
+.plan-mod-chat-clear,
+.plan-mod-chat-close { font-size: 1.5rem; color: var(--chat-header-text); padding: var(--space-xs); background: none; border: none; cursor: pointer; opacity: 0.8; line-height: 1; }
+.plan-mod-chat-clear:hover,
+.plan-mod-chat-close:hover { opacity: 1; }

--- a/js/app.js
+++ b/js/app.js
@@ -31,8 +31,8 @@ import {
     getSummaryFromLastCompletedQuiz, // For potential use in app.js
     getSummaryFromPreviousQuizzes // For potential use in app.js
 } from './adaptiveQuiz.js';
+export { openPlanModificationChat } from './planModChat.js';
 
-const planModificationPrompt = 'Моля, опишете накратко желаните от вас промени в плана.';
 
 function normalizeText(input) {
     if (input === undefined || input === null) return '';
@@ -729,32 +729,6 @@ export async function _handleTriggerAdaptiveQuizClientSide() { // Exported for e
     _openAdaptiveQuizModal(); // from adaptiveQuiz.js
 }
 
-export async function openPlanModificationChat(userIdOverride = null) {
-    const uid = userIdOverride || currentUserId;
-    if (!uid) { showToast('Моля, влезте първо.', true); return; }
-    clearChat();
-    if (!selectors.chatWidget?.classList.contains('visible')) toggleChatWidget(true);
-    displayChatTypingIndicator(true);
-    let promptOverride = null;
-    let modelFromPrompt = null;
-    try {
-        const respPrompt = await fetch(`${apiEndpoints.getPlanModificationPrompt}?userId=${uid}`);
-        if (respPrompt.ok) {
-            const dataPrompt = await respPrompt.json();
-            if (dataPrompt && dataPrompt.prompt) promptOverride = dataPrompt.prompt;
-            if (dataPrompt && dataPrompt.model) modelFromPrompt = dataPrompt.model;
-        }
-    } catch (err) {
-        console.warn('Failed to fetch plan modification prompt:', err);
-        showToast('Грешка при зареждане на промпта за промени', true);
-    }
-    displayChatTypingIndicator(false);
-    chatModelOverride = modelFromPrompt;
-    chatPromptOverride = promptOverride;
-    displayChatMessage(planModificationPrompt, 'bot');
-    chatHistory.push({ text: planModificationPrompt, sender: 'bot', isError: false });
-    if (selectors.chatInput) selectors.chatInput.focus();
-}
 
 // ==========================================================================
 // ЧАТ ФУНКЦИИ (API комуникация и управление на историята)

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -14,9 +14,14 @@ import {
     handleChatSend, handleChatInputKeypress, // from app.js / chat.js
     _handlePrevQuizQuestion, _handleNextQuizQuestion, _handleSubmitQuizAnswersClientSide, // from app.js
     _handleTriggerAdaptiveQuizClientSide, // from app.js
-    todaysMealCompletionStatus, activeTooltip, currentUserId, // from app.js
-    openPlanModificationChat
+    todaysMealCompletionStatus, activeTooltip, currentUserId
 } from './app.js';
+import {
+    openPlanModificationChat,
+    clearPlanModChat,
+    handlePlanModChatSend,
+    handlePlanModChatInputKeypress
+} from './planModChat.js';
 import { toggleChatWidget, closeChatWidget, clearChat } from './chat.js';
 import { computeSwipeTargetIndex } from './swipeUtils.js';
 import { handleAchievementClick } from './achievements.js';
@@ -146,6 +151,11 @@ export function setupStaticEventListeners() {
     if (selectors.chatClear) selectors.chatClear.addEventListener('click', clearChat);
     if (selectors.chatSend) selectors.chatSend.addEventListener('click', handleChatSend);
     if (selectors.chatInput) selectors.chatInput.addEventListener('keypress', handleChatInputKeypress);
+
+    if (selectors.planModChatClose) selectors.planModChatClose.addEventListener('click', () => closeModal('planModChatModal'));
+    if (selectors.planModChatClear) selectors.planModChatClear.addEventListener('click', clearPlanModChat);
+    if (selectors.planModChatSend) selectors.planModChatSend.addEventListener('click', handlePlanModChatSend);
+    if (selectors.planModChatInput) selectors.planModChatInput.addEventListener('keypress', handlePlanModChatInputKeypress);
 
     if (selectors.feedbackFab) selectors.feedbackFab.addEventListener('click', () => openModal('feedbackModal')); // openModal from uiHandlers
     if (selectors.feedbackForm) selectors.feedbackForm.addEventListener('submit', handleFeedbackFormSubmit);

--- a/js/planModChat.js
+++ b/js/planModChat.js
@@ -1,0 +1,130 @@
+import { selectors } from './uiElements.js';
+import { apiEndpoints } from './config.js';
+import { openModal, showToast } from './uiHandlers.js';
+import { escapeHtml } from './utils.js';
+import { currentUserId, chatHistory, chatModelOverride, chatPromptOverride, stripPlanModSignature, pollPlanStatus } from './app.js';
+
+const planModificationPrompt = 'Моля, опишете накратко желаните от вас промени в плана.';
+
+export function clearPlanModChat() {
+  if (selectors.planModChatMessages) selectors.planModChatMessages.innerHTML = '';
+  chatHistory.length = 0;
+}
+
+export function displayPlanModChatMessage(text, sender = 'bot', isError = false) {
+  if (!selectors.planModChatMessages) return;
+  const div = document.createElement('div');
+  div.classList.add('message', sender);
+  if (isError) div.classList.add('error');
+  text = escapeHtml(text)
+    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.*?)\*/g, '<em>$1</em>');
+  div.innerHTML = text.replace(/\n/g, '<br>');
+  selectors.planModChatMessages.appendChild(div);
+  scrollToPlanModChatBottom();
+}
+
+export function displayPlanModChatTypingIndicator(show) {
+  if (!selectors.planModChatMessages) return;
+  let indicator = selectors.planModChatMessages.querySelector('.typing-indicator');
+  if (show) {
+    if (!indicator) {
+      indicator = document.createElement('div');
+      indicator.classList.add('message', 'bot', 'typing-indicator');
+      indicator.textContent = 'Асистентът пише...';
+      selectors.planModChatMessages.appendChild(indicator);
+    }
+  } else {
+    indicator?.remove();
+  }
+  scrollToPlanModChatBottom();
+}
+
+export function scrollToPlanModChatBottom() {
+  if (selectors.planModChatMessages)
+    selectors.planModChatMessages.scrollTop = selectors.planModChatMessages.scrollHeight;
+}
+
+export async function handlePlanModChatSend() {
+  if (!selectors.planModChatInput || !selectors.planModChatSend) return;
+  const messageText = selectors.planModChatInput.value.trim();
+  if (!messageText || !currentUserId) return;
+
+  displayPlanModChatMessage(messageText, 'user');
+  chatHistory.push({ text: messageText, sender: 'user', isError: false });
+
+  selectors.planModChatInput.value = '';
+  selectors.planModChatInput.disabled = true;
+  selectors.planModChatSend.disabled = true;
+  displayPlanModChatTypingIndicator(true);
+  try {
+    const payload = { userId: currentUserId, message: messageText, history: chatHistory.slice(-10) };
+    if (chatModelOverride) payload.model = chatModelOverride;
+    if (chatPromptOverride) payload.promptOverride = chatPromptOverride;
+    const response = await fetch(apiEndpoints.chat, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const result = await response.json();
+    if (!response.ok || !result.success) throw new Error(result.message || `HTTP ${response.status}`);
+    let botReply = result.reply || '';
+    const cleaned = stripPlanModSignature(botReply);
+    if (cleaned !== botReply) {
+      botReply = cleaned;
+      pollPlanStatus();
+      chatModelOverride = null;
+      chatPromptOverride = null;
+    } else {
+      botReply = cleaned;
+    }
+    displayPlanModChatMessage(botReply, 'bot');
+    chatHistory.push({ text: botReply, sender: 'bot', isError: false });
+  } catch (e) {
+    const errorMsg = `Грешка при комуникация с асистента: ${e.message}`;
+    displayPlanModChatMessage(errorMsg, 'bot', true);
+    chatHistory.push({ text: errorMsg, sender: 'bot', isError: true });
+  } finally {
+    displayPlanModChatTypingIndicator(false);
+    selectors.planModChatInput.disabled = false;
+    selectors.planModChatInput.focus();
+    selectors.planModChatSend.disabled = false;
+  }
+}
+
+export function handlePlanModChatInputKeypress(e) {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    handlePlanModChatSend();
+  }
+}
+
+export async function openPlanModificationChat(userIdOverride = null) {
+  const uid = userIdOverride || currentUserId;
+  if (!uid) {
+    showToast('Моля, влезте първо.', true);
+    return;
+  }
+  clearPlanModChat();
+  openModal('planModChatModal');
+  displayPlanModChatTypingIndicator(true);
+  let promptOverride = null;
+  let modelFromPrompt = null;
+  try {
+    const respPrompt = await fetch(`${apiEndpoints.getPlanModificationPrompt}?userId=${uid}`);
+    if (respPrompt.ok) {
+      const dataPrompt = await respPrompt.json();
+      if (dataPrompt && dataPrompt.prompt) promptOverride = dataPrompt.prompt;
+      if (dataPrompt && dataPrompt.model) modelFromPrompt = dataPrompt.model;
+    }
+  } catch (err) {
+    console.warn('Failed to fetch plan modification prompt:', err);
+    showToast('Грешка при зареждане на промпта за промени', true);
+  }
+  displayPlanModChatTypingIndicator(false);
+  chatModelOverride = modelFromPrompt;
+  chatPromptOverride = promptOverride;
+  displayPlanModChatMessage(planModificationPrompt, 'bot');
+  chatHistory.push({ text: planModificationPrompt, sender: 'bot', isError: false });
+  if (selectors.planModChatInput) selectors.planModChatInput.focus();
+}

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -29,6 +29,12 @@ export function initializeSelectors() {
         adaptiveQuizContainer: 'adaptiveQuizWrapper',
         planModificationBtn: 'planModificationBtn',
         planModInProgressIcon: 'planModInProgressIcon',
+        planModChatModal: 'planModChatModal',
+        planModChatMessages: 'planModChatMessages',
+        planModChatInput: 'planModChatInput',
+        planModChatSend: 'planModChatSend',
+        planModChatClose: 'planModChatClose',
+        planModChatClear: 'planModChatClear',
         infoModal: 'infoModal', infoModalTitle: 'infoModalTitle', infoModalBody: 'infoModalBody',
         feedbackModal: 'feedbackModal',
         feedbackFab: 'feedback-fab',
@@ -57,6 +63,8 @@ export function initializeSelectors() {
             const optionalOrDynamic = [
                 'menuClose', 'extraMealFormContainer', 'userAllergiesNote', 'userAllergiesList',
                 'feedbackForm', 'tooltipTracker', 'planModificationBtn', 'planModInProgressIcon',
+                'planModChatModal', 'planModChatMessages', 'planModChatInput',
+                'planModChatSend', 'planModChatClose', 'planModChatClear',
                 'streakGrid', 'streakCount', 'analyticsCardsContainer',
                 'goalCard', 'engagementCard', 'healthCard', 'streakCard'
             ];


### PR DESCRIPTION
## Summary
- create dedicated modal for plan modification chat and include CSS/JS
- export new openPlanModificationChat from separate module
- wire new selectors and event listeners

## Testing
- `npm test` *(fails: Jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851c8402f1483269c121fcef36a78fd