### PR TITLE
Check login response content type

### DIFF
--- a/login.html
+++ b/login.html
@@ -89,7 +89,15 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username: user, password: pass })
     })
-    .then(res => res.json())
+    .then(res => {
+      const ct = res.headers.get('content-type') || '';
+      if (!ct.includes('application/json')) {
+        return res.text().then(() => {
+          throw new Error('invalid_json');
+        });
+      }
+      return res.json();
+    })
     .then(data => {
       if (data.success) {
         if (rememberChk.checked) {
@@ -106,7 +114,11 @@
     })
     .catch(err => {
       const errDiv = document.getElementById('errorMsg');
-      errDiv.textContent = 'Грешка при заявката: ' + err.message;
+      if (err.message === 'invalid_json') {
+        errDiv.textContent = 'Сървърът върна невалиден JSON. Уверете се, че login.php се изпълнява на PHP сървър.';
+      } else {
+        errDiv.textContent = 'Грешка при заявката: ' + err.message;
+      }
       errDiv.style.display = 'block';
     });
   });


### PR DESCRIPTION
## Summary
- enhance client login logic to detect non-JSON responses
- show a localized warning when the server doesn't send JSON

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68537655f7a4832693d894b13a0afac0