### PR TITLE
Add missing profile fields

### DIFF
--- a/clientProfile.html
+++ b/clientProfile.html
@@ -46,6 +46,19 @@
             <p>Лекарства: <span id="medications"></span></p>
             <p>Прием на вода: <span id="waterIntake"></span></p>
             <p>Предпочитания: <span id="foodPreferences"></span></p>
+            <p>Честота на преяждане: <span id="overeatingFrequency"></span></p>
+            <p>Желания за храна: <span id="foodCravings"></span></p>
+            <p>Тригери за храна: <span id="foodTriggers"></span></p>
+            <p>Консумация на алкохол: <span id="alcoholFrequency"></span></p>
+            <p>Хранителни навици: <span id="eatingHabits"></span></p>
+            <p>Целеви BMI: <span id="targetBmi"></span></p>
+            <p>Продължителност на съня: <span id="sleepHours"></span></p>
+            <p>Събуждания по време на сън: <span id="sleepInterruptions"></span></p>
+            <p>Хронотип: <span id="chronotype"></span></p>
+            <p>Ниво на активност: <span id="activityLevel"></span></p>
+            <p>Физическа активност: <span id="physicalActivity"></span></p>
+            <p>Височина (стойност): <span id="heightValue"></span></p>
+            <p>Основна цел (план): <span id="mainGoal"></span></p>
           </div>
           <div class="col-md-6">
             <form id="profileForm">


### PR DESCRIPTION
## Summary
- show additional values in profile tab to match fillProfile()

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857007735d083268633ac63b42ebfd9