### PR TITLE
Enhance admin UI

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -72,8 +72,12 @@
     </details>
 
     <details id="dashboardSection">
-      <summary>Пълни данни (JSON)</summary>
-      <pre id="dashboardData" class="json"></pre>
+      <summary>Пълни данни</summary>
+      <div id="dashboardSummary"></div>
+      <details>
+        <summary>JSON</summary>
+        <pre id="dashboardData" class="json"></pre>
+      </details>
     </details>
     <button id="exportData">Експортирай всички данни</button>
     <button id="exportPlan">Експортирай плана като JSON</button>
@@ -100,8 +104,8 @@
     <pre id="statsOutput"></pre>
   </section>
 
-  <section id="aiConfigSection" class="card">
-    <h2>AI конфигурация</h2>
+  <details id="aiConfigSection" class="card">
+    <summary>AI конфигурация</summary>
     <form id="aiConfigForm">
       <p class="note">Токените за моделите се задават като Worker secrets и не се
         редактират от този панел. Полето „Admin Token" се използва за
@@ -129,7 +133,7 @@
       </div>
       <button type="submit">Запази</button>
     </form>
-  </section>
+  </details>
 
   <script type="module" src="js/admin.js"></script>
 </body>

--- a/css/admin.css
+++ b/css/admin.css
@@ -94,3 +94,37 @@ details[open] summary::after {
   cursor: pointer;
   margin-bottom: 5px;
 }
+
+#aiConfigForm {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+#aiConfigForm fieldset {
+  border: 1px solid #ccc;
+  padding: 8px;
+}
+#aiConfigForm input[type="text"] {
+  width: 100%;
+  max-width: 300px;
+}
+.preset-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+#dashboardSummary section {
+  margin-bottom: 10px;
+}
+#dashboardSummary dl {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 4px 8px;
+}
+#dashboardSummary dt {
+  font-weight: 600;
+}
+#dashboardSummary dd {
+  margin: 0;
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -38,6 +38,7 @@ const planMenuPre = document.getElementById('planMenu');
 const dailyLogsPre = document.getElementById('dailyLogs');
 const exportPlanBtn = document.getElementById('exportPlan');
 const dashboardPre = document.getElementById('dashboardData');
+const dashboardSummaryDiv = document.getElementById('dashboardSummary');
 const exportDataBtn = document.getElementById('exportData');
 const profileForm = document.getElementById('profileForm');
 const profileName = document.getElementById('profileName');
@@ -224,6 +225,27 @@ function displayDailyLogs(logs) {
     dailyLogsPre.appendChild(table);
 }
 
+function displayDashboardSummary(data) {
+    if (!dashboardSummaryDiv) return;
+    dashboardSummaryDiv.innerHTML = '';
+    if (!data) {
+        dashboardSummaryDiv.textContent = 'Няма данни';
+        return;
+    }
+    const profileSec = document.createElement('section');
+    profileSec.innerHTML = '<h3>Профил</h3>';
+    profileSec.appendChild(renderObjectAsList(data.initialAnswers || {}));
+    const statusSec = document.createElement('section');
+    statusSec.innerHTML = '<h3>Текущ статус</h3>';
+    statusSec.appendChild(renderObjectAsList(data.currentStatus || {}));
+    const analyticsSec = document.createElement('section');
+    analyticsSec.innerHTML = '<h3>Анализ</h3>';
+    analyticsSec.appendChild(renderObjectAsList(data.analytics || {}));
+    dashboardSummaryDiv.appendChild(profileSec);
+    dashboardSummaryDiv.appendChild(statusSec);
+    dashboardSummaryDiv.appendChild(analyticsSec);
+}
+
 async function loadClients() {
     try {
         const resp = await fetch(apiEndpoints.listClients);
@@ -383,6 +405,7 @@ async function showClient(userId) {
             const menu = dashData.planData?.week1Menu || {};
             displayPlanMenu(menu);
             displayDailyLogs(dashData.dailyLogs || []);
+            displayDashboardSummary(dashData);
             if (dashboardPre) dashboardPre.textContent = JSON.stringify(dashData, null, 2);
             if (notesField) notesField.value = dashData.currentStatus?.adminNotes || '';
             if (tagsField) tagsField.value = (dashData.currentStatus?.adminTags || []).join(',');


### PR DESCRIPTION
## Summary
- show structured profile summary when viewing a client
- collapse AI config form in a `<details>` element
- tweak admin styles for mobile friendly AI config form and profile summary

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68560e6f034883268335fce179cb3a4d