### PR TITLE
Add state for plan modification chat

### DIFF
--- a/js/__tests__/openPlanModificationChat.test.js
+++ b/js/__tests__/openPlanModificationChat.test.js
@@ -62,7 +62,7 @@ beforeEach(async () => {
 test('shows toast on fetch error', async () => {
   await app.openPlanModificationChat('u1');
   expect(showToastMock).toHaveBeenCalledWith('Грешка при зареждане на промпта за промени', true);
-  expect(app.chatHistory.length).toBe(0);
+  expect(app.planModChatHistory.length).toBe(0);
 });
 
 test('uses backend prompt when fetch succeeds', async () => {
@@ -71,7 +71,7 @@ test('uses backend prompt when fetch succeeds', async () => {
     json: async () => ({ promptOverride: 'BACK', model: 'm' })
   });
   await app.openPlanModificationChat('u1');
-  expect(app.chatHistory[0].text).toBe('BACK');
+  expect(app.planModChatHistory[0].text).toBe('BACK');
 });
 
 test('handles non-ok response without initial message', async () => {
@@ -82,5 +82,16 @@ test('handles non-ok response without initial message', async () => {
   });
   await app.openPlanModificationChat('u1');
   expect(showToastMock).toHaveBeenCalledWith('Server error', true);
-  expect(app.chatHistory.length).toBe(0);
+  expect(app.planModChatHistory.length).toBe(0);
+});
+
+test('opening plan mod chat does not affect main chat history', async () => {
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ promptOverride: 'BACK', model: 'm' })
+  });
+  app.chatHistory.push({ text: 'hi', sender: 'user', isError: false });
+  await app.openPlanModificationChat('u1');
+  expect(app.chatHistory.length).toBe(1);
+  expect(app.planModChatHistory[0].text).toBe('BACK');
 });

--- a/js/app.js
+++ b/js/app.js
@@ -53,9 +53,14 @@ export let todaysMealCompletionStatus = {}; // Updated by populateUI and eventLi
 export let activeTooltip = null; // Managed by uiHandlers via setActiveTooltip
 export let chatModelOverride = null; // Optional model override for next chat message
 export let chatPromptOverride = null; // Optional prompt override for next chat message
+export let planModChatHistory = [];
+export let planModChatModelOverride = null;
+export let planModChatPromptOverride = null;
 
 export function setChatModelOverride(val) { chatModelOverride = val; }
 export function setChatPromptOverride(val) { chatPromptOverride = val; }
+export function setPlanModChatModelOverride(val) { planModChatModelOverride = val; }
+export function setPlanModChatPromptOverride(val) { planModChatPromptOverride = val; }
 
 // Управление на интервал за проверка на статус на плана
 let planStatusInterval = null;
@@ -80,6 +85,9 @@ export function resetAppState() {
     todaysMealCompletionStatus = {};
     activeTooltip = null;
     chatPromptOverride = null;
+    planModChatHistory = [];
+    planModChatModelOverride = null;
+    planModChatPromptOverride = null;
     currentQuizData = null;
     userQuizAnswers = {};
     currentQuestionIndex = 0;

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -20,7 +20,8 @@ import {
     openPlanModificationChat,
     clearPlanModChat,
     handlePlanModChatSend,
-    handlePlanModChatInputKeypress
+    handlePlanModChatInputKeypress,
+    closePlanModChat
 } from './planModChat.js';
 import { toggleChatWidget, closeChatWidget, clearChat } from './chat.js';
 import { computeSwipeTargetIndex } from './swipeUtils.js';
@@ -125,13 +126,15 @@ export function setupStaticEventListeners() {
         const closeBtn = event.target.closest('[data-modal-close]');
         if (closeBtn) {
             const modalId = closeBtn.dataset.modalClose;
-            closeModal(modalId);
+            if (modalId === 'planModChatModal') closePlanModChat();
+            else closeModal(modalId);
             if (modalId === 'infoModal') acknowledgeAiUpdate();
             return;
         }
         if (event.target.classList.contains('modal') && event.target.classList.contains('visible')) {
             const modalId = event.target.id;
-            closeModal(modalId);
+            if (modalId === 'planModChatModal') closePlanModChat();
+            else closeModal(modalId);
             if (modalId === 'infoModal') acknowledgeAiUpdate();
         }
     });
