### PR TITLE
Improve admin panel usability

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -27,6 +27,9 @@
       <option value="processing">processing</option>
       <option value="ready">ready</option>
     </select>
+    <select id="tagFilter">
+      <option value="all">Всички етикети</option>
+    </select>
     <select id="sortOrder">
       <option value="name">Сортирай по име</option>
       <option value="date">Сортирай по дата</option>
@@ -38,6 +41,15 @@
 
   <main id="clientDetails" class="main-content card hidden">
     <h2 id="clientName">Клиент</h2>
+    <nav id="clientTabs" class="tabs styled-tabs" role="tablist">
+      <button class="tab-btn" role="tab" aria-selected="true" data-target="profileTab">Профил</button>
+      <button class="tab-btn" role="tab" aria-selected="false" data-target="notesTab">Бележки</button>
+      <button class="tab-btn" role="tab" aria-selected="false" data-target="qaTab">Въпросник</button>
+      <button class="tab-btn" role="tab" aria-selected="false" data-target="menuTab">Меню</button>
+      <button class="tab-btn" role="tab" aria-selected="false" data-target="logsTab">Дневници</button>
+      <button class="tab-btn" role="tab" aria-selected="false" data-target="dashboardTab">Данни</button>
+    </nav>
+    <section id="profileTab" class="client-tab active-tab-content" role="tabpanel">
     <details id="profileSection">
       <summary>Лични данни</summary>
       <form id="profileForm">
@@ -49,28 +61,34 @@
     </details>
     <button id="regeneratePlan">Генерирай нов план</button>
     <button id="aiSummary">AI резюме</button>
+    </section>
+    <section id="notesTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="notesSection">
       <summary>Бележки</summary>
       <textarea id="adminNotes" rows="3" cols="40"></textarea><br>
       <label>Етикети: <input id="adminTags"></label>
       <button id="saveNotes">Запази бележките</button>
     </details>
-
+    </section>
+    <section id="qaTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="qaSection">
       <summary>Данни от въпросника</summary>
       <div id="initialAnswers"></div>
     </details>
-
+    </section>
+    <section id="menuTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="menuSection">
       <summary>Текущо меню</summary>
       <div id="planMenu"></div>
     </details>
-
+    </section>
+    <section id="logsTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="logsSection">
       <summary>Дневници</summary>
       <div id="dailyLogs"></div>
     </details>
-
+    </section>
+    <section id="dashboardTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="dashboardSection">
       <summary>Пълни данни</summary>
       <div id="dashboardSummary"></div>
@@ -81,6 +99,8 @@
     </details>
     <button id="exportData">Експортирай всички данни</button>
     <button id="exportPlan">Експортирай плана като JSON</button>
+    <button id="exportCsv">Експортирай дневниците CSV</button>
+    </section>
 
     <details id="queriesSection">
       <summary>Запитвания <span id="queriesDot" class="notification-dot hidden"></span></summary>
@@ -102,6 +122,7 @@
   <section id="statsSection" class="hidden">
     <h2>Статистика</h2>
     <pre id="statsOutput"></pre>
+    <canvas id="statusChart" width="300" height="200"></canvas>
   </section>
 
   <details id="aiConfigSection" class="card">
@@ -135,6 +156,7 @@
     </form>
   </details>
 
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="js/admin.js"></script>
 </body>
 </html>

--- a/css/admin.css
+++ b/css/admin.css
@@ -128,3 +128,30 @@ details[open] summary::after {
 #dashboardSummary dd {
   margin: 0;
 }
