### PR TITLE
Change color of supplement tips card

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -85,6 +85,7 @@
   --note-important-bg: #fffde7; --note-important-text: #f57f17; --note-important-border: #ff8f00;
   --note-info-bg: #e3f2fd; --note-info-text: #0d47a1; --note-info-border: #1976d2;
   --note-success-bg: #e8f5e9; --note-success-text: #1b5e20; --note-success-border: #2e7d32;
+  --supplement-card-bg: #f0f9e0;
 
   --primary-rgb: 58, 80, 107;
   --header-height: 60px;
@@ -155,6 +156,7 @@ body.dark-theme {
   --note-important-bg: rgba(255, 143, 0, 0.2); --note-important-text: #ffcc80; --note-important-border: #ff8f00;
   --note-info-bg: rgba(25, 118, 210, 0.2); --note-info-text: #90caf9; --note-info-border: #1976d2;
   --note-success-bg: rgba(46, 125, 50, 0.2); --note-success-text: #a5d6a7; --note-success-border: #2e7d32;
+  --supplement-card-bg: rgba(152, 251, 152, 0.2);
 
   --primary-rgb: 91, 192, 190;
 

--- a/css/recommendations_panel_styles.css
+++ b/css/recommendations_panel_styles.css
@@ -22,6 +22,7 @@
 #recs-panel .tip-card-critical { background-color: var(--note-critical-bg); }
 #recs-panel .tip-card-info { background-color: var(--note-info-bg); }
 #recs-panel .tip-card-warning { background-color: var(--note-important-bg); }
+#recSupplementsCard { background-color: var(--supplement-card-bg); }
 body.dark-theme .recommendation-section .card {
   background-color: var(--metric-value-group-bg-initial);
 }


### PR DESCRIPTION
## Summary
- add CSS var for supplement card color for light/dark themes
- apply the new background color to the Supplements card in the tips tab

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855605c0340832697043ff5fe79a235