### PR TITLE
Add dashboard JSON visibility & copy

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -101,6 +101,7 @@
       <div id="dashboardSummary"></div>
       <details>
         <summary>JSON</summary>
+        <button id="copyDashboardJson" class="button button-small hidden" type="button">Копирай JSON</button>
         <pre id="dashboardData" class="json"></pre>
       </details>
     </details>

--- a/css/admin.css
+++ b/css/admin.css
@@ -191,3 +191,8 @@ details[open] summary::after {
   border: none;
   margin-top: 10px;
 }
+
+.button-small {
+  font-size: 0.8rem;
+  padding: var(--space-xs) var(--space-sm);
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -42,6 +42,7 @@ const openFullProfileLink = document.getElementById('openFullProfile');
 const toggleFullProfileBtn = document.getElementById('toggleFullProfile');
 const fullProfileFrame = document.getElementById('fullProfileFrame');
 const dashboardPre = document.getElementById('dashboardData');
+const copyDashboardJsonBtn = document.getElementById('copyDashboardJson');
 const dashboardSummaryDiv = document.getElementById('dashboardSummary');
 const exportDataBtn = document.getElementById('exportData');
 const exportCsvBtn = document.getElementById('exportCsv');
@@ -655,7 +656,11 @@ async function showClient(userId) {
             displayPlanMenu(menu, false);
             displayDailyLogs(dashData.dailyLogs || [], false);
             displayDashboardSummary(dashData);
-            if (dashboardPre) dashboardPre.textContent = JSON.stringify(dashData, null, 2);
+            if (dashboardPre) {
+                dashboardPre.textContent = JSON.stringify(dashData, null, 2);
+                dashboardPre.classList.remove('hidden');
+            }
+            if (copyDashboardJsonBtn) copyDashboardJsonBtn.classList.remove('hidden');
             if (notesField) notesField.value = dashData.currentStatus?.adminNotes || '';
             if (tagsField) tagsField.value = (dashData.currentStatus?.adminTags || []).join(',');
             currentPlanData = dashData.planData || null;
@@ -671,6 +676,11 @@ async function showClient(userId) {
             displayInitialAnswers(null, true);
             displayPlanMenu(null, true);
             displayDailyLogs(null, true);
+            if (dashboardPre) {
+                dashboardPre.textContent = '';
+                dashboardPre.classList.add('hidden');
+            }
+            if (copyDashboardJsonBtn) copyDashboardJsonBtn.classList.add('hidden');
             hasError = true;
         }
         if (hasError) {
@@ -798,6 +808,14 @@ if (exportCsvBtn) {
         a.download = `${currentUserId || 'logs'}.csv`;
         a.click();
         URL.revokeObjectURL(url);
+    });
+}
+
+if (copyDashboardJsonBtn) {
+    copyDashboardJsonBtn.addEventListener('click', () => {
+        if (dashboardPre && dashboardPre.textContent) {
+            navigator.clipboard.writeText(dashboardPre.textContent).catch(() => alert('Неуспешно копиране'));
+        }
     });
 }
 


### PR DESCRIPTION
## Summary
- show or hide dashboard JSON depending on available data
- allow copying dashboard JSON via a new button
- add `.button-small` style for compact buttons

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685771af50f883268cd0aa045ef3d2ab