### PR TITLE
Add Userdata viewer integration

### DIFF
--- a/Userdata.html
+++ b/Userdata.html
@@ -735,10 +735,24 @@
         </div>
     </div>
 
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            // Зареждане на първоначалния JSON
-            const initialJson = document.getElementById('json-input').value;
+    <script type="module">
+        import { apiEndpoints } from './js/config.js';
+        document.addEventListener('DOMContentLoaded', async function() {
+            const params = new URLSearchParams(window.location.search);
+            const userId = params.get('userId');
+            let initialJson = document.getElementById('json-input').value;
+            if (userId) {
+                try {
+                    const resp = await fetch(`${apiEndpoints.dashboard}?userId=${encodeURIComponent(userId)}`);
+                    const data = await resp.json();
+                    if (resp.ok && data.success && data.planData) {
+                        initialJson = JSON.stringify(data.planData, null, 2);
+                        document.getElementById('json-input').value = initialJson;
+                    }
+                } catch (err) {
+                    console.error('Грешка при зареждане на данните:', err);
+                }
+            }
             try {
                 const profileData = JSON.parse(initialJson);
                 renderProfile(profileData);

--- a/admin.html
+++ b/admin.html
@@ -64,6 +64,7 @@
     <button id="aiSummary">AI резюме</button>
     <iframe id="fullProfileFrame" class="profile-frame hidden" title="Пълен профил"></iframe>
     <a id="openFullProfile" href="#" target="_blank">Отвори в нов таб</a>
+    <a id="openUserData" href="#" target="_blank">JSON изглед</a>
     </section>
     <section id="notesTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="notesSection">

--- a/js/admin.js
+++ b/js/admin.js
@@ -40,6 +40,7 @@ const planMenuPre = document.getElementById('planMenu');
 const dailyLogsPre = document.getElementById('dailyLogs');
 const exportPlanBtn = document.getElementById('exportPlan');
 const openFullProfileLink = document.getElementById('openFullProfile');
+const openUserDataLink = document.getElementById('openUserData');
 const fullProfileFrame = document.getElementById('fullProfileFrame');
 const dashboardPre = document.getElementById('dashboardData');
 const copyDashboardJsonBtn = document.getElementById('copyDashboardJson');
@@ -702,6 +703,7 @@ async function showClient(userId) {
             if (profileEmail) profileEmail.value = data.email || '';
             if (profilePhone) profilePhone.value = data.phone || '';
             if (openFullProfileLink) openFullProfileLink.href = `clientProfile.html?userId=${encodeURIComponent(userId)}`;
+            if (openUserDataLink) openUserDataLink.href = `Userdata.html?userId=${encodeURIComponent(userId)}`;
             if (fullProfileFrame) fullProfileFrame.src = `clientProfile.html?userId=${encodeURIComponent(userId)}`;
             await Promise.all([
                 loadQueries(true),


### PR DESCRIPTION
## Summary
- link `Userdata.html` from admin profile section
- add href assignment in `admin.js` for the new link
- fetch plan JSON in `Userdata.html` when opened with `userId`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68584abb0200832682e5d049c3c51d28