### PR TITLE
Remove initial answers card and fallback profile data

### DIFF
--- a/Userdata.html
+++ b/Userdata.html
@@ -471,11 +471,6 @@
                     </div>
                 </div>
                 
-                <div class="card mt-4">
-                    <div class="card-header"><i class="fas fa-file-alt me-2"></i>Първоначални отговори</div>
-                    <div class="card-body" id="initialAnswersContainer">
-                        <div class="empty-placeholder"><span class="loader"></span>Зареждане на данни...</div>
-                    </div>
                 </div>
             </div>
 

--- a/js/__tests__/clientProfile.test.js
+++ b/js/__tests__/clientProfile.test.js
@@ -19,9 +19,12 @@ beforeEach(async () => {
     <input id="phoneInput">
     <input id="emailInput">
     <input id="heightInput">
+    <span id="userName"></span>
+    <span id="userGoalHeader"></span>
+    <span id="userHeightHeader"></span>
+    <div id="demographicsInfo"></div>
     <div id="adminNotes"></div>
     <ul id="adminTags"></ul>
-    <div id="initialAnswersContainer"></div>
     <textarea id="planJson"></textarea>
     <button id="savePlanBtn"></button>
     <button id="saveProfileBtn"></button>
@@ -33,7 +36,7 @@ beforeEach(async () => {
     .replace("https://cdn.jsdelivr.net/npm/jsonrepair/+esm", jsonrepairMockPath)
     .replace('./config.js', '../config.js')
     .replace('./labelMap.js', '../labelMap.js')
-    + '\nexport { fillProfile, fillAdminNotes, fillInitialAnswers };';
+    + '\nexport { fillProfile, fillAdminNotes };';
   const tempPath = path.join(path.dirname(jsonrepairMockPath), 'clientProfile.patched.js');
   await fs.promises.writeFile(tempPath, patched);
   mod = await import(pathToFileURL(tempPath) + '?' + Date.now());
@@ -92,15 +95,14 @@ test('fillProfile populates form inputs', async () => {
   expect(document.getElementById('heightInput').value).toBe('180');
 });
 
-test('admin notes and questionnaire answers render correctly', async () => {
+test('admin notes render and initial answers fill blanks', async () => {
   jest.unstable_mockModule('../labelMap.js', () => ({ labelMap: {} }));
   mod.fillAdminNotes({ adminNotes: 'Бележки', adminTags: ['t1', 't2'] });
-  mod.fillInitialAnswers({ sleep: 'Добре', nested: { foo: 'bar' } });
+  mod.fillProfile({ age: 25 }, { name: 'Init', fullname: 'Init Name' });
   expect(document.getElementById('adminNotes').textContent).toBe('Бележки');
   const tagTexts = Array.from(document.querySelectorAll('#adminTags li')).map(li => li.textContent);
   expect(tagTexts).toEqual(['t1', 't2']);
-  const dl = document.querySelector('#initialAnswersContainer dl');
-  expect(dl).not.toBeNull();
-  expect(dl.querySelector('dt').textContent).toBe('sleep');
-  expect(dl.querySelector('dd').textContent).toContain('Добре');
+  expect(document.getElementById('nameInput').value).toBe('Init');
+  expect(document.getElementById('userName').textContent).toBe('Init');
+  expect(document.getElementById('demographicsInfo').textContent).toContain('Init Name');
 });

--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -52,57 +52,65 @@ async function loadData() {
     ]);
     const profileData = await profileRes.json();
     const dashData = await dashRes.json();
-    if (profileRes.ok && profileData.success) fillProfile(profileData);
+    if (profileRes.ok && profileData.success) {
+      fillProfile(profileData, dashData.initialAnswers);
+    }
     if (dashRes.ok && dashData.success) {
       fillDashboard(dashData);
       fillAdminNotes(dashData.currentStatus);
-      fillInitialAnswers(dashData.initialAnswers);
     }
   } catch (err) {
     console.error('Load error', err);
   }
 }
 
-function fillProfile(data) {
-  setText('userName', data.name);
-  setText('userGoalHeader', data.mainGoal);
-  setText('userHeightHeader', data.height, ' см');
+function fillProfile(data, initialAnswers = {}) {
+  const getVal = key => {
+    const v = data?.[key];
+    return v !== undefined && v !== null && v !== '' ? v : initialAnswers?.[key];
+  };
+
+  setText('userName', getVal('name'));
+  setText('userGoalHeader', getVal('mainGoal'));
+  setText('userHeightHeader', getVal('height'), ' см');
 
   const demographics = {
-    fullname: data.fullname,
-    gender: data.gender,
-    age: data.age,
-    phone: data.phone,
-    email: data.email
+    fullname: getVal('fullname'),
+    gender: getVal('gender'),
+    age: getVal('age'),
+    phone: getVal('phone'),
+    email: getVal('email')
   };
+  const heightVal = getVal('height');
   const physical = {
-    height: data.height ? `${data.height} см` : undefined
+    height: heightVal ? `${heightVal} см` : undefined
   };
   const goals = {
-    mainGoal: data.mainGoal,
-    motivationLevel: data.motivationLevel,
-    targetBmi: data.targetBmi
+    mainGoal: getVal('mainGoal'),
+    motivationLevel: getVal('motivationLevel'),
+    targetBmi: getVal('targetBmi')
   };
   const sleep = {
-    sleepHours: data.sleepHours,
-    sleepInterruptions: data.sleepInterruptions,
-    chronotype: data.chronotype,
-    activityLevel: data.activityLevel,
-    physicalActivity: data.physicalActivity
+    sleepHours: getVal('sleepHours'),
+    sleepInterruptions: getVal('sleepInterruptions'),
+    chronotype: getVal('chronotype'),
+    activityLevel: getVal('activityLevel'),
+    physicalActivity: getVal('physicalActivity')
   };
+  const mc = getVal('medicalConditions');
   const health = {
-    medicalConditions: Array.isArray(data.medicalConditions) ? data.medicalConditions.join(', ') : data.medicalConditions,
-    stressLevel: data.stressLevel,
-    medications: data.medications,
-    waterIntake: data.waterIntake
+    medicalConditions: Array.isArray(mc) ? mc.join(', ') : mc,
+    stressLevel: getVal('stressLevel'),
+    medications: getVal('medications'),
+    waterIntake: getVal('waterIntake')
   };
   const food = {
-    foodPreferences: data.foodPreferences,
-    overeatingFrequency: data.overeatingFrequency,
-    foodCravings: data.foodCravings,
-    foodTriggers: data.foodTriggers,
-    alcoholFrequency: data.alcoholFrequency,
-    eatingHabits: data.eatingHabits
+    foodPreferences: getVal('foodPreferences'),
+    overeatingFrequency: getVal('overeatingFrequency'),
+    foodCravings: getVal('foodCravings'),
+    foodTriggers: getVal('foodTriggers'),
+    alcoholFrequency: getVal('alcoholFrequency'),
+    eatingHabits: getVal('eatingHabits')
   };
   const sections = {
     demographics: demographics,
@@ -122,12 +130,12 @@ function fillProfile(data) {
   });
 
   // Populate edit fields if present
-  if ($('nameInput')) $('nameInput').value = data.name || '';
-  if ($('fullnameInput')) $('fullnameInput').value = data.fullname || '';
-  if ($('ageInput')) $('ageInput').value = data.age ?? '';
-  if ($('phoneInput')) $('phoneInput').value = data.phone || '';
-  if ($('emailInput')) $('emailInput').value = data.email || '';
-  if ($('heightInput')) $('heightInput').value = data.height ?? '';
+  if ($('nameInput')) $('nameInput').value = getVal('name') || '';
+  if ($('fullnameInput')) $('fullnameInput').value = getVal('fullname') || '';
+  if ($('ageInput')) $('ageInput').value = getVal('age') ?? '';
+  if ($('phoneInput')) $('phoneInput').value = getVal('phone') || '';
+  if ($('emailInput')) $('emailInput').value = getVal('email') || '';
+  if ($('heightInput')) $('heightInput').value = getVal('height') ?? '';
 }
 
 function fillDashboard(data) {
@@ -502,16 +510,6 @@ function fillAdminNotes(status) {
     }
 }
 
-function fillInitialAnswers(ans) {
-  const container = $('initialAnswersContainer');
-  if (!container) return;
-  container.innerHTML = '';
-  if (!ans || Object.keys(ans).length === 0) {
-    container.textContent = 'Няма данни';
-    return;
-  }
-  container.appendChild(renderObjectAsList(ans));
-}
 
 async function savePlan() {
   const userId = getUserId();

--- a/profileTemplate.html
+++ b/profileTemplate.html
@@ -471,11 +471,6 @@
                     </div>
                 </div>
                 
-                <div class="card mt-4">
-                    <div class="card-header"><i class="fas fa-file-alt me-2"></i>Първоначални отговори</div>
-                    <div class="card-body" id="initialAnswersContainer">
-                        <div class="empty-placeholder"><span class="loader"></span>Зареждане на данни...</div>
-                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- delete `initialAnswersContainer` from profile templates
- drop unused `fillInitialAnswers` helper
- let `fillProfile` use questionnaire answers when profile values are missing
- update `loadData` and tests for new behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68577705b7dc8326a8730db87da579e4