### PR TITLE
Refactor dashboard summary sections as accordion

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -128,8 +128,14 @@ details[open] summary::after {
   gap: 8px;
   align-items: center;
 }
-#dashboardSummary section {
+#dashboardSummary .accordion-container {
   margin-bottom: 10px;
+}
+#dashboardSummary details.accordion-container > .accordion-content {
+  display: none;
+}
+#dashboardSummary details.accordion-container[open] > .accordion-content {
+  display: block;
 }
 #dashboardSummary dl {
   display: grid;

--- a/js/admin.js
+++ b/js/admin.js
@@ -321,15 +321,25 @@ function displayDashboardSummary(data) {
         dashboardSummaryDiv.textContent = 'Няма данни';
         return;
     }
-    const profileSec = document.createElement('section');
-    profileSec.innerHTML = '<h3>Профил</h3>';
-    profileSec.appendChild(renderObjectAsList(data.initialAnswers || {}));
-    const statusSec = document.createElement('section');
-    statusSec.innerHTML = '<h3>Текущ статус</h3>';
-    statusSec.appendChild(renderObjectAsList(data.currentStatus || {}));
-    const analyticsSec = document.createElement('section');
-    analyticsSec.innerHTML = '<h3>Анализ</h3>';
-    analyticsSec.appendChild(renderObjectAsList(data.analytics || {}));
+
+    function createAccordion(title, contentObj) {
+        const details = document.createElement('details');
+        details.className = 'accordion-container';
+        const summary = document.createElement('summary');
+        summary.className = 'accordion-header';
+        summary.textContent = title;
+        const content = document.createElement('div');
+        content.className = 'accordion-content';
+        content.appendChild(renderObjectAsList(contentObj || {}));
+        details.appendChild(summary);
+        details.appendChild(content);
+        return details;
+    }
+
+    const profileSec = createAccordion('Профил', data.initialAnswers);
+    const statusSec = createAccordion('Текущ статус', data.currentStatus);
+    const analyticsSec = createAccordion('Анализ', data.analytics);
+
     dashboardSummaryDiv.appendChild(profileSec);
     dashboardSummaryDiv.appendChild(statusSec);
     dashboardSummaryDiv.appendChild(analyticsSec);


### PR DESCRIPTION
## Summary
- refactor `displayDashboardSummary()` to generate accordion-style details
- update admin stylesheet for new accordion markup

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f227f6cc83268305f51b1f4e6e59