### PR TITLE
Remove fallback text in plan mod chat

### DIFF
--- a/js/planModChat.js
+++ b/js/planModChat.js
@@ -4,8 +4,6 @@ import { openModal, showToast } from './uiHandlers.js';
 import { escapeHtml } from './utils.js';
 import { currentUserId, chatHistory, setChatModelOverride, setChatPromptOverride, chatModelOverride, chatPromptOverride, stripPlanModSignature, pollPlanStatus } from './app.js';
 
-const planModificationPrompt = 'Моля, опишете накратко желаните от вас промени в плана.';
-
 export function clearPlanModChat() {
   if (selectors.planModChatMessages) selectors.planModChatMessages.innerHTML = '';
   chatHistory.length = 0;
@@ -124,8 +122,6 @@ export async function openPlanModificationChat(userIdOverride = null, initialMes
   displayPlanModChatTypingIndicator(false);
   setChatModelOverride(modelFromPrompt);
   setChatPromptOverride(promptOverride);
-  displayPlanModChatMessage(planModificationPrompt, 'bot');
-  chatHistory.push({ text: planModificationPrompt, sender: 'bot', isError: false });
 
   if (initialMessage) {
     displayPlanModChatMessage(initialMessage, 'user');


### PR DESCRIPTION
## Summary
- ensure the plan modification chat relies solely on the prompt retrieved from KV
- drop the hardcoded Bulgarian message shown when opening the modal

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685240e7d9988326aac0c62a92e03fbf