### PR TITLE
Add docs for testAiModel endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,17 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
 - `GET /api/getAiPreset` – връща данните за конкретен пресет.
 - `POST /api/saveAiPreset` – съхранява нов пресет или обновява съществуващ.
 - `POST /api/testAiModel` – проверява връзката с конкретен AI модел.
+
+  ```bash
+  curl -X POST https://<your-domain>/api/testAiModel \
+    -H "Authorization: Bearer <WORKER_ADMIN_TOKEN>" \
+    -H "Content-Type: application/json" \
+    --data '{"model":"@cf/meta/llama-3-8b-instruct"}'
+  ```
+
+  Възможен е отговор **HTTP 500**, ако името на модела е невалидно или липсват
+  необходимите Cloudflare AI секрети. Имената на моделите трябва да са във
+  формата `@cf/...` и да съвпадат с наличните модели в Cloudflare.
 - **Дебъг логове** – при изпращане на заглавие `X-Debug: 1` към който и да е API
 ендпойнт, worker-ът записва в конзолата кратка информация за заявката.
 


### PR DESCRIPTION
## Summary
- document usage of `/api/testAiModel`
- mention possible HTTP 500 reasons and model name format

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685605cfb300832686dc4b5ab83df484