### PR TITLE
Add debug logging via X-Debug header

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ Replace the placeholders with your own values and keep the token secret.
 - `POST /api/submitFeedback` – изпраща обратна връзка от клиента.
 - `GET /api/getAiConfig` – зарежда текущата AI конфигурация.
 - `POST /api/setAiConfig` – записва токени и модели в `RESOURCES_KV`.
+- **Дебъг логове** – при изпращане на заглавие `X-Debug: 1` към който и да е API
+ендпойнт, worker-ът записва в конзолата кратка информация за заявката.
 
 ### Промяна на плана
 

--- a/worker.js
+++ b/worker.js
@@ -1,4 +1,6 @@
-// Cloudflare Worker Script (index.js) - Версия 2.2 (Интегрирана, с подобрения по TODO, добавени адаптивни въпросници и log-extra-meal)
+// Cloudflare Worker Script (index.js) - Версия 2.3
+// Добавен е режим за дебъг чрез HTTP заглавие `X-Debug: 1`
+// Също така са запазени всички функционалности от предходните версии
 // Включва:
 // - Пълна логика за Адаптивен Въпросник: генериране, подаване, анализ на отговори. (Запазена и подобрена от v2.1)
 // - Актуализиран handlePrincipleAdjustment с по-детайлни данни от въпросник. (Запазено от v2.1)
@@ -77,6 +79,12 @@ export default {
         const url = new URL(request.url);
         const path = url.pathname;
         const method = request.method;
+
+        // Debug logging when header X-Debug: 1 е подаден
+        const debugEnabled = request.headers.get('X-Debug') === '1';
+        if (debugEnabled) {
+            console.log(`[DEBUG] ${method} ${path} @ ${new Date().toISOString()}`);
+        }
 
         const allowedOrigins = [
             'https://radilovk.github.io',


### PR DESCRIPTION
## Summary
- describe debug header in README
- log each request when header `X-Debug: 1` is present

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855a5c9a7c88326b54a3b07a81a5d34