### PR TITLE
Enhance menu appearance

### DIFF
--- a/code.html
+++ b/code.html
@@ -108,6 +108,16 @@
                         <span class="menu-icon" aria-hidden="true">✏️</span>Редакция на профил
                     </a>
                 </li>
+                <li>
+                    <a href="faq.html" id="menu-help-link">
+                        <span class="menu-icon" aria-hidden="true">❓</span>Помощ
+                    </a>
+                </li>
+                <li>
+                    <a href="about.html" id="menu-about-link">
+                        <span class="menu-icon" aria-hidden="true">ℹ️</span>За нас
+                    </a>
+                </li>
             </ul>
             <div class="menu-footer">
                 <button id="logoutButton">

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -65,6 +65,7 @@
   --menu-bg: rgba(255, 255, 255, 0.95);
   --menu-blur: 10px;
   --menu-overlay-bg: rgba(0, 0, 0, 0.5);
+  --menu-hover-bg: color-mix(in srgb, var(--primary-color) 12%, transparent);
 
   --fab-bg: var(--primary-color); --fab-icon: #fff;
 
@@ -136,6 +137,7 @@ body.dark-theme {
 
   --menu-bg: rgba(30, 30, 50, 0.9);
   --menu-overlay-bg: rgba(0, 0, 0, 0.65);
+  --menu-hover-bg: color-mix(in srgb, var(--primary-color) 35%, transparent);
 
   --fab-bg: var(--primary-color); --fab-icon: #1A1A2E;
 

--- a/css/layout_styles.css
+++ b/css/layout_styles.css
@@ -63,12 +63,12 @@ header h1 { color: var(--text-color-on-primary); margin: 0; font-size: clamp(1.3
 }
 #main-menu.menu-open { transform: translateX(0); }
 #main-menu nav { display: flex; flex-direction: column; gap: var(--space-xs); }
-#main-menu nav a, #main-menu nav button { 
+#main-menu nav a, #main-menu nav button {
   display: flex; align-items: center; gap: var(--space-md);
   padding: var(--space-sm) var(--space-md); color: var(--text-color-primary);
   text-decoration: none; font-size: 1.05rem; font-weight: 500;
-  border-radius: var(--radius-md); transition: background-color 0.2s, color 0.2s;
-  text-align: left; width: 100%; border: none; background: none; cursor: pointer;
+  border-radius: var(--radius-md); transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+  text-align: left; width: 100%; border: 1px solid transparent; background: none; cursor: pointer;
 }
 #main-menu .menu-icon { 
   font-size: 1.2em; 
@@ -78,8 +78,9 @@ header h1 { color: var(--text-color-on-primary); margin: 0; font-size: clamp(1.3
   transition: transform 0.2s ease-in-out;
 }
 #main-menu nav a:hover, #main-menu nav button:hover {
-  background-color: color-mix(in srgb, var(--primary-color) 10%, transparent);
+  background-color: var(--menu-hover-bg);
   color: var(--primary-color);
+  border-color: var(--primary-color);
 }
 #main-menu nav a:hover .menu-icon, 
 #main-menu nav button:hover .menu-icon {


### PR DESCRIPTION
## Summary
- tweak menu styles with a new `--menu-hover-bg` variable
- adjust menu item hover/border effect
- add help and about links to the main menu

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854b6a3b51883269ee8701df24dbd22