### PR TITLE
Fix admin tab reset

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -519,6 +519,8 @@ if (toggleWeightChartBtn) {
 if (closeProfileBtn) {
     closeProfileBtn.addEventListener('click', () => {
         detailsSection.classList.add('hidden');
+        resetTabs();
+        sessionStorage.removeItem('activeTabId');
         currentUserId = null;
     });
 }


### PR DESCRIPTION
## Summary
- reset tab state and stored active tab when closing profile

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856205a28748326947f6a9a2bb03952