### PR TITLE
Improve admin data tab

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -109,6 +109,10 @@
           <summary class="accordion-header">Анализ</summary>
           <div id="analyticsSummary"></div>
         </details>
+        <details id="planSummarySection" class="accordion-container">
+          <summary class="accordion-header">План</summary>
+          <div id="planSummary"></div>
+        </details>
       </div>
       <details id="dashboardJsonSection">
         <summary>JSON</summary>

--- a/css/responsive_styles.css
+++ b/css/responsive_styles.css
@@ -56,9 +56,12 @@
   .note-base { flex-direction: column; gap: var(--space-xs); align-items: flex-start;}
   .note-base .icon.prefix-icon { margin-bottom: var(--space-xs); } 
 
-  .detailed-metric-item .metric-item-values { 
-      padding-left: 0; 
-      grid-template-columns: 1fr; 
+  .detailed-metric-item .metric-item-values {
+      padding-left: 0;
+      grid-template-columns: 1fr;
+  }
+  #dashboardSummary dl {
+    grid-template-columns: 1fr;
   }
   .detailed-metric-item .metric-label { font-size: 1.05em; }
   .detailed-metric-item .value-current { font-size: 1em; }
@@ -158,6 +161,10 @@
   #toast { width: calc(100% - 2 * var(--space-md)); }
   td { padding-left: 40%; }
   td::before { width: 35%; }
+
+  #dashboardSummary dl {
+    grid-template-columns: 1fr;
+  }
 
   nav.tabs.styled-tabs .tab-btn { padding: 0.4rem 0.2rem; } 
   nav.tabs.styled-tabs .tab-btn .tab-icon { font-size: 1.1em; }

--- a/js/admin.js
+++ b/js/admin.js
@@ -47,6 +47,7 @@ const copyDashboardJsonBtn = document.getElementById('copyDashboardJson');
 const profileSummaryDiv = document.getElementById('profileSummary');
 const statusSummaryDiv = document.getElementById('statusSummary');
 const analyticsSummaryDiv = document.getElementById('analyticsSummary');
+const planSummaryDiv = document.getElementById('planSummary');
 const exportDataBtn = document.getElementById('exportData');
 const exportCsvBtn = document.getElementById('exportCsv');
 const generatePraiseBtn = document.getElementById('generatePraise');
@@ -370,17 +371,19 @@ function renderDetailedMetrics(metrics) {
 }
 
 function displayDashboardSummary(data) {
-    if (!profileSummaryDiv || !statusSummaryDiv || !analyticsSummaryDiv) return;
+    if (!profileSummaryDiv || !statusSummaryDiv || !analyticsSummaryDiv || !planSummaryDiv) return;
 
     profileSummaryDiv.innerHTML = '';
     statusSummaryDiv.innerHTML = '';
     analyticsSummaryDiv.innerHTML = '';
+    planSummaryDiv.innerHTML = '';
 
     if (!data) {
         const msg = 'Няма данни';
         profileSummaryDiv.textContent = msg;
         statusSummaryDiv.textContent = msg;
         analyticsSummaryDiv.textContent = msg;
+        planSummaryDiv.textContent = msg;
         return;
     }
 
@@ -409,6 +412,15 @@ function displayDashboardSummary(data) {
         const p = document.createElement('p');
         p.textContent = `${labelMap.streak || 'streak'}: ${analytics.streak.currentCount || 0} дни`;
         analyticsSummaryDiv.appendChild(p);
+    }
+
+    if (data.planData?.caloriesMacros) {
+        planSummaryDiv.appendChild(renderObjectAsList(data.planData.caloriesMacros));
+    }
+    if (data.planData?.profileSummary) {
+        const p = document.createElement('p');
+        p.textContent = data.planData.profileSummary;
+        planSummaryDiv.appendChild(p);
     }
 }
 

--- a/js/labelMap.js
+++ b/js/labelMap.js
@@ -80,7 +80,14 @@ export const labelMap = {
   streak: 'Поредица',
   goalProgress: 'Напредък към целта',
   engagementScore: 'Ангажираност',
-  overallHealthScore: 'Общ здравен индекс'
+  overallHealthScore: 'Общ здравен индекс',
+  calories: 'Калории',
+  protein_grams: 'Протеини (g)',
+  carbs_grams: 'Въглехидрати (g)',
+  fat_grams: 'Мазнини (g)',
+  protein_percent: 'Протеини (%)',
+  carbs_percent: 'Въглехидрати (%)',
+  fat_percent: 'Мазнини (%)'
 };
 
 export const statusMap = {


### PR DESCRIPTION
## Summary
- add plan summary section to admin dashboard
- display macros and profile summary in admin data tab
- map macro labels to Bulgarian names
- adjust dashboard summary layout on small screens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68584fb2e57c83268d7f70e3c5a3dd20