### PR TITLE
Implement basic admin panel

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+  <meta charset="UTF-8">
+  <title>Администраторски панел</title>
+  <link rel="stylesheet" href="css/admin.css">
+</head>
+<body>
+  <h1>Администраторски панел</h1>
+  <p><a href="logout.php">Изход</a></p>
+  <section id="clientsSection">
+    <h2>Клиенти</h2>
+    <p id="clientsCount"></p>
+    <button id="showStats">Покажи статистика</button>
+    <ul id="clientsList"></ul>
+  </section>
+
+  <section id="clientDetails" class="hidden">
+    <h2 id="clientName">Клиент</h2>
+    <form id="profileForm">
+      <label>Име: <input name="name"></label><br>
+      <label>Възраст: <input type="number" name="age"></label><br>
+      <label>Ръст: <input type="number" name="height"></label><br>
+      <button type="submit">Запази</button>
+    </form>
+    <h3>Запитвания</h3>
+    <ul id="queriesList"></ul>
+    <textarea id="newQueryText" rows="3" cols="40"></textarea><br>
+    <button id="sendQuery">Изпрати запитване</button>
+  </section>
+
+  <section id="statsSection" class="hidden">
+    <h2>Статистика</h2>
+    <pre id="statsOutput"></pre>
+  </section>
+
+  <script type="module" src="js/admin.js"></script>
+</body>
+</html>

