### PR TITLE
Fix confirm button duplication in chat

### DIFF
--- a/css/plan_mod_chat_styles.css
+++ b/css/plan_mod_chat_styles.css
@@ -100,3 +100,15 @@
 .plan-mod-chat-close { font-size: 1.5rem; color: var(--chat-header-text); padding: var(--space-xs); background: none; border: none; cursor: pointer; opacity: 0.8; line-height: 1; }
 .plan-mod-chat-clear:hover,
 .plan-mod-chat-close:hover { opacity: 1; }
+
+.plan-mod-confirm-btn {
+  padding: 0.6rem 1rem;
+  background-color: var(--primary-color);
+  color: var(--text-color-on-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+.plan-mod-confirm-btn:hover {
+  background-color: color-mix(in srgb, var(--primary-color) 85%, black);
+}

--- a/js/__tests__/handleChatSendPlanMod.test.js
+++ b/js/__tests__/handleChatSendPlanMod.test.js
@@ -3,6 +3,8 @@ import { jest } from '@jest/globals';
 
 let handleChatSend;
 let openPlanModificationChatMock;
+let selectors;
+let chatMessages;
 
 beforeEach(async () => {
   jest.resetModules();
@@ -23,13 +25,14 @@ beforeEach(async () => {
     scrollToChatBottom: jest.fn(),
     setAutomatedChatPending: jest.fn()
   }));
-  const chatMessages = document.createElement('div');
+  chatMessages = document.createElement('div');
+  selectors = {
+    chatInput: { value: 'hi', disabled: false, focus: jest.fn() },
+    chatSend: { disabled: false },
+    chatMessages
+  };
   jest.unstable_mockModule('../uiElements.js', () => ({
-    selectors: {
-      chatInput: { value: 'hi', disabled: false, focus: jest.fn() },
-      chatSend: { disabled: false },
-      chatMessages
-    },
+    selectors,
     initializeSelectors: jest.fn(),
     trackerInfoTexts: {},
     detailedMetricInfoTexts: {}
@@ -78,4 +81,12 @@ beforeEach(async () => {
 test('does not open plan modification chat without confirmation', async () => {
   await handleChatSend();
   expect(openPlanModificationChatMock).not.toHaveBeenCalled();
+});
+
+test('confirmation button is not duplicated', async () => {
+  await handleChatSend();
+  selectors.chatInput.value = 'hi';
+  await handleChatSend();
+  const btns = chatMessages.querySelectorAll('.plan-mod-confirm-btn');
+  expect(btns).toHaveLength(1);
 });

--- a/js/app.js
+++ b/js/app.js
@@ -36,6 +36,8 @@ export { openPlanModificationChat };
 
 function showPlanModificationConfirm(initialMessage) {
     if (!selectors.chatMessages) return;
+    const existing = selectors.chatMessages.querySelector('.plan-mod-confirm-btn');
+    existing?.parentElement?.remove();
     const wrapper = document.createElement('div');
     const btn = document.createElement('button');
     btn.textContent = 'Потвърди промяната';


### PR DESCRIPTION
## Summary
- style confirm button for plan modification chat
- avoid duplicate confirm buttons in `showPlanModificationConfirm`
- verify confirm button uniqueness in tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685344543f64832692f5e14ef557bf4a