### PR TITLE
Fix worker publish date

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ To set the token:
 1. Generate an API token with **Edit Cloudflare Workers** permissions.
 2. In your repository settings, create a GitHub secret named `CF_API_TOKEN` containing the token value.
 
-The worker configuration is stored in `wrangler.toml`. Update `account_id` with your Cloudflare account if needed. For the `USER_METADATA_KV` namespace the file expects the environment variables `USER_METADATA_KV_ID` and `USER_METADATA_KV_PREVIEW_ID`. Configure them as GitHub secrets so the workflow can substitute the correct IDs before publishing.
+The worker configuration is stored in `wrangler.toml`. Update `account_id` with your Cloudflare account if needed. For the `USER_METADATA_KV` namespace the file expects the environment variables `USER_METADATA_KV_ID` and `USER_METADATA_KV_PREVIEW_ID`. Configure them as GitHub secrets so the workflow can substitute the correct IDs before publishing. **Важно:** полето `compatibility_date` не може да сочи в бъдещето спрямо датата на деплой. Ако е зададена по-нова дата, Cloudflare ще откаже публикуването. Затова поддържайте стойност, която е днес или по-стара. Например:
+
+```toml
+compatibility_date = "2025-06-20"
+```
 You can verify this setup locally by running:
 
 ```bash

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,7 @@
 name = "openapichatbot"
 account_id = "c2015f4060e04bc3c414f78a9946668e"
 workers_dev = true
-compatibility_date = "2025-06-06"
+compatibility_date = "2025-06-20"
 main = "worker.js"
 
 [[kv_namespaces]]


### PR DESCRIPTION
## Summary
- set `compatibility_date` to 2025‑06‑20 in `wrangler.toml`
- document why the date matters in Cloudflare deploy section

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855981e57c88326ac0b07fb0ef388c4