### PR TITLE
Improve admin panel usability

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -27,6 +27,9 @@
       <option value="processing">processing</option>
       <option value="ready">ready</option>
     </select>
+    <select id="tagFilter">
+      <option value="all">Всички етикети</option>
+    </select>
     <select id="sortOrder">
       <option value="name">Сортирай по име</option>
       <option value="date">Сортирай по дата</option>
@@ -38,6 +41,15 @@
 
   <main id="clientDetails" class="main-content card hidden">
     <h2 id="clientName">Клиент</h2>
+    <nav id="clientTabs" class="tabs styled-tabs" role="tablist">
+      <button class="tab-btn" role="tab" aria-selected="true" data-target="profileTab">Профил</button>
+      <button class="tab-btn" role="tab" aria-selected="false" data-target="notesTab">Бележки</button>
+      <button class="tab-btn" role="tab" aria-selected="false" data-target="qaTab">Въпросник</button>
+      <button class="tab-btn" role="tab" aria-selected="false" data-target="menuTab">Меню</button>
+      <button class="tab-btn" role="tab" aria-selected="false" data-target="logsTab">Дневници</button>
+      <button class="tab-btn" role="tab" aria-selected="false" data-target="dashboardTab">Данни</button>
+    </nav>
+    <section id="profileTab" class="client-tab active-tab-content" role="tabpanel">
     <details id="profileSection">
       <summary>Лични данни</summary>
       <form id="profileForm">
@@ -49,28 +61,37 @@
     </details>
     <button id="regeneratePlan">Генерирай нов план</button>
     <button id="aiSummary">AI резюме</button>
+    </section>
+    <section id="notesTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="notesSection">
       <summary>Бележки</summary>
       <textarea id="adminNotes" rows="3" cols="40"></textarea><br>
       <label>Етикети: <input id="adminTags"></label>
+      <p class="help-text">Разделяйте етикетите със запетая.</p>
       <button id="saveNotes">Запази бележките</button>
     </details>
-
+    </section>
+    <section id="qaTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="qaSection">
       <summary>Данни от въпросника</summary>
       <div id="initialAnswers"></div>
     </details>
-
+    </section>
+    <section id="menuTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="menuSection">
       <summary>Текущо меню</summary>
       <div id="planMenu"></div>
     </details>
-
+    </section>
+    <section id="logsTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="logsSection">
       <summary>Дневници</summary>
       <div id="dailyLogs"></div>
+      <button id="toggleWeightChart">Покажи графика</button>
+      <canvas id="weightChart" width="300" height="200" class="hidden"></canvas>
     </details>
-
+    </section>
+    <section id="dashboardTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="dashboardSection">
       <summary>Пълни данни</summary>
       <div id="dashboardSummary"></div>
@@ -81,6 +102,9 @@
     </details>
     <button id="exportData">Експортирай всички данни</button>
     <button id="exportPlan">Експортирай плана като JSON</button>
+    <button id="exportCsv">Експортирай дневниците CSV</button>
+    <p class="help-text">Експортираните файлове се запазват локално.</p>
+    </section>
 
     <details id="queriesSection">
       <summary>Запитвания <span id="queriesDot" class="notification-dot hidden"></span></summary>
@@ -102,6 +126,7 @@
   <section id="statsSection" class="hidden">
     <h2>Статистика</h2>
     <pre id="statsOutput"></pre>
+    <canvas id="statusChart" width="300" height="200"></canvas>
   </section>
 
   <details id="aiConfigSection" class="card">
@@ -135,6 +160,7 @@
     </form>
   </details>
 
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="js/admin.js"></script>
 </body>
 </html>

--- a/css/admin.css
+++ b/css/admin.css
@@ -128,3 +128,40 @@ details[open] summary::after {
 #dashboardSummary dd {
   margin: 0;
 }
+
+.status-badge {
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.75rem;
+  margin-left: 4px;
+}
+.status-ready { background-color: #28a745; }
+.status-processing { background-color: #ffc107; }
+.status-pending { background-color: #dc3545; }
+
+.tag-badge {
+  display: inline-block;
+  background-color: #6c757d;
+  color: #fff;
+  border-radius: 3px;
+  padding: 1px 4px;
+  font-size: 0.7rem;
+  margin-left: 3px;
+}
+
+#clientTabs {
+  margin-bottom: 10px;
+}
+.client-tab { display: none; }
+.client-tab.active-tab-content { display: block; }
+
+.help-text {
+  font-size: 0.8rem;
+  color: #555;
+  margin-top: 4px;
+}
+
+#weightChart {
+  margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- add tag filter dropdown and client tabs in admin panel
- export daily logs to CSV
- visualize plan status with badges and a chart
- style badges and tabs in admin CSS
- support tag filtering and chart rendering in admin JS
- show last update date and weight chart
- add help text hints

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68561472df7c8326b5f92309d2bbbda2