### PR TITLE
Add AI configuration presets

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -117,6 +117,14 @@
         <legend>Модификация на плана</legend>
         <label>Модел: <input id="modModel" type="text"></label>
       </fieldset>
+      <div class="preset-controls">
+        <label>Запазени настройки:
+          <select id="aiPresetSelect"></select>
+        </label>
+        <button type="button" id="applyPreset">Зареди</button>
+        <label>Ново име: <input id="presetName" type="text"></label>
+        <button type="button" id="savePreset">Запази пресет</button>
+      </div>
       <button type="submit">Запази</button>
     </form>
   </section>

--- a/js/__tests__/aiPresets.test.js
+++ b/js/__tests__/aiPresets.test.js
@@ -1,0 +1,32 @@
+import { jest } from '@jest/globals';
+import { handleSaveAiPreset, handleListAiPresets, handleGetAiPreset } from '../../worker.js';
+
+function createStore(initial = {}) {
+  const store = { ...initial };
+  return {
+    list: jest.fn(async ({ prefix } = {}) => ({ keys: Object.keys(store).filter(k => !prefix || k.startsWith(prefix)).map(name => ({ name })) })),
+    get: jest.fn(async key => store[key] || null),
+    put: jest.fn(async (key, value) => { store[key] = String(value); }),
+    _store: store
+  };
+}
+
+test('save preset and retrieve it', async () => {
+  const kv = createStore();
+  const env = { RESOURCES_KV: kv, WORKER_ADMIN_TOKEN: 'secret' };
+  const reqSave = {
+    headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
+    json: async () => ({ name: 'test', config: { planModel: 'm1' } })
+  };
+  const saveRes = await handleSaveAiPreset(reqSave, env);
+  expect(saveRes.success).toBe(true);
+  expect(kv._store['aiPreset_test']).toBe(JSON.stringify({ planModel: 'm1' }));
+
+  const listRes = await handleListAiPresets({}, env);
+  expect(listRes.success).toBe(true);
+  expect(listRes.presets).toContain('test');
+
+  const getRes = await handleGetAiPreset({ url: 'https://x/api/getAiPreset?name=test' }, env);
+  expect(getRes.success).toBe(true);
+  expect(getRes.config.planModel).toBe('m1');
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -47,6 +47,10 @@ const aiConfigForm = document.getElementById('aiConfigForm');
 const planModelInput = document.getElementById('planModel');
 const chatModelInput = document.getElementById('chatModel');
 const modModelInput = document.getElementById('modModel');
+const presetSelect = document.getElementById('aiPresetSelect');
+const savePresetBtn = document.getElementById('savePreset');
+const applyPresetBtn = document.getElementById('applyPreset');
+const presetNameInput = document.getElementById('presetName');
 const clientNameHeading = document.getElementById('clientName');
 const notificationsList = document.getElementById('notificationsList');
 const notificationsSection = document.getElementById('notificationsSection');
@@ -611,12 +615,82 @@ async function saveAiConfig() {
     }
 }
 
+async function loadAiPresets() {
+    if (!presetSelect) return;
+    try {
+        const resp = await fetch(apiEndpoints.listAiPresets);
+        const data = await resp.json();
+        if (!resp.ok || !data.success) throw new Error(data.message || 'Error');
+        presetSelect.innerHTML = '<option value="">--Изберете--</option>';
+        (data.presets || []).forEach(name => {
+            const opt = document.createElement('option');
+            opt.value = name;
+            opt.textContent = name;
+            presetSelect.appendChild(opt);
+        });
+    } catch (err) {
+        console.error('Error loading presets:', err);
+    }
+}
+
+async function applySelectedPreset() {
+    const name = presetSelect?.value;
+    if (!name) return;
+    try {
+        const resp = await fetch(`${apiEndpoints.getAiPreset}?name=${encodeURIComponent(name)}`);
+        const data = await resp.json();
+        if (!resp.ok || !data.success) throw new Error(data.message || 'Error');
+        const cfg = data.config || {};
+        planModelInput.value = cfg.planModel || cfg.model_plan_generation || '';
+        chatModelInput.value = cfg.chatModel || cfg.model_chat || '';
+        modModelInput.value = cfg.modModel || cfg.model_principle_adjustment || '';
+    } catch (err) {
+        console.error('Error applying preset:', err);
+        alert('Грешка при зареждане на пресета.');
+    }
+}
+
+async function saveCurrentPreset() {
+    const name = presetNameInput?.value.trim();
+    if (!name) {
+        alert('Въведете име за пресета.');
+        return;
+    }
+    const payload = {
+        name,
+        config: {
+            planModel: planModelInput.value.trim(),
+            chatModel: chatModelInput.value.trim(),
+            modModel: modModelInput.value.trim()
+        }
+    };
+    try {
+        const adminToken = localStorage.getItem('adminToken') || '';
+        const headers = { 'Content-Type': 'application/json' };
+        if (adminToken) headers.Authorization = `Bearer ${adminToken}`;
+        const resp = await fetch(apiEndpoints.saveAiPreset, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(payload)
+        });
+        const data = await resp.json();
+        if (!resp.ok || !data.success) throw new Error(data.message || 'Error');
+        presetNameInput.value = '';
+        alert('Пресетът е записан.');
+        await loadAiPresets();
+    } catch (err) {
+        console.error('Error saving preset:', err);
+        alert('Грешка при запис на пресета.');
+    }
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
     await ensureLoggedIn();
     await loadClients();
     await checkForNotifications();
     await loadNotifications();
     await loadAiConfig();
+    await loadAiPresets();
     setInterval(checkForNotifications, 60000);
     setInterval(loadNotifications, 60000);
 });
@@ -626,6 +700,8 @@ if (aiConfigForm) {
         e.preventDefault();
         await saveAiConfig();
     });
+    savePresetBtn?.addEventListener('click', saveCurrentPreset);
+    applyPresetBtn?.addEventListener('click', applySelectedPreset);
 }
 
 export {

--- a/js/config.js
+++ b/js/config.js
@@ -37,7 +37,10 @@ export const apiEndpoints = {
     getPlanModificationPrompt: `${workerBaseUrl}/api/getPlanModificationPrompt`,
     updateStatus: `${workerBaseUrl}/api/updateStatus`,
     getAiConfig: `${workerBaseUrl}/api/getAiConfig`,
-    setAiConfig: `${workerBaseUrl}/api/setAiConfig`
+    setAiConfig: `${workerBaseUrl}/api/setAiConfig`,
+    listAiPresets: `${workerBaseUrl}/api/listAiPresets`,
+    getAiPreset: `${workerBaseUrl}/api/getAiPreset`,
+    saveAiPreset: `${workerBaseUrl}/api/saveAiPreset`
 };
 
 // Cloudflare Account ID за използване в чат асистента

--- a/worker.js
+++ b/worker.js
@@ -179,6 +179,12 @@ export default {
                 responseBody = await handleGetAiConfig(request, env);
             } else if (method === 'POST' && path === '/api/setAiConfig') {
                 responseBody = await handleSetAiConfig(request, env);
+            } else if (method === 'GET' && path === '/api/listAiPresets') {
+                responseBody = await handleListAiPresets(request, env);
+            } else if (method === 'GET' && path === '/api/getAiPreset') {
+                responseBody = await handleGetAiPreset(request, env);
+            } else if (method === 'POST' && path === '/api/saveAiPreset') {
+                responseBody = await handleSaveAiPreset(request, env);
             } else if (method === 'GET' && path === '/api/getFeedbackMessages') {
                 responseBody = await handleGetFeedbackMessagesRequest(request, env);
             } else {
@@ -1512,6 +1518,64 @@ async function handleSetAiConfig(request, env) {
     }
 }
 // ------------- END FUNCTION: handleSetAiConfig -------------
+
+// ------------- START FUNCTION: handleListAiPresets -------------
+async function handleListAiPresets(request, env) {
+    try {
+        const { keys } = await env.RESOURCES_KV.list({ prefix: 'aiPreset_' });
+        const presets = keys.map(k => k.name.replace(/^aiPreset_/, ''));
+        return { success: true, presets };
+    } catch (error) {
+        console.error('Error in handleListAiPresets:', error.message, error.stack);
+        return { success: false, message: 'Грешка при зареждане на пресетите.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleListAiPresets -------------
+
+// ------------- START FUNCTION: handleGetAiPreset -------------
+async function handleGetAiPreset(request, env) {
+    try {
+        const url = new URL(request.url);
+        const name = url.searchParams.get('name');
+        if (!name) {
+            return { success: false, message: 'Липсва име.', statusHint: 400 };
+        }
+        const val = await env.RESOURCES_KV.get(`aiPreset_${name}`);
+        if (!val) {
+            return { success: false, message: 'Няма такъв пресет.', statusHint: 404 };
+        }
+        return { success: true, config: JSON.parse(val) };
+    } catch (error) {
+        console.error('Error in handleGetAiPreset:', error.message, error.stack);
+        return { success: false, message: 'Грешка при зареждане на пресета.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleGetAiPreset -------------
+
+// ------------- START FUNCTION: handleSaveAiPreset -------------
+async function handleSaveAiPreset(request, env) {
+    try {
+        const auth = request.headers.get('Authorization') || '';
+        const token = auth.replace(/^Bearer\s+/i, '').trim();
+        const expected = env[WORKER_ADMIN_TOKEN_SECRET_NAME];
+        if (!expected || token !== expected) {
+            return { success: false, message: 'Невалиден токен.', statusHint: 403 };
+        }
+
+        const body = await request.json();
+        const name = body.name && String(body.name).trim();
+        const cfg = body.config;
+        if (!name || !cfg || typeof cfg !== 'object') {
+            return { success: false, message: 'Липсват данни.', statusHint: 400 };
+        }
+        await env.RESOURCES_KV.put(`aiPreset_${name}`, JSON.stringify(cfg));
+        return { success: true };
+    } catch (error) {
+        console.error('Error in handleSaveAiPreset:', error.message, error.stack);
+        return { success: false, message: 'Грешка при запис на пресета.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleSaveAiPreset -------------
 
 
 // ------------- START BLOCK: PlanGenerationHeaderComment -------------
@@ -3321,4 +3385,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, callCfAi, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, callCfAi, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements };


### PR DESCRIPTION
## Summary
- allow storing AI config presets in admin menu
- implement preset management API in worker
- add unit test for new API handlers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855d6353f908326b22d25d17c6d50b0