### PR TITLE
Add collapsible advice cards

### DIFF
--- a/code.html
+++ b/code.html
@@ -293,36 +293,44 @@
                     <h2>💡 Препоръки</h2>
                     <div class="recommendation-section">
                         <h3>🍎 Основи на Храненето</h3>
-                        <div id="recFoodAllowedCard" class="card">
+                        <div id="recFoodAllowedCard" class="card collapsible-card">
                             <h4>✅ Препоръчителни Храни</h4>
-                            <div id="recFoodAllowedContent">
-                                <p class="placeholder">Зареждане...</p>
-                            </div>
-                            <div class="info-note note-base hidden" data-condition-type="medical" data-condition-value="хипотиреоидизъм">
-                                <svg class="icon prefix-icon"><use href="#icon-info"></use></svg>
-                                <span><strong>Забележка (Хипотиреоидизъм):</strong> Обърнете внимание на храни, богати на селен, цинк и йод. Избягвайте сурови кръстоцветни в големи количества.</span>
-                            </div>
-                        </div>
-                        <div id="recFoodLimitCard" class="card">
-                            <h4>❌ Храни за Внимание/Ограничаване</h4>
-                            <div id="recFoodLimitContent">
-                                <div id="userAllergiesNote" class="critical-note note-base hidden">
-                                    <svg class="icon prefix-icon"><use href="#icon-warning-triangle"></use></svg>
-                                    <span><strong>Ваши специфични алергени/непоносимости:</strong> <span id="userAllergiesList">Липсват данни</span></span>
+                            <div class="collapsible-content">
+                                <div id="recFoodAllowedContent">
+                                    <p class="placeholder">Зареждане...</p>
                                 </div>
-                                <p class="placeholder">Зареждане на общи препоръки...</p>
+                                <div class="info-note note-base hidden" data-condition-type="medical" data-condition-value="хипотиреоидизъм">
+                                    <svg class="icon prefix-icon"><use href="#icon-info"></use></svg>
+                                    <span><strong>Забележка (Хипотиреоидизъм):</strong> Обърнете внимание на храни, богати на селен, цинк и йод. Избягвайте сурови кръстоцветни в големи количества.</span>
+                                </div>
                             </div>
                         </div>
-                        <div id="recHydrationCard" class="card">
+                        <div id="recFoodLimitCard" class="card collapsible-card">
+                            <h4>❌ Храни за Внимание/Ограничаване</h4>
+                            <div class="collapsible-content">
+                                <div id="recFoodLimitContent">
+                                    <div id="userAllergiesNote" class="critical-note note-base hidden">
+                                        <svg class="icon prefix-icon"><use href="#icon-warning-triangle"></use></svg>
+                                        <span><strong>Ваши специфични алергени/непоносимости:</strong> <span id="userAllergiesList">Липсват данни</span></span>
+                                    </div>
+                                    <p class="placeholder">Зареждане на общи препоръки...</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="recHydrationCard" class="card collapsible-card">
                             <h4>💧 Хидратация и Напитки</h4>
-                            <div id="recHydrationContent">
-                                <p class="placeholder">Зареждане...</p>
+                            <div class="collapsible-content">
+                                <div id="recHydrationContent">
+                                    <p class="placeholder">Зареждане...</p>
+                                </div>
                             </div>
                         </div>
-                        <div id="recCookingMethodsCard" class="card">
+                        <div id="recCookingMethodsCard" class="card collapsible-card">
                             <h4>🍳 Методи на Готвене</h4>
-                            <div id="recCookingMethodsContent">
-                                <p class="placeholder">Зареждане...</p>
+                            <div class="collapsible-content">
+                                <div id="recCookingMethodsContent">
+                                    <p class="placeholder">Зареждане...</p>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -334,13 +342,16 @@
                     </div>
                     <div class="recommendation-section">
                         <h3>💊 Хранителни Добавки</h3>
-                        <div id="recSupplementsCard" class="card">
-                            <div id="recSupplementsContent">
-                                <p class="placeholder">Зареждане...</p>
-                            </div>
-                            <div class="important-note note-base">
-                                <svg class="icon prefix-icon"><use href="#icon-info"></use></svg>
-                                <span><strong>Важно:</strong> Винаги се консултирайте с лекар преди прием на нови хранителни добавки, особено ако имате съществуващи заболявания или приемате медикаменти.</span>
+                        <div id="recSupplementsCard" class="card collapsible-card">
+                            <h4>Хранителни Добавки</h4>
+                            <div class="collapsible-content">
+                                <div id="recSupplementsContent">
+                                    <p class="placeholder">Зареждане...</p>
+                                </div>
+                                <div class="important-note note-base">
+                                    <svg class="icon prefix-icon"><use href="#icon-info"></use></svg>
+                                    <span><strong>Важно:</strong> Винаги се консултирайте с лекар преди прием на нови хранителни добавки, особено ако имате съществуващи заболявания или приемате медикаменти.</span>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -36,6 +36,24 @@
   to { opacity: 1; max-height: 1000px; padding-top: var(--space-lg); padding-bottom: var(--space-lg); }
 }
 
