### PR TITLE
Add configurable initial chat message

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,18 @@ curl https://api.cloudflare.com/client/v4/accounts/<CF_ACCOUNT_ID>/ai/run/@cf/me
 ```
 
 Replace the placeholders with your own values and keep the token secret.
+
+### Промяна на началното съобщение в чата
+
+Текстът, който се показва при първо отваряне на чата, се намира в `js/config.js`
+под формата на променлива `initialBotMessage`. Можете да редактирате този файл
+или временно да презапишете стойността чрез конзолата:
+
+```javascript
+localStorage.setItem('initialBotMessage', 'Добре дошли!');
+```
+
+След презареждане на страницата чатът ще използва новото съобщение.
 ## Допълнителни функции
 - **Извънредно хранене** – бутонът "Добави извънредно хранене" в `code.html` отваря модалната форма `extra-meal-entry-form.html`. Логиката в `js/extraMealForm.js` изпраща данните към `/api/log-extra-meal` в `worker.js`.
 - **Изследвания** – POST заявки към `/api/uploadTestResult` и `/api/uploadIrisDiag` записват данни за проведени тестове или ирисова диагностика в KV и създават събитие за автоматична адаптация на плана.

--- a/js/chat.js
+++ b/js/chat.js
@@ -2,7 +2,7 @@
 // chat.js - Логика за Чат
 import { selectors } from './uiElements.js';
 import { chatHistory, currentUserId } from './app.js'; // Access chatHistory and userId
-import { apiEndpoints } from './config.js';
+import { apiEndpoints, initialBotMessage } from './config.js';
 import { escapeHtml } from './utils.js';
 
 export let automatedChatPending = false;
@@ -25,7 +25,6 @@ export function toggleChatWidget(skipInit = false) {
         if(selectors.chatInput) selectors.chatInput.focus();
         if (selectors.chatMessages) {
             if (!skipInit && chatHistory.length === 0 && selectors.chatMessages.children.length === 0) {
-                 const initialBotMessage = "Здравейте! Аз съм вашият виртуален асистент MyBody.Best. Как мога да ви помогна днес?";
                  displayMessage(initialBotMessage, 'bot');
                  chatHistory.push({ text: initialBotMessage, sender: 'bot', isError: false });
             } else if (selectors.chatMessages.children.length === 0 && chatHistory.length > 0) {

--- a/js/config.js
+++ b/js/config.js
@@ -44,3 +44,10 @@ export const apiEndpoints = {
 export const cloudflareAccountId = window.CF_ACCOUNT_ID || 'c2015f4060e04bc3c414f78a9946668e';
 
 export const generateId = (prefix = 'id') => `${prefix}-${Math.random().toString(36).substr(2, 9)}`;
+
+// Първоначално съобщение в чата. Може да се презапише чрез sessionStorage или
+// localStorage с ключ "initialBotMessage".
+export const initialBotMessage =
+    (typeof sessionStorage !== 'undefined' && sessionStorage.getItem('initialBotMessage')) ||
+    (typeof localStorage !== 'undefined' && localStorage.getItem('initialBotMessage')) ||
+    'Здравейте! Аз съм вашият виртуален асистент MyBody.Best. Как мога да ви помогна днес?';


### PR DESCRIPTION
## Summary
- allow overriding the greeting text from `js/config.js`
- display that message in `chat.js`
- document how to change the first bot message

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855d5052aa08326875958b57de27ed9