### PR TITLE
Add client profile tests

### DIFF
--- a/js/testHelpers/jsonrepairMock.js
+++ b/js/testHelpers/jsonrepairMock.js
@@ -1,0 +1,1 @@
+export function jsonrepair(str) { return str; }


### PR DESCRIPTION
## Summary
- add unit tests for client profile helpers
- include helper module for jsonrepair mock

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68576aad759083268ac37a1cd5bc605d