### PR TITLE
Add userId query parameter to plan modification fetch

### DIFF
--- a/js/__tests__/openPlanModificationChat.test.js
+++ b/js/__tests__/openPlanModificationChat.test.js
@@ -129,3 +129,8 @@ test('forceRefresh ignores cache and updates prompt', async () => {
     JSON.stringify({ promptOverride: 'NEW', model: 'b' })
   );
 });
+
+test('fetch called with userId in query', async () => {
+  await app.openPlanModificationChat('u1');
+  expect(global.fetch).toHaveBeenCalledWith('/prompt?userId=u1');
+});

--- a/js/planModChat.js
+++ b/js/planModChat.js
@@ -124,7 +124,9 @@ export async function openPlanModificationChat(userIdOverride = null, forceRefre
   }
   if (!promptOverride && !modelFromPrompt || forceRefresh) {
     try {
-      const respPrompt = await fetch(apiEndpoints.getPlanModificationPrompt);
+      const respPrompt = await fetch(
+        `${apiEndpoints.getPlanModificationPrompt}?userId=${uid}`
+      );
       if (!respPrompt.ok) {
         let errorText;
         try {


### PR DESCRIPTION
## Summary
- include `userId` query parameter when fetching the plan modification prompt
- verify the parameter is sent in a new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68520949506083269139810a9d3ccab5