### PR TITLE
Add test for updating plan data

### DIFF
--- a/js/__tests__/updatePlanData.test.js
+++ b/js/__tests__/updatePlanData.test.js
@@ -1,0 +1,13 @@
+import { jest } from '@jest/globals';
+import { handleUpdatePlanRequest } from '../../worker.js';
+
+describe('handleUpdatePlanRequest', () => {
+  test('stores plan data using final plan key', async () => {
+    const env = { USER_METADATA_KV: { put: jest.fn() } };
+    const planData = { week: 1 };
+    const request = { json: async () => ({ userId: 'u1', planData }) };
+    const res = await handleUpdatePlanRequest(request, env);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_final_plan', JSON.stringify(planData));
+    expect(res.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `updatePlanData.test.js` to cover `handleUpdatePlanRequest`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856e33176a48326b8fe0f6bd2b457ee