### PR TITLE
Implement collapsible progress history card

### DIFF
--- a/code.html
+++ b/code.html
@@ -184,9 +184,9 @@
                             <div id="streakGrid" class="streak-grid"></div>
                             <p id="streakCount" class="index-value">0</p>
                         </div>
-                        <div class="card index-card" id="progressHistoryCard">
+                        <div class="card index-card collapsible-card" id="progressHistoryCard">
                             <h4><svg class="icon" style="width: 1em; height: 1em; margin-right: 0.3em;"><use href="#icon-chart-line"></use></svg> История на Напредъка</h4>
-                            <div class="chart-container">
+                            <div class="collapsible-content chart-container">
                                 <p class="placeholder">Зареждане на историята на напредъка...</p>
                             </div>
                         </div>

--- a/css/recommendations_panel_styles.css
+++ b/css/recommendations_panel_styles.css
@@ -46,10 +46,13 @@ body.dark-theme .recommendation-section .card {
 #recFoodAllowedContent ul:first-of-type strong { margin-top: 0; }
 
 /* --- 6.5. Нови секции: История на прогреса --- */
-#progressHistoryCard .chart-container {
+#progressHistoryCard .collapsible-content {
     /* Стандартна височина като останалите index-card карти */
     min-height: 100px;
     position: relative;
     padding: var(--space-sm);
+}
+#progressHistoryCard:not(.open) .collapsible-content {
+    display: none;
 }
 /* #motivationalMessageCard - Премахнато */

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -224,7 +224,7 @@ export function setupStaticEventListeners() {
 }
 
 export function initializeCollapsibleCards() {
-    const cards = document.querySelectorAll('#recs-panel .collapsible-card');
+    const cards = document.querySelectorAll('.collapsible-card');
     cards.forEach(card => {
         const header = card.querySelector('h4');
         const content = card.querySelector('.collapsible-content');

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -675,17 +675,16 @@ export function handleAccordionToggle(event) {
 
 function populateProgressHistory(dailyLogs, initialData) {
     if (!selectors.progressHistoryCard) return;
-    selectors.progressHistoryCard.innerHTML = '';
+    const content = selectors.progressHistoryCard.querySelector('.collapsible-content');
+    if (!content) return;
+    content.innerHTML = '';
 
     const canvas = document.createElement('canvas');
     canvas.id = 'progressChart';
-    const chartContainer = document.createElement('div');
-    chartContainer.className = 'chart-container';
-    chartContainer.appendChild(canvas);
-    selectors.progressHistoryCard.appendChild(chartContainer);
+    content.appendChild(canvas);
 
     if (typeof Chart === 'undefined') {
-        selectors.progressHistoryCard.innerHTML = '<p class="placeholder">Библиотеката за графики (Chart.js) не е заредена. Историята на прогреса не може да бъде показана.</p>';
+        content.innerHTML = '<p class="placeholder">Библиотеката за графики (Chart.js) не е заредена. Историята на прогреса не може да бъде показана.</p>';
         console.warn("Chart.js is not loaded.");
         return;
     }
@@ -713,7 +712,7 @@ function populateProgressHistory(dailyLogs, initialData) {
     });
 
     if (labels.length < 2 && weightData.length < 2) {
-         selectors.progressHistoryCard.innerHTML = '<p class="placeholder">Няма достатъчно данни за показване на история на прогреса в теглото.</p>';
+         content.innerHTML = '<p class="placeholder">Няма достатъчно данни за показване на история на прогреса в теглото.</p>';
          return;
     }
 


### PR DESCRIPTION
## Summary
- allow all `.collapsible-card` widgets to be initialized
- move progress history chart into `.collapsible-content`
- hide chart by default so the card matches the rest

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854c6f16ab083268548f211a82cbc41