### PR TITLE
Handle server errors when fetching plan modification prompt

### DIFF
--- a/js/__tests__/openPlanModificationChat.test.js
+++ b/js/__tests__/openPlanModificationChat.test.js
@@ -63,3 +63,13 @@ test('shows toast on fetch error', async () => {
   await app.openPlanModificationChat('u1');
   expect(showToastMock).toHaveBeenCalledWith('Грешка при зареждане на промпта за промени', true);
 });
+
+test('shows toast on server error status', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: async () => ({ message: 'srv' })
+  });
+  await app.openPlanModificationChat('u1');
+  expect(showToastMock).toHaveBeenCalledWith('srv', true);
+});

--- a/js/planModChat.js
+++ b/js/planModChat.js
@@ -112,11 +112,20 @@ export async function openPlanModificationChat(userIdOverride = null, initialMes
   let modelFromPrompt = null;
   try {
     const respPrompt = await fetch(`${apiEndpoints.getPlanModificationPrompt}?userId=${uid}`);
-    if (respPrompt.ok) {
-      const dataPrompt = await respPrompt.json();
-      if (dataPrompt && dataPrompt.prompt) promptOverride = dataPrompt.prompt;
-      if (dataPrompt && dataPrompt.model) modelFromPrompt = dataPrompt.model;
+    if (!respPrompt.ok) {
+      let message = 'Грешка при зареждане на промпта за промени';
+      try {
+        const data = await respPrompt.json();
+        if (data && data.message) message = data.message;
+      } catch (e) {
+        // ignore JSON parse errors
+      }
+      showToast(message, true);
+      return;
     }
+    const dataPrompt = await respPrompt.json();
+    if (dataPrompt && dataPrompt.prompt) promptOverride = dataPrompt.prompt;
+    if (dataPrompt && dataPrompt.model) modelFromPrompt = dataPrompt.model;
   } catch (err) {
     console.warn('Failed to fetch plan modification prompt:', err);
     showToast('Грешка при зареждане на промпта за промени', true);


### PR DESCRIPTION
## Summary
- handle non-OK responses when fetching plan modification prompt
- test toast notification on server error

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685338beca3c832693f65f18c1abf901