--- a/css/admin.css
+++ b/css/admin.css
@@ -1,0 +1,6 @@
+body { font-family: Arial, sans-serif; padding: 20px; }
+.hidden { display: none; }
+#clientsList li { margin-bottom: 5px; }
+#clientsList button + button { margin-left: 5px; }
+#clientDetails { margin-top: 20px; }
+#statsSection { margin-top: 20px; }

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,162 @@
+import { apiEndpoints } from './config.js';
+
+async function ensureLoggedIn() {
+    try {
+        const resp = await fetch('session_check.php');
+        const data = await resp.json();
+        if (!resp.ok || !data.success) {
+            window.location.href = 'login.html';
+        }
+    } catch (err) {
+        window.location.href = 'login.html';
+    }
+}
+
+const clientsList = document.getElementById('clientsList');
+const clientsCount = document.getElementById('clientsCount');
+const detailsSection = document.getElementById('clientDetails');
+const profileForm = document.getElementById('profileForm');
+const queriesList = document.getElementById('queriesList');
+const newQueryText = document.getElementById('newQueryText');
+const sendQueryBtn = document.getElementById('sendQuery');
+const statsOutput = document.getElementById('statsOutput');
+const showStatsBtn = document.getElementById('showStats');
+let currentUserId = null;
+
+async function loadClients() {
+    try {
+        const resp = await fetch(apiEndpoints.listClients);
+        const data = await resp.json();
+        if (resp.ok && data.success) {
+            clientsList.innerHTML = '';
+            clientsCount.textContent = `Общ брой клиенти: ${data.clients.length}`;
+            data.clients.forEach(c => {
+                const li = document.createElement('li');
+                const btn = document.createElement('button');
+                btn.textContent = `${c.name} (${c.userId})`;
+                btn.addEventListener('click', () => showClient(c.userId));
+                li.appendChild(btn);
+                const exportBtn = document.createElement('button');
+                exportBtn.textContent = 'CSV';
+                exportBtn.style.marginLeft = '5px';
+                exportBtn.addEventListener('click', () => exportProfileCsv(c.userId));
+                li.appendChild(exportBtn);
+                clientsList.appendChild(li);
+            });
+            statsOutput.textContent = JSON.stringify({ clients: data.clients.length }, null, 2);
+        }
+    } catch (err) {
+        console.error('Error loading clients:', err);
+    }
+}
+
+showStatsBtn.addEventListener('click', () => {
+    const sec = document.getElementById('statsSection');
+    sec.classList.toggle('hidden');
+});
+
+async function exportProfileCsv(userId) {
+    try {
+        const resp = await fetch(`${apiEndpoints.getProfile}?userId=${userId}`);
+        const data = await resp.json();
+        if (resp.ok && data.success) {
+            const rows = [ ['userId', 'name', 'age', 'height'],
+                [userId, data.name || '', data.age || '', data.height || ''] ];
+            const csv = rows.map(r => r.map(v => '"' + String(v).replace(/"/g, '""') + '"').join(',')).join('\n');
+            const blob = new Blob([csv], { type: 'text/csv' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `${userId}.csv`;
+            a.click();
+            URL.revokeObjectURL(url);
+        }
+    } catch (err) {
+        console.error('Error exporting CSV:', err);
+    }
+}
+
+async function showClient(userId) {
+    try {
+        const resp = await fetch(`${apiEndpoints.getProfile}?userId=${userId}`);
+        const data = await resp.json();
+        if (resp.ok && data.success) {
+            currentUserId = userId;
+            detailsSection.classList.remove('hidden');
+            document.getElementById('clientName').textContent = data.name || 'Клиент';
+            profileForm.name.value = data.name || '';
+            profileForm.age.value = data.age || '';
+            profileForm.height.value = data.height || '';
+            await loadQueries();
+        }
+    } catch (err) {
+        console.error('Error loading profile:', err);
+    }
+}
+
+profileForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    if (!currentUserId) return;
+    const payload = {
+        userId: currentUserId,
+        name: profileForm.name.value,
+        age: parseInt(profileForm.age.value, 10) || null,
+        height: parseInt(profileForm.height.value, 10) || null
+    };
+    try {
+        const resp = await fetch(apiEndpoints.updateProfile, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+        const data = await resp.json();
+        alert(data.message || (data.success ? 'Успешно записан профил.' : 'Грешка при запис.'));
+    } catch (err) {
+        alert('Грешка при изпращане');
+    }
+});
+
+sendQueryBtn.addEventListener('click', async () => {
+    if (!currentUserId) return;
+    const msg = newQueryText.value.trim();
+    if (!msg) return;
+    try {
+        const resp = await fetch(apiEndpoints.addAdminQuery, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ userId: currentUserId, message: msg })
+        });
+        const data = await resp.json();
+        if (resp.ok && data.success) {
+            newQueryText.value = '';
+            await loadQueries();
+        } else {
+            alert(data.message || 'Грешка при изпращане.');
+        }
+    } catch (err) {
+        console.error('Error sending query:', err);
+    }
+});
+
+async function loadQueries() {
+    if (!currentUserId) return;
+    try {
+        const resp = await fetch(`${apiEndpoints.getAdminQueries}?userId=${currentUserId}`);
+        const data = await resp.json();
+        queriesList.innerHTML = '';
+        if (resp.ok && data.success) {
+            data.queries.forEach(q => {
+                const li = document.createElement('li');
+                li.textContent = q.message;
+                queriesList.appendChild(li);
+            });
+        }
+    } catch (err) {
+        console.error('Error loading queries:', err);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    await ensureLoggedIn();
+    await loadClients();
+});

--- a/js/app.js
+++ b/js/app.js
@@ -52,6 +52,24 @@ function normalizeText(input) {
     return String(input);
 }
 
+async function checkAdminQueries(userId) {
+    try {
+        const resp = await fetch(`${apiEndpoints.getAdminQueries}?userId=${userId}`);
+        const data = await resp.json();
+        if (resp.ok && data.success && Array.isArray(data.queries) && data.queries.length > 0) {
+            data.queries.forEach(q => {
+                displayChatMessage(`Администратор: ${escapeHtml(q.message)}`, 'bot');
+            });
+            if (!selectors.chatWidget?.classList.contains('visible')) {
+                if (selectors.chatFab) selectors.chatFab.classList.add('notification');
+                setAutomatedChatPending(true);
+            }
+        }
+    } catch (err) {
+        console.error('Error fetching admin queries:', err);
+    }
+}
+
 // ==========================================================================
 // ГЛОБАЛНИ ПРОМЕНЛИВИ ЗА СЪСТОЯНИЕТО НА ПРИЛОЖЕНИЕТО
 // ==========================================================================
@@ -286,6 +304,7 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
             populateUI();
             initializeAchievements(currentUserId);
             setupDynamicEventListeners();
+            await checkAdminQueries(currentUserId);
 
             const activeTabId = sessionStorage.getItem('activeTabId') || selectors.tabButtons[0]?.id;
             const activeTabButton = activeTabId ? document.getElementById(activeTabId) : (selectors.tabButtons && selectors.tabButtons[0]);
@@ -380,6 +399,7 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
 
         initializeAchievements(currentUserId);
         setupDynamicEventListeners();
+        await checkAdminQueries(currentUserId);
 
         const activeTabId = sessionStorage.getItem('activeTabId') || selectors.tabButtons[0]?.id;
         const activeTabButton = activeTabId ? document.getElementById(activeTabId) : (selectors.tabButtons && selectors.tabButtons[0]);

--- a/js/config.js
+++ b/js/config.js
@@ -26,6 +26,9 @@ export const apiEndpoints = {
     getAchievements: `${workerBaseUrl}/api/getAchievements`,
     generatePraise: `${workerBaseUrl}/api/generatePraise`,
     aiHelper: `${workerBaseUrl}/api/aiHelper`,
+    listClients: `${workerBaseUrl}/api/listClients`,
+    addAdminQuery: `${workerBaseUrl}/api/addAdminQuery`,
+    getAdminQueries: `${workerBaseUrl}/api/getAdminQueries`,
     getPlanModificationPrompt: `${workerBaseUrl}/api/getPlanModificationPrompt`
 };
 

--- a/session_check.php
+++ b/session_check.php
@@ -1,0 +1,9 @@
+<?php
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+if (isset($_SESSION['isAdmin']) && $_SESSION['isAdmin'] === true) {
+    echo json_encode(["success" => true]);
+} else {
+    echo json_encode(["success" => false, "message" => "Not logged in"]);
+}
+?>

--- a/worker.js
+++ b/worker.js
@@ -151,6 +151,12 @@ export default {
                 responseBody = await handleGetPlanModificationPrompt(request, env);
             } else if (method === 'POST' && path === '/api/aiHelper') {
                 responseBody = await handleAiHelperRequest(request, env);
+            } else if (method === 'GET' && path === '/api/listClients') {
+                responseBody = await handleListClientsRequest(request, env);
+            } else if (method === 'POST' && path === '/api/addAdminQuery') {
+                responseBody = await handleAddAdminQueryRequest(request, env);
+            } else if (method === 'GET' && path === '/api/getAdminQueries') {
+                responseBody = await handleGetAdminQueriesRequest(request, env);
             } else {
                 responseBody = { success: false, error: 'Not Found', message: 'Ресурсът не е намерен.' };
                 responseStatus = 404;
@@ -1255,6 +1261,68 @@ async function handleAiHelperRequest(request, env) {
     }
 }
 // ------------- END FUNCTION: handleAiHelperRequest -------------
+
+// ------------- START FUNCTION: handleListClientsRequest -------------
+async function handleListClientsRequest(request, env) {
+    try {
+        const list = await env.USER_METADATA_KV.list();
+        const ids = new Set();
+        for (const key of list.keys) {
+            const m = key.name.match(/^(.*)_initial_answers$/);
+            if (m) ids.add(m[1]);
+        }
+        const clients = [];
+        for (const id of ids) {
+            const ansStr = await env.USER_METADATA_KV.get(`${id}_initial_answers`);
+            if (!ansStr) continue;
+            const ans = safeParseJson(ansStr, {});
+            clients.push({ userId: id, name: ans.name || 'Клиент' });
+        }
+        return { success: true, clients };
+    } catch (error) {
+        console.error('Error in handleListClientsRequest:', error.message, error.stack);
+        return { success: false, message: 'Грешка при зареждане на клиентите.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleListClientsRequest -------------
+
+// ------------- START FUNCTION: handleAddAdminQueryRequest -------------
+async function handleAddAdminQueryRequest(request, env) {
+    try {
+        const { userId, message } = await request.json();
+        if (!userId || !message) return { success: false, message: 'Липсват данни.', statusHint: 400 };
+        const key = `${userId}_admin_queries`;
+        const existing = safeParseJson(await env.USER_METADATA_KV.get(key), []);
+        existing.push({ message, ts: Date.now(), read: false });
+        await env.USER_METADATA_KV.put(key, JSON.stringify(existing));
+        return { success: true };
+    } catch (error) {
+        console.error('Error in handleAddAdminQueryRequest:', error.message, error.stack);
+        return { success: false, message: 'Грешка при запис.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleAddAdminQueryRequest -------------
+
+// ------------- START FUNCTION: handleGetAdminQueriesRequest -------------
+async function handleGetAdminQueriesRequest(request, env) {
+    try {
+        const url = new URL(request.url);
+        const userId = url.searchParams.get('userId');
+        if (!userId) return { success: false, message: 'Липсва userId.', statusHint: 400 };
+        const key = `${userId}_admin_queries`;
+        const arr = safeParseJson(await env.USER_METADATA_KV.get(key), []);
+        const unread = arr.filter(q => !q.read);
+        if (unread.length > 0) {
+            arr.forEach(q => { q.read = true; });
+            await env.USER_METADATA_KV.put(key, JSON.stringify(arr));
+        }
+        return { success: true, queries: unread };
+    } catch (error) {
+        console.error('Error in handleGetAdminQueriesRequest:', error.message, error.stack);
+        return { success: false, message: 'Грешка при зареждане на запитванията.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleGetAdminQueriesRequest -------------
 
 // ------------- START FUNCTION: handleGetPlanModificationPrompt -------------
 async function handleGetPlanModificationPrompt(request, env) {
@@ -2965,4 +3033,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleGetPlanModificationPrompt, callCfAi, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleGetPlanModificationPrompt, callCfAi, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt };


### PR DESCRIPTION
## Summary
- add minimal admin UI with client list and query management
- fetch admin queries on client dashboard
- extend config with admin endpoints
- implement admin API handlers in worker
- enhance admin panel with session check, CSV export and stats

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853670d495083269f9a2c0ed930d81a