### PR TITLE
Fix plan mod chat error handling

### DIFF
--- a/js/__tests__/openPlanModificationChat.test.js
+++ b/js/__tests__/openPlanModificationChat.test.js
@@ -3,10 +3,12 @@ import { jest } from '@jest/globals';
 
 let app;
 let showToastMock;
+let closeModalMock;
 
 beforeEach(async () => {
   jest.resetModules();
   showToastMock = jest.fn();
+  closeModalMock = jest.fn();
   jest.unstable_mockModule('../uiHandlers.js', () => ({
     toggleMenu: jest.fn(),
     closeMenu: jest.fn(),
@@ -19,7 +21,7 @@ beforeEach(async () => {
     activateTab: jest.fn(),
     handleTabKeydown: jest.fn(),
     openModal: jest.fn(),
-    closeModal: jest.fn(),
+    closeModal: closeModalMock,
     openInfoModalWithDetails: jest.fn(),
     openMainIndexInfo: jest.fn(),
     toggleDailyNote: jest.fn(),
@@ -62,6 +64,11 @@ beforeEach(async () => {
 test('shows toast on fetch error', async () => {
   await app.openPlanModificationChat('u1');
   expect(showToastMock).toHaveBeenCalledWith('Грешка при зареждане на промпта за промени', true);
+});
+
+test('modal closes on fetch error', async () => {
+  await app.openPlanModificationChat('u1');
+  expect(closeModalMock).toHaveBeenCalledWith('planModChatModal');
 });
 
 test('shows toast on server error status', async () => {

--- a/js/planModChat.js
+++ b/js/planModChat.js
@@ -151,6 +151,8 @@ export async function openPlanModificationChat(userIdOverride = null, initialMes
       showToast(message, true);
       closeModal('planModChatModal');
       displayPlanModChatTypingIndicator(false);
+      setChatModelOverride(null);
+      setChatPromptOverride(null);
       return;
     }
     const dataPrompt = await respPrompt.json();
@@ -159,6 +161,11 @@ export async function openPlanModificationChat(userIdOverride = null, initialMes
   } catch (err) {
     console.warn('Failed to fetch plan modification prompt:', err);
     showToast('Грешка при зареждане на промпта за промени', true);
+    closeModal('planModChatModal');
+    displayPlanModChatTypingIndicator(false);
+    setChatModelOverride(null);
+    setChatPromptOverride(null);
+    return;
   }
   displayPlanModChatTypingIndicator(false);
   setChatModelOverride(modelFromPrompt);


### PR DESCRIPTION
## Summary
- show and hide typing indicator correctly on fetch failures
- clear chat overrides when plan modification prompt cannot be fetched
- test modal close on fetch error

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68534452a5a48326a24a36626a543f19