### PR TITLE
Remove userId requirement from plan mod prompt

### DIFF
--- a/js/planModChat.js
+++ b/js/planModChat.js
@@ -112,7 +112,7 @@ export async function openPlanModificationChat(userIdOverride = null) {
   let modelFromPrompt = null;
   let promptError = false;
   try {
-    const respPrompt = await fetch(`${apiEndpoints.getPlanModificationPrompt}?userId=${uid}`);
+    const respPrompt = await fetch(apiEndpoints.getPlanModificationPrompt);
     if (!respPrompt.ok) {
       let errorText;
       try {

--- a/worker.js
+++ b/worker.js
@@ -1220,13 +1220,13 @@ async function handleGetPlanModificationPrompt(request, env) {
     try {
         const url = new URL(request.url);
         const userId = url.searchParams.get('userId');
-        if (!userId) return { success: false, message: 'Липсва ID на потребител.', statusHint: 400 };
+        if (userId) console.log(`PLAN_MOD_PROMPT requested by ${userId}`);
 
         const promptTpl = await env.RESOURCES_KV.get('prompt_plan_modification');
         const model = await env.RESOURCES_KV.get('model_chat');
 
         if (!promptTpl || !model) {
-            console.error(`PLAN_MOD_PROMPT_ERROR (${userId}): Missing prompt or model.`);
+            console.error(`PLAN_MOD_PROMPT_ERROR${userId ? ` (${userId})` : ''}: Missing prompt or model.`);
             return { success: false, message: 'Липсва промпт или модел.', statusHint: 500 };
         }
 


### PR DESCRIPTION
## Summary
- log userId when requesting plan modification prompt but no longer require it
- stop sending `userId` when fetching plan modification prompt from the UI

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851ec9fa3d8832692134f4b31fc454b