### PR TITLE
Improve admin panel with profile editor

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -2,7 +2,12 @@
 <html lang="bg">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Администраторски панел</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/base_styles.css">
+  <link rel="stylesheet" href="css/layout_styles.css">
+  <link rel="stylesheet" href="css/components_styles.css">
   <link rel="stylesheet" href="css/admin.css">
 </head>
 <body>
@@ -25,7 +30,15 @@
 
   <main class="main-content card" id="clientDetails" class="hidden">
     <h2 id="clientName">Клиент</h2>
-    <!-- Формата за лични данни е премахната -->
+    <details id="profileSection">
+      <summary>Лични данни</summary>
+      <form id="profileForm">
+        <label>Име: <input id="profileName" type="text"></label><br>
+        <label>Имейл: <input id="profileEmail" type="email"></label><br>
+        <label>Телефон: <input id="profilePhone" type="tel"></label><br>
+        <button type="submit">Запази профила</button>
+      </form>
+    </details>
     <button id="regeneratePlan">Генерирай нов план</button>
     <button id="aiSummary">AI резюме</button>
     <details id="notesSection">

--- a/css/admin.css
+++ b/css/admin.css
@@ -1,4 +1,8 @@
-body { font-family: Arial, sans-serif; padding: 20px; background: #f0f2f5; }
+body {
+  font-family: var(--font-primary, Arial, sans-serif);
+  padding: var(--space-md);
+  background: var(--bg-color) var(--bg-gradient);
+}
 .hidden { display: none; }
 #clientsList li { margin-bottom: 5px; }
 #clientsList button {
@@ -25,10 +29,10 @@ pre { background: #f5f5f5; padding: 10px; overflow: auto; }
   flex: 3 1 400px;
 }
 .card {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-  padding: 15px;
+  background: var(--card-bg, #fff);
+  border-radius: var(--radius-md, 8px);
+  box-shadow: var(--shadow-md, 0 2px 5px rgba(0,0,0,0.1));
+  padding: var(--space-md, 15px);
 }
 pre.json {
   background: #272822;

--- a/js/admin.js
+++ b/js/admin.js
@@ -37,6 +37,11 @@ const dailyLogsPre = document.getElementById('dailyLogs');
 const exportPlanBtn = document.getElementById('exportPlan');
 const dashboardPre = document.getElementById('dashboardData');
 const exportDataBtn = document.getElementById('exportData');
+const profileForm = document.getElementById('profileForm');
+const profileName = document.getElementById('profileName');
+const profileEmail = document.getElementById('profileEmail');
+const profilePhone = document.getElementById('profilePhone');
+const clientNameHeading = document.getElementById('clientName');
 let currentUserId = null;
 let currentPlanData = null;
 let currentDashboardData = null;
@@ -152,7 +157,7 @@ function renderClients() {
     const filter = statusFilter.value;
     clientsList.innerHTML = '';
     const list = allClients.filter(c => {
-        const matchText = `${c.userId}`.toLowerCase();
+        const matchText = `${c.userId} ${c.name || ''} ${c.email || ''}`.toLowerCase();
         const matchesSearch = matchText.includes(search);
         const matchesStatus = filter === 'all' || c.status === filter;
         return matchesSearch && matchesStatus;
@@ -161,7 +166,7 @@ function renderClients() {
     list.forEach(c => {
         const li = document.createElement('li');
         const btn = document.createElement('button');
-        btn.textContent = `${c.userId} - ${c.status}`;
+        btn.textContent = `${c.name} (${c.userId}) - ${c.status}`;
         btn.addEventListener('click', () => showClient(c.userId));
         li.appendChild(btn);
         clientsList.appendChild(li);
@@ -183,7 +188,10 @@ async function showClient(userId) {
         if (resp.ok && data.success) {
             currentUserId = userId;
             detailsSection.classList.remove('hidden');
-            document.getElementById('clientName').textContent = userId;
+            clientNameHeading.textContent = data.name ? `${data.name} (${userId})` : userId;
+            if (profileName) profileName.value = data.name || '';
+            if (profileEmail) profileEmail.value = data.email || '';
+            if (profilePhone) profilePhone.value = data.phone || '';
             await loadQueries();
             await loadFeedback();
         }
@@ -292,6 +300,28 @@ if (exportDataBtn) {
         a.download = `${currentUserId || 'data'}.json`;
         a.click();
         URL.revokeObjectURL(url);
+    });
+}
+
+if (profileForm) {
+    profileForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        if (!currentUserId) return;
+        try {
+            await fetch(apiEndpoints.updateProfile, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    userId: currentUserId,
+                    name: profileName.value.trim(),
+                    email: profileEmail.value.trim(),
+                    phone: profilePhone.value.trim()
+                })
+            });
+            alert('Профилът е обновен.');
+        } catch (err) {
+            console.error('Error updating profile:', err);
+        }
     });
 }
 

--- a/worker.js
+++ b/worker.js
@@ -1287,7 +1287,9 @@ async function handleListClientsRequest(request, env) {
             const ansStr = await env.USER_METADATA_KV.get(`${id}_initial_answers`);
             if (!ansStr) continue;
             const ans = safeParseJson(ansStr, {});
-            clients.push({ userId: id, name: ans.name || 'Клиент' });
+            const profileStr = await env.USER_METADATA_KV.get(`${id}_profile`);
+            const profile = profileStr ? safeParseJson(profileStr, {}) : {};
+            clients.push({ userId: id, name: ans.name || 'Клиент', email: profile.email || '' });
         }
         return { success: true, clients };
     } catch (error) {


### PR DESCRIPTION
## Summary
- style admin panel using base styles for consistency
- list client names and emails, not just IDs
- add profile details section for editing name, email and phone
- update worker API to return email with clients
- tweak card styles to use base CSS vars

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854c76297f08326925e3a2e63d1f6e1