### PR TITLE
Refine admin dashboard layout

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -95,20 +95,30 @@
     </details>
     </section>
     <section id="dashboardTab" class="client-tab" role="tabpanel" aria-hidden="true">
-    <details id="dashboardSection">
-      <summary>Пълни данни</summary>
-      <div id="dashboardSummary"></div>
-      <details>
+      <div id="dashboardSummary">
+        <details id="profileSection" class="accordion-container">
+          <summary class="accordion-header">Профил</summary>
+          <div id="profileSummary"></div>
+        </details>
+        <details id="statusSection" class="accordion-container">
+          <summary class="accordion-header">Текущ статус</summary>
+          <div id="statusSummary"></div>
+        </details>
+        <details id="analyticsSection" class="accordion-container">
+          <summary class="accordion-header">Анализ</summary>
+          <div id="analyticsSummary"></div>
+        </details>
+      </div>
+      <details id="dashboardJsonSection">
         <summary>JSON</summary>
         <button id="copyDashboardJson" class="button button-small hidden" type="button">Копирай JSON</button>
         <pre id="dashboardData" class="json"></pre>
       </details>
-    </details>
-    <button id="exportData">Експортирай всички данни</button>
-    <button id="exportPlan">Експортирай плана като JSON</button>
-    <button id="exportCsv">Експортирай дневниците CSV</button>
-    <button id="generatePraise">Генерирай похвала</button>
-    <p class="help-text">Експортираните файлове се запазват локално.</p>
+      <button id="exportData">Експортирай всички данни</button>
+      <button id="exportPlan">Експортирай плана като JSON</button>
+      <button id="exportCsv">Експортирай дневниците CSV</button>
+      <button id="generatePraise">Генерирай похвала</button>
+      <p class="help-text">Експортираните файлове се запазват локално.</p>
     </section>
 
     <details id="queriesSection">

--- a/js/admin.js
+++ b/js/admin.js
@@ -43,7 +43,9 @@ const openFullProfileLink = document.getElementById('openFullProfile');
 const fullProfileFrame = document.getElementById('fullProfileFrame');
 const dashboardPre = document.getElementById('dashboardData');
 const copyDashboardJsonBtn = document.getElementById('copyDashboardJson');
-const dashboardSummaryDiv = document.getElementById('dashboardSummary');
+const profileSummaryDiv = document.getElementById('profileSummary');
+const statusSummaryDiv = document.getElementById('statusSummary');
+const analyticsSummaryDiv = document.getElementById('analyticsSummary');
 const exportDataBtn = document.getElementById('exportData');
 const exportCsvBtn = document.getElementById('exportCsv');
 const generatePraiseBtn = document.getElementById('generatePraise');
@@ -316,34 +318,29 @@ function displayDailyLogs(logs, isError = false) {
 }
 
 function displayDashboardSummary(data) {
-    if (!dashboardSummaryDiv) return;
-    dashboardSummaryDiv.innerHTML = '';
+    if (!profileSummaryDiv || !statusSummaryDiv || !analyticsSummaryDiv) return;
+
+    profileSummaryDiv.innerHTML = '';
+    statusSummaryDiv.innerHTML = '';
+    analyticsSummaryDiv.innerHTML = '';
+
     if (!data) {
-        dashboardSummaryDiv.textContent = 'Няма данни';
+        const msg = 'Няма данни';
+        profileSummaryDiv.textContent = msg;
+        statusSummaryDiv.textContent = msg;
+        analyticsSummaryDiv.textContent = msg;
         return;
     }
 
-    function createAccordion(title, contentObj) {
-        const details = document.createElement('details');
-        details.className = 'accordion-container';
-        const summary = document.createElement('summary');
-        summary.className = 'accordion-header';
-        summary.textContent = title;
-        const content = document.createElement('div');
-        content.className = 'accordion-content';
-        content.appendChild(renderObjectAsList(contentObj || {}));
-        details.appendChild(summary);
-        details.appendChild(content);
-        return details;
-    }
-
-    const profileSec = createAccordion('Профил', data.initialAnswers);
-    const statusSec = createAccordion('Текущ статус', data.currentStatus);
-    const analyticsSec = createAccordion('Анализ', data.analytics);
-
-    dashboardSummaryDiv.appendChild(profileSec);
-    dashboardSummaryDiv.appendChild(statusSec);
-    dashboardSummaryDiv.appendChild(analyticsSec);
+    profileSummaryDiv.appendChild(
+        renderObjectAsList(data.initialAnswers || {})
+    );
+    statusSummaryDiv.appendChild(
+        renderObjectAsList(data.currentStatus || {})
+    );
+    analyticsSummaryDiv.appendChild(
+        renderObjectAsList(data.analytics || {})
+    );
 }
 
 async function loadClients() {


### PR DESCRIPTION
## Summary
- split dashboard tab into profile, status and analytics blocks
- update JS handlers for new sections
- keep JSON export controls

## Testing
- `npm run lint`
- `npm test`
- `npm run dev` *(manual check)*

------
https://chatgpt.com/codex/tasks/task_e_6857f3597d9883269a1f85f8238d595a