### PR TITLE
Fix user can't see admin messages

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -459,6 +459,10 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
         console.error("Error loading/processing dashboard data:", error);
         showToast(`Грешка при зареждане: ${error.message}`, true, 7000);
         showPlanPendingState(`Възникна грешка: ${error.message}. Опитайте да презаредите страницата или <a href='index.html' style='color: var(--primary-color); text-decoration: underline;'>влезте отново</a>.`);
+        if (currentUserId) {
+            await checkAdminQueries(currentUserId);
+            startAdminQueriesPolling();
+        }
     } finally {
         showLoading(false);
     }


### PR DESCRIPTION
## Summary
- ensure admin queries are fetched even if dashboard loading fails

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556e8029e88326b26aa73995a558b8