### PR TITLE
Open details sections automatically

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -464,6 +464,13 @@ function resetTabs() {
     });
 }
 
+function openDetailsSections() {
+    const detailElems = document.querySelectorAll('#clientDetails details');
+    detailElems.forEach(d => {
+        d.open = true;
+    });
+}
+
 async function loadNotifications() {
     if (!notificationsList || !notificationsSection) return;
     notificationsList.innerHTML = '';
@@ -558,6 +565,7 @@ async function showClient(userId) {
             currentUserId = userId;
             detailsSection.classList.remove('hidden');
             resetTabs();
+            openDetailsSections();
             const clientInfo = allClients.find(c => c.userId === userId);
             const regDate = clientInfo?.registrationDate ? new Date(clientInfo.registrationDate).toLocaleDateString('bg-BG') : '';
             const name = clientInfo?.name || data.name || userId;


### PR DESCRIPTION
## Summary
- add helper `openDetailsSections` in admin panel script
- open all `<details>` whenever a client is shown

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856a42b525883269c1e7ec16b945109