### PR TITLE
Rename dashboard section to analytics

### DIFF
--- a/clientProfile.html
+++ b/clientProfile.html
@@ -42,7 +42,7 @@
         </button>
       </li>
       <li class="nav-item" role="presentation">
-        <button class="nav-link" id="dashboard-tab" data-bs-toggle="tab" data-bs-target="#dashboard" type="button" role="tab">
+        <button class="nav-link" id="analytics-tab" data-bs-toggle="tab" data-bs-target="#analytics" type="button" role="tab">
           <i class="fas fa-chart-line me-2"></i>Анализ на прогреса
         </button>
       </li>
@@ -134,10 +134,10 @@
         </table>
       </div>
 
-      <div class="tab-pane fade" id="dashboard" role="tabpanel">
+      <div class="tab-pane fade" id="analytics" role="tabpanel">
         <div class="row mb-4" id="macroCards"></div>
         <div class="card mb-4">
-          <div class="card-body p-0" id="dashboardInfo"></div>
+          <div class="card-body p-0" id="analyticsInfo"></div>
         </div>
         <div class="mb-2">
           <div class="progress">

--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -170,7 +170,7 @@ function fillDashboard(data) {
   const weightVals = logs.map(l => parseFloat(l.data?.weight)).filter(v => !isNaN(v));
   const energyVals = logs.map(l => parseFloat(l.data?.energy)).filter(v => !isNaN(v));
   const sleepVals = logs.map(l => parseFloat(l.data?.sleep)).filter(v => !isNaN(v));
-  const infoContainer = $('dashboardInfo');
+  const infoContainer = $('analyticsInfo');
   if (infoContainer) {
     infoContainer.innerHTML = '';
     const fields = {


### PR DESCRIPTION
## Summary
- use `analytics-tab` and `#analytics` in the profile page
- adjust JS selector to `analyticsInfo`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68570d0061d4832681b3534b92595a53