### PR TITLE
Ensure statuses display in Bulgarian

### DIFF
--- a/js/__tests__/clientProfile.test.js
+++ b/js/__tests__/clientProfile.test.js
@@ -79,7 +79,7 @@ afterEach(() => {
 });
 
 test('fillProfile populates form inputs', async () => {
-  jest.unstable_mockModule('../labelMap.js', () => ({ labelMap: {} }));
+  jest.unstable_mockModule('../labelMap.js', () => ({ labelMap: {}, statusMap: {} }));
   mod.fillProfile({
     name: 'Ivan',
     fullname: 'Ivan Ivanov',
@@ -97,7 +97,7 @@ test('fillProfile populates form inputs', async () => {
 });
 
 test('admin notes render and initial answers fill blanks', async () => {
-  jest.unstable_mockModule('../labelMap.js', () => ({ labelMap: {} }));
+  jest.unstable_mockModule('../labelMap.js', () => ({ labelMap: {}, statusMap: {} }));
   mod.fillAdminNotes({ adminNotes: 'Бележки', adminTags: ['t1', 't2'] });
   mod.fillProfile({ age: 25 }, { name: 'Init', fullname: 'Init Name' });
   expect(document.getElementById('adminNotes').textContent).toBe('Бележки');

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,5 +1,5 @@
 import { apiEndpoints } from './config.js';
-import { labelMap } from './labelMap.js';
+import { labelMap, statusMap } from './labelMap.js';
 
 async function ensureLoggedIn() {
     if (localStorage.getItem('adminSession') === 'true') {
@@ -414,7 +414,7 @@ function renderClients() {
         btn.textContent = `${c.name}${dateText}${lastText}`;
         const statusEl = document.createElement('span');
         statusEl.className = `status-badge status-${c.status}`;
-        statusEl.textContent = c.status;
+        statusEl.textContent = statusMap[c.status] || c.status;
         btn.appendChild(statusEl);
         (c.tags || []).forEach(t => {
             const tagEl = document.createElement('span');
@@ -456,7 +456,7 @@ function updateStatusChart(stats) {
     statusChart = new Chart(ctx, {
         type: 'doughnut',
         data: {
-            labels: ['ready', 'processing', 'pending'],
+            labels: [statusMap.ready, statusMap.processing, statusMap.pending],
             datasets: [{
                 data: [stats.ready, stats.processing, stats.pending],
                 backgroundColor: ['#28a745', '#ffc107', '#dc3545']

--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -1,5 +1,5 @@
 import { apiEndpoints } from './config.js';
-import { labelMap } from './labelMap.js';
+import { labelMap, statusMap } from './labelMap.js';
 import { initPlanEditor, gatherPlanFormData } from './planEditor.js';
 
 function $(id) {
@@ -140,8 +140,8 @@ function fillProfile(data, initialAnswers = {}) {
 function fillDashboard(data) {
   const curW = data.currentStatus?.weight;
   setText('currentWeightHeader', curW, ' кг');
-  setText('planStatus', data.planStatus);
-  setText('planStatusBadge', data.planStatus);
+  setText('planStatus', statusMap[data.planStatus] || data.planStatus);
+  setText('planStatusBadge', statusMap[data.planStatus] || data.planStatus);
   const badge = $('planStatusBadge');
   if (badge) {
     badge.classList.remove('bg-success', 'bg-warning');
@@ -542,8 +542,8 @@ async function savePlan() {
     if (resp.ok && data.success) {
       alert('Планът е записан.');
       $('planJson').value = JSON.stringify(json, null, 2);
-      setText('planStatus', 'ready');
-      setText('planStatusBadge', 'ready');
+      setText('planStatus', statusMap.ready);
+      setText('planStatusBadge', statusMap.ready);
       const badge = $('planStatusBadge');
       if (badge) {
         badge.classList.remove('bg-warning');

--- a/js/labelMap.js
+++ b/js/labelMap.js
@@ -83,3 +83,11 @@ export const labelMap = {
   overallHealthScore: 'Общ здравен индекс'
 };
 
+export const statusMap = {
+  ready: 'Готов',
+  processing: 'В процес',
+  pending: 'Изчакване',
+  error: 'Грешка',
+  unknown: 'Неизвестно'
+};
+


### PR DESCRIPTION
## Summary
- provide Bulgarian status labels in `labelMap.js`
- use Bulgarian labels in admin client list and status chart
- display translated plan status in client profile
- update tests for new export

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857fec586648326a1904de6be0b1d1c