### PR TITLE
Improve admin login reliability and UI features

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,10 @@ The PHP helper scripts expect the following variables set in the server environm
 - `CF_API_TOKEN` – token used by `save-questions.php` to update the Cloudflare KV store.
 
 The admin panel по подразбиране използва фиксирани данни за вход – потребителско име `admin` и парола `6131`.
-Ако е зададенa променлива `ADMIN_PASS_HASH`, паролата се проверява по нейния bcrypt хеш.
+Ако е зададенa променлива `ADMIN_PASS_HASH`, паролата се проверява по нейния bcrypt хеш. Празни стойности на `ADMIN_PASS_HASH` или `ADMIN_USERNAME` се игнорират и се използват стандартните данни.
 Може да се зададе и `ADMIN_USERNAME` за друго потребителско име.
+Интерфейсът на страницата за вход позволява показване на паролата и опция
+"Запомни ме", която съхранява потребителското име в `localStorage`.
 Пример за генериране на хеш:
 
 ```bash

--- a/login.html
+++ b/login.html
@@ -59,14 +59,31 @@
   <h2>Администраторски Вход</h2>
   <input type="text" id="adminUsername" placeholder="Потребителско име" />
   <input type="password" id="adminPassword" placeholder="Парола" />
+  <label><input type="checkbox" id="showPass"> Покажи паролата</label>
+  <label><input type="checkbox" id="rememberUser"> Запомни ме</label>
   <button id="loginBtn">Влез</button>
   <div id="errorMsg">Грешна парола или грешка при заявката.</div>
 </div>
 
 <script>
+  const userInput = document.getElementById('adminUsername');
+  const passInput = document.getElementById('adminPassword');
+  const showPass = document.getElementById('showPass');
+  const rememberChk = document.getElementById('rememberUser');
+
+  const savedUser = localStorage.getItem('savedAdminUser');
+  if (savedUser) {
+    userInput.value = savedUser;
+    rememberChk.checked = true;
+  }
+
+  showPass.addEventListener('change', () => {
+    passInput.type = showPass.checked ? 'text' : 'password';
+  });
+
   document.getElementById('loginBtn').addEventListener('click', () => {
-    const user = document.getElementById('adminUsername').value;
-    const pass = document.getElementById('adminPassword').value;
+    const user = userInput.value;
+    const pass = passInput.value;
     fetch('login.php', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -75,6 +92,11 @@
     .then(res => res.json())
     .then(data => {
       if (data.success) {
+        if (rememberChk.checked) {
+          localStorage.setItem('savedAdminUser', user);
+        } else {
+          localStorage.removeItem('savedAdminUser');
+        }
         window.location.href = 'admin.html';
       } else {
         const err = document.getElementById('errorMsg');

--- a/login.php
+++ b/login.php
@@ -18,16 +18,16 @@ $username = trim($data['username']);
 $password = $data['password'];
 $envUser = getenv('ADMIN_USERNAME');
 $envHash = getenv('ADMIN_PASS_HASH');
-$expectedUser = $envUser !== false ? $envUser : 'admin';
+$expectedUser = ($envUser !== false && $envUser !== '') ? $envUser : 'admin';
 
 if ($username === $expectedUser) {
-    if ($envHash !== false && password_verify($password, $envHash)) {
+    if ($envHash !== false && $envHash !== '' && password_verify($password, $envHash)) {
         $_SESSION['isAdmin'] = true;
         session_regenerate_id(true);
         echo json_encode(["success" => true, "message" => "Logged in"]);
         exit;
     }
-    if ($envHash === false && $password === '6131') {
+    if (($envHash === false || $envHash === '') && $password === '6131') {
         $_SESSION['isAdmin'] = true;
         session_regenerate_id(true);
         echo json_encode(["success" => true, "message" => "Logged in"]);


### PR DESCRIPTION
## Summary
- handle empty ADMIN_* variables in login
- show password and remember username on login page
- document new behavior in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853743be3308326b341d10e4249dcd6