### PR TITLE
Add test for saveAiConfig request

### DIFF
--- a/js/__tests__/saveAiConfig.test.js
+++ b/js/__tests__/saveAiConfig.test.js
@@ -1,0 +1,70 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+beforeEach(() => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <div id="notificationIndicator" class="hidden"></div>
+    <ul id="clientsList"></ul>
+    <span id="clientsCount"></span>
+    <input id="clientSearch" />
+    <select id="statusFilter"><option value="all">all</option></select>
+    <button id="showStats"></button>
+    <button id="sendQuery"></button>
+    <div id="clientDetails" class="hidden"></div>
+    <h2 id="clientName"></h2>
+    <input id="profileName" />
+    <input id="profileEmail" />
+    <input id="profilePhone" />
+    <ul id="queriesList"></ul>
+    <ul id="clientRepliesList"></ul>
+    <ul id="feedbackList"></ul>
+    <pre id="dashboardData"></pre>
+    <form id="aiConfigForm">
+      <input id="planToken" />
+      <input id="planModel" />
+      <input id="chatToken" />
+      <input id="chatModel" />
+      <input id="modToken" />
+      <input id="modModel" />
+      <button type="submit">Save</button>
+    </form>
+  `;
+  window.WORKER_ADMIN_TOKEN = 'admintoken';
+  localStorage.clear();
+});
+
+afterEach(() => {
+  delete window.WORKER_ADMIN_TOKEN;
+  if (global.fetch) {
+    global.fetch.mockRestore();
+  }
+});
+
+test('saveAiConfig sends updates with Authorization header', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true })
+  });
+  await import('../admin.js');
+  const form = document.getElementById('aiConfigForm');
+  document.getElementById('planToken').value = 'pt';
+  document.getElementById('planModel').value = 'pm';
+  document.getElementById('chatToken').value = 'ct';
+  document.getElementById('chatModel').value = 'cm';
+  document.getElementById('modToken').value = 'mt';
+  document.getElementById('modModel').value = 'mm';
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+  await Promise.resolve();
+  expect(global.fetch).toHaveBeenCalledTimes(1);
+  const [, options] = global.fetch.mock.calls[0];
+  expect(JSON.parse(options.body)).toEqual({ updates: {
+    planToken: 'pt',
+    planModel: 'pm',
+    chatToken: 'ct',
+    chatModel: 'cm',
+    modToken: 'mt',
+    modModel: 'mm'
+  }});
+  expect(options.headers.Authorization).toBe('Bearer admintoken');
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -549,7 +549,7 @@ async function loadAiConfig() {
 
 async function saveAiConfig() {
     if (!aiConfigForm) return;
-    const payload = {
+    const updates = {
         planToken: planTokenInput.value.trim(),
         planModel: planModelInput.value.trim(),
         chatToken: chatTokenInput.value.trim(),
@@ -557,15 +557,18 @@ async function saveAiConfig() {
         modToken: modTokenInput.value.trim(),
         modModel: modModelInput.value.trim()
     };
-    if (!payload.planToken || !payload.chatToken || !payload.modToken) {
+    if (!updates.planToken || !updates.chatToken || !updates.modToken) {
         alert('Моля, попълнете всички токени.');
         return;
     }
     try {
+        const adminToken = window.WORKER_ADMIN_TOKEN || '';
+        const headers = { 'Content-Type': 'application/json' };
+        if (adminToken) headers.Authorization = `Bearer ${adminToken}`;
         const resp = await fetch(apiEndpoints.setAiConfig, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload)
+            headers,
+            body: JSON.stringify({ updates })
         });
         const data = await resp.json();
         if (!resp.ok || !data.success) throw new Error(data.message || 'Error');


### PR DESCRIPTION
## Summary
- update `saveAiConfig` to send `{ updates: ... }` and optional Authorization header
- add Jest test for `saveAiConfig`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855ce94fb748326a88823392879785d