### PR TITLE
Add Bulgarian labels for dashboard keys

### DIFF
--- a/js/labelMap.js
+++ b/js/labelMap.js
@@ -68,6 +68,18 @@ export const labelMap = {
   avgEnergy: 'Средна енергия',
   avgSleep: 'Средна продължителност на съня',
   weightPeriod: 'Период на теглото',
-  currentStreak: 'Текуща серия'
+  currentStreak: 'Текуща серия',
+  planStatus: 'Статус на плана',
+  bmi: 'BMI',
+  adminNotes: 'Бележки от администратор',
+  adminTags: 'Етикети',
+  lastUpdated: 'Последна промяна',
+  current: 'Текущи данни',
+  detailed: 'Детайлни метрики',
+  textualAnalysis: 'Текстов анализ',
+  streak: 'Поредица',
+  goalProgress: 'Напредък към целта',
+  engagementScore: 'Ангажираност',
+  overallHealthScore: 'Общ здравен индекс'
 };
 


### PR DESCRIPTION
## Summary
- expand `labelMap` with missing dashboard terms

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f22ced0c832690611d47cac2b76a