### PR TITLE
Add phone display for profiles

### DIFF
--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -21,7 +21,8 @@ function createInfoItem(label, value) {
   l.textContent = label;
   const v = document.createElement('div');
   v.className = 'info-value';
-  v.textContent = value ?? '--';
+  v.textContent =
+    value !== undefined && value !== null && value !== '' ? value : '--';
   div.appendChild(l);
   div.appendChild(v);
   return div;
@@ -62,6 +63,7 @@ function fillProfile(data) {
     fullname: data.fullname,
     gender: data.gender,
     age: data.age,
+    phone: data.phone,
     email: data.email
   };
   const physical = {


### PR DESCRIPTION
## Summary
- include phone field when rendering demographics info
- ensure empty phone values show `--`

## Testing
- `npm run lint`
- `script -q -c "npm test" /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68576aa3d78483268f6400c8c4f294d9