### PR TITLE
Handle Cloudflare AI errors in AI helper

### DIFF
--- a/js/__tests__/aiHelper.test.js
+++ b/js/__tests__/aiHelper.test.js
@@ -52,5 +52,6 @@ describe('handleAiHelperRequest', () => {
     const request = { json: async () => ({ userId: 'u1' }) };
     const res = await handleAiHelperRequest(request, env);
     expect(res.success).toBe(false);
+    expect(res.message).toMatch('bad');
   });
 });

--- a/worker.js
+++ b/worker.js
@@ -1323,7 +1323,7 @@ async function handleAiHelperRequest(request, env) {
         return { success: true, aiResponse: aiResp };
     } catch (error) {
         console.error('Error in handleAiHelperRequest:', error.message, error.stack);
-        return { success: false, message: 'Грешка при извикване на Cloudflare AI.', statusHint: 500 };
+        return { success: false, message: `Грешка от Cloudflare AI: ${error.message}`, statusHint: 500 };
     }
 }
 // ------------- END FUNCTION: handleAiHelperRequest -------------


### PR DESCRIPTION
## Summary
- include Cloudflare AI error details in `/api/aiHelper`
- test that error message reaches client

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855f35d636883268fc637111a2c0319