### PR TITLE
Уеднаквен дизайн на чат прозорците

### DIFF
--- a/assistant.html
+++ b/assistant.html
@@ -14,11 +14,16 @@
     <symbol id="icon-send" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
         <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"></path>
     </symbol>
+    <symbol id="icon-trash" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"/>
+    </symbol>
 </svg>
 <div id="chat-widget" class="chat-widget visible" role="log" aria-live="polite">
     <div class="chat-header">
         <h4>💬 Cloudflare Асистент</h4>
-        <button id="chat-clear" class="chat-clear-btn" aria-label="Изчисти чата">🗑</button>
+        <button id="chat-clear" class="chat-clear-btn" aria-label="Изчисти чата">
+            <svg class="icon"><use href="#icon-trash"></use></svg>
+        </button>
     </div>
     <p style="margin:0.5rem 1rem;">Тук можете директно да давате инструкции към AI worker-а, който управлява целия бекенд.</p>
     <div id="chat-messages" class="chat-messages"></div>

--- a/code.html
+++ b/code.html
@@ -33,6 +33,9 @@
         <symbol id="icon-menu-burger" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5"> <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"></path> </symbol>
         <symbol id="icon-close" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5"> <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"></path> </symbol>
         <symbol id="icon-send" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"></path></symbol>
+        <symbol id="icon-trash" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"/>
+        </symbol>
         <symbol id="icon-spinner" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"></path></symbol>
         <symbol id="icon-chevron-right" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5"> <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"></path> </symbol>
         <symbol id="icon-feedback" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 12H5.17L4 15.17V4h16v10zm-6-5.41L14.59 8 12 10.59 9.41 8 8 9.41 10.59 12 8 14.59 9.41 16 12 13.41 14.59 16 16 14.59 13.41 12 16 9.41z"/></symbol>
@@ -576,17 +579,19 @@
         <!-- Plan Modification Chat Modal -->
         <div id="planModChatModal" class="modal" role="dialog" aria-labelledby="planModChatTitle" aria-modal="true" aria-hidden="true">
             <div class="modal-content plan-mod-chat-content">
-                <div class="plan-mod-chat-header">
+                <div class="plan-mod-chat-header chat-header">
                     <h4 id="planModChatTitle">💬 Промяна на план</h4>
                     <div class="chat-actions">
-                        <button id="planModChatClear" class="plan-mod-chat-clear" aria-label="Изчисти чата">🗑</button>
-                        <button id="planModChatClose" class="plan-mod-chat-close" aria-label="Затвори чата">
+                        <button id="planModChatClear" class="plan-mod-chat-clear chat-clear-btn" aria-label="Изчисти чата">
+                            <svg class="icon"><use href="#icon-trash"></use></svg>
+                        </button>
+                        <button id="planModChatClose" class="plan-mod-chat-close chat-close-btn" aria-label="Затвори чата">
                             <svg class="icon"><use href="#icon-close"></use></svg>
                         </button>
                     </div>
                 </div>
-                <div id="planModChatMessages" class="plan-mod-chat-messages"></div>
-                <div class="plan-mod-chat-input-area">
+                <div id="planModChatMessages" class="plan-mod-chat-messages chat-messages"></div>
+                <div class="plan-mod-chat-input-area chat-input-area">
                     <textarea id="planModChatInput" placeholder="Вашето съобщение..." rows="2" aria-label="Поле за въвеждане на съобщение"></textarea>
                     <button id="planModChatSend" aria-label="Изпрати съобщение">
                         <svg class="icon"><use href="#icon-send"></use></svg>
@@ -618,7 +623,9 @@
             <div class="chat-header">
                 <h4>💬 Чат с Асистент</h4>
                 <div class="chat-actions">
-                    <button id="chat-clear" class="chat-clear-btn" aria-label="Изчисти чата">🗑</button>
+                    <button id="chat-clear" class="chat-clear-btn" aria-label="Изчисти чата">
+                        <svg class="icon"><use href="#icon-trash"></use></svg>
+                    </button>
                     <button id="chat-close" class="chat-close-btn" aria-label="Затвори чата">
                         <svg class="icon"><use href="#icon-close"></use></svg>
                     </button>

--- a/js/app.js
+++ b/js/app.js
@@ -54,6 +54,9 @@ export let activeTooltip = null; // Managed by uiHandlers via setActiveTooltip
 export let chatModelOverride = null; // Optional model override for next chat message
 export let chatPromptOverride = null; // Optional prompt override for next chat message
 
+export function setChatModelOverride(val) { chatModelOverride = val; }
+export function setChatPromptOverride(val) { chatPromptOverride = val; }
+
 // Управление на интервал за проверка на статус на плана
 let planStatusInterval = null;
 let planStatusTimeout = null;

--- a/js/planModChat.js
+++ b/js/planModChat.js
@@ -2,13 +2,13 @@ import { selectors } from './uiElements.js';
 import { apiEndpoints } from './config.js';
 import { openModal, showToast } from './uiHandlers.js';
 import { escapeHtml } from './utils.js';
-import { currentUserId, chatHistory, chatModelOverride, chatPromptOverride, stripPlanModSignature, pollPlanStatus } from './app.js';
+import * as appState from './app.js';
 
 const planModificationPrompt = 'Моля, опишете накратко желаните от вас промени в плана.';
 
 export function clearPlanModChat() {
   if (selectors.planModChatMessages) selectors.planModChatMessages.innerHTML = '';
-  chatHistory.length = 0;
+  appState.chatHistory.length = 0;
 }
 
 export function displayPlanModChatMessage(text, sender = 'bot', isError = false) {
@@ -48,19 +48,19 @@ export function scrollToPlanModChatBottom() {
 export async function handlePlanModChatSend() {
   if (!selectors.planModChatInput || !selectors.planModChatSend) return;
   const messageText = selectors.planModChatInput.value.trim();
-  if (!messageText || !currentUserId) return;
+  if (!messageText || !appState.currentUserId) return;
 
   displayPlanModChatMessage(messageText, 'user');
-  chatHistory.push({ text: messageText, sender: 'user', isError: false });
+  appState.chatHistory.push({ text: messageText, sender: 'user', isError: false });
 
   selectors.planModChatInput.value = '';
   selectors.planModChatInput.disabled = true;
   selectors.planModChatSend.disabled = true;
   displayPlanModChatTypingIndicator(true);
   try {
-    const payload = { userId: currentUserId, message: messageText, history: chatHistory.slice(-10) };
-    if (chatModelOverride) payload.model = chatModelOverride;
-    if (chatPromptOverride) payload.promptOverride = chatPromptOverride;
+    const payload = { userId: appState.currentUserId, message: messageText, history: appState.chatHistory.slice(-10) };
+    if (appState.chatModelOverride) payload.model = appState.chatModelOverride;
+    if (appState.chatPromptOverride) payload.promptOverride = appState.chatPromptOverride;
     const response = await fetch(apiEndpoints.chat, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -69,21 +69,21 @@ export async function handlePlanModChatSend() {
     const result = await response.json();
     if (!response.ok || !result.success) throw new Error(result.message || `HTTP ${response.status}`);
     let botReply = result.reply || '';
-    const cleaned = stripPlanModSignature(botReply);
+    const cleaned = appState.stripPlanModSignature(botReply);
     if (cleaned !== botReply) {
       botReply = cleaned;
-      pollPlanStatus();
-      chatModelOverride = null;
-      chatPromptOverride = null;
+      appState.pollPlanStatus();
+      appState.setChatModelOverride(null);
+      appState.setChatPromptOverride(null);
     } else {
       botReply = cleaned;
     }
     displayPlanModChatMessage(botReply, 'bot');
-    chatHistory.push({ text: botReply, sender: 'bot', isError: false });
+    appState.chatHistory.push({ text: botReply, sender: 'bot', isError: false });
   } catch (e) {
     const errorMsg = `Грешка при комуникация с асистента: ${e.message}`;
     displayPlanModChatMessage(errorMsg, 'bot', true);
-    chatHistory.push({ text: errorMsg, sender: 'bot', isError: true });
+    appState.chatHistory.push({ text: errorMsg, sender: 'bot', isError: true });
   } finally {
     displayPlanModChatTypingIndicator(false);
     selectors.planModChatInput.disabled = false;
@@ -100,7 +100,7 @@ export function handlePlanModChatInputKeypress(e) {
 }
 
 export async function openPlanModificationChat(userIdOverride = null) {
-  const uid = userIdOverride || currentUserId;
+  const uid = userIdOverride || appState.currentUserId;
   if (!uid) {
     showToast('Моля, влезте първо.', true);
     return;
@@ -122,9 +122,9 @@ export async function openPlanModificationChat(userIdOverride = null) {
     showToast('Грешка при зареждане на промпта за промени', true);
   }
   displayPlanModChatTypingIndicator(false);
-  chatModelOverride = modelFromPrompt;
-  chatPromptOverride = promptOverride;
+  appState.setChatModelOverride(modelFromPrompt);
+  appState.setChatPromptOverride(promptOverride);
   displayPlanModChatMessage(planModificationPrompt, 'bot');
-  chatHistory.push({ text: planModificationPrompt, sender: 'bot', isError: false });
+  appState.chatHistory.push({ text: planModificationPrompt, sender: 'bot', isError: false });
   if (selectors.planModChatInput) selectors.planModChatInput.focus();
 }


### PR DESCRIPTION
## Summary
- добавена SVG икона `icon-trash` и използвана за бутоните за изчистване на чата
- унифицирани класове на прозореца за промяна на план с тези от чат асистента
- добавени сетър функции за `chatModelOverride` и `chatPromptOverride`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851e49d29d083268ea64725db3fc417