### PR TITLE
Update client profile cards

### DIFF
--- a/clientProfile.html
+++ b/clientProfile.html
@@ -51,7 +51,32 @@
     <div class="tab-content pt-3">
       <div class="tab-pane fade show active" id="profile" role="tabpanel">
         <div class="row">
-          <div class="col-md-6" id="profileInfo"></div>
+          <div class="col-md-6" id="profileInfo">
+            <div class="card mb-3">
+              <div class="card-header"><i class="fas fa-user me-2"></i>Демографски данни</div>
+              <div class="card-body p-0" id="demographicsInfo"></div>
+            </div>
+            <div class="card mb-3">
+              <div class="card-header"><i class="fas fa-weight me-2"></i>Физически характеристики</div>
+              <div class="card-body p-0" id="physicalInfo"></div>
+            </div>
+            <div class="card mb-3">
+              <div class="card-header"><i class="fas fa-bullseye me-2"></i>Цели и мотивация</div>
+              <div class="card-body p-0" id="goalsInfo"></div>
+            </div>
+            <div class="card mb-3">
+              <div class="card-header"><i class="fas fa-bed me-2"></i>Сън и активност</div>
+              <div class="card-body p-0" id="sleepInfo"></div>
+            </div>
+            <div class="card mb-3">
+              <div class="card-header"><i class="fas fa-notes-medical me-2"></i>Здравословни особености</div>
+              <div class="card-body p-0" id="healthInfo"></div>
+            </div>
+            <div class="card">
+              <div class="card-header"><i class="fas fa-utensils me-2"></i>Хранителни модели</div>
+              <div class="card-body p-0" id="foodInfo"></div>
+            </div>
+          </div>
           <div class="col-md-6">
             <form id="profileForm">
               <div class="mb-2">
@@ -91,6 +116,10 @@
       </div>
 
       <div class="tab-pane fade" id="plan" role="tabpanel">
+        <div class="alert alert-info">
+          <i class="fas fa-info-circle me-2"></i>Статус на плана:
+          <span id="planStatusBadge" class="badge bg-warning"></span>
+        </div>
         <div id="planMenu"></div>
         <textarea id="planJson" class="form-control" rows="10" hidden></textarea>
         <button id="savePlanBtn" type="button" class="btn btn-primary mt-2">Запази план</button>

--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -58,27 +58,34 @@ function fillProfile(data) {
   setText('userGoalHeader', data.mainGoal);
   setText('userHeightHeader', data.height, ' см');
 
-  const container = $('profileInfo');
-  if (!container) return;
-  container.innerHTML = '';
-  const fields = {
+  const demographics = {
     fullname: data.fullname,
     gender: data.gender,
     age: data.age,
-    email: data.email,
-    height: data.height ? `${data.height} см` : undefined,
+    email: data.email
+  };
+  const physical = {
+    height: data.height ? `${data.height} см` : undefined
+  };
+  const goals = {
     mainGoal: data.mainGoal,
     motivationLevel: data.motivationLevel,
-    targetBmi: data.targetBmi,
+    targetBmi: data.targetBmi
+  };
+  const sleep = {
     sleepHours: data.sleepHours,
     sleepInterruptions: data.sleepInterruptions,
     chronotype: data.chronotype,
     activityLevel: data.activityLevel,
-    physicalActivity: data.physicalActivity,
+    physicalActivity: data.physicalActivity
+  };
+  const health = {
     medicalConditions: Array.isArray(data.medicalConditions) ? data.medicalConditions.join(', ') : data.medicalConditions,
     stressLevel: data.stressLevel,
     medications: data.medications,
-    waterIntake: data.waterIntake,
+    waterIntake: data.waterIntake
+  };
+  const food = {
     foodPreferences: data.foodPreferences,
     overeatingFrequency: data.overeatingFrequency,
     foodCravings: data.foodCravings,
@@ -86,21 +93,34 @@ function fillProfile(data) {
     alcoholFrequency: data.alcoholFrequency,
     eatingHabits: data.eatingHabits
   };
-  const card = document.createElement('div');
-  card.className = 'card';
-  const body = document.createElement('div');
-  body.className = 'card-body p-0';
-  Object.entries(fields).forEach(([k, v]) => {
-    body.appendChild(createInfoItem(labelMap[k] || k, v));
+  const sections = {
+    demographics: demographics,
+    physical: physical,
+    goals: goals,
+    sleep: sleep,
+    health: health,
+    food: food
+  };
+  Object.entries(sections).forEach(([key, obj]) => {
+    const el = $(`${key}Info`);
+    if (!el) return;
+    el.innerHTML = '';
+    Object.entries(obj).forEach(([k, v]) => {
+      el.appendChild(createInfoItem(labelMap[k] || k, v));
+    });
   });
-  card.appendChild(body);
-  container.appendChild(card);
 }
 
 function fillDashboard(data) {
   const curW = data.currentStatus?.weight;
   setText('currentWeightHeader', curW, ' кг');
   setText('planStatus', data.planStatus);
+  setText('planStatusBadge', data.planStatus);
+  const badge = $('planStatusBadge');
+  if (badge) {
+    badge.classList.remove('bg-success', 'bg-warning');
+    badge.classList.add(data.planStatus === 'ready' ? 'bg-success' : 'bg-warning');
+  }
 
   const macrosContainer = $('macroCards');
   if (macrosContainer) {
@@ -329,6 +349,12 @@ async function savePlan() {
     if (resp.ok && data.success) {
       alert('Планът е записан.');
       setText('planStatus', 'ready');
+      setText('planStatusBadge', 'ready');
+      const badge = $('planStatusBadge');
+      if (badge) {
+        badge.classList.remove('bg-warning');
+        badge.classList.add('bg-success');
+      }
     } else {
       alert(data.message || 'Грешка при запис.');
     }


### PR DESCRIPTION
## Summary
- organize client profile details into multiple card sections
- display plan status badge inside the meal plan tab
- update `fillProfile` to populate each new section
- show plan status badge and styling in `fillDashboard`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857094249948326ab0619db4e5ce514