### PR TITLE
Update plan summary with menu diff

### DIFF
--- a/js/__tests__/planSummary.test.js
+++ b/js/__tests__/planSummary.test.js
@@ -49,4 +49,27 @@ describe('createPlanUpdateSummary', () => {
     const total = summary.changes.join(' ');
     expect(total).not.toContain('[object Object]');
   });
+
+  test('detects new dishes in week1Menu', () => {
+    const newPlan = {
+      week1Menu: {
+        monday: [
+          { meal_name: 'Закуска', items: [{ name: 'Овесена каша' }] },
+          { meal_name: 'Обяд', items: [{ name: 'Пиле' }] }
+        ]
+      }
+    };
+    const oldPlan = {
+      week1Menu: {
+        monday: [
+          { meal_name: 'Закуска', items: [{ name: 'Омлет' }] },
+          { meal_name: 'Обяд', items: [{ name: 'Пиле' }] }
+        ]
+      }
+    };
+    const summary = createPlanUpdateSummary(newPlan, oldPlan);
+    const joined = summary.changes.join(' ');
+    expect(joined).toContain('Понеделник');
+    expect(joined).toContain('Закуска');
+  });
 });


### PR DESCRIPTION
## Summary
- enhance `createPlanUpdateSummary` to list changed dishes from `week1Menu`
- cover new behaviour in `planSummary.test.js`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854b6f36f388326a263b3e79a771bfc