### PR TITLE
Add reusable message utilities

### DIFF
--- a/forgot-password.html
+++ b/forgot-password.html
@@ -93,22 +93,12 @@
 
     <script type="module">
         import { apiEndpoints } from './js/config.js';
+        import { showMessage, hideMessage } from './js/messageUtils.js';
 
         const form = document.getElementById('forgot-password-form');
         const messageEl = document.getElementById('forgot-message');
         const backBtn = document.getElementById('back-to-login');
 
-        function showMessage(element, text, isError = true) {
-            element.textContent = text;
-            element.className = isError ? 'message error' : 'message success';
-            element.style.display = 'block';
-            element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
-
-        function hideMessage(element) {
-            element.textContent = '';
-            element.style.display = 'none';
-        }
 
         backBtn.addEventListener('click', () => {
             window.location.href = 'index.html';

--- a/index.html
+++ b/index.html
@@ -65,7 +65,8 @@
         </div>
     </div>
 
-    <script>
+    <script type="module">
+        import { showMessage, hideMessage } from './js/messageUtils.js';
         // Селектори
         const loginSection = document.getElementById('login-section');
         const registerSection = document.getElementById('register-section');
@@ -92,20 +93,7 @@
         // URL за пренасочване след логин
         const dashboardUrl = 'code.html'; // Променено, ако code.html е в същата директория
 
-        // Функция за показване на съобщения
-        function showMessage(element, text, isError = true) {
-            element.textContent = text;
-            element.className = isError ? 'message error' : 'message success';
-            element.style.display = 'block';
-            // Скролиране до съобщението, ако е извън видимата област
-            element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
 
-        // Функция за скриване на съобщения
-        function hideMessage(element) {
-             element.textContent = '';
-             element.style.display = 'none';
-        }
 
         // Превключване между формите
         showRegisterLink.addEventListener('click', () => {

--- a/js/messageUtils.js
+++ b/js/messageUtils.js
@@ -1,0 +1,23 @@
+// messageUtils.js - Универсални функции за съобщения
+
+/**
+ * Показва съобщение в DOM елемент.
+ * @param {HTMLElement} element - Елементът, в който да се покаже съобщението.
+ * @param {string} text - Текстът на съобщението.
+ * @param {boolean} [isError=true] - Дали съобщението е за грешка.
+ */
+export function showMessage(element, text, isError = true) {
+    element.textContent = text;
+    element.className = isError ? 'message error' : 'message success';
+    element.style.display = 'block';
+    element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+}
+
+/**
+ * Скрива съобщението в дадения елемент.
+ * @param {HTMLElement} element - Елементът, който да се скрие.
+ */
+export function hideMessage(element) {
+    element.textContent = '';
+    element.style.display = 'none';
+}


### PR DESCRIPTION
## Summary
- add `js/messageUtils.js` with `showMessage` and `hideMessage`
- import message utils in `index.html` and `forgot-password.html`
- remove local message helper definitions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853566b3c748326a2093f1417ad8044