### PR TITLE
Fix CORS handling for null origin

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -90,11 +90,15 @@ export default {
             'https://radilovk.github.io',
             'https://radilov-k.github.io',
             'http://localhost:5173',
-            'http://localhost:3000'
+            'http://localhost:3000',
+            'null' // за отваряне през file://
         ];
         const requestOrigin = request.headers.get('Origin');
+        const originToSend = requestOrigin === null
+            ? 'null'
+            : allowedOrigins.includes(requestOrigin) ? requestOrigin : allowedOrigins[0];
         const corsHeaders = {
-            'Access-Control-Allow-Origin': allowedOrigins.includes(requestOrigin) ? requestOrigin : allowedOrigins[0],
+            'Access-Control-Allow-Origin': originToSend,
             'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
             'Access-Control-Allow-Headers': 'Content-Type, Authorization',
             'Access-Control-Max-Age': '86400',


### PR DESCRIPTION
## Summary
- добавен е `'null'` в масива `allowedOrigins`
- когато в заявката липсва или е `null` Origin, `Access-Control-Allow-Origin` връща `'null'`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68562e95c3ac83268bc98c857d848261