### PR TITLE
Add JSON repair and size check when saving plan

### DIFF
--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -1,4 +1,5 @@
 import { apiEndpoints } from './config.js';
+import { jsonrepair } from 'jsonrepair';
 
 function $(id) {
   return document.getElementById(id);
@@ -136,7 +137,13 @@ async function savePlan() {
   const userId = getUserId();
   if (!userId) return;
   try {
-    const json = JSON.parse($('planJson').value);
+    const text = $('planJson').value;
+    if (text.length > 20000) {
+      alert('Планът е твърде голям (максимум 20 000 символа).');
+      return;
+    }
+    const repaired = jsonrepair(text);
+    const json = JSON.parse(repaired);
     const resp = await fetch(apiEndpoints.updatePlanData, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -145,6 +152,7 @@ async function savePlan() {
     const data = await resp.json();
     if (resp.ok && data.success) {
       alert('Планът е записан.');
+      setText('planStatus', 'ready');
     } else {
       alert(data.message || 'Грешка при запис.');
     }


### PR DESCRIPTION
## Summary
- use `jsonrepair` when saving the plan
- validate input length before save
- update `planStatus` after a successful save

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856e4d4bfb08326aec9f43c34c58269