### PR TITLE
Profile edit and menu styling

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -27,7 +27,9 @@
     <h2 id="clientName">Клиент</h2>
     <form id="profileForm">
       <label>Име: <input name="name"></label><br>
+      <label>Имена: <input name="fullname"></label><br>
       <label>Възраст: <input type="number" name="age"></label><br>
+      <label>Телефон: <input name="phone"></label><br>
       <label>Ръст: <input type="number" name="height"></label><br>
       <label>Email: <input name="email" disabled></label><br>
       <label>Тегло: <input type="number" name="weight"></label><br>

--- a/css/layout_styles.css
+++ b/css/layout_styles.css
@@ -62,8 +62,8 @@ header h1 { color: var(--text-color-on-primary); margin: 0; font-size: clamp(1.3
   color: var(--text-color-primary);
 }
 #main-menu.menu-open { transform: translateX(0); }
-#main-menu nav { display: flex; flex-direction: column; gap: var(--space-xs); }
-#main-menu nav a, #main-menu nav button {
+#main-menu ul { display: flex; flex-direction: column; gap: var(--space-xs); }
+#main-menu ul a, #main-menu ul button {
   display: flex; align-items: center; gap: var(--space-md);
   padding: var(--space-sm) var(--space-md); color: var(--text-color-primary);
   text-decoration: none; font-size: 1.05rem; font-weight: 500;
@@ -77,13 +77,13 @@ header h1 { color: var(--text-color-on-primary); margin: 0; font-size: clamp(1.3
   margin-right: 0.1em; 
   transition: transform 0.2s ease-in-out;
 }
-#main-menu nav a:hover, #main-menu nav button:hover {
+#main-menu ul a:hover, #main-menu ul button:hover {
   background-color: var(--menu-hover-bg);
   color: var(--primary-color);
   border-color: var(--primary-color);
 }
-#main-menu nav a:hover .menu-icon, 
-#main-menu nav button:hover .menu-icon {
+#main-menu ul a:hover .menu-icon,
+#main-menu ul button:hover .menu-icon {
   transform: scale(1.1) rotate(-5deg);
 }
 #main-menu .menu-close {

--- a/js/admin.js
+++ b/js/admin.js
@@ -212,7 +212,9 @@ async function showClient(userId) {
             detailsSection.classList.remove('hidden');
             document.getElementById('clientName').textContent = data.name || 'Клиент';
             profileForm.name.value = data.name || '';
+            profileForm.fullname.value = data.fullname || '';
             profileForm.age.value = data.age || '';
+            profileForm.phone.value = data.phone || '';
             profileForm.height.value = data.height || '';
             profileForm.email.value = data.email || '';
             profileForm.weight.value = data.weight || '';
@@ -244,7 +246,9 @@ profileForm.addEventListener('submit', async e => {
     const payload = {
         userId: currentUserId,
         name: profileForm.name.value,
+        fullname: profileForm.fullname.value,
         age: parseInt(profileForm.age.value, 10) || null,
+        phone: profileForm.phone.value,
         height: parseInt(profileForm.height.value, 10) || null,
         email: profileForm.email.value || undefined
     };

--- a/js/profileEdit.js
+++ b/js/profileEdit.js
@@ -20,9 +20,13 @@ if (form) {
       const data = await res.json();
 
       form.name.value = safeGet(data, 'name', '');
+      form.fullname.value = safeGet(data, 'fullname', '');
 
       const age = safeParseFloat(safeGet(data, 'age'));
       if (age !== null && age !== undefined) form.age.value = age;
+
+      form.phone.value = safeGet(data, 'phone', '');
+      form.email.value = safeGet(data, 'email', '');
 
       const height = safeParseFloat(safeGet(data, 'height'));
       if (height !== null && height !== undefined) form.height.value = height;
@@ -39,7 +43,10 @@ if (form) {
 
     const data = {
       name: form.name.value.trim(),
+      fullname: form.fullname.value.trim(),
       age: safeParseFloat(form.age.value),
+      phone: form.phone.value.trim(),
+      email: form.email.value.trim(),
       height: safeParseFloat(form.height.value),
     };
 

--- a/profile-edit.html
+++ b/profile-edit.html
@@ -57,10 +57,25 @@
           <input id="name" name="name" type="text" required>
         </div>
 
-      <div class="form-group">
-        <label for="age">Възраст</label>
-        <input id="age" name="age" type="number" min="0" step="1">
-      </div>
+        <div class="form-group">
+          <label for="fullname">Имена</label>
+          <input id="fullname" name="fullname" type="text">
+        </div>
+
+        <div class="form-group">
+          <label for="age">Възраст</label>
+          <input id="age" name="age" type="number" min="0" step="1">
+        </div>
+
+        <div class="form-group">
+          <label for="phone">Телефон</label>
+          <input id="phone" name="phone" type="tel">
+        </div>
+
+        <div class="form-group">
+          <label for="email">Имейл</label>
+          <input id="email" name="email" type="email">
+        </div>
 
         <div class="form-group">
           <label for="height">Височина (см)</label>

--- a/worker.js
+++ b/worker.js
@@ -885,7 +885,10 @@ async function handleUpdateProfileRequest(request, env) {
         if (!userId) return { success: false, message: "Липсва ID на потребител.", statusHint: 400 };
         const profile = {
             name: data.name ? String(data.name).trim() : "",
+            fullname: data.fullname ? String(data.fullname).trim() : "",
             age: (typeof data.age === "number" && !isNaN(data.age)) ? data.age : null,
+            phone: data.phone ? String(data.phone).trim() : "",
+            email: data.email ? String(data.email).trim().toLowerCase() : "",
             height: (typeof data.height === "number" && !isNaN(data.height)) ? data.height : null
         };
         await env.USER_METADATA_KV.put(`${userId}_profile`, JSON.stringify(profile));


### PR DESCRIPTION
## Summary
- expand profile editor form with fields for full name, phone and email
- handle these new fields in profileEdit.js
- allow admin interface to load and save the added profile data
- persist extra fields in Worker updateProfile handler
- unify hamburger menu styling

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c0184bc48326aaeabcde4923ac4a