+.collapsible-card h4 {
+  cursor: pointer;
+  position: relative;
+  padding-right: 1.2em;
+}
+.collapsible-card h4::after {
+  content: '\25B6';
+  position: absolute;
+  right: 0;
+  top: 0.2em;
+  transition: transform 0.3s ease;
+}
+.collapsible-card.open h4::after {
+  transform: rotate(90deg);
+}
+.collapsible-card .collapsible-content { display: none; }
+.collapsible-card.open .collapsible-content { display: block; }
+
 /* ==========================================================================
    7. МОДАЛНИ ПРОЗОРЦИ, TOAST, ЧАТ, FABs
    ========================================================================== */

--- a/js/app.js
+++ b/js/app.js
@@ -10,7 +10,7 @@ import {
 } from './uiHandlers.js';
 import { populateUI } from './populateUI.js';
 // КОРЕКЦИЯ: Премахваме handleDelegatedClicks от импорта тук
-import { setupStaticEventListeners, setupDynamicEventListeners } from './eventListeners.js';
+import { setupStaticEventListeners, setupDynamicEventListeners, initializeCollapsibleCards } from './eventListeners.js';
 import {
     displayMessage as displayChatMessage,
     displayTypingIndicator as displayChatTypingIndicator, scrollToChatBottom,
@@ -260,6 +260,7 @@ async function initializeApp() {
             return;
         }
         setupStaticEventListeners(); // from eventListeners.js
+        initializeCollapsibleCards();
         initializeTheme(); // from uiHandlers.js
         loadDashboardData();
         if (isLocalDevelopment) console.log("initializeApp finished successfully.");

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -220,6 +220,28 @@ export function setupStaticEventListeners() {
     });
 }
 
+export function initializeCollapsibleCards() {
+    const cards = document.querySelectorAll('#recs-panel .collapsible-card');
+    cards.forEach(card => {
+        const header = card.querySelector('h4');
+        const content = card.querySelector('.collapsible-content');
+        if (!header || !content) return;
+        header.setAttribute('tabindex', '0');
+        header.setAttribute('aria-expanded', 'false');
+        const toggle = () => {
+            const isOpen = card.classList.toggle('open');
+            header.setAttribute('aria-expanded', isOpen);
+        };
+        header.addEventListener('click', toggle);
+        header.addEventListener('keydown', e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggle();
+            }
+        });
+    });
+}
+
 export function setupDynamicEventListeners() {
     document.body.removeEventListener('click', handleDelegatedClicks);
     document.body.addEventListener('click', handleDelegatedClicks);

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -24,6 +24,8 @@ export function initializeSelectors() {
         recFoodAllowedContent: 'recFoodAllowedContent', recFoodLimitContent: 'recFoodLimitContent', userAllergiesNote: 'userAllergiesNote',
         userAllergiesList: 'userAllergiesList', recHydrationContent: 'recHydrationContent', recCookingMethodsContent: 'recCookingMethodsContent',
         recStrategiesContent: 'recStrategiesContent', recSupplementsContent: 'recSupplementsContent',
+        recFoodAllowedCard: 'recFoodAllowedCard', recFoodLimitCard: 'recFoodLimitCard',
+        recHydrationCard: 'recHydrationCard', recCookingMethodsCard: 'recCookingMethodsCard', recSupplementsCard: 'recSupplementsCard',
         welcomeScreenModal: 'welcomeScreenModal', extraMealEntryModal: 'extraMealEntryModal', extraMealFormContainer: 'extraMealFormContainer',
         adaptiveQuizModal: 'adaptiveQuizWrapper',
         adaptiveQuizContainer: 'adaptiveQuizWrapper',
@@ -66,7 +68,9 @@ export function initializeSelectors() {
                 'planModChatModal', 'planModChatMessages', 'planModChatInput',
                 'planModChatSend', 'planModChatClose', 'planModChatClear',
                 'streakGrid', 'streakCount', 'analyticsCardsContainer',
-                'goalCard', 'engagementCard', 'healthCard', 'streakCard'
+                'goalCard', 'engagementCard', 'healthCard', 'streakCard',
+                'recFoodAllowedCard', 'recFoodLimitCard', 'recHydrationCard',
+                'recCookingMethodsCard', 'recSupplementsCard'
             ];
             if (!optionalOrDynamic.includes(key) && key !== 'adaptiveQuizModal' && key !== 'adaptiveQuizContainer') {
                 console.warn(`HTML element not found: ${key} (selector: '${selectorValue}')`);


### PR DESCRIPTION
## Summary
- collapse recommendation cards by default
- provide CSS for collapsible cards with arrow
- hook up card toggles in JS and selectors
- ensure collapsible content hidden via CSS instead of inline styles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854b10799248326b5dcc20a49707906