### PR TITLE
Update admin profile display

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -62,7 +62,6 @@
     </details>
     <button id="regeneratePlan">Генерирай нов план</button>
     <button id="aiSummary">AI резюме</button>
-    <button id="toggleFullProfile">Покажи пълен профил</button>
     <iframe id="fullProfileFrame" class="profile-frame hidden" title="Пълен профил"></iframe>
     <a id="openFullProfile" href="#" target="_blank">Отвори в нов таб</a>
     </section>

--- a/js/admin.js
+++ b/js/admin.js
@@ -39,7 +39,6 @@ const planMenuPre = document.getElementById('planMenu');
 const dailyLogsPre = document.getElementById('dailyLogs');
 const exportPlanBtn = document.getElementById('exportPlan');
 const openFullProfileLink = document.getElementById('openFullProfile');
-const toggleFullProfileBtn = document.getElementById('toggleFullProfile');
 const fullProfileFrame = document.getElementById('fullProfileFrame');
 const dashboardPre = document.getElementById('dashboardData');
 const copyDashboardJsonBtn = document.getElementById('copyDashboardJson');
@@ -584,18 +583,6 @@ if (toggleWeightChartBtn) {
     });
 }
 
-if (toggleFullProfileBtn) {
-    toggleFullProfileBtn.addEventListener('click', () => {
-        if (currentUserId && fullProfileFrame && !fullProfileFrame.src) {
-            fullProfileFrame.src = `clientProfile.html?userId=${encodeURIComponent(currentUserId)}`;
-        }
-        if (currentUserId && openFullProfileLink) {
-            openFullProfileLink.href = `clientProfile.html?userId=${encodeURIComponent(currentUserId)}`;
-        }
-        const isHidden = fullProfileFrame?.classList.toggle('hidden');
-        toggleFullProfileBtn.textContent = isHidden ? 'Покажи пълен профил' : 'Скрий пълен профил';
-    });
-}
 
 if (closeProfileBtn) {
     closeProfileBtn.addEventListener('click', () => {
@@ -612,8 +599,7 @@ if (sortOrderSelect) sortOrderSelect.addEventListener('change', renderClients);
 if (tagFilterSelect) tagFilterSelect.addEventListener('change', renderClients);
 
 async function showClient(userId) {
-    if (fullProfileFrame) fullProfileFrame.classList.add('hidden');
-    if (toggleFullProfileBtn) toggleFullProfileBtn.textContent = 'Покажи пълен профил';
+    if (fullProfileFrame) fullProfileFrame.classList.remove('hidden');
     try {
         const [profileResp, dashResp] = await Promise.all([
             fetch(`${apiEndpoints.getProfile}?userId=${userId}`),


### PR DESCRIPTION
## Summary
- drop the `toggleFullProfile` button
- always display profile iframe when selecting a client

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857ea97d6c08326a6dbda08f27133b8