### PR TITLE
Improve admin analytics layout

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -198,6 +198,30 @@ details[open] summary::after {
   margin-top: 10px;
 }
 
+/* Аналитични индекси с прогрес барове */
+#analyticsSummary .progress-bar-container {
+  width: 100%;
+  margin-top: 4px;
+}
+#analyticsSummary .progress-bar {
+  background: var(--progress-gradient);
+  border-radius: var(--progress-bar-radius);
+  position: relative;
+  height: var(--progress-bar-height);
+  overflow: hidden;
+}
+#analyticsSummary .progress-mask {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: auto;
+  background: var(--progress-bar-bg-empty);
+  transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  width: 100%;
+  border-radius: 0;
+}
+
 .button-small {
   font-size: 0.8rem;
   padding: var(--space-xs) var(--space-sm);

--- a/js/admin.js
+++ b/js/admin.js
@@ -320,15 +320,28 @@ function displayDailyLogs(logs, isError = false) {
 function renderAnalyticsCurrent(cur) {
     const dl = document.createElement('dl');
     const fields = {
-        goalProgress: cur.goalProgress != null ? `${cur.goalProgress}%` : '--',
-        engagementScore: cur.engagementScore != null ? `${cur.engagementScore}%` : '--',
-        overallHealthScore: cur.overallHealthScore != null ? `${cur.overallHealthScore}%` : '--'
+        goalProgress: cur.goalProgress,
+        engagementScore: cur.engagementScore,
+        overallHealthScore: cur.overallHealthScore
     };
-    Object.entries(fields).forEach(([k, v]) => {
+    Object.entries(fields).forEach(([k, val]) => {
         const dt = document.createElement('dt');
         dt.textContent = labelMap[k] || k;
         const dd = document.createElement('dd');
-        dd.textContent = v;
+        const pct = typeof val === 'number' ? Math.round(val) : null;
+        dd.textContent = pct != null ? `${pct}%` : 'Няма данни';
+        if (pct != null) {
+            const pbContainer = document.createElement('div');
+            pbContainer.className = 'progress-bar-container';
+            const pb = document.createElement('div');
+            pb.className = 'progress-bar';
+            const mask = document.createElement('div');
+            mask.className = 'progress-mask';
+            mask.style.width = `${100 - pct}%`;
+            pb.appendChild(mask);
+            pbContainer.appendChild(pb);
+            dd.appendChild(pbContainer);
+        }
         dl.appendChild(dt);
         dl.appendChild(dd);
     });


### PR DESCRIPTION
## Summary
- show progress bars for analytics metrics in admin dashboard
- style analytics progress bars

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685803f86fac83269709001d715b5497