### PR TITLE
Add confirmation step before opening plan modification chat

### DIFF
--- a/js/__tests__/handleChatSendPlanMod.test.js
+++ b/js/__tests__/handleChatSendPlanMod.test.js
@@ -23,10 +23,12 @@ beforeEach(async () => {
     scrollToChatBottom: jest.fn(),
     setAutomatedChatPending: jest.fn()
   }));
+  const chatMessages = document.createElement('div');
   jest.unstable_mockModule('../uiElements.js', () => ({
     selectors: {
       chatInput: { value: 'hi', disabled: false, focus: jest.fn() },
-      chatSend: { disabled: false }
+      chatSend: { disabled: false },
+      chatMessages
     },
     initializeSelectors: jest.fn(),
     trackerInfoTexts: {},
@@ -73,10 +75,7 @@ beforeEach(async () => {
   app.setCurrentUserId('u1');
 });
 
-test('opens plan modification chat when marker detected', async () => {
+test('does not open plan modification chat without confirmation', async () => {
   await handleChatSend();
-  expect(openPlanModificationChatMock).toHaveBeenCalledWith('u1', 'hi');
-  const chatCall = global.fetch.mock.calls.find(c => c[0] === '/chat');
-  const body = JSON.parse(chatCall[1].body);
-  expect(body.source).toBeUndefined();
+  expect(openPlanModificationChatMock).not.toHaveBeenCalled();
 });

--- a/js/app.js
+++ b/js/app.js
@@ -34,6 +34,21 @@ import {
 import { openPlanModificationChat } from './planModChat.js';
 export { openPlanModificationChat };
 
+function showPlanModificationConfirm(initialMessage) {
+    if (!selectors.chatMessages) return;
+    const wrapper = document.createElement('div');
+    const btn = document.createElement('button');
+    btn.textContent = 'Потвърди промяната';
+    btn.classList.add('plan-mod-confirm-btn');
+    btn.addEventListener('click', () => {
+        wrapper.remove();
+        openPlanModificationChat(currentUserId, initialMessage);
+    });
+    wrapper.appendChild(btn);
+    selectors.chatMessages.appendChild(wrapper);
+    scrollToChatBottom();
+}
+
 
 function normalizeText(input) {
     if (input === undefined || input === null) return '';
@@ -768,7 +783,7 @@ export async function handleChatSend() { // Exported for eventListeners.js
         const cleaned = stripPlanModSignature(botReply);
         if (cleaned !== botReply) {
             botReply = cleaned;
-            openPlanModificationChat(currentUserId, messageText);
+            showPlanModificationConfirm(messageText);
         } else {
             botReply = cleaned;
         }


### PR DESCRIPTION
## Summary
- prompt user to confirm before opening plan modification chat
- adjust chat logic to send initial message only after confirmation
- update tests for the new behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68533fa154bc832684af0e52d7cd0059