### PR TITLE
Handle inline plan modification flow

### DIFF
--- a/js/__tests__/inlinePlanModFlow.test.js
+++ b/js/__tests__/inlinePlanModFlow.test.js
@@ -1,0 +1,111 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let app;
+let selectors;
+let showToastMock;
+let displayMessageMock;
+
+beforeEach(async () => {
+  jest.resetModules();
+  displayMessageMock = jest.fn();
+  showToastMock = jest.fn();
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    toggleMenu: jest.fn(),
+    closeMenu: jest.fn(),
+    handleOutsideMenuClick: jest.fn(),
+    handleMenuKeydown: jest.fn(),
+    initializeTheme: jest.fn(),
+    applyTheme: jest.fn(),
+    toggleTheme: jest.fn(),
+    updateThemeButtonText: jest.fn(),
+    activateTab: jest.fn(),
+    handleTabKeydown: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: jest.fn(),
+    openInfoModalWithDetails: jest.fn(),
+    openMainIndexInfo: jest.fn(),
+    toggleDailyNote: jest.fn(),
+    showTrackerTooltip: jest.fn(),
+    hideTrackerTooltip: jest.fn(),
+    handleTrackerTooltipShow: jest.fn(),
+    handleTrackerTooltipHide: jest.fn(),
+    showLoading: jest.fn(),
+    showToast: showToastMock,
+    updateTabsOverflowIndicator: jest.fn()
+  }));
+  jest.unstable_mockModule('../chat.js', () => ({
+    toggleChatWidget: jest.fn(),
+    closeChatWidget: jest.fn(),
+    clearChat: jest.fn(),
+    displayMessage: displayMessageMock,
+    displayTypingIndicator: jest.fn(),
+    scrollToChatBottom: jest.fn(),
+    setAutomatedChatPending: jest.fn()
+  }));
+  selectors = {
+    chatInput: { value: '', disabled: false, focus: jest.fn() },
+    chatSend: { disabled: false }
+  };
+  jest.unstable_mockModule('../uiElements.js', () => ({
+    selectors,
+    initializeSelectors: jest.fn(),
+    trackerInfoTexts: {},
+    detailedMetricInfoTexts: {}
+  }));
+  jest.unstable_mockModule('../config.js', () => ({
+    isLocalDevelopment: false,
+    workerBaseUrl: '',
+    apiEndpoints: { chat: '/chat', getPlanModificationPrompt: '/prompt' },
+    generateId: jest.fn()
+  }));
+  global.fetch = jest.fn(() => Promise.reject(new Error('fail')));
+  app = await import('../app.js');
+  global.fetch.mockClear();
+  app.setCurrentUserId('u1');
+});
+
+test('starts plan modification flow on marker', async () => {
+  selectors.chatInput.value = 'hi';
+  global.fetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, reply: 'bot\n[PLAN_MODIFICATION_REQUEST] c' })
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ promptOverride: 'P', model: 'm' })
+    });
+
+  await app.handleChatSend();
+
+  expect(global.fetch).toHaveBeenNthCalledWith(1, '/chat', expect.any(Object));
+  expect(global.fetch).toHaveBeenNthCalledWith(2, '/prompt?userId=u1');
+  expect(app.chatPromptOverride).toBe('P');
+  expect(app.chatModelOverride).toBe('m');
+  expect(app.planModFlowActive).toBe(true);
+  expect(app.planModRequestHistory.length).toBe(2);
+});
+
+test('uses plan modification history and finishes on second marker', async () => {
+  app.setPlanModFlowActive(true);
+  app.planModRequestHistory.push(
+    { text: 'u', sender: 'user', isError: false },
+    { text: 'b', sender: 'bot', isError: false }
+  );
+  app.setChatPromptOverride('P');
+  app.setChatModelOverride('m');
+  selectors.chatInput.value = 'next';
+
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ success: true, reply: 'done [PLAN_MODIFICATION_REQUEST]' })
+  });
+
+  await app.handleChatSend();
+
+  const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+  expect(body.history.length).toBe(3);
+  expect(app.planModFlowActive).toBe(false);
+  expect(app.planModRequestHistory.length).toBe(0);
+});

--- a/js/app.js
+++ b/js/app.js
@@ -56,6 +56,11 @@ export let chatPromptOverride = null; // Optional prompt override for next chat 
 export let planModChatHistory = [];
 export let planModChatModelOverride = null;
 export let planModChatPromptOverride = null;
+export let planModRequestHistory = [];
+export let planModFlowActive = false;
+
+export function setPlanModFlowActive(val) { planModFlowActive = val; }
+export function setCurrentUserId(val) { currentUserId = val; }
 
 export function setChatModelOverride(val) { chatModelOverride = val; }
 export function setChatPromptOverride(val) { chatPromptOverride = val; }
@@ -85,6 +90,8 @@ export function resetAppState() {
     todaysMealCompletionStatus = {};
     activeTooltip = null;
     chatPromptOverride = null;
+    planModRequestHistory = [];
+    planModFlowActive = false;
     planModChatHistory = [];
     planModChatModelOverride = null;
     planModChatPromptOverride = null;
@@ -757,11 +764,13 @@ export async function handleChatSend() { // Exported for eventListeners.js
 
     displayChatMessage(messageText, 'user'); // from chat.js
     chatHistory.push({ text: messageText, sender: 'user', isError: false });
+    if (planModFlowActive) planModRequestHistory.push({ text: messageText, sender: 'user', isError: false });
 
     selectors.chatInput.value = ''; selectors.chatInput.disabled = true; selectors.chatSend.disabled = true;
     displayChatTypingIndicator(true); // from chat.js
     try {
-        const payload = { userId: currentUserId, message: messageText, history: chatHistory.slice(-10) }; // Send some history context
+        const historyToSend = planModFlowActive ? planModRequestHistory.slice(-10) : chatHistory.slice(-10);
+        const payload = { userId: currentUserId, message: messageText, history: historyToSend }; // Send some history context
         if (chatModelOverride) payload.model = chatModelOverride;
         if (chatPromptOverride) payload.promptOverride = chatPromptOverride;
         const response = await fetch(apiEndpoints.chat, {
@@ -772,22 +781,50 @@ export async function handleChatSend() { // Exported for eventListeners.js
 
         let botReply = result.reply || '';
         const cleaned = stripPlanModSignature(botReply);
-        if (cleaned !== botReply) {
-            botReply = cleaned;
-            pollPlanStatus();
-            chatModelOverride = null; // reset after plan modification request
-            chatPromptOverride = null;
-        } else {
-            botReply = cleaned;
-        }
+        const hasMarker = cleaned !== botReply;
+        botReply = cleaned;
 
         displayChatMessage(botReply, 'bot'); // from chat.js
         chatHistory.push({ text: botReply, sender: 'bot', isError: false });
+
+        if (planModFlowActive) {
+            planModRequestHistory.push({ text: botReply, sender: 'bot', isError: false });
+            if (hasMarker) {
+                pollPlanStatus();
+                setPlanModFlowActive(false);
+                planModRequestHistory = [];
+                chatModelOverride = null;
+                chatPromptOverride = null;
+            }
+        } else if (hasMarker) {
+            planModRequestHistory = [
+                { text: messageText, sender: 'user', isError: false },
+                { text: botReply, sender: 'bot', isError: false }
+            ];
+            setPlanModFlowActive(true);
+            try {
+                const respPrompt = await fetch(`${apiEndpoints.getPlanModificationPrompt}?userId=${currentUserId}`);
+                if (!respPrompt.ok) {
+                    let errorText;
+                    try { errorText = (await respPrompt.text()) || `HTTP ${respPrompt.status}`; }
+                    catch { errorText = `HTTP ${respPrompt.status}`; }
+                    showToast(errorText, true);
+                } else {
+                    const dataPrompt = await respPrompt.json();
+                    if (dataPrompt && dataPrompt.promptOverride) chatPromptOverride = dataPrompt.promptOverride;
+                    if (dataPrompt && dataPrompt.model) chatModelOverride = dataPrompt.model;
+                }
+            } catch (err) {
+                console.warn('Failed to fetch plan modification prompt:', err);
+                showToast('Грешка при зареждане на промпта за промени', true);
+            }
+        }
 
     } catch (e) {
         const errorMsg = `Грешка при комуникация с асистента: ${e.message}`;
         displayChatMessage(errorMsg, 'bot', true); // from chat.js
         chatHistory.push({ text: errorMsg, sender: 'bot', isError: true });
+        if (planModFlowActive) planModRequestHistory.push({ text: errorMsg, sender: 'bot', isError: true });
     } finally {
         displayChatTypingIndicator(false); // from chat.js
         if(selectors.chatInput) { selectors.chatInput.disabled = false; selectors.chatInput.focus(); }


### PR DESCRIPTION
## Summary
- get plan modification prompt when `[PLAN_MODIFICATION_REQUEST]` is returned
- keep separate history while gathering plan changes
- restore normal chat prompt once modification is confirmed
- test inline plan modification flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68520b966f84832696e159de4fcb1064