### PR TITLE
Add closePlanModificationChat helper

### DIFF
--- a/js/__tests__/closePlanModificationChat.test.js
+++ b/js/__tests__/closePlanModificationChat.test.js
@@ -1,0 +1,70 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let closePlanModificationChat;
+let appState;
+let closeModalMock;
+const focusMock = jest.fn();
+
+beforeEach(async () => {
+  jest.resetModules();
+  closeModalMock = jest.fn();
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    toggleMenu: jest.fn(),
+    closeMenu: jest.fn(),
+    handleOutsideMenuClick: jest.fn(),
+    handleMenuKeydown: jest.fn(),
+    initializeTheme: jest.fn(),
+    applyTheme: jest.fn(),
+    toggleTheme: jest.fn(),
+    updateThemeButtonText: jest.fn(),
+    activateTab: jest.fn(),
+    handleTabKeydown: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: closeModalMock,
+    openInfoModalWithDetails: jest.fn(),
+    openMainIndexInfo: jest.fn(),
+    toggleDailyNote: jest.fn(),
+    showTrackerTooltip: jest.fn(),
+    hideTrackerTooltip: jest.fn(),
+    handleTrackerTooltipShow: jest.fn(),
+    handleTrackerTooltipHide: jest.fn(),
+    showLoading: jest.fn(),
+    showToast: jest.fn(),
+    updateTabsOverflowIndicator: jest.fn()
+  }));
+  jest.unstable_mockModule('../chat.js', () => ({
+    toggleChatWidget: jest.fn(),
+    closeChatWidget: jest.fn(),
+    clearChat: jest.fn(),
+    displayMessage: jest.fn(),
+    displayTypingIndicator: jest.fn(),
+    scrollToChatBottom: jest.fn(),
+    setAutomatedChatPending: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({
+    isLocalDevelopment: false,
+    workerBaseUrl: '',
+    apiEndpoints: {},
+    generateId: jest.fn()
+  }));
+  global.fetch = jest.fn(() => Promise.resolve({ json: async () => ({}) }));
+  jest.unstable_mockModule('../uiElements.js', () => ({
+    selectors: { planModificationBtn: { focus: focusMock } },
+    initializeSelectors: jest.fn(),
+    trackerInfoTexts: {},
+    detailedMetricInfoTexts: {}
+  }));
+  appState = await import('../app.js');
+  ({ closePlanModificationChat } = await import('../planModChat.js'));
+  appState.setPlanModChatModelOverride('m');
+  appState.setPlanModChatPromptOverride('p');
+});
+
+test('resets overrides and focuses button', () => {
+  closePlanModificationChat();
+  expect(closeModalMock).toHaveBeenCalledWith('planModChatModal');
+  expect(appState.planModChatModelOverride).toBe(null);
+  expect(appState.planModChatPromptOverride).toBe(null);
+  expect(focusMock).toHaveBeenCalled();
+});

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -21,7 +21,7 @@ import {
     clearPlanModChat,
     handlePlanModChatSend,
     handlePlanModChatInputKeypress,
-    closePlanModChat
+    closePlanModificationChat
 } from './planModChat.js';
 import { toggleChatWidget, closeChatWidget, clearChat } from './chat.js';
 import { computeSwipeTargetIndex } from './swipeUtils.js';
@@ -126,14 +126,14 @@ export function setupStaticEventListeners() {
         const closeBtn = event.target.closest('[data-modal-close]');
         if (closeBtn) {
             const modalId = closeBtn.dataset.modalClose;
-            if (modalId === 'planModChatModal') closePlanModChat();
+            if (modalId === 'planModChatModal') closePlanModificationChat();
             else closeModal(modalId);
             if (modalId === 'infoModal') acknowledgeAiUpdate();
             return;
         }
         if (event.target.classList.contains('modal') && event.target.classList.contains('visible')) {
             const modalId = event.target.id;
-            if (modalId === 'planModChatModal') closePlanModChat();
+            if (modalId === 'planModChatModal') closePlanModificationChat();
             else closeModal(modalId);
             if (modalId === 'infoModal') acknowledgeAiUpdate();
         }
@@ -143,7 +143,7 @@ export function setupStaticEventListeners() {
             const visibleModal = document.querySelector('.modal.visible');
             if (visibleModal) {
                 const modalId = visibleModal.id;
-                if (modalId === 'planModChatModal') closePlanModChat();
+                if (modalId === 'planModChatModal') closePlanModificationChat();
                 else closeModal(modalId);
                 if (modalId === 'infoModal') acknowledgeAiUpdate();
             }
@@ -156,7 +156,7 @@ export function setupStaticEventListeners() {
     if (selectors.chatSend) selectors.chatSend.addEventListener('click', handleChatSend);
     if (selectors.chatInput) selectors.chatInput.addEventListener('keypress', handleChatInputKeypress);
 
-    if (selectors.planModChatClose) selectors.planModChatClose.addEventListener('click', closePlanModChat);
+    if (selectors.planModChatClose) selectors.planModChatClose.addEventListener('click', closePlanModificationChat);
     if (selectors.planModChatClear) selectors.planModChatClear.addEventListener('click', clearPlanModChat);
     if (selectors.planModChatSend) selectors.planModChatSend.addEventListener('click', handlePlanModChatSend);
     if (selectors.planModChatInput) selectors.planModChatInput.addEventListener('keypress', handlePlanModChatInputKeypress);

--- a/js/planModChat.js
+++ b/js/planModChat.js
@@ -170,3 +170,10 @@ export function closePlanModChat() {
   appState.setPlanModChatPromptOverride(null);
   closeModal('planModChatModal');
 }
+
+export function closePlanModificationChat() {
+  closeModal('planModChatModal');
+  appState.setPlanModChatModelOverride(null);
+  appState.setPlanModChatPromptOverride(null);
+  if (selectors.planModificationBtn) selectors.planModificationBtn.focus();
+}


### PR DESCRIPTION
## Summary
- add `closePlanModificationChat` that resets overrides and focuses the button
- use new helper in eventListeners
- test closing behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685201f6f00083268e5036b746bf9818