+
+.status-badge {
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.75rem;
+  margin-left: 4px;
+}
+.status-ready { background-color: #28a745; }
+.status-processing { background-color: #ffc107; }
+.status-pending { background-color: #dc3545; }
+
+.tag-badge {
+  display: inline-block;
+  background-color: #6c757d;
+  color: #fff;
+  border-radius: 3px;
+  padding: 1px 4px;
+  font-size: 0.7rem;
+  margin-left: 3px;
+}
+
+#clientTabs {
+  margin-bottom: 10px;
+}
+.client-tab { display: none; }
+.client-tab.active-tab-content { display: block; }

--- a/js/admin.js
+++ b/js/admin.js
@@ -19,6 +19,7 @@ const clientsList = document.getElementById('clientsList');
 const clientsCount = document.getElementById('clientsCount');
 const clientSearch = document.getElementById('clientSearch');
 const statusFilter = document.getElementById('statusFilter');
+const tagFilterSelect = document.getElementById('tagFilter');
 const detailsSection = document.getElementById('clientDetails');
 const regenBtn = document.getElementById('regeneratePlan');
 const aiSummaryBtn = document.getElementById('aiSummary');
@@ -40,6 +41,7 @@ const exportPlanBtn = document.getElementById('exportPlan');
 const dashboardPre = document.getElementById('dashboardData');
 const dashboardSummaryDiv = document.getElementById('dashboardSummary');
 const exportDataBtn = document.getElementById('exportData');
+const exportCsvBtn = document.getElementById('exportCsv');
 const profileForm = document.getElementById('profileForm');
 const profileName = document.getElementById('profileName');
 const profileEmail = document.getElementById('profileEmail');
@@ -63,6 +65,8 @@ const notificationDot = document.getElementById('notificationIndicator');
 const queriesDot = document.getElementById('queriesDot');
 const repliesDot = document.getElementById('repliesDot');
 const feedbackDot = document.getElementById('feedbackDot');
+const statusChartCanvas = document.getElementById('statusChart');
+let statusChart = null;
 let currentUserId = null;
 let currentPlanData = null;
 let currentDashboardData = null;
@@ -254,15 +258,21 @@ async function loadClients() {
             const withStatus = await Promise.all(
                 data.clients.map(async c => {
                     try {
-                        const sResp = await fetch(`${apiEndpoints.planStatus}?userId=${c.userId}`);
-                        const sData = await sResp.json();
-                        return { ...c, status: sData.planStatus || 'unknown' };
+                        const dResp = await fetch(`${apiEndpoints.dashboard}?userId=${c.userId}`);
+                        const dData = await dResp.json();
+                        return {
+                            ...c,
+                            status: dData.planStatus || 'unknown',
+                            tags: dData.currentStatus?.adminTags || [],
+                            lastUpdated: dData.currentStatus?.lastUpdated || ''
+                        };
                     } catch {
-                        return { ...c, status: 'unknown' };
+                        return { ...c, status: 'unknown', tags: [] };
                     }
                 })
             );
             allClients = withStatus;
+            updateTagFilterOptions();
             renderClients();
             const stats = {
                 clients: withStatus.length,
@@ -271,6 +281,7 @@ async function loadClients() {
                 processing: withStatus.filter(c => c.status === 'processing').length
             };
             statsOutput.textContent = JSON.stringify(stats, null, 2);
+            updateStatusChart(stats);
         }
     } catch (err) {
         console.error('Error loading clients:', err);
@@ -280,13 +291,15 @@ async function loadClients() {
 function renderClients() {
     const search = (clientSearch.value || '').toLowerCase();
     const filter = statusFilter.value;
+    const tagFilter = tagFilterSelect ? tagFilterSelect.value : 'all';
     const sortOrder = sortOrderSelect ? sortOrderSelect.value : 'name';
     clientsList.innerHTML = '';
     const list = allClients.filter(c => {
         const matchText = `${c.userId} ${c.name || ''} ${c.email || ''}`.toLowerCase();
         const matchesSearch = matchText.includes(search);
         const matchesStatus = filter === 'all' || c.status === filter;
-        return matchesSearch && matchesStatus;
+        const matchesTag = tagFilter === 'all' || (c.tags || []).includes(tagFilter);
+        return matchesSearch && matchesStatus && matchesTag;
     });
     list.sort((a, b) => {
         if (sortOrder === 'date') {
@@ -301,7 +314,17 @@ function renderClients() {
         const li = document.createElement('li');
         const btn = document.createElement('button');
         const dateText = c.registrationDate ? ` - ${new Date(c.registrationDate).toLocaleDateString('bg-BG')}` : '';
-        btn.textContent = `${c.name}${dateText} - ${c.status}`;
+        btn.textContent = `${c.name}${dateText}`;
+        const statusEl = document.createElement('span');
+        statusEl.className = `status-badge status-${c.status}`;
+        statusEl.textContent = c.status;
+        btn.appendChild(statusEl);
+        (c.tags || []).forEach(t => {
+            const tagEl = document.createElement('span');
+            tagEl.className = 'tag-badge';
+            tagEl.textContent = t;
+            btn.appendChild(tagEl);
+        });
         if (unreadClients.has(c.userId)) {
             const dot = document.createElement('span');
             dot.classList.add('notification-dot');
@@ -311,6 +334,51 @@ function renderClients() {
         li.appendChild(btn);
         clientsList.appendChild(li);
     });
+}
+
+function updateTagFilterOptions() {
+    if (!tagFilterSelect) return;
+    const tags = new Set();
+    allClients.forEach(c => (c.tags || []).forEach(t => tags.add(t)));
+    const current = tagFilterSelect.value;
+    tagFilterSelect.innerHTML = '<option value="all">Всички етикети</option>';
+    Array.from(tags).sort().forEach(t => {
+        const opt = document.createElement('option');
+        opt.value = t;
+        opt.textContent = t;
+        tagFilterSelect.appendChild(opt);
+    });
+    if (current && Array.from(tags).includes(current)) tagFilterSelect.value = current;
+}
+
+function updateStatusChart(stats) {
+    if (!statusChartCanvas || typeof Chart === 'undefined') return;
+    if (statusChart) statusChart.destroy();
+    const ctx = statusChartCanvas.getContext('2d');
+    statusChart = new Chart(ctx, {
+        type: 'doughnut',
+        data: {
+            labels: ['ready', 'processing', 'pending'],
+            datasets: [{
+                data: [stats.ready, stats.processing, stats.pending],
+                backgroundColor: ['#28a745', '#ffc107', '#dc3545']
+            }]
+        },
+        options: { plugins: { legend: { position: 'bottom' } } }
+    });
+}
+
+function setupTabs() {
+    const buttons = document.querySelectorAll('#clientTabs .tab-btn');
+    const panels = document.querySelectorAll('.client-tab');
+    if (buttons.length === 0) return;
+    const activate = (btn) => {
+        const target = btn.getAttribute('data-target');
+        buttons.forEach(b => b.setAttribute('aria-selected', b === btn ? 'true' : 'false'));
+        panels.forEach(p => p.classList.toggle('active-tab-content', p.id === target));
+    };
+    buttons.forEach(b => b.addEventListener('click', () => activate(b)));
+    activate(buttons[0]);
 }
 
 async function loadNotifications() {
@@ -375,6 +443,7 @@ showStatsBtn.addEventListener('click', () => {
 if (clientSearch) clientSearch.addEventListener('input', renderClients);
 if (statusFilter) statusFilter.addEventListener('change', renderClients);
 if (sortOrderSelect) sortOrderSelect.addEventListener('change', renderClients);
+if (tagFilterSelect) tagFilterSelect.addEventListener('change', renderClients);
 
 async function showClient(userId) {
     try {
@@ -411,6 +480,13 @@ async function showClient(userId) {
             if (tagsField) tagsField.value = (dashData.currentStatus?.adminTags || []).join(',');
             currentPlanData = dashData.planData || null;
             currentDashboardData = dashData;
+            const clientInfo = allClients.find(c => c.userId === userId);
+            if (clientInfo) {
+                clientInfo.tags = dashData.currentStatus?.adminTags || [];
+                clientInfo.lastUpdated = dashData.currentStatus?.lastUpdated || '';
+                updateTagFilterOptions();
+                renderClients();
+            }
         }
     } catch (err) {
         console.error('Error loading profile:', err);
@@ -505,6 +581,25 @@ if (exportDataBtn) {
         const a = document.createElement('a');
         a.href = url;
         a.download = `${currentUserId || 'data'}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    });
+}
+
+if (exportCsvBtn) {
+    exportCsvBtn.addEventListener('click', () => {
+        if (!currentDashboardData) return;
+        const logs = currentDashboardData.dailyLogs || [];
+        let csv = 'Дата,Тегло,Бележка\n';
+        logs.forEach(l => {
+            const note = (l.data?.note || '').replace(/\n/g, ' ');
+            csv += `${l.date},${l.data?.weight || ''},${note}\n`;
+        });
+        const blob = new Blob([csv], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${currentUserId || 'logs'}.csv`;
         a.click();
         URL.revokeObjectURL(url);
     });
@@ -772,6 +867,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     loadAdminToken();
     await loadAiConfig();
     await loadAiPresets();
+    setupTabs();
     setInterval(checkForNotifications, 60000);
     setInterval(loadNotifications, 60000);
 });


### PR DESCRIPTION
## Summary
- add tag filter dropdown and client tabs in admin panel
- export daily logs to CSV
- visualize plan status with badges and a chart
- style badges and tabs in admin CSS
- support tag filtering and chart rendering in admin JS

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68561472df7c8326b5f92309d2bbbda2