### PR TITLE
Add admin token field

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ php -r "echo password_hash('yourPassword', PASSWORD_DEFAULT);"
 
 Администраторският скрипт `admin.js` добавя автоматично тази
 заглавка, ако в `localStorage` съществува ключ `adminToken`.
-Може ръчно да запишете стойността му през конзолата:
+Стойността може да зададете от панела в полето „Admin Token“,
+което я записва в `localStorage`. Може и ръчно да я зададете през конзолата:
 
 ```javascript
 localStorage.setItem('adminToken', '<вашият токен>');

--- a/admin.html
+++ b/admin.html
@@ -103,8 +103,10 @@
   <section id="aiConfigSection" class="card">
     <h2>AI конфигурация</h2>
     <form id="aiConfigForm">
-      <p class="note">Токените се задават като Worker secrets и не се
-        редактират от този панел.</p>
+      <p class="note">Токените за моделите се задават като Worker secrets и не се
+        редактират от този панел. Полето „Admin Token" се използва за
+        удостоверяване на заявките към API.</p>
+      <label>Admin Token: <input id="adminToken" type="text"></label>
       <fieldset>
         <legend>Генериране на план</legend>
         <label>Модел: <input id="planModel" type="text"></label>

--- a/js/__tests__/saveAiConfig.test.js
+++ b/js/__tests__/saveAiConfig.test.js
@@ -11,6 +11,7 @@ beforeEach(async () => {
       <input id="planModel" />
       <input id="chatModel" />
       <input id="modModel" />
+      <input id="adminToken" />
     </form>
     <button id="showStats"></button>
     <button id="sendQuery"></button>
@@ -31,6 +32,7 @@ beforeEach(async () => {
   }));
 
   await import('../admin.js');
+  document.getElementById('adminToken').value = 'newSecret';
 });
 
 afterEach(() => {
@@ -54,7 +56,7 @@ test('saveAiConfig sends updates payload with Authorization header', async () =>
   const [url, options] = global.fetch.mock.calls[0];
   expect(url).toBe('/api/setAiConfig');
   expect(options.method).toBe('POST');
-  expect(options.headers.Authorization).toBe('Bearer secret');
+  expect(options.headers.Authorization).toBe('Bearer newSecret');
   const body = JSON.parse(options.body);
   expect(body).toEqual({
     updates: {
@@ -63,4 +65,5 @@ test('saveAiConfig sends updates payload with Authorization header', async () =>
       modModel: 'mm'
     }
   });
+  expect(localStorage.getItem('adminToken')).toBe('newSecret');
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -47,6 +47,7 @@ const aiConfigForm = document.getElementById('aiConfigForm');
 const planModelInput = document.getElementById('planModel');
 const chatModelInput = document.getElementById('chatModel');
 const modModelInput = document.getElementById('modModel');
+const adminTokenInput = document.getElementById('adminToken');
 const presetSelect = document.getElementById('aiPresetSelect');
 const savePresetBtn = document.getElementById('savePreset');
 const applyPresetBtn = document.getElementById('applyPreset');
@@ -571,6 +572,11 @@ async function loadClientReplies(markRead = false) {
     }
 }
 
+function loadAdminToken() {
+    if (!adminTokenInput) return;
+    adminTokenInput.value = localStorage.getItem('adminToken') || '';
+}
+
 async function loadAiConfig() {
     if (!aiConfigForm) return;
     try {
@@ -597,7 +603,13 @@ async function saveAiConfig() {
         }
     };
     try {
-        const adminToken = localStorage.getItem('adminToken') || '';
+        let adminToken = '';
+        if (adminTokenInput) {
+            adminToken = adminTokenInput.value.trim();
+            localStorage.setItem('adminToken', adminToken);
+        } else {
+            adminToken = localStorage.getItem('adminToken') || '';
+        }
         const headers = { 'Content-Type': 'application/json' };
         if (adminToken) headers.Authorization = `Bearer ${adminToken}`;
         const resp = await fetch(apiEndpoints.setAiConfig, {
@@ -689,6 +701,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     await loadClients();
     await checkForNotifications();
     await loadNotifications();
+    loadAdminToken();
     await loadAiConfig();
     await loadAiPresets();
     setInterval(checkForNotifications, 60000);


### PR DESCRIPTION
## Summary
- add "Admin Token" text field to admin settings
- store token in localStorage and preload it when page loads
- update tests for new token logic
- document new UI field in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855eaca981483269df62722dc122ac2