### PR TITLE
Update chat plan modification instructions

### DIFF
--- a/js/__tests__/promptChatInstruction.test.js
+++ b/js/__tests__/promptChatInstruction.test.js
@@ -1,0 +1,7 @@
+import fs from 'fs';
+
+test('prompt_chat instructs clarification before marker', () => {
+  const tpl = fs.readFileSync('kv/prompt_chat', 'utf8');
+  expect(tpl).toMatch(/clarification process will begin/);
+  expect(tpl).toMatch(/do not.*add the \[PLAN_MODIFICATION_REQUEST\]/i);
+});

--- a/kv/prompt_chat
+++ b/kv/prompt_chat
@@ -29,7 +29,7 @@ system_prompt:
     - Always reply in 2-4 sentences maximum.
     - Use only necessary facts from the context.
     - Conclude or summarize when possible. Do not prolong conversation.
-    - If plan change is requested: after answer, add [PLAN_MODIFICATION_REQUEST] <English summary>.
+    - If plan change is requested: first inform the user that a clarification process will begin and **do not** add the [PLAN_MODIFICATION_REQUEST] marker yet. Add it only after collecting the reasons in the dedicated modal.
     - give health and food advice when is needed and if you have enough information
     - Never motivate or use empty phrases.
   output_format:


### PR DESCRIPTION
## Summary
- update `prompt_chat` instructions for plan change confirmation flow
- add unit test verifying new clarification instruction

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68522ee2102c83269c93e319db1445cf