@@ -140,7 +143,8 @@ export function setupStaticEventListeners() {
             const visibleModal = document.querySelector('.modal.visible');
             if (visibleModal) {
                 const modalId = visibleModal.id;
-                closeModal(modalId);
+                if (modalId === 'planModChatModal') closePlanModChat();
+                else closeModal(modalId);
                 if (modalId === 'infoModal') acknowledgeAiUpdate();
             }
             if (activeTooltip) handleTrackerTooltipHide(); // Call hide from uiHandlers
@@ -152,7 +156,7 @@ export function setupStaticEventListeners() {
     if (selectors.chatSend) selectors.chatSend.addEventListener('click', handleChatSend);
     if (selectors.chatInput) selectors.chatInput.addEventListener('keypress', handleChatInputKeypress);
 
-    if (selectors.planModChatClose) selectors.planModChatClose.addEventListener('click', () => closeModal('planModChatModal'));
+    if (selectors.planModChatClose) selectors.planModChatClose.addEventListener('click', closePlanModChat);
     if (selectors.planModChatClear) selectors.planModChatClear.addEventListener('click', clearPlanModChat);
     if (selectors.planModChatSend) selectors.planModChatSend.addEventListener('click', handlePlanModChatSend);
     if (selectors.planModChatInput) selectors.planModChatInput.addEventListener('keypress', handlePlanModChatInputKeypress);

--- a/js/planModChat.js
+++ b/js/planModChat.js
@@ -1,6 +1,6 @@
 import { selectors } from './uiElements.js';
 import { apiEndpoints } from './config.js';
-import { openModal, showToast } from './uiHandlers.js';
+import { openModal, showToast, closeModal } from './uiHandlers.js';
 import { escapeHtml } from './utils.js';
 import * as appState from './app.js';
 
@@ -8,7 +8,7 @@ const planModificationPrompt = 'Моля, опишете накратко жел
 
 export function clearPlanModChat() {
   if (selectors.planModChatMessages) selectors.planModChatMessages.innerHTML = '';
-  appState.chatHistory.length = 0;
+  appState.planModChatHistory.length = 0;
 }
 
 export function displayPlanModChatMessage(text, sender = 'bot', isError = false) {
@@ -51,16 +51,16 @@ export async function handlePlanModChatSend() {
   if (!messageText || !appState.currentUserId) return;
 
   displayPlanModChatMessage(messageText, 'user');
-  appState.chatHistory.push({ text: messageText, sender: 'user', isError: false });
+  appState.planModChatHistory.push({ text: messageText, sender: 'user', isError: false });
 
   selectors.planModChatInput.value = '';
   selectors.planModChatInput.disabled = true;
   selectors.planModChatSend.disabled = true;
   displayPlanModChatTypingIndicator(true);
   try {
-    const payload = { userId: appState.currentUserId, message: messageText, history: appState.chatHistory.slice(-10) };
-    if (appState.chatModelOverride) payload.model = appState.chatModelOverride;
-    if (appState.chatPromptOverride) payload.promptOverride = appState.chatPromptOverride;
+    const payload = { userId: appState.currentUserId, message: messageText, history: appState.planModChatHistory.slice(-10) };
+    if (appState.planModChatModelOverride) payload.model = appState.planModChatModelOverride;
+    if (appState.planModChatPromptOverride) payload.promptOverride = appState.planModChatPromptOverride;
     const response = await fetch(apiEndpoints.chat, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -73,17 +73,17 @@ export async function handlePlanModChatSend() {
     if (cleaned !== botReply) {
       botReply = cleaned;
       appState.pollPlanStatus();
-      appState.setChatModelOverride(null);
-      appState.setChatPromptOverride(null);
+      appState.setPlanModChatModelOverride(null);
+      appState.setPlanModChatPromptOverride(null);
     } else {
       botReply = cleaned;
     }
     displayPlanModChatMessage(botReply, 'bot');
-    appState.chatHistory.push({ text: botReply, sender: 'bot', isError: false });
+    appState.planModChatHistory.push({ text: botReply, sender: 'bot', isError: false });
   } catch (e) {
     const errorMsg = `Грешка при комуникация с асистента: ${e.message}`;
     displayPlanModChatMessage(errorMsg, 'bot', true);
-    appState.chatHistory.push({ text: errorMsg, sender: 'bot', isError: true });
+    appState.planModChatHistory.push({ text: errorMsg, sender: 'bot', isError: true });
   } finally {
     displayPlanModChatTypingIndicator(false);
     selectors.planModChatInput.disabled = false;
@@ -134,12 +134,18 @@ export async function openPlanModificationChat(userIdOverride = null) {
     promptError = true;
   }
   displayPlanModChatTypingIndicator(false);
-  appState.setChatModelOverride(modelFromPrompt);
-  appState.setChatPromptOverride(promptOverride);
+  appState.setPlanModChatModelOverride(modelFromPrompt);
+  appState.setPlanModChatPromptOverride(promptOverride);
   if (!promptError) {
     const initialMsg = promptOverride || planModificationPrompt;
     displayPlanModChatMessage(initialMsg, 'bot');
-    appState.chatHistory.push({ text: initialMsg, sender: 'bot', isError: false });
+    appState.planModChatHistory.push({ text: initialMsg, sender: 'bot', isError: false });
   }
   if (selectors.planModChatInput) selectors.planModChatInput.focus();
+}
+
+export function closePlanModChat() {
+  appState.setPlanModChatModelOverride(null);
+  appState.setPlanModChatPromptOverride(null);
+  closeModal('planModChatModal');
 }


### PR DESCRIPTION
## Summary
- track plan modification chat data separately in app state
- handle plan mod chat close and history reset
- use new state in event listeners
- test that opening plan mod chat doesn't touch main chat history

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851fe585414832698dfc84776d8671b