### PR TITLE
Отделна история за модал План

### DIFF
--- a/js/__tests__/planModChatHistory.test.js
+++ b/js/__tests__/planModChatHistory.test.js
@@ -1,0 +1,62 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let clearPlanModChat, planModChatHistory;
+let app;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = '<div id="planModChatMessages"></div>';
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    toggleMenu: jest.fn(),
+    closeMenu: jest.fn(),
+    handleOutsideMenuClick: jest.fn(),
+    handleMenuKeydown: jest.fn(),
+    initializeTheme: jest.fn(),
+    applyTheme: jest.fn(),
+    toggleTheme: jest.fn(),
+    updateThemeButtonText: jest.fn(),
+    activateTab: jest.fn(),
+    handleTabKeydown: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: jest.fn(),
+    openInfoModalWithDetails: jest.fn(),
+    openMainIndexInfo: jest.fn(),
+    toggleDailyNote: jest.fn(),
+    showTrackerTooltip: jest.fn(),
+    hideTrackerTooltip: jest.fn(),
+    handleTrackerTooltipShow: jest.fn(),
+    handleTrackerTooltipHide: jest.fn(),
+    showLoading: jest.fn(),
+    showToast: jest.fn(),
+    updateTabsOverflowIndicator: jest.fn()
+  }));
+  jest.unstable_mockModule('../uiElements.js', () => ({
+    selectors: {
+      planModChatMessages: document.getElementById('planModChatMessages'),
+    },
+    initializeSelectors: jest.fn(),
+    trackerInfoTexts: {},
+    detailedMetricInfoTexts: {},
+  }));
+  jest.unstable_mockModule('../chat.js', () => ({
+    toggleChatWidget: jest.fn(),
+    closeChatWidget: jest.fn(),
+    clearChat: jest.fn(),
+    displayMessage: jest.fn(),
+    displayTypingIndicator: jest.fn(),
+    scrollToChatBottom: jest.fn(),
+    setAutomatedChatPending: jest.fn(),
+  }));
+  global.fetch = jest.fn().mockResolvedValue({ json: async () => [] });
+  ({ clearPlanModChat, planModChatHistory } = await import('../planModChat.js'));
+  app = await import('../app.js');
+});
+
+test('main chat history is preserved when clearing plan modification chat', () => {
+  app.chatHistory.push({ text: 'hi', sender: 'user', isError: false });
+  planModChatHistory.push({ text: 'pm', sender: 'user', isError: false });
+  clearPlanModChat();
+  expect(app.chatHistory.length).toBe(1);
+  expect(planModChatHistory.length).toBe(0);
+});


### PR DESCRIPTION
## Summary
- създаден е масив `planModChatHistory` за историята на чата при промяна на план
- използването на `chatHistory` в този модул е заменено с новия масив
- при изчистване се занулява само тази история
- към бекенда се изпращат последните 10 съобщения от `planModChatHistory`
- добавен е тест за запазване на основната история на чата

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685339af25f48326a772f20026ce12e1