### PR TITLE
Unify tips card size and add context colors

### DIFF
--- a/code.html
+++ b/code.html
@@ -307,7 +307,7 @@
                     <h2>💡 Препоръки</h2>
                     <div class="recommendation-section">
                         <h3>🍎 Основи на Храненето</h3>
-                        <div id="recFoodAllowedCard" class="card collapsible-card">
+                        <div id="recFoodAllowedCard" class="card collapsible-card tip-card-success">
                             <h4>✅ Препоръчителни Храни</h4>
                             <div class="collapsible-content">
                                 <div id="recFoodAllowedContent">
@@ -319,7 +319,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div id="recFoodLimitCard" class="card collapsible-card">
+                        <div id="recFoodLimitCard" class="card collapsible-card tip-card-critical">
                             <h4>❌ Храни за Внимание/Ограничаване</h4>
                             <div class="collapsible-content">
                                 <div id="recFoodLimitContent">
@@ -331,7 +331,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div id="recHydrationCard" class="card collapsible-card">
+                        <div id="recHydrationCard" class="card collapsible-card tip-card-info">
                             <h4>💧 Хидратация и Напитки</h4>
                             <div class="collapsible-content">
                                 <div id="recHydrationContent">
@@ -339,7 +339,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div id="recCookingMethodsCard" class="card collapsible-card">
+                        <div id="recCookingMethodsCard" class="card collapsible-card tip-card-info">
                             <h4>🍳 Методи на Готвене</h4>
                             <div class="collapsible-content">
                                 <div id="recCookingMethodsContent">
@@ -356,7 +356,7 @@
                     </div>
                     <div class="recommendation-section">
                         <h3>💊 Хранителни Добавки</h3>
-                        <div id="recSupplementsCard" class="card collapsible-card">
+                        <div id="recSupplementsCard" class="card collapsible-card tip-card-warning">
                             <h4>Хранителни Добавки</h4>
                             <div class="collapsible-content">
                                 <div id="recSupplementsContent">

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -87,8 +87,9 @@
   --note-success-bg: #e8f5e9; --note-success-text: #1b5e20; --note-success-border: #2e7d32;
 
   --primary-rgb: 58, 80, 107;
-  --header-height: 60px; 
+  --header-height: 60px;
   --tabs-height: 65px;
+  --tips-collapsed-height: 4.5rem;
 
   --metric-value-group-bg-initial: color-mix(in srgb, var(--surface-background) 95%, var(--border-color-soft));
   --metric-value-group-bg-expected: color-mix(in srgb, var(--surface-background) 95%, var(--accent-color) 20%);

--- a/css/recommendations_panel_styles.css
+++ b/css/recommendations_panel_styles.css
@@ -4,12 +4,24 @@
   font-size: clamp(1.35rem, 3.2vw, 1.75rem); border-bottom: 2px solid var(--border-color);
   padding-bottom: var(--space-sm); margin-bottom: var(--space-lg);
 }
-.recommendation-section .card { 
-  margin-bottom: var(--space-lg); 
-  background-color: var(--metric-value-group-bg-initial); 
+.recommendation-section .card {
+  margin-bottom: var(--space-lg);
+  background-color: var(--metric-value-group-bg-initial);
   border: 1px solid var(--border-color);
   padding: var(--space-lg);
 }
+
+/* Уеднаквяване размера на картите в таб "Съвети" при сгънато състояние */
+#recs-panel .collapsible-card {
+  min-height: var(--tips-collapsed-height, 4.5rem);
+  transition: background-color 0.3s ease;
+}
+
+/* Цветови нюанси според контекста */
+#recs-panel .tip-card-success { background-color: var(--note-success-bg); }
+#recs-panel .tip-card-critical { background-color: var(--note-critical-bg); }
+#recs-panel .tip-card-info { background-color: var(--note-info-bg); }
+#recs-panel .tip-card-warning { background-color: var(--note-important-bg); }
 body.dark-theme .recommendation-section .card {
   background-color: var(--metric-value-group-bg-initial);
 }


### PR DESCRIPTION
## Summary
- enforce consistent collapsed height for recommendation cards in the "Tips" tab
- add context color classes to recommendation cards and apply in HTML
- expose a `--tips-collapsed-height` variable for easier adjustment

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854be24761c8326b6b17c28a7e88c6d