### PR TITLE
Handle plan mod prompt fetch failure

### DIFF
--- a/js/__tests__/planModPromptFailModalClose.test.js
+++ b/js/__tests__/planModPromptFailModalClose.test.js
@@ -1,0 +1,81 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let app;
+let closeModalMock;
+let showToastMock;
+let planModChatMessages;
+
+beforeEach(async () => {
+  jest.resetModules();
+  closeModalMock = jest.fn();
+  showToastMock = jest.fn();
+  planModChatMessages = document.createElement('div');
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    toggleMenu: jest.fn(),
+    closeMenu: jest.fn(),
+    handleOutsideMenuClick: jest.fn(),
+    handleMenuKeydown: jest.fn(),
+    initializeTheme: jest.fn(),
+    applyTheme: jest.fn(),
+    toggleTheme: jest.fn(),
+    updateThemeButtonText: jest.fn(),
+    activateTab: jest.fn(),
+    handleTabKeydown: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: closeModalMock,
+    openInfoModalWithDetails: jest.fn(),
+    openMainIndexInfo: jest.fn(),
+    toggleDailyNote: jest.fn(),
+    showTrackerTooltip: jest.fn(),
+    hideTrackerTooltip: jest.fn(),
+    handleTrackerTooltipShow: jest.fn(),
+    handleTrackerTooltipHide: jest.fn(),
+    showLoading: jest.fn(),
+    showToast: showToastMock,
+    updateTabsOverflowIndicator: jest.fn()
+  }));
+  jest.unstable_mockModule('../chat.js', () => ({
+    toggleChatWidget: jest.fn(),
+    closeChatWidget: jest.fn(),
+    clearChat: jest.fn(),
+    displayMessage: jest.fn(),
+    displayTypingIndicator: jest.fn(),
+    scrollToChatBottom: jest.fn(),
+    setAutomatedChatPending: jest.fn()
+  }));
+  const planModChatModal = document.createElement('div');
+  jest.unstable_mockModule('../uiElements.js', () => ({
+    selectors: {
+      chatWidget: { classList: { contains: () => true } },
+      chatInput: null,
+      planModChatModal,
+      planModChatMessages,
+      planModChatInput: { disabled: false },
+      planModChatSend: { disabled: false }
+    },
+    initializeSelectors: jest.fn(),
+    trackerInfoTexts: {},
+    detailedMetricInfoTexts: {}
+  }));
+  jest.unstable_mockModule('../config.js', () => ({
+    isLocalDevelopment: false,
+    workerBaseUrl: '',
+    apiEndpoints: { getPlanModificationPrompt: '/prompt' },
+    generateId: jest.fn()
+  }));
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: async () => ({ message: 'fail' })
+  });
+
+  app = await import('../app.js');
+});
+
+test('modal closes and typing indicator hides on fetch failure', async () => {
+  await app.openPlanModificationChat('u1');
+  expect(showToastMock).toHaveBeenCalledWith('fail', true);
+  expect(closeModalMock).toHaveBeenCalledWith('planModChatModal');
+  expect(planModChatMessages.querySelector('.typing-indicator')).toBeNull();
+});

--- a/js/planModChat.js
+++ b/js/planModChat.js
@@ -1,6 +1,6 @@
 import { selectors } from './uiElements.js';
 import { apiEndpoints } from './config.js';
-import { openModal, showToast } from './uiHandlers.js';
+import { openModal, showToast, closeModal } from './uiHandlers.js';
 import { escapeHtml } from './utils.js';
 import { currentUserId, setChatModelOverride, setChatPromptOverride, chatModelOverride, chatPromptOverride, stripPlanModSignature, pollPlanStatus } from './app.js';
 
@@ -109,6 +109,8 @@ export async function openPlanModificationChat(userIdOverride = null, initialMes
   }
   clearPlanModChat();
   openModal('planModChatModal');
+  if (selectors.planModChatInput) selectors.planModChatInput.disabled = true;
+  if (selectors.planModChatSend) selectors.planModChatSend.disabled = true;
   displayPlanModChatTypingIndicator(true);
   let promptOverride = null;
   let modelFromPrompt = null;
@@ -123,6 +125,8 @@ export async function openPlanModificationChat(userIdOverride = null, initialMes
         // ignore JSON parse errors
       }
       showToast(message, true);
+      closeModal('planModChatModal');
+      displayPlanModChatTypingIndicator(false);
       return;
     }
     const dataPrompt = await respPrompt.json();
@@ -137,6 +141,8 @@ export async function openPlanModificationChat(userIdOverride = null, initialMes
   setChatPromptOverride(promptOverride);
   displayPlanModChatMessage(planModificationPrompt, 'bot');
   planModChatHistory.push({ text: planModificationPrompt, sender: 'bot', isError: false });
+  if (selectors.planModChatInput) selectors.planModChatInput.disabled = false;
+  if (selectors.planModChatSend) selectors.planModChatSend.disabled = false;
 
   if (initialMessage) {
     displayPlanModChatMessage(initialMessage, 'user');


### PR DESCRIPTION
## Summary
- disable plan mod input while loading prompt
- close modal and hide indicator on prompt load errors
- re-enable controls once prompt is loaded
- test modal closing and indicator removal when prompt fetch fails

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68533e34847483268d602c9fb5a4f2be