### PR TITLE
Improve admin client tabs display

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -128,6 +128,11 @@ details[open] summary::after {
 #dashboardSummary dd {
   margin: 0;
 }
+#dashboardSummary dd ul,
+#dashboardSummary dd dl {
+  margin-left: 1em;
+  padding-left: 0.5em;
+}
 
 .status-badge {
   padding: 2px 6px;

--- a/js/admin.js
+++ b/js/admin.js
@@ -158,13 +158,35 @@ async function checkForNotifications() {
     }
 }
 
+function renderValue(val) {
+    if (Array.isArray(val)) {
+        const ul = document.createElement('ul');
+        val.forEach(item => {
+            const li = document.createElement('li');
+            if (item && typeof item === 'object') {
+                li.appendChild(renderValue(item));
+            } else {
+                li.textContent = item;
+            }
+            ul.appendChild(li);
+        });
+        return ul;
+    }
+    if (val && typeof val === 'object') {
+        return renderObjectAsList(val);
+    }
+    const span = document.createElement('span');
+    span.textContent = val;
+    return span;
+}
+
 function renderObjectAsList(obj) {
     const dl = document.createElement('dl');
     Object.entries(obj || {}).forEach(([key, val]) => {
         const dt = document.createElement('dt');
         dt.textContent = key;
         const dd = document.createElement('dd');
-        dd.textContent = typeof val === 'object' ? JSON.stringify(val) : val;
+        dd.appendChild(renderValue(val));
         dl.appendChild(dt);
         dl.appendChild(dd);
     });


### PR DESCRIPTION
## Summary
- enhance nested object rendering for client details
- add styles for nested lists in dashboard summary

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68561bab997483268a8321797514f92a