### PR TITLE
Add callModel tests for Cloudflare AI options

### DIFF
--- a/js/__tests__/callModel.test.js
+++ b/js/__tests__/callModel.test.js
@@ -1,0 +1,51 @@
+import { jest } from '@jest/globals';
+import { callModel } from '../../worker.js';
+
+const originalFetch = global.fetch;
+
+describe('callModel with CF provider', () => {
+  const env = { CF_ACCOUNT_ID: 'acc', CF_AI_TOKEN: 'token' };
+  const model = '@cf/test-model';
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('sends temperature and max_tokens to fetch', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { response: 'ok' } })
+    });
+
+    const res = await callModel(model, 'hi', env, { temperature: 0.5, maxTokens: 42 });
+
+    expect(res).toBe('ok');
+    const expectedUrl = 'https://api.cloudflare.com/client/v4/accounts/acc/ai/run/@cf/test-model';
+    expect(global.fetch).toHaveBeenCalledWith(
+      expectedUrl,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          messages: [{ role: 'user', content: 'hi' }],
+          stream: false,
+          temperature: 0.5,
+          max_tokens: 42
+        })
+      }
+    );
+  });
+
+  test('throws error from callCfAi', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ errors: [{ message: 'bad' }] })
+    });
+
+    await expect(callModel(model, 'hi', env)).rejects.toThrow('CF AI error: bad');
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -2834,7 +2834,16 @@ function getModelProvider(model) {
 async function callModel(model, prompt, env, { temperature = 0.7, maxTokens = 800 } = {}) {
     const provider = getModelProvider(model);
     if (provider === 'cf') {
-        return callCfAi(model, { messages: [{ role: 'user', content: prompt }], stream: false }, env);
+        return callCfAi(
+            model,
+            {
+                messages: [{ role: 'user', content: prompt }],
+                stream: false,
+                temperature,
+                max_tokens: maxTokens
+            },
+            env
+        );
     }
     if (provider === 'openai') {
         const key = env[OPENAI_API_KEY_SECRET_NAME];
@@ -3409,4 +3418,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, callCfAi, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, callCfAi, callModel, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements };


### PR DESCRIPTION
## Summary
- include `temperature` and `max_tokens` when calling Cloudflare AI models
- export `callModel` from worker
- add Jest tests for `callModel`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685605cb4ea4832691460f0b8da3cf2e