### PR TITLE
Improve admin panel data view

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -8,7 +8,8 @@
 <body>
   <h1>Администраторски панел</h1>
   <p><a href="logout.html">Изход</a></p>
-  <section id="clientsSection">
+  <div class="layout">
+  <aside class="sidebar card" id="clientsSection">
     <h2>Клиенти</h2>
     <input id="clientSearch" placeholder="Търсене по име/ID">
     <select id="statusFilter">
@@ -20,9 +21,9 @@
     <p id="clientsCount"></p>
     <button id="showStats">Покажи статистика</button>
     <ul id="clientsList"></ul>
-  </section>
+  </aside>
 
-  <section id="clientDetails" class="hidden">
+  <main class="main-content card" id="clientDetails" class="hidden">
     <h2 id="clientName">Клиент</h2>
     <form id="profileForm">
       <label>Име: <input name="name"></label><br>
@@ -44,12 +45,16 @@
     <pre id="planMenu"></pre>
     <h3>Дневници</h3>
     <pre id="dailyLogs"></pre>
+    <h3>Пълни данни</h3>
+    <pre id="dashboardData" class="json"></pre>
+    <button id="exportData">Експортирай всички данни</button>
     <button id="exportPlan">Експортирай плана като JSON</button>
     <h3>Запитвания</h3>
     <ul id="queriesList"></ul>
     <textarea id="newQueryText" rows="3" cols="40"></textarea><br>
     <button id="sendQuery">Изпрати запитване</button>
-  </section>
+  </main>
+  </div>
 
   <section id="statsSection" class="hidden">
     <h2>Статистика</h2>

--- a/css/admin.css
+++ b/css/admin.css
@@ -1,4 +1,4 @@
-body { font-family: Arial, sans-serif; padding: 20px; }
+body { font-family: Arial, sans-serif; padding: 20px; background: #f0f2f5; }
 .hidden { display: none; }
 #clientsList li { margin-bottom: 5px; }
 #clientsList button + button { margin-left: 5px; }
@@ -8,3 +8,33 @@ body { font-family: Arial, sans-serif; padding: 20px; }
 #clientDetails { margin-top: 20px; }
 #statsSection { margin-top: 20px; }
 pre { background: #f5f5f5; padding: 10px; overflow: auto; }
+
+.layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+.sidebar {
+  flex: 1 1 250px;
+  max-width: 300px;
+}
+.main-content {
+  flex: 3 1 400px;
+}
+.card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  padding: 15px;
+}
+pre.json {
+  background: #272822;
+  color: #f8f8f2;
+  white-space: pre-wrap;
+}
+@media (max-width: 768px) {
+  .sidebar, .main-content {
+    flex: 1 1 100%;
+    max-width: 100%;
+  }
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -35,8 +35,11 @@ const initialAnswersPre = document.getElementById('initialAnswers');
 const planMenuPre = document.getElementById('planMenu');
 const dailyLogsPre = document.getElementById('dailyLogs');
 const exportPlanBtn = document.getElementById('exportPlan');
+const dashboardPre = document.getElementById('dashboardData');
+const exportDataBtn = document.getElementById('exportData');
 let currentUserId = null;
 let currentPlanData = null;
+let currentDashboardData = null;
 let allClients = [];
 
 async function loadClients() {
@@ -149,10 +152,12 @@ async function showClient(userId) {
                 planMenuPre.textContent = JSON.stringify(menu, null, 2);
             }
             if (dailyLogsPre) dailyLogsPre.textContent = JSON.stringify(dashData.dailyLogs || [], null, 2);
+            if (dashboardPre) dashboardPre.textContent = JSON.stringify(dashData, null, 2);
             if (notesField) notesField.value = dashData.currentStatus?.adminNotes || '';
             if (tagsField) tagsField.value = (dashData.currentStatus?.adminTags || []).join(',');
             profileForm.weight.value = dashData.currentStatus?.weight || profileForm.weight.value;
             currentPlanData = dashData.planData || null;
+            currentDashboardData = dashData;
         }
     } catch (err) {
         console.error('Error loading profile:', err);
@@ -264,6 +269,19 @@ if (exportPlanBtn) {
         const a = document.createElement('a');
         a.href = url;
         a.download = `${currentUserId || 'plan'}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    });
+}
+
+if (exportDataBtn) {
+    exportDataBtn.addEventListener('click', () => {
+        if (!currentDashboardData) return;
+        const blob = new Blob([JSON.stringify(currentDashboardData, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${currentUserId || 'data'}.json`;
         a.click();
         URL.revokeObjectURL(url);
     });


### PR DESCRIPTION
## Summary
- add responsive layout and card styles
- show full dashboard data in admin panel
- allow exporting of dashboard data

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68537fd9f1e4832680944c147dcfa1b6