### PR TITLE
Fix tag duplication in admin notes

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -742,7 +742,14 @@ if (saveNotesBtn) {
             body: JSON.stringify({
                 userId: currentUserId,
                 adminNotes: notesField.value,
-                adminTags: (tagsField.value || '').split(',').map(t => t.trim()).filter(Boolean)
+                adminTags: Array.from(
+                    new Set(
+                        (tagsField.value || '')
+                            .split(',')
+                            .map(t => t.trim())
+                            .filter(Boolean)
+                    )
+                )
             })
         });
         alert('Бележките са записани');

--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -433,22 +433,22 @@ function fillAdminNotes(status) {
   if (!status) return;
   const notesEl = $('adminNotes');
   if (notesEl) notesEl.textContent = status.adminNotes || '--';
-  const tagsEl = $('adminTags');
-  if (tagsEl) {
-    tagsEl.innerHTML = '';
-    const tags = Array.isArray(status.adminTags) ? status.adminTags : [];
-    if (tags.length === 0) {
-      const li = document.createElement('li');
-      li.textContent = '--';
-      tagsEl.appendChild(li);
-    } else {
-      tags.forEach(t => {
+    const tagsEl = $('adminTags');
+    if (tagsEl) {
+      tagsEl.innerHTML = '';
+      const uniqueTags = new Set(Array.isArray(status.adminTags) ? status.adminTags : []);
+      if (uniqueTags.size === 0) {
         const li = document.createElement('li');
-        li.textContent = t;
+        li.textContent = '--';
         tagsEl.appendChild(li);
-      });
+      } else {
+        uniqueTags.forEach(t => {
+          const li = document.createElement('li');
+          li.textContent = t;
+          tagsEl.appendChild(li);
+        });
+      }
     }
-  }
 }
 
 function fillInitialAnswers(ans) {


### PR DESCRIPTION
## Summary
- deduplicate tags before saving notes in admin dashboard
- render unique admin tags in client profile view

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68577127da008326b50d35e38f73416d