### PR TITLE
Add client loading error alert

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -324,6 +324,7 @@ async function loadClients() {
         }
     } catch (err) {
         console.error('Error loading clients:', err);
+        alert('Грешка при зареждане на клиентите. Проверете връзката с API.');
     }
 }
 


### PR DESCRIPTION
## Summary
- notify users if loading clients fails in the admin panel

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68562e9e4f908326a688eab78858ee34