### PR TITLE
Fix admin list labels

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1,4 +1,5 @@
 import { apiEndpoints } from './config.js';
+import { labelMap } from './labelMap.js';
 
 async function ensureLoggedIn() {
     if (localStorage.getItem('adminSession') === 'true') {
@@ -189,7 +190,7 @@ function renderObjectAsList(obj) {
     const dl = document.createElement('dl');
     Object.entries(obj || {}).forEach(([key, val]) => {
         const dt = document.createElement('dt');
-        dt.textContent = key;
+        dt.textContent = labelMap[key] || key;
         const dd = document.createElement('dd');
         dd.appendChild(renderValue(val));
         dl.appendChild(dt);


### PR DESCRIPTION
## Summary
- import `labelMap` in `js/admin.js`
- use label map when rendering object lists in admin panel

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f222a7b883269b5d29eef5d3db6b