### PR TITLE
Add ARIA progressbar attributes

### DIFF
--- a/code.html
+++ b/code.html
@@ -140,7 +140,7 @@
                         <div class="card index-card" id="goalCard">
                             <h4>🎯 Напредък към Цел</h4>
                             <div class="progress-bar-container">
-                                <div id="goalProgressBar" class="progress-bar">
+                                <div id="goalProgressBar" class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100">
                                     <div id="goalProgressMask" class="progress-mask"></div>
                                 </div>
                             </div>
@@ -149,7 +149,7 @@
                         <div class="card index-card" id="engagementCard">
                             <h4>🔗 Ангажираност</h4>
                             <div class="progress-bar-container">
-                                <div id="engagementProgressBar" class="progress-bar">
+                                <div id="engagementProgressBar" class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100">
                                     <div id="engagementProgressMask" class="progress-mask"></div>
                                 </div>
                             </div>
@@ -158,7 +158,7 @@
                         <div class="card index-card" id="healthCard">
                             <h4>❤️ Общо Здраве</h4>
                             <div class="progress-bar-container">
-                                <div id="healthProgressBar" class="progress-bar">
+                                <div id="healthProgressBar" class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100">
                                     <div id="healthProgressMask" class="progress-mask"></div>
                                 </div>
                             </div>

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -39,10 +39,14 @@ function populateDashboardMainIndexes(currentAnalytics) {
         if(selectors.goalProgressMask) selectors.goalProgressMask.style.width = '100%';
         if(selectors.engagementProgressMask) selectors.engagementProgressMask.style.width = '100%';
         if(selectors.healthProgressMask) selectors.healthProgressMask.style.width = '100%';
+        if(selectors.goalProgressBar) selectors.goalProgressBar.setAttribute('aria-valuenow', '0');
+        if(selectors.engagementProgressBar) selectors.engagementProgressBar.setAttribute('aria-valuenow', '0');
+        if(selectors.healthProgressBar) selectors.healthProgressBar.setAttribute('aria-valuenow', '0');
         return;
     }
     const goalProgressPercent = safeGet(currentAnalytics, 'goalProgress', 0);
     if (selectors.goalProgressMask) selectors.goalProgressMask.style.width = `${100 - Math.max(0, Math.min(100, goalProgressPercent))}%`;
+    if (selectors.goalProgressBar) selectors.goalProgressBar.setAttribute('aria-valuenow', `${Math.round(goalProgressPercent)}`);
     if (selectors.goalProgressText) {
         const goal = safeGet(fullDashboardData.initialAnswers, 'goal', '').toLowerCase();
         const startWeight = safeParseFloat(safeGet(fullDashboardData.initialData, 'weight'));
@@ -58,9 +62,11 @@ function populateDashboardMainIndexes(currentAnalytics) {
     }
     const engagementScore = safeGet(currentAnalytics, 'engagementScore', 0);
     if (selectors.engagementProgressMask) selectors.engagementProgressMask.style.width = `${100 - Math.max(0, Math.min(100, engagementScore))}%`;
+    if (selectors.engagementProgressBar) selectors.engagementProgressBar.setAttribute('aria-valuenow', `${Math.round(engagementScore)}`);
     if (selectors.engagementProgressText) selectors.engagementProgressText.textContent = `${Math.round(engagementScore)}%`;
     const healthScore = safeGet(currentAnalytics, 'overallHealthScore', 0);
     if (selectors.healthProgressMask) selectors.healthProgressMask.style.width = `${100 - Math.max(0, Math.min(100, healthScore))}%`;
+    if (selectors.healthProgressBar) selectors.healthProgressBar.setAttribute('aria-valuenow', `${Math.round(healthScore)}`);
     if (selectors.healthProgressText) selectors.healthProgressText.textContent = `${Math.round(healthScore)}%`;
 }
 


### PR DESCRIPTION
## Summary
- add required ARIA attributes to progress bars
- update populateDashboardMainIndexes to set `aria-valuenow`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68535cc0a2588326abb2204c4ddea044