### PR TITLE
Improve admin UI initialization

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -945,17 +945,23 @@ async function testAiModel(modelName) {
     }
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
-    await ensureLoggedIn();
-    await loadClients();
-    await checkForNotifications();
-    await loadNotifications();
-    loadAdminToken();
-    await loadAiConfig();
-    await loadAiPresets();
+document.addEventListener('DOMContentLoaded', () => {
+    // Инициализира табовете веднага
     setupTabs();
-    setInterval(checkForNotifications, 60000);
-    setInterval(loadNotifications, 60000);
+
+    // Стартира асинхронните операции в отделен IIFE,
+    // за да не блокират работата на интерфейса
+    (async () => {
+        await ensureLoggedIn();
+        await loadClients();
+        await checkForNotifications();
+        await loadNotifications();
+        loadAdminToken();
+        await loadAiConfig();
+        await loadAiPresets();
+        setInterval(checkForNotifications, 60000);
+        setInterval(loadNotifications, 60000);
+    })();
 });
 
 if (aiConfigForm) {


### PR DESCRIPTION
## Summary
- move `setupTabs()` to the top of `DOMContentLoaded` handler
- run initialization tasks inside async IIFE so tabs activate immediately

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856258ce5bc8326bc446f1e6b915ad4