### PR TITLE
Implement plan modification chat flow

### DIFF
--- a/js/__tests__/handleChatSendPlanMod.test.js
+++ b/js/__tests__/handleChatSendPlanMod.test.js
@@ -1,0 +1,79 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let handleChatSend;
+let openPlanModificationChatMock;
+
+beforeEach(async () => {
+  jest.resetModules();
+  openPlanModificationChatMock = jest.fn();
+
+  jest.unstable_mockModule('../planModChat.js', () => ({
+    openPlanModificationChat: openPlanModificationChatMock,
+    clearPlanModChat: jest.fn(),
+    handlePlanModChatSend: jest.fn(),
+    handlePlanModChatInputKeypress: jest.fn()
+  }));
+  jest.unstable_mockModule('../chat.js', () => ({
+    toggleChatWidget: jest.fn(),
+    closeChatWidget: jest.fn(),
+    clearChat: jest.fn(),
+    displayMessage: jest.fn(),
+    displayTypingIndicator: jest.fn(),
+    scrollToChatBottom: jest.fn(),
+    setAutomatedChatPending: jest.fn()
+  }));
+  jest.unstable_mockModule('../uiElements.js', () => ({
+    selectors: {
+      chatInput: { value: 'hi', disabled: false, focus: jest.fn() },
+      chatSend: { disabled: false }
+    },
+    initializeSelectors: jest.fn(),
+    trackerInfoTexts: {},
+    detailedMetricInfoTexts: {}
+  }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    toggleMenu: jest.fn(),
+    closeMenu: jest.fn(),
+    handleOutsideMenuClick: jest.fn(),
+    handleMenuKeydown: jest.fn(),
+    initializeTheme: jest.fn(),
+    applyTheme: jest.fn(),
+    toggleTheme: jest.fn(),
+    updateThemeButtonText: jest.fn(),
+    activateTab: jest.fn(),
+    handleTabKeydown: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: jest.fn(),
+    openInfoModalWithDetails: jest.fn(),
+    openMainIndexInfo: jest.fn(),
+    toggleDailyNote: jest.fn(),
+    showTrackerTooltip: jest.fn(),
+    hideTrackerTooltip: jest.fn(),
+    handleTrackerTooltipShow: jest.fn(),
+    handleTrackerTooltipHide: jest.fn(),
+    showLoading: jest.fn(),
+    showToast: jest.fn(),
+    updateTabsOverflowIndicator: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({
+    isLocalDevelopment: false,
+    workerBaseUrl: '',
+    apiEndpoints: { chat: '/chat' },
+    generateId: jest.fn()
+  }));
+
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true, reply: 'ok\n[PLAN_MODIFICATION_REQUEST] change' })
+  });
+
+  const app = await import('../app.js');
+  handleChatSend = app.handleChatSend;
+  app.setCurrentUserId('u1');
+});
+
+test('opens plan modification chat when marker detected', async () => {
+  await handleChatSend();
+  expect(openPlanModificationChatMock).toHaveBeenCalledWith('hi');
+});

--- a/js/app.js
+++ b/js/app.js
@@ -31,7 +31,8 @@ import {
     getSummaryFromLastCompletedQuiz, // For potential use in app.js
     getSummaryFromPreviousQuizzes // For potential use in app.js
 } from './adaptiveQuiz.js';
-export { openPlanModificationChat } from './planModChat.js';
+import { openPlanModificationChat } from './planModChat.js';
+export { openPlanModificationChat };
 
 
 function normalizeText(input) {
@@ -46,6 +47,7 @@ function normalizeText(input) {
 // ГЛОБАЛНИ ПРОМЕНЛИВИ ЗА СЪСТОЯНИЕТО НА ПРИЛОЖЕНИЕТО
 // ==========================================================================
 export let currentUserId = null;
+export function setCurrentUserId(val) { currentUserId = val; }
 export let fullDashboardData = {};
 let toastTimeoutApp; // Managed by app.js, uiHandlers.js has its own for its showToast
 export let chatHistory = [];
@@ -53,6 +55,9 @@ export let todaysMealCompletionStatus = {}; // Updated by populateUI and eventLi
 export let activeTooltip = null; // Managed by uiHandlers via setActiveTooltip
 export let chatModelOverride = null; // Optional model override for next chat message
 export let chatPromptOverride = null; // Optional prompt override for next chat message
+
+export function setChatModelOverride(val) { chatModelOverride = val; }
+export function setChatPromptOverride(val) { chatPromptOverride = val; }
 
 // Управление на интервал за проверка на статус на плана
 let planStatusInterval = null;
@@ -763,9 +768,7 @@ export async function handleChatSend() { // Exported for eventListeners.js
         const cleaned = stripPlanModSignature(botReply);
         if (cleaned !== botReply) {
             botReply = cleaned;
-            pollPlanStatus();
-            chatModelOverride = null; // reset after plan modification request
-            chatPromptOverride = null;
+            openPlanModificationChat(messageText);
         } else {
             botReply = cleaned;
         }


### PR DESCRIPTION
## Summary
- openPlanModificationChat accepts initial message and sends to model
- adjust handleChatSend to trigger plan modification chat when needed
- expose setters for chat overrides and current user ID
- update planModChat logic to use setters
- add unit test for handleChatSend plan mod path
- update existing tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685226dcbfc883269403625bd3babc20