### PR TITLE
Add simple plan editor forms

### DIFF
--- a/Userdata.html
+++ b/Userdata.html
@@ -730,6 +730,24 @@
                             <label for="planJson" class="form-label">JSON на плана:</label>
                             <textarea class="form-control json-editor" id="planJson" rows="15">{"message": "Данните ще се заредят автоматично"}</textarea>
                         </div>
+                        <div id="planEditorForms" class="mb-3">
+                            <h6>Меню по дни</h6>
+                            <div class="table-responsive">
+                                <table class="table" id="menuEditTable"></table>
+                            </div>
+                            <div class="mt-3">
+                                <label for="allowedFoodsInput" class="form-label">Позволени храни</label>
+                                <textarea id="allowedFoodsInput" class="form-control" rows="3"></textarea>
+                            </div>
+                            <div class="mt-3">
+                                <label for="forbiddenFoodsInput" class="form-label">Забранени храни</label>
+                                <textarea id="forbiddenFoodsInput" class="form-control" rows="3"></textarea>
+                            </div>
+                            <div class="mt-3">
+                                <label for="principlesInput" class="form-label">Принципи</label>
+                                <textarea id="principlesInput" class="form-control" rows="4"></textarea>
+                            </div>
+                        </div>
                         <button class="btn btn-primary" id="savePlanBtn">
                             <i class="fas fa-save me-2"></i>Запази плана
                         </button>

--- a/js/__tests__/clientProfile.test.js
+++ b/js/__tests__/clientProfile.test.js
@@ -36,6 +36,7 @@ beforeEach(async () => {
     .replace("https://cdn.jsdelivr.net/npm/jsonrepair/+esm", jsonrepairMockPath)
     .replace('./config.js', '../config.js')
     .replace('./labelMap.js', '../labelMap.js')
+    .replace('./planEditor.js', '../planEditor.js')
     + '\nexport { fillProfile, fillAdminNotes };';
   const tempPath = path.join(path.dirname(jsonrepairMockPath), 'clientProfile.patched.js');
   await fs.promises.writeFile(tempPath, patched);

--- a/js/__tests__/clientProfileFill.test.js
+++ b/js/__tests__/clientProfileFill.test.js
@@ -11,6 +11,7 @@ beforeEach(() => {
     <div id="cookingMethodsContainer"></div>
   `;
   jest.unstable_mockModule('https://cdn.jsdelivr.net/npm/jsonrepair/+esm', () => ({ jsonrepair: jest.fn() }), { virtual: true });
+  jest.unstable_mockModule('../planEditor.js', () => ({ initPlanEditor: jest.fn(), gatherPlanFormData: jest.fn(() => ({})) }));
 });
 
 test('fillAllowedFoods renders items', async () => {

--- a/js/planEditor.js
+++ b/js/planEditor.js
@@ -1,0 +1,82 @@
+export function initPlanEditor(planData = {}) {
+  const menuTable = document.getElementById('menuEditTable');
+  const allowedInput = document.getElementById('allowedFoodsInput');
+  const forbiddenInput = document.getElementById('forbiddenFoodsInput');
+  const principlesInput = document.getElementById('principlesInput');
+
+  if (menuTable) {
+    menuTable.innerHTML = '';
+    const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+    days.forEach(day => {
+      const row = document.createElement('tr');
+      const dayCell = document.createElement('th');
+      dayCell.textContent = capitalizeDay(day);
+      const cell = document.createElement('td');
+      const ta = document.createElement('textarea');
+      ta.className = 'form-control';
+      ta.rows = 2;
+      ta.dataset.day = day;
+      ta.value = (planData.week1Menu?.[day] || []).map(m => m.meal_name).join('\n');
+      cell.appendChild(ta);
+      row.appendChild(dayCell);
+      row.appendChild(cell);
+      menuTable.appendChild(row);
+    });
+  }
+
+  if (allowedInput) {
+    const arr = planData.allowedForbiddenFoods?.main_allowed_foods;
+    allowedInput.value = Array.isArray(arr) ? arr.join('\n') : '';
+  }
+  if (forbiddenInput) {
+    const arr = planData.allowedForbiddenFoods?.main_forbidden_foods;
+    forbiddenInput.value = Array.isArray(arr) ? arr.join('\n') : '';
+  }
+  if (principlesInput) {
+    const pr = planData.principlesWeek2_4;
+    if (Array.isArray(pr)) principlesInput.value = pr.join('\n');
+    else if (typeof pr === 'string') principlesInput.value = pr;
+  }
+}
+
+function parseList(text) {
+  return text.split('\n').map(s => s.trim()).filter(Boolean);
+}
+
+export function gatherPlanFormData() {
+  const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+  const week1Menu = {};
+  days.forEach(day => {
+    const ta = document.querySelector(`#menuEditTable textarea[data-day="${day}"]`);
+    if (ta) {
+      const meals = parseList(ta.value).map(name => ({ meal_name: name, items: [] }));
+      week1Menu[day] = meals;
+    }
+  });
+
+  const allowed = parseList(document.getElementById('allowedFoodsInput')?.value || '');
+  const forbidden = parseList(document.getElementById('forbiddenFoodsInput')?.value || '');
+  const principlesLines = parseList(document.getElementById('principlesInput')?.value || '');
+
+  return {
+    week1Menu,
+    allowedForbiddenFoods: {
+      main_allowed_foods: allowed,
+      main_forbidden_foods: forbidden
+    },
+    principlesWeek2_4: principlesLines.join('\n')
+  };
+}
+
+function capitalizeDay(day) {
+  const map = {
+    monday: 'Понеделник',
+    tuesday: 'Вторник',
+    wednesday: 'Сряда',
+    thursday: 'Четвъртък',
+    friday: 'Петък',
+    saturday: 'Събота',
+    sunday: 'Неделя'
+  };
+  return map[day] || day;
+}

--- a/profileTemplate.html
+++ b/profileTemplate.html
@@ -730,6 +730,24 @@
                             <label for="planJson" class="form-label">JSON на плана:</label>
                             <textarea class="form-control json-editor" id="planJson" rows="15">{"message": "Данните ще се заредят автоматично"}</textarea>
                         </div>
+                        <div id="planEditorForms" class="mb-3">
+                            <h6>Меню по дни</h6>
+                            <div class="table-responsive">
+                                <table class="table" id="menuEditTable"></table>
+                            </div>
+                            <div class="mt-3">
+                                <label for="allowedFoodsInput" class="form-label">Позволени храни</label>
+                                <textarea id="allowedFoodsInput" class="form-control" rows="3"></textarea>
+                            </div>
+                            <div class="mt-3">
+                                <label for="forbiddenFoodsInput" class="form-label">Забранени храни</label>
+                                <textarea id="forbiddenFoodsInput" class="form-control" rows="3"></textarea>
+                            </div>
+                            <div class="mt-3">
+                                <label for="principlesInput" class="form-label">Принципи</label>
+                                <textarea id="principlesInput" class="form-control" rows="4"></textarea>
+                            </div>
+                        </div>
                         <button class="btn btn-primary" id="savePlanBtn">
                             <i class="fas fa-save me-2"></i>Запази плана
                         </button>


### PR DESCRIPTION
## Summary
- add `planEditor.js` module for editing menu, allowed foods, forbidden foods and principles
- wire up plan editor into `clientProfile.js`
- show new forms in profile and userdata templates
- adjust unit tests to stub the new module

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857ecd8a4608326802f4f1d2d0aedfe