### PR TITLE
Escape HTML in info modal content

### DIFF
--- a/js/__tests__/uiHandlersEscapeHtml.test.js
+++ b/js/__tests__/uiHandlersEscapeHtml.test.js
@@ -1,0 +1,65 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+describe('uiHandlers escapeHtml usage', () => {
+  test('openInfoModalWithDetails escapes HTML content', async () => {
+    jest.resetModules();
+    const selectors = {
+      infoModalTitle: document.createElement('div'),
+      infoModalBody: document.createElement('div')
+    };
+    document.body.appendChild(selectors.infoModalTitle);
+    document.body.appendChild(selectors.infoModalBody);
+    document.body.appendChild(Object.assign(document.createElement('div'), { id: 'infoModal' }));
+
+    jest.unstable_mockModule('../uiElements.js', () => ({
+      selectors,
+      trackerInfoTexts: {},
+      detailedMetricInfoTexts: {},
+      mainIndexInfoTexts: {}
+    }));
+
+    jest.unstable_mockModule('../app.js', () => ({
+      fullDashboardData: { recipeData: { r1: { title: 'T <b>', body: 'B <i>\nline' } } },
+      activeTooltip: null,
+      setActiveTooltip: jest.fn()
+    }));
+
+    const { openInfoModalWithDetails } = await import('../uiHandlers.js');
+    openInfoModalWithDetails('r1', 'recipe');
+
+    expect(selectors.infoModalTitle.innerHTML).toBe('T &lt;b&gt;');
+    expect(selectors.infoModalBody.innerHTML).toBe('B &lt;i&gt;<br>line');
+  });
+
+  test('openMainIndexInfo escapes HTML content', async () => {
+    jest.resetModules();
+    const selectors = {
+      infoModalTitle: document.createElement('div'),
+      infoModalBody: document.createElement('div')
+    };
+    document.body.appendChild(selectors.infoModalTitle);
+    document.body.appendChild(selectors.infoModalBody);
+    document.body.appendChild(Object.assign(document.createElement('div'), { id: 'infoModal' }));
+
+    jest.unstable_mockModule('../uiElements.js', () => ({
+      selectors,
+      trackerInfoTexts: {},
+      detailedMetricInfoTexts: {},
+      mainIndexInfoTexts: { m1: { title: 'Title <b>', text: 'Body <i>' } }
+    }));
+
+    jest.unstable_mockModule('../app.js', () => ({
+      fullDashboardData: {},
+      activeTooltip: null,
+      setActiveTooltip: jest.fn()
+    }));
+
+    const { openMainIndexInfo } = await import('../uiHandlers.js');
+    openMainIndexInfo('m1');
+
+    expect(selectors.infoModalTitle.innerHTML).toBe('Title &lt;b&gt;');
+    expect(selectors.infoModalBody.innerHTML).toBe('Body &lt;i&gt;');
+  });
+});
+

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -6,7 +6,7 @@ import {
     setActiveTooltip // function from app.js to update activeTooltip state
 } from './app.js';
 import { trackerInfoTexts, detailedMetricInfoTexts, mainIndexInfoTexts } from './uiElements.js';
-import { capitalizeFirstLetter, safeGet } from './utils.js';
+import { capitalizeFirstLetter, safeGet, escapeHtml } from './utils.js';
 
 // Продължителност на анимацията при скриване/показване на модали
 const MODAL_TRANSITION_MS = 300;
@@ -182,8 +182,10 @@ export function openInfoModalWithDetails(key, type) {
             body += "\n\nСтойности:\n" + Object.values(metricInfo.levels).join("\n");
         }
     }
-    if (selectors.infoModalTitle) selectors.infoModalTitle.textContent = title;
-    if (selectors.infoModalBody) selectors.infoModalBody.innerHTML = String(body).replace(/\n/g, '<br>');
+    const escapedTitle = escapeHtml(title);
+    const escapedBody = escapeHtml(body).replace(/\n/g, '<br>');
+    if (selectors.infoModalTitle) selectors.infoModalTitle.innerHTML = escapedTitle;
+    if (selectors.infoModalBody) selectors.infoModalBody.innerHTML = escapedBody;
     openModal('infoModal');
 }
 
@@ -191,8 +193,10 @@ export function openMainIndexInfo(key) {
     const info = mainIndexInfoTexts[key] || {};
     const title = info.title || 'Информация';
     const body = info.text || 'Няма налична информация.';
-    if (selectors.infoModalTitle) selectors.infoModalTitle.textContent = title;
-    if (selectors.infoModalBody) selectors.infoModalBody.innerHTML = String(body).replace(/\n/g, '<br>');
+    const escapedTitle = escapeHtml(title);
+    const escapedBody = escapeHtml(body).replace(/\n/g, '<br>');
+    if (selectors.infoModalTitle) selectors.infoModalTitle.innerHTML = escapedTitle;
+    if (selectors.infoModalBody) selectors.infoModalBody.innerHTML = escapedBody;
     openModal('infoModal');
 }
 


### PR DESCRIPTION
## Summary
- sanitize titles and bodies in info modals using `escapeHtml`
- use `escapeHtml` in `openInfoModalWithDetails` and `openMainIndexInfo`
- test escaping of HTML tags in modal utilities

## Testing
- `npm run lint`
- `npm test`
- `NODE_OPTIONS=--experimental-vm-modules npx jest js/__tests__/uiHandlersEscapeHtml.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685235bfa31883269776127d36c4c5ca