### PR TITLE
Add editable client profile page

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -62,6 +62,7 @@
     </details>
     <button id="regeneratePlan">Генерирай нов план</button>
     <button id="aiSummary">AI резюме</button>
+    <a id="openFullProfile" href="#" target="_blank">Пълен профил</a>
     </section>
     <section id="notesTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="notesSection">

--- a/clientProfile.html
+++ b/clientProfile.html
@@ -1,0 +1,629 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Потребителски профил</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+        :root {
+            --primary-color: #2c3e50;
+            --secondary-color: #3498db;
+            --accent-color: #e74c3c;
+            --light-color: #ecf0f1;
+            --success-color: #27ae60;
+            --warning-color: #f39c12;
+        }
+        
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: #f8f9fa;
+            color: #333;
+            padding-top: 20px;
+        }
+        
+        .container-main {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 10px;
+            box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+            padding: 20px;
+            margin-bottom: 30px;
+        }
+        
+        .header {
+            background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+            color: white;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 25px;
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .header::before {
+            content: "";
+            position: absolute;
+            top: -50px;
+            right: -50px;
+            width: 200px;
+            height: 200px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 50%;
+        }
+        
+        .header h1 {
+            font-weight: 700;
+            margin-bottom: 5px;
+        }
+        
+        .header p {
+            opacity: 0.9;
+            margin-bottom: 0;
+        }
+        
+        .nav-tabs .nav-link {
+            font-weight: 600;
+            color: var(--primary-color);
+            border: none;
+            padding: 12px 20px;
+            transition: all 0.3s;
+        }
+        
+        .nav-tabs .nav-link.active {
+            color: var(--secondary-color);
+            border-bottom: 3px solid var(--secondary-color);
+            background: transparent;
+        }
+        
+        .nav-tabs .nav-link:hover:not(.active) {
+            color: var(--secondary-color);
+            background-color: rgba(52, 152, 219, 0.1);
+        }
+        
+        .tab-content {
+            padding: 25px 0;
+        }
+        
+        .section-title {
+            color: var(--primary-color);
+            border-bottom: 2px solid var(--secondary-color);
+            padding-bottom: 8px;
+            margin-bottom: 20px;
+            font-weight: 700;
+        }
+        
+        .card {
+            border: none;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            margin-bottom: 20px;
+            transition: transform 0.3s;
+        }
+        
+        .card:hover {
+            transform: translateY(-5px);
+        }
+        
+        .card-header {
+            background: linear-gradient(to right, var(--light-color), white);
+            font-weight: 600;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+        }
+        
+        .info-item {
+            padding: 12px 15px;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+            display: flex;
+        }
+        
+        .info-item:last-child {
+            border-bottom: none;
+        }
+        
+        .info-label {
+            font-weight: 600;
+            min-width: 220px;
+            color: var(--primary-color);
+        }
+        
+        .info-value {
+            flex: 1;
+        }
+        
+        .progress {
+            height: 20px;
+            border-radius: 10px;
+            margin-bottom: 5px;
+        }
+        
+        .metric-card {
+            text-align: center;
+            padding: 15px;
+            border-radius: 8px;
+            background: white;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+            height: 100%;
+        }
+        
+        .metric-title {
+            font-weight: 600;
+            margin-bottom: 10px;
+            color: var(--primary-color);
+        }
+        
+        .metric-value {
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 5px;
+        }
+        
+        .metric-subtitle {
+            color: #777;
+            font-size: 14px;
+        }
+        
+        .day-menu {
+            margin-bottom: 25px;
+            padding: 15px;
+            border-left: 4px solid var(--secondary-color);
+            background: rgba(52, 152, 219, 0.05);
+            border-radius: 0 8px 8px 0;
+        }
+        
+        .meal-title {
+            font-weight: 600;
+            color: var(--primary-color);
+            margin-bottom: 8px;
+        }
+        
+        .meal-item {
+            margin-bottom: 5px;
+            padding-left: 15px;
+            position: relative;
+        }
+        
+        .meal-item::before {
+            content: "•";
+            position: absolute;
+            left: 0;
+            color: var(--secondary-color);
+        }
+        
+        .badge-custom {
+            background: var(--secondary-color);
+            font-weight: normal;
+            padding: 5px 10px;
+            border-radius: 20px;
+        }
+        
+        .status-indicator {
+            display: inline-block;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            margin-right: 8px;
+        }
+        
+        .status-ready {
+            background-color: var(--success-color);
+        }
+        
+        .status-pending {
+            background-color: var(--warning-color);
+        }
+        
+        @media (max-width: 768px) {
+            .info-item {
+                flex-direction: column;
+            }
+            
+            .info-label {
+                min-width: 100%;
+                margin-bottom: 5px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container container-main">
+        <div class="header">
+            <div class="d-flex justify-content-between align-items-center">
+                <div>
+                    <h1><i class="fas fa-user-circle me-2"></i><span id="userName">Име на потребителя</span></h1>
+                    <p><i class="fas fa-id-card me-2"></i>Потребителски профил</p>
+                </div>
+                <div class="text-end">
+                    <p class="mb-1"><i class="fas fa-weight me-2"></i><strong>Текущо тегло:</strong> <span id="currentWeight">-- кг</span></p>
+                    <p class="mb-1"><i class="fas fa-ruler-vertical me-2"></i><strong>Височина:</strong> <span id="userHeight">-- см</span></p>
+                    <p class="mb-0"><i class="fas fa-bullseye me-2"></i><strong>Основна цел:</strong> <span id="userGoal">--</span></p>
+                </div>
+            </div>
+        </div>
+
+        <ul class="nav nav-tabs" id="profileTab" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link active" id="basic-tab" data-bs-toggle="tab" data-bs-target="#basic" type="button" role="tab">
+                    <i class="fas fa-info-circle me-2"></i>Основна информация
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="plan-tab" data-bs-toggle="tab" data-bs-target="#plan" type="button" role="tab">
+                    <i class="fas fa-utensils me-2"></i>Хранителен план
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="logs-tab" data-bs-toggle="tab" data-bs-target="#logs" type="button" role="tab">
+                    <i class="fas fa-clipboard-list me-2"></i>Дневни записи
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="analytics-tab" data-bs-toggle="tab" data-bs-target="#analytics" type="button" role="tab">
+                    <i class="fas fa-chart-line me-2"></i>Анализ на прогреса
+                </button>
+            </li>
+        </ul>
+
+        <div class="tab-content" id="profileTabContent">
+            <!-- Основна информация -->
+            <div class="tab-pane fade show active" id="basic" role="tabpanel">
+                <h3 class="section-title"><i class="fas fa-user me-2"></i>Лични данни</h3>
+                
+                <div class="card">
+                    <div class="card-header"><i class="fas fa-user me-2"></i>Демографски данни</div>
+                    <div class="card-body p-0">
+                        <div class="info-item">
+                            <div class="info-label">Име:</div>
+                            <div class="info-value" id="userFullName">--</div>
+                        </div>
+                        <div class="info-item">
+                            <div class="info-label">Пол:</div>
+                            <div class="info-value" id="userGender">--</div>
+                        </div>
+                        <div class="info-item">
+                            <div class="info-label">Възраст:</div>
+                            <div class="info-value" id="userAge">--</div>
+                        </div>
+                        <div class="info-item">
+                            <div class="info-label">Имейл:</div>
+                            <div class="info-value" id="userEmail">--</div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="row">
+                    <div class="col-md-6">
+                        <div class="card">
+                            <div class="card-header"><i class="fas fa-weight me-2"></i>Физически характеристики</div>
+                            <div class="card-body p-0">
+                                <div class="info-item">
+                                    <div class="info-label">Височина:</div>
+                                    <div class="info-value" id="heightValue">--</div>
+                                </div>
+                                <div class="info-item">
+                                    <div class="info-label">Текущо тегло:</div>
+                                    <div class="info-value" id="weightValue">--</div>
+                                </div>
+                                <div class="info-item">
+                                    <div class="info-label">ИТМ (BMI):</div>
+                                    <div class="info-value" id="bmiValue">--</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="col-md-6">
+                        <div class="card">
+                            <div class="card-header"><i class="fas fa-bullseye me-2"></i>Цели и мотивация</div>
+                            <div class="card-body p-0">
+                                <div class="info-item">
+                                    <div class="info-label">Основна цел:</div>
+                                    <div class="info-value" id="mainGoal">--</div>
+                                </div>
+                                <div class="info-item">
+                                    <div class="info-label">Ниво на мотивация:</div>
+                                    <div class="info-value" id="motivationLevel">--</div>
+                                </div>
+                                <div class="info-item">
+                                    <div class="info-label">Целево ИТМ:</div>
+                                    <div class="info-value" id="targetBmi">--</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                
+                <h3 class="section-title mt-4"><i class="fas fa-heartbeat me-2"></i>Здравословни данни</h3>
+                
+                <div class="row">
+                    <div class="col-md-6">
+                        <div class="card">
+                            <div class="card-header"><i class="fas fa-bed me-2"></i>Сън и активност</div>
+                            <div class="card-body p-0">
+                                <div class="info-item">
+                                    <div class="info-label">Продължителност на съня:</div>
+                                    <div class="info-value" id="sleepHours">--</div>
+                                </div>
+                                <div class="info-item">
+                                    <div class="info-label">Прекъсвания на съня:</div>
+                                    <div class="info-value" id="sleepInterruptions">--</div>
+                                </div>
+                                <div class="info-item">
+                                    <div class="info-label">Хронотип:</div>
+                                    <div class="info-value" id="chronotype">--</div>
+                                </div>
+                                <div class="info-item">
+                                    <div class="info-label">Ниво на активност:</div>
+                                    <div class="info-value" id="activityLevel">--</div>
+                                </div>
+                                <div class="info-item">
+                                    <div class="info-label">Физическа активност:</div>
+                                    <div class="info-value" id="physicalActivity">--</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="col-md-6">
+                        <div class="card">
+                            <div class="card-header"><i class="fas fa-notes-medical me-2"></i>Здравословни особености</div>
+                            <div class="card-body p-0">
+                                <div class="info-item">
+                                    <div class="info-label">Медицински състояния:</div>
+                                    <div class="info-value" id="medicalConditions">--</div>
+                                </div>
+                                <div class="info-item">
+                                    <div class="info-label">Ниво на стрес:</div>
+                                    <div class="info-value" id="stressLevel">--</div>
+                                </div>
+                                <div class="info-item">
+                                    <div class="info-label">Хапчета/медикаменти:</div>
+                                    <div class="info-value" id="medications">--</div>
+                                </div>
+                                <div class="info-item">
+                                    <div class="info-label">Прием на вода:</div>
+                                    <div class="info-value" id="waterIntake">--</div>
+                                </div>
+                                <div class="info-item">
+                                    <div class="info-label">Хранителни предпочитания:</div>
+                                    <div class="info-value" id="foodPreferences">--</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                
+                <h3 class="section-title mt-4"><i class="fas fa-apple-alt me-2"></i>Хранителни навици</h3>
+                
+                <div class="card">
+                    <div class="card-header"><i class="fas fa-utensils me-2"></i>Хранителни модели</div>
+                    <div class="card-body p-0">
+                        <div class="info-item">
+                            <div class="info-label">Честота на преяждане:</div>
+                            <div class="info-value" id="overeatingFrequency">--</div>
+                        </div>
+                        <div class="info-item">
+                            <div class="info-label">Пристрастяване към храна:</div>
+                            <div class="info-value" id="foodCravings">--</div>
+                        </div>
+                        <div class="info-item">
+                            <div class="info-label">Тригери за хранене:</div>
+                            <div class="info-value" id="foodTriggers">--</div>
+                        </div>
+                        <div class="info-item">
+                            <div class="info-label">Честота на алкохол:</div>
+                            <div class="info-value" id="alcoholFrequency">--</div>
+                        </div>
+                    <div class="info-item">
+                        <div class="info-label">Навици при хранене:</div>
+                        <div class="info-value" id="eatingHabits">--</div>
+                    </div>
+                </div>
+            </div>
+            <div class="mt-4">
+                <h3 class="section-title"><i class="fas fa-edit me-2"></i>Редакция</h3>
+                <form id="profileEditForm" class="row g-2">
+                    <div class="col-md-4"><input id="nameInput" class="form-control" placeholder="Име"></div>
+                    <div class="col-md-4"><input id="fullnameInput" class="form-control" placeholder="Пълно име"></div>
+                    <div class="col-md-2"><input id="ageInput" type="number" class="form-control" placeholder="Възраст"></div>
+                    <div class="col-md-2"><input id="heightInput" type="number" class="form-control" placeholder="Височина"></div>
+                    <div class="col-md-4"><input id="emailInput" type="email" class="form-control" placeholder="Имейл"></div>
+                    <div class="col-md-4"><input id="phoneInput" class="form-control" placeholder="Телефон"></div>
+                    <div class="col-12"><button type="button" id="saveProfileBtn" class="btn btn-primary">Запази профила</button></div>
+                </form>
+            </div>
+        </div>
+
+        <!-- Хранителен план -->
+        <div class="tab-pane fade" id="plan" role="tabpanel">
+                <div class="alert alert-info">
+                    <i class="fas fa-info-circle me-2"></i>Статус на плана: 
+                    <span class="badge bg-warning" id="planStatus">Статус</span>
+                </div>
+                
+                <h3 class="section-title"><i class="fas fa-calculator me-2"></i>Калории и макроелементи</h3>
+                
+                <div class="row mb-4">
+                    <div class="col-md-3 mb-3">
+                        <div class="metric-card">
+                            <div class="metric-title">Калории</div>
+                            <div class="metric-value" id="caloriesValue">--</div>
+                            <div class="metric-subtitle">kcal дневно</div>
+                        </div>
+                    </div>
+                    <div class="col-md-3 mb-3">
+                        <div class="metric-card">
+                            <div class="metric-title">Протеини</div>
+                            <div class="metric-value" id="proteinValue">--</div>
+                            <div class="metric-subtitle" id="proteinPercent">--</div>
+                        </div>
+                    </div>
+                    <div class="col-md-3 mb-3">
+                        <div class="metric-card">
+                            <div class="metric-title">Въглехидрати</div>
+                            <div class="metric-value" id="carbsValue">--</div>
+                            <div class="metric-subtitle" id="carbsPercent">--</div>
+                        </div>
+                    </div>
+                    <div class="col-md-3 mb-3">
+                        <div class="metric-card">
+                            <div class="metric-title">Мазнини</div>
+                            <div class="metric-value" id="fatValue">--</div>
+                            <div class="metric-subtitle" id="fatPercent">--</div>
+                        </div>
+                    </div>
+                </div>
+                
+                <h3 class="section-title"><i class="fas fa-calendar-alt me-2"></i>Седмично меню</h3>
+                
+                <div class="row" id="weeklyMenu">
+                    <!-- Седмичното меню ще бъде генерирано тук -->
+                </div>
+                
+                <h3 class="section-title"><i class="fas fa-lightbulb me-2"></i>Принципи и насоки</h3>
+                
+                <div class="row" id="principlesSection">
+                    <!-- Принципите ще бъдат генерирани тук -->
+                </div>
+                <div class="mt-4">
+                    <h3 class="section-title"><i class="fas fa-edit me-2"></i>Редакция</h3>
+                    <textarea id="planJson" class="form-control" rows="10"></textarea>
+                    <button type="button" id="savePlanBtn" class="btn btn-primary mt-2">Запази плана</button>
+                </div>
+            </div>
+
+            <!-- Дневни записи -->
+            <div class="tab-pane fade" id="logs" role="tabpanel">
+                <h3 class="section-title"><i class="fas fa-history me-2"></i>История на записите</h3>
+                
+                <div class="table-responsive">
+                    <table class="table table-striped table-hover">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Дата</th>
+                                <th>Тегло (кг)</th>
+                                <th>Настроение</th>
+                                <th>Енергия</th>
+                                <th>Спокойствие</th>
+                                <th>Хидратация</th>
+                                <th>Сън</th>
+                                <th>Завършени хранения</th>
+                            </tr>
+                        </thead>
+                        <tbody id="logsTableBody">
+                            <!-- Редовете ще бъдат генерирани тук -->
+                        </tbody>
+                    </table>
+                    <textarea id="logsText" class="form-control mt-3" rows="5" readonly></textarea>
+                </div>
+                
+                <h3 class="section-title mt-4"><i class="fas fa-chart-simple me-2"></i>Статистика на записите</h3>
+                
+                <div class="row">
+                    <div class="col-md-4 mb-4">
+                        <div class="metric-card">
+                            <div class="metric-title">Средно тегло</div>
+                            <div class="metric-value" id="avgWeight">--</div>
+                            <div class="metric-subtitle" id="weightPeriod">--</div>
+                        </div>
+                    </div>
+                    <div class="col-md-4 mb-4">
+                        <div class="metric-card">
+                            <div class="metric-title">Средно ниво на енергия</div>
+                            <div class="metric-value" id="avgEnergy">--</div>
+                            <div class="metric-subtitle">(1-5 скала)</div>
+                        </div>
+                    </div>
+                    <div class="col-md-4 mb-4">
+                        <div class="metric-card">
+                            <div class="metric-title">Средно качество на съня</div>
+                            <div class="metric-value" id="avgSleep">--</div>
+                            <div class="metric-subtitle">(1-5 скала)</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Анализ на прогреса -->
+            <div class="tab-pane fade" id="analytics" role="tabpanel">
+                <h3 class="section-title"><i class="fas fa-tachometer-alt me-2"></i>Общ прогрес</h3>
+                
+                <div class="row mb-4">
+                    <div class="col-md-4 mb-3">
+                        <div class="metric-card">
+                            <div class="metric-title">Прогрес към целта</div>
+                            <div class="metric-value" id="goalProgress">--</div>
+                            <div class="progress mt-3">
+                                <div class="progress-bar bg-success" id="goalProgressBar" role="progressbar" style="width: 0%"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4 mb-3">
+                        <div class="metric-card">
+                            <div class="metric-title">Активност</div>
+                            <div class="metric-value" id="engagementScore">--</div>
+                            <div class="progress mt-3">
+                                <div class="progress-bar bg-info" id="engagementBar" role="progressbar" style="width: 0%"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4 mb-3">
+                        <div class="metric-card">
+                            <div class="metric-title">Общо здраве</div>
+                            <div class="metric-value" id="healthScore">--</div>
+                            <div class="progress mt-3">
+                                <div class="progress-bar bg-primary" id="healthBar" role="progressbar" style="width: 0%"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                
+                <h3 class="section-title"><i class="fas fa-chart-bar me-2"></i>Детайлен анализ</h3>
+                
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Метрика</th>
+                                <th>Начална стойност</th>
+                                <th>Целева стойност</th>
+                                <th>Текуща стойност</th>
+                                <th>Прогрес</th>
+                            </tr>
+                        </thead>
+                        <tbody id="analyticsTableBody">
+                            <!-- Редовете ще бъдат генерирани тук -->
+                        </tbody>
+                    </table>
+                </div>
+                
+                <h3 class="section-title mt-4"><i class="fas fa-fire me-2"></i>Последователност</h3>
+                
+                <div class="card">
+                    <div class="card-header"><i class="fas fa-calendar-check me-2"></i>Редовност на дневните записи</div>
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between mb-3">
+                            <div>
+                                <span class="badge bg-success">Записан ден</span>
+                                <span class="badge bg-light text-dark ms-2">Липсващ запис</span>
+                            </div>
+                            <div>
+                                <strong>Текуща последователност:</strong> <span class="badge bg-info" id="currentStreak">0 дни</span>
+                            </div>
+                        </div>
+                        
+                        <div class="d-flex justify-content-around" id="streakCalendar">
+                            <!-- Календарът ще бъде генериран тук -->
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script type="module" src="js/clientProfile.js"></script>
+</body>
+</html>

--- a/js/admin.js
+++ b/js/admin.js
@@ -38,6 +38,7 @@ const initialAnswersPre = document.getElementById('initialAnswers');
 const planMenuPre = document.getElementById('planMenu');
 const dailyLogsPre = document.getElementById('dailyLogs');
 const exportPlanBtn = document.getElementById('exportPlan');
+const openFullProfileLink = document.getElementById('openFullProfile');
 const dashboardPre = document.getElementById('dashboardData');
 const dashboardSummaryDiv = document.getElementById('dashboardSummary');
 const exportDataBtn = document.getElementById('exportData');
@@ -573,6 +574,7 @@ async function showClient(userId) {
             if (profileName) profileName.value = data.name || '';
             if (profileEmail) profileEmail.value = data.email || '';
             if (profilePhone) profilePhone.value = data.phone || '';
+            if (openFullProfileLink) openFullProfileLink.href = `clientProfile.html?userId=${encodeURIComponent(userId)}`;
             await Promise.all([
                 loadQueries(true),
                 loadFeedback(),

--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -1,0 +1,104 @@
+import { apiEndpoints } from './config.js';
+
+function $(id) {
+  return document.getElementById(id);
+}
+
+function getUserId() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('userId');
+}
+
+async function loadData() {
+  const userId = getUserId();
+  if (!userId) return;
+  try {
+    const [profileRes, dashRes] = await Promise.all([
+      fetch(`${apiEndpoints.getProfile}?userId=${userId}`),
+      fetch(`${apiEndpoints.dashboard}?userId=${userId}`)
+    ]);
+    const profileData = await profileRes.json();
+    const dashData = await dashRes.json();
+    if (profileRes.ok && profileData.success) fillProfile(profileData);
+    if (dashRes.ok && dashData.success) fillDashboard(dashData);
+  } catch (err) {
+    console.error('Load error', err);
+  }
+}
+
+function fillProfile(data) {
+  $('userName').textContent = data.name || '';
+  $('userFullName').textContent = data.fullname || '';
+  $('userGender').textContent = data.gender || '';
+  if (typeof data.age !== 'undefined') $('userAge').textContent = data.age;
+  $('userEmail').textContent = data.email || '';
+  if (typeof data.height !== 'undefined') {
+    $('userHeight').textContent = `${data.height} см`;
+    $('heightValue').textContent = `${data.height} см`;
+  }
+  $('userGoal').textContent = data.mainGoal || '';
+}
+
+function fillDashboard(data) {
+  const curW = data.currentStatus?.weight || '';
+  $('currentWeight').textContent = curW ? `${curW} кг` : '-- кг';
+  $('weightValue').textContent = curW ? `${curW} кг` : '--';
+  const bmi = data.currentStatus?.bmi || '';
+  $('bmiValue').textContent = bmi || '--';
+  $('planJson').value = JSON.stringify(data.planData || {}, null, 2);
+  const logs = data.dailyLogs || [];
+  const list = logs.map(l => `${l.date}: ${l.data?.weight || ''} кг - ${l.data?.note || ''}`).join('\n');
+  $('logsText').value = list;
+}
+
+async function savePlan() {
+  const userId = getUserId();
+  if (!userId) return;
+  try {
+    const json = JSON.parse($('planJson').value);
+    const resp = await fetch(apiEndpoints.updatePlanData, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId, planData: json })
+    });
+    const data = await resp.json();
+    if (resp.ok && data.success) {
+      alert('Планът е записан.');
+    } else {
+      alert(data.message || 'Грешка при запис.');
+    }
+  } catch (err) {
+    alert('Невалиден JSON.');
+  }
+}
+
+async function saveProfile() {
+  const userId = getUserId();
+  if (!userId) return;
+  const payload = {
+    userId,
+    name: $('nameInput').value.trim(),
+    fullname: $('fullnameInput').value.trim(),
+    age: Number($('ageInput').value) || null,
+    phone: $('phoneInput').value.trim(),
+    email: $('emailInput').value.trim(),
+    height: Number($('heightInput').value) || null
+  };
+  const resp = await fetch(apiEndpoints.updateProfile, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const data = await resp.json();
+  if (resp.ok && data.success) {
+    alert('Профилът е записан.');
+  } else {
+    alert(data.message || 'Грешка при запис.');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadData();
+  $('savePlanBtn').addEventListener('click', savePlan);
+  $('saveProfileBtn').addEventListener('click', saveProfile);
+});

--- a/js/config.js
+++ b/js/config.js
@@ -17,6 +17,7 @@ export const apiEndpoints = {
     logExtraMeal: `${workerBaseUrl}/api/log-extra-meal`,
     getProfile: `${workerBaseUrl}/api/getProfile`,
     updateProfile: `${workerBaseUrl}/api/updateProfile`,
+    updatePlanData: `${workerBaseUrl}/api/updatePlanData`,
     getAdaptiveQuiz: `${workerBaseUrl}/api/getAdaptiveQuiz`,
     submitAdaptiveQuiz: `${workerBaseUrl}/api/submitAdaptiveQuiz`,
     acknowledgeAiUpdate: `${workerBaseUrl}/api/acknowledgeAiUpdate`,

--- a/worker.js
+++ b/worker.js
@@ -145,6 +145,8 @@ export default {
                 responseBody = await handleGetProfileRequest(request, env);
             } else if (method === 'POST' && path === '/api/updateProfile') {
                 responseBody = await handleUpdateProfileRequest(request, env);
+            } else if (method === 'POST' && path === '/api/updatePlanData') {
+                responseBody = await handleUpdatePlanRequest(request, env);
             } else if (method === 'POST' && path === '/api/requestPasswordReset') {
                 responseBody = { success: false, message: 'Функцията "Забравена парола" е в разработка.' };
                 responseStatus = 501;
@@ -951,6 +953,27 @@ async function handleUpdateProfileRequest(request, env) {
 }
 }
 // ------------- END FUNCTION: handleUpdateProfileRequest -------------
+
+// ------------- START FUNCTION: handleUpdatePlanRequest -------------
+async function handleUpdatePlanRequest(request, env) {
+    try {
+        const data = await request.json();
+        const userId = data.userId;
+        const planData = data.planData;
+        if (!userId) return { success: false, message: 'Липсва ID на потребител.', statusHint: 400 };
+        if (!planData || typeof planData !== 'object') {
+            return { success: false, message: 'Невалидни данни за плана.', statusHint: 400 };
+        }
+        await env.USER_METADATA_KV.put(`${userId}_final_plan`, JSON.stringify(planData));
+        await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'ready', { metadata: { status: 'ready' } });
+        return { success: true, message: 'Планът е обновен успешно' };
+    } catch (error) {
+        console.error('Error in handleUpdatePlanRequest:', error.message, error.stack);
+        const uid = (await request.json().catch(() => ({}))).userId || 'unknown_user';
+        return { success: false, message: 'Грешка при запис на плана.', statusHint: 500, userId: uid };
+    }
+}
+// ------------- END FUNCTION: handleUpdatePlanRequest -------------
 
 // ------------- START FUNCTION: handleGetAdaptiveQuizRequest -------------
 async function handleGetAdaptiveQuizRequest(request, env) {
@@ -3428,4 +3451,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, callCfAi, callModel, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, callCfAi, callModel, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements };


### PR DESCRIPTION
## Summary
- implement `/api/updatePlanData` endpoint in worker
- add full profile link in admin panel
- create `clientProfile.html` and JS for detailed view and editing
- expose new endpoint in config

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856cbfe8efc832686e742226865ab8c