### PR TITLE
Reset overrides on closing PlanMod chat

### DIFF
--- a/js/__tests__/planModChatCloseReset.test.js
+++ b/js/__tests__/planModChatCloseReset.test.js
@@ -1,0 +1,148 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let setupStaticEventListeners;
+let selectors;
+let app;
+
+beforeEach(async () => {
+  jest.resetModules();
+
+  selectors = {
+    planModChatClose: document.createElement('button'),
+    planModChatModal: document.createElement('div'),
+    menuToggle: null,
+    menuClose: null,
+    menuOverlay: null,
+    mainMenu: null,
+    themeToggleMenu: null,
+    logoutButton: null,
+    tabsContainer: null,
+    tabButtons: [],
+    addNoteBtn: null,
+    saveLogBtn: null,
+    openExtraMealModalBtn: null,
+    planModificationBtn: null,
+    detailedAnalyticsAccordion: null,
+    goalCard: null,
+    engagementCard: null,
+    healthCard: null,
+    streakCard: null,
+    dailyTracker: null,
+    chatFab: null,
+    chatClose: null,
+    chatClear: null,
+    chatSend: null,
+    chatInput: null,
+    planModChatClear: null,
+    planModChatSend: null,
+    planModChatInput: null,
+    feedbackFab: null,
+    feedbackForm: null,
+    prevQuestionBtn: null,
+    nextQuestionBtn: null,
+    submitQuizBtn: null
+  };
+  selectors.planModChatModal.id = 'planModChatModal';
+  selectors.planModChatModal.className = 'modal visible';
+
+  document.body.innerHTML = '';
+  document.body.appendChild(selectors.planModChatModal);
+  document.body.appendChild(selectors.planModChatClose);
+
+  jest.unstable_mockModule('../uiElements.js', () => ({
+    selectors,
+    initializeSelectors: jest.fn(),
+    trackerInfoTexts: {},
+    detailedMetricInfoTexts: {}
+  }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    toggleMenu: jest.fn(),
+    closeMenu: jest.fn(),
+    handleOutsideMenuClick: jest.fn(),
+    handleMenuKeydown: jest.fn(),
+    initializeTheme: jest.fn(),
+    toggleTheme: jest.fn(),
+    activateTab: jest.fn(),
+    handleTabKeydown: jest.fn(),
+    closeModal: jest.fn(),
+    openInfoModalWithDetails: jest.fn(),
+    toggleDailyNote: jest.fn(),
+    openMainIndexInfo: jest.fn(),
+    updateTabsOverflowIndicator: jest.fn(),
+    showTrackerTooltip: jest.fn(),
+    hideTrackerTooltip: jest.fn(),
+    handleTrackerTooltipShow: jest.fn(),
+    handleTrackerTooltipHide: jest.fn(),
+    showToast: jest.fn(),
+    showLoading: jest.fn(),
+    applyTheme: jest.fn(),
+    updateThemeButtonText: jest.fn(),
+    openModal: jest.fn()
+  }));
+  jest.unstable_mockModule('../auth.js', () => ({ handleLogout: jest.fn() }));
+  jest.unstable_mockModule('../extraMealForm.js', () => ({ openExtraMealModal: jest.fn() }));
+  jest.unstable_mockModule('../planModChat.js', () => ({
+    openPlanModificationChat: jest.fn(),
+    clearPlanModChat: jest.fn(),
+    handlePlanModChatSend: jest.fn(),
+    handlePlanModChatInputKeypress: jest.fn()
+  }));
+  jest.unstable_mockModule('../chat.js', () => ({
+    toggleChatWidget: jest.fn(),
+    closeChatWidget: jest.fn(),
+    clearChat: jest.fn(),
+    displayMessage: jest.fn(),
+    displayTypingIndicator: jest.fn(),
+    scrollToChatBottom: jest.fn(),
+    setAutomatedChatPending: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({
+    isLocalDevelopment: false,
+    workerBaseUrl: '',
+    apiEndpoints: {},
+    cloudflareAccountId: 'c',
+    generateId: jest.fn()
+  }));
+  jest.unstable_mockModule('../swipeUtils.js', () => ({ computeSwipeTargetIndex: jest.fn() }));
+  jest.unstable_mockModule('../achievements.js', () => ({
+    handleAchievementClick: jest.fn(),
+    initializeAchievements: jest.fn()
+  }));
+
+  window.matchMedia = window.matchMedia || (() => ({
+    matches: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  }));
+
+  app = await import('../app.js');
+  ({ setupStaticEventListeners } = await import('../eventListeners.js'));
+
+  app.setChatModelOverride('x');
+  app.setChatPromptOverride('y');
+  setupStaticEventListeners();
+});
+
+test('close button clears overrides', () => {
+  selectors.planModChatClose.dispatchEvent(new Event('click'));
+  expect(app.chatModelOverride).toBeNull();
+  expect(app.chatPromptOverride).toBeNull();
+});
+
+test('escape key clears overrides', () => {
+  app.setChatModelOverride('a');
+  app.setChatPromptOverride('b');
+  const evt = new KeyboardEvent('keydown', { key: 'Escape' });
+  document.dispatchEvent(evt);
+  expect(app.chatModelOverride).toBeNull();
+  expect(app.chatPromptOverride).toBeNull();
+});
+
+test('overlay click clears overrides', () => {
+  app.setChatModelOverride('m');
+  app.setChatPromptOverride('p');
+  selectors.planModChatModal.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  expect(app.chatModelOverride).toBeNull();
+  expect(app.chatPromptOverride).toBeNull();
+});

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -14,7 +14,8 @@ import {
     handleChatSend, handleChatInputKeypress, // from app.js / chat.js
     _handlePrevQuizQuestion, _handleNextQuizQuestion, _handleSubmitQuizAnswersClientSide, // from app.js
     _handleTriggerAdaptiveQuizClientSide, // from app.js
-    todaysMealCompletionStatus, activeTooltip, currentUserId
+    todaysMealCompletionStatus, activeTooltip, currentUserId,
+    setChatModelOverride, setChatPromptOverride
 } from './app.js';
 import {
     openPlanModificationChat,
@@ -132,6 +133,10 @@ export function setupStaticEventListeners() {
         if (event.target.classList.contains('modal') && event.target.classList.contains('visible')) {
             const modalId = event.target.id;
             closeModal(modalId);
+            if (modalId === 'planModChatModal') {
+                setChatModelOverride(null);
+                setChatPromptOverride(null);
+            }
             if (modalId === 'infoModal') acknowledgeAiUpdate();
         }
     });
@@ -141,6 +146,10 @@ export function setupStaticEventListeners() {
             if (visibleModal) {
                 const modalId = visibleModal.id;
                 closeModal(modalId);
+                if (modalId === 'planModChatModal') {
+                    setChatModelOverride(null);
+                    setChatPromptOverride(null);
+                }
                 if (modalId === 'infoModal') acknowledgeAiUpdate();
             }
             if (activeTooltip) handleTrackerTooltipHide(); // Call hide from uiHandlers
@@ -152,7 +161,11 @@ export function setupStaticEventListeners() {
     if (selectors.chatSend) selectors.chatSend.addEventListener('click', handleChatSend);
     if (selectors.chatInput) selectors.chatInput.addEventListener('keypress', handleChatInputKeypress);
 
-    if (selectors.planModChatClose) selectors.planModChatClose.addEventListener('click', () => closeModal('planModChatModal'));
+    if (selectors.planModChatClose) selectors.planModChatClose.addEventListener('click', () => {
+        setChatModelOverride(null);
+        setChatPromptOverride(null);
+        closeModal('planModChatModal');
+    });
     if (selectors.planModChatClear) selectors.planModChatClear.addEventListener('click', clearPlanModChat);
     if (selectors.planModChatSend) selectors.planModChatSend.addEventListener('click', handlePlanModChatSend);
     if (selectors.planModChatInput) selectors.planModChatInput.addEventListener('keypress', handlePlanModChatInputKeypress);


### PR DESCRIPTION
## Summary
- reset Chat model and prompt overrides when closing Plan Modification chat
- handle Escape and overlay close for the modal
- cover override reset with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853398744788326aab36931dcdfc56f