### PR TITLE
Fix admin AI config key names

### DIFF
--- a/js/__tests__/aiPresets.test.js
+++ b/js/__tests__/aiPresets.test.js
@@ -16,11 +16,11 @@ test('save preset and retrieve it', async () => {
   const env = { RESOURCES_KV: kv, WORKER_ADMIN_TOKEN: 'secret' };
   const reqSave = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
-    json: async () => ({ name: 'test', config: { planModel: 'm1' } })
+    json: async () => ({ name: 'test', config: { model_plan_generation: 'm1' } })
   };
   const saveRes = await handleSaveAiPreset(reqSave, env);
   expect(saveRes.success).toBe(true);
-  expect(kv._store['aiPreset_test']).toBe(JSON.stringify({ planModel: 'm1' }));
+  expect(kv._store['aiPreset_test']).toBe(JSON.stringify({ model_plan_generation: 'm1' }));
 
   const listRes = await handleListAiPresets({}, env);
   expect(listRes.success).toBe(true);
@@ -28,5 +28,5 @@ test('save preset and retrieve it', async () => {
 
   const getRes = await handleGetAiPreset({ url: 'https://x/api/getAiPreset?name=test' }, env);
   expect(getRes.success).toBe(true);
-  expect(getRes.config.planModel).toBe('m1');
+  expect(getRes.config.model_plan_generation).toBe('m1');
 });

--- a/js/__tests__/saveAiConfig.test.js
+++ b/js/__tests__/saveAiConfig.test.js
@@ -58,9 +58,9 @@ test('saveAiConfig sends updates payload with Authorization header', async () =>
   const body = JSON.parse(options.body);
   expect(body).toEqual({
     updates: {
-      planModel: 'pm',
-      chatModel: 'cm',
-      modModel: 'mm'
+      model_plan_generation: 'pm',
+      model_chat: 'cm',
+      model_principle_adjustment: 'mm'
     }
   });
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -591,9 +591,9 @@ async function saveAiConfig() {
     if (!aiConfigForm) return;
     const payload = {
         updates: {
-            planModel: planModelInput.value.trim(),
-            chatModel: chatModelInput.value.trim(),
-            modModel: modModelInput.value.trim()
+            model_plan_generation: planModelInput.value.trim(),
+            model_chat: chatModelInput.value.trim(),
+            model_principle_adjustment: modModelInput.value.trim()
         }
     };
     try {
@@ -667,9 +667,9 @@ async function saveCurrentPreset() {
     const payload = {
         name,
         config: {
-            planModel: planModelInput.value.trim(),
-            chatModel: chatModelInput.value.trim(),
-            modModel: modModelInput.value.trim()
+            model_plan_generation: planModelInput.value.trim(),
+            model_chat: chatModelInput.value.trim(),
+            model_principle_adjustment: modModelInput.value.trim()
         }
     };
     try {


### PR DESCRIPTION
## Summary
- update `saveAiConfig` and `saveCurrentPreset` to use model key names
- adjust tests for new key names

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855efabb5f88326b02443669549ee4c