### PR TITLE
Handle prompt override for plan modifications

### DIFF
--- a/js/__tests__/openPlanModificationChat.test.js
+++ b/js/__tests__/openPlanModificationChat.test.js
@@ -63,3 +63,12 @@ test('shows toast on fetch error', async () => {
   await app.openPlanModificationChat('u1');
   expect(showToastMock).toHaveBeenCalledWith('Грешка при зареждане на промпта за промени', true);
 });
+
+test('uses backend prompt when fetch succeeds', async () => {
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ promptOverride: 'BACK', model: 'm' })
+  });
+  await app.openPlanModificationChat('u1');
+  expect(app.chatHistory[0].text).toBe('BACK');
+});

--- a/js/planModChat.js
+++ b/js/planModChat.js
@@ -112,11 +112,11 @@ export async function openPlanModificationChat(userIdOverride = null) {
   let modelFromPrompt = null;
   try {
     const respPrompt = await fetch(`${apiEndpoints.getPlanModificationPrompt}?userId=${uid}`);
-    if (respPrompt.ok) {
-      const dataPrompt = await respPrompt.json();
-      if (dataPrompt && dataPrompt.prompt) promptOverride = dataPrompt.prompt;
-      if (dataPrompt && dataPrompt.model) modelFromPrompt = dataPrompt.model;
-    }
+    if (!respPrompt.ok) throw new Error(`HTTP ${respPrompt.status}`);
+    const dataPrompt = await respPrompt.json();
+    if (dataPrompt && dataPrompt.promptOverride)
+      promptOverride = dataPrompt.promptOverride;
+    if (dataPrompt && dataPrompt.model) modelFromPrompt = dataPrompt.model;
   } catch (err) {
     console.warn('Failed to fetch plan modification prompt:', err);
     showToast('Грешка при зареждане на промпта за промени', true);
@@ -124,7 +124,8 @@ export async function openPlanModificationChat(userIdOverride = null) {
   displayPlanModChatTypingIndicator(false);
   appState.setChatModelOverride(modelFromPrompt);
   appState.setChatPromptOverride(promptOverride);
-  displayPlanModChatMessage(planModificationPrompt, 'bot');
-  appState.chatHistory.push({ text: planModificationPrompt, sender: 'bot', isError: false });
+  const initialMsg = promptOverride || planModificationPrompt;
+  displayPlanModChatMessage(initialMsg, 'bot');
+  appState.chatHistory.push({ text: initialMsg, sender: 'bot', isError: false });
   if (selectors.planModChatInput) selectors.planModChatInput.focus();
 }


### PR DESCRIPTION
## Summary
- use `/api/getPlanModificationPrompt` response `promptOverride` as initial message
- fall back to constant and show toast on any fetch error
- test prompt override integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851e945dd04832697e9d857a6ea5a62