### PR TITLE
Add embedded full profile in admin panel

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -62,7 +62,9 @@
     </details>
     <button id="regeneratePlan">Генерирай нов план</button>
     <button id="aiSummary">AI резюме</button>
-    <a id="openFullProfile" href="#" target="_blank">Пълен профил</a>
+    <button id="toggleFullProfile">Покажи пълен профил</button>
+    <iframe id="fullProfileFrame" class="profile-frame hidden" title="Пълен профил"></iframe>
+    <a id="openFullProfile" href="#" target="_blank">Отвори в нов таб</a>
     </section>
     <section id="notesTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="notesSection">

--- a/css/admin.css
+++ b/css/admin.css
@@ -184,3 +184,10 @@ details[open] summary::after {
 #weightChart {
   margin-top: 10px;
 }
+
+.profile-frame {
+  width: 100%;
+  height: 80vh;
+  border: none;
+  margin-top: 10px;
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -39,6 +39,8 @@ const planMenuPre = document.getElementById('planMenu');
 const dailyLogsPre = document.getElementById('dailyLogs');
 const exportPlanBtn = document.getElementById('exportPlan');
 const openFullProfileLink = document.getElementById('openFullProfile');
+const toggleFullProfileBtn = document.getElementById('toggleFullProfile');
+const fullProfileFrame = document.getElementById('fullProfileFrame');
 const dashboardPre = document.getElementById('dashboardData');
 const dashboardSummaryDiv = document.getElementById('dashboardSummary');
 const exportDataBtn = document.getElementById('exportData');
@@ -537,6 +539,12 @@ if (toggleWeightChartBtn) {
     });
 }
 
+if (toggleFullProfileBtn) {
+    toggleFullProfileBtn.addEventListener('click', () => {
+        fullProfileFrame?.classList.toggle('hidden');
+    });
+}
+
 if (closeProfileBtn) {
     closeProfileBtn.addEventListener('click', () => {
         detailsSection.classList.add('hidden');
@@ -575,6 +583,7 @@ async function showClient(userId) {
             if (profileEmail) profileEmail.value = data.email || '';
             if (profilePhone) profilePhone.value = data.phone || '';
             if (openFullProfileLink) openFullProfileLink.href = `Userdata.html?userId=${encodeURIComponent(userId)}`;
+            if (fullProfileFrame) fullProfileFrame.src = `Userdata.html?userId=${encodeURIComponent(userId)}`;
             await Promise.all([
                 loadQueries(true),
                 loadFeedback(),


### PR DESCRIPTION
## Summary
- embed `Userdata.html` in admin panel via iframe
- style new frame
- toggle frame visibility with button and set source when a client is loaded

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856e97e2d208326b3885ed08fc18e94