### PR TITLE
Allow admin login without PHP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,14 @@ The PHP helper scripts expect the following variables set in the server environm
 - `CF_API_TOKEN` – token used by `save-questions.php` to update the Cloudflare KV store.
 
 The admin panel по подразбиране използва фиксирани данни за вход – потребителско име `admin` и парола `6131`.
-Ако е зададенa променлива `ADMIN_PASS_HASH`, паролата се проверява по нейния bcrypt хеш.
+Ако е зададенa променлива `ADMIN_PASS_HASH`, паролата се проверява по нейния bcrypt хеш. Празни стойности на `ADMIN_PASS_HASH` или `ADMIN_USERNAME` се игнорират и се използват стандартните данни.
 Може да се зададе и `ADMIN_USERNAME` за друго потребителско име.
+Интерфейсът на страницата за вход позволява показване на паролата и опция
+"Запомни ме", която съхранява потребителското име в `localStorage`.
+Ако `login.php` липсва (напр. при статичен хостинг), скриптът в `login.html`
+ще валидира локално стандартните данни и ще запази сесията в `localStorage`.
+Файлът `logout.html` изчиства съхранената сесия и пренасочва обратно към
+екрана за вход.
 Пример за генериране на хеш:
 
 ```bash

--- a/admin.html
+++ b/admin.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <h1>Администраторски панел</h1>
-  <p><a href="logout.php">Изход</a></p>
+  <p><a href="logout.html">Изход</a></p>
   <section id="clientsSection">
     <h2>Клиенти</h2>
     <p id="clientsCount"></p>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,6 +1,9 @@
 import { apiEndpoints } from './config.js';
 
 async function ensureLoggedIn() {
+    if (localStorage.getItem('adminSession') === 'true') {
+        return;
+    }
     try {
         const resp = await fetch('session_check.php');
         const data = await resp.json();

--- a/login.html
+++ b/login.html
@@ -59,14 +59,31 @@
   <h2>Администраторски Вход</h2>
   <input type="text" id="adminUsername" placeholder="Потребителско име" />
   <input type="password" id="adminPassword" placeholder="Парола" />
+  <label><input type="checkbox" id="showPass"> Покажи паролата</label>
+  <label><input type="checkbox" id="rememberUser"> Запомни ме</label>
   <button id="loginBtn">Влез</button>
   <div id="errorMsg">Грешна парола или грешка при заявката.</div>
 </div>
 
 <script>
+  const userInput = document.getElementById('adminUsername');
+  const passInput = document.getElementById('adminPassword');
+  const showPass = document.getElementById('showPass');
+  const rememberChk = document.getElementById('rememberUser');
+
+  const savedUser = localStorage.getItem('savedAdminUser');
+  if (savedUser) {
+    userInput.value = savedUser;
+    rememberChk.checked = true;
+  }
+
+  showPass.addEventListener('change', () => {
+    passInput.type = showPass.checked ? 'text' : 'password';
+  });
+
   document.getElementById('loginBtn').addEventListener('click', () => {
-    const user = document.getElementById('adminUsername').value;
-    const pass = document.getElementById('adminPassword').value;
+    const user = userInput.value;
+    const pass = passInput.value;
     fetch('login.php', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -75,6 +92,12 @@
     .then(res => res.json())
     .then(data => {
       if (data.success) {
+        localStorage.setItem('adminSession', 'true');
+        if (rememberChk.checked) {
+          localStorage.setItem('savedAdminUser', user);
+        } else {
+          localStorage.removeItem('savedAdminUser');
+        }
         window.location.href = 'admin.html';
       } else {
         const err = document.getElementById('errorMsg');
@@ -83,6 +106,11 @@
       }
     })
     .catch(err => {
+      if (user === 'admin' && pass === '6131') {
+        localStorage.setItem('adminSession', 'true');
+        window.location.href = 'admin.html';
+        return;
+      }
       const errDiv = document.getElementById('errorMsg');
       errDiv.textContent = 'Грешка при заявката: ' + err.message;
       errDiv.style.display = 'block';

--- a/login.php
+++ b/login.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     echo json_encode(["success"=>false, "message"=>"Only POST allowed"]);
@@ -18,16 +19,16 @@ $username = trim($data['username']);
 $password = $data['password'];
 $envUser = getenv('ADMIN_USERNAME');
 $envHash = getenv('ADMIN_PASS_HASH');
-$expectedUser = $envUser !== false ? $envUser : 'admin';
+$expectedUser = ($envUser !== false && $envUser !== '') ? $envUser : 'admin';
 
 if ($username === $expectedUser) {
-    if ($envHash !== false && password_verify($password, $envHash)) {
+    if ($envHash !== false && $envHash !== '' && password_verify($password, $envHash)) {
         $_SESSION['isAdmin'] = true;
         session_regenerate_id(true);
         echo json_encode(["success" => true, "message" => "Logged in"]);
         exit;
     }
-    if ($envHash === false && $password === '6131') {
+    if (($envHash === false || $envHash === '') && $password === '6131') {
         $_SESSION['isAdmin'] = true;
         session_regenerate_id(true);
         echo json_encode(["success" => true, "message" => "Logged in"]);
@@ -35,4 +36,5 @@ if ($username === $expectedUser) {
     }
 }
 
+http_response_code(401);
 echo json_encode(["success" => false, "message" => "Невалидни данни"]);

--- a/logout.html
+++ b/logout.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+  <meta charset="UTF-8">
+  <title>Изход</title>
+</head>
+<body>
+<script>
+  // Опитваме да информираме сървъра, ако съществува PHP скрипт
+  fetch('logout.php').catch(() => {});
+  localStorage.removeItem('adminSession');
+  window.location.href = 'login.html';
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support static-host admin login via `localStorage`
- logout clears stored session token
- fallback to default credentials if `login.php` is missing
- document new behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853743be3308326b341d10e4249dcd6