### PR TITLE
Fix openPlanModificationChat args

### DIFF
--- a/js/__tests__/handleChatSendPlanMod.test.js
+++ b/js/__tests__/handleChatSendPlanMod.test.js
@@ -75,7 +75,7 @@ beforeEach(async () => {
 
 test('opens plan modification chat when marker detected', async () => {
   await handleChatSend();
-  expect(openPlanModificationChatMock).toHaveBeenCalledWith('hi');
+  expect(openPlanModificationChatMock).toHaveBeenCalledWith('u1', 'hi');
   const chatCall = global.fetch.mock.calls.find(c => c[0] === '/chat');
   const body = JSON.parse(chatCall[1].body);
   expect(body.source).toBeUndefined();

--- a/js/app.js
+++ b/js/app.js
@@ -768,7 +768,7 @@ export async function handleChatSend() { // Exported for eventListeners.js
         const cleaned = stripPlanModSignature(botReply);
         if (cleaned !== botReply) {
             botReply = cleaned;
-            openPlanModificationChat(messageText);
+            openPlanModificationChat(currentUserId, messageText);
         } else {
             botReply = cleaned;
         }


### PR DESCRIPTION
## Summary
- pass user id when opening plan modification chat
- update test for new argument order

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68523878b3ac832681e20a02fae22100