### PR TITLE
Improve Userdata page

### DIFF
--- a/Userdata.html
+++ b/Userdata.html
@@ -38,6 +38,12 @@
             margin: 0 auto;
             padding: 20px;
         }
+
+        @media (max-width: 768px) {
+            .container {
+                padding: 15px;
+            }
+        }
         
         header {
             background: linear-gradient(135deg, var(--primary), var(--secondary));
@@ -102,8 +108,15 @@
         .card-header.collapsed i {
             transform: rotate(180deg);
         }
-        
+
         .card-body {
+            max-height: 0;
+            overflow: hidden;
+            padding: 0 25px;
+            transition: max-height 0.3s ease, padding 0.3s ease;
+        }
+
+        .card-body.open {
             padding: 25px;
         }
         
@@ -179,9 +192,16 @@
         }
         
         .accordion-body {
-            padding: 20px;
+            max-height: 0;
+            overflow: hidden;
+            padding: 0 20px;
             background: white;
             border-radius: 0 0 var(--border-radius) var(--border-radius);
+            transition: max-height 0.3s ease, padding 0.3s ease;
+        }
+
+        .accordion-item.active .accordion-body {
+            padding: 20px;
         }
         
         .target-grid {
@@ -324,16 +344,20 @@
         
         .flex-column {
             flex: 1;
-            min-width: 300px;
+            min-width: 250px;
         }
         
         @media (max-width: 768px) {
             .macro-container {
                 flex-direction: column;
             }
-            
+
             .macro-item {
                 margin: 10px 0;
+            }
+
+            .flex-column {
+                min-width: 100%;
             }
             
             h1 {
@@ -523,6 +547,32 @@
                 <div class="card-body">
                     <div id="profile-summary">
                         <!-- Данните ще се зареждат тук -->
+                    </div>
+                </div>
+            </div>
+
+            <!-- Лични данни -->
+            <div class="card">
+                <div class="card-header" data-toggle="card">
+                    <h2><i class="fas fa-id-card"></i> Лични Данни</h2>
+                    <i class="fas fa-chevron-down"></i>
+                </div>
+                <div class="card-body">
+                    <div id="personal-info">
+                        <!-- Личните данни ще се зареждат тук -->
+                    </div>
+                </div>
+            </div>
+
+            <!-- Отговори от въпросника -->
+            <div class="card">
+                <div class="card-header" data-toggle="card">
+                    <h2><i class="fas fa-question-circle"></i> Отговори от въпросника</h2>
+                    <i class="fas fa-chevron-down"></i>
+                </div>
+                <div class="card-body">
+                    <div id="questionnaire-info">
+                        <!-- Отговорите ще се зареждат тук -->
                     </div>
                 </div>
             </div>
@@ -732,11 +782,144 @@
                     </div>
                 </div>
             </div>
+
+            <!-- Допълнителни насоки -->
+            <div class="card">
+                <div class="card-header" data-toggle="card">
+                    <h2><i class="fas fa-list-ul"></i> Допълнителни Насоки</h2>
+                    <i class="fas fa-chevron-down"></i>
+                </div>
+                <div class="card-body">
+                    <div id="extra-guidelines">
+                        <!-- Допълнителни насоки -->
+                    </div>
+                </div>
+            </div>
+
+            <!-- Аналитика -->
+            <div class="card">
+                <div class="card-header" data-toggle="card">
+                    <h2><i class="fas fa-chart-line"></i> Аналитика</h2>
+                    <i class="fas fa-chevron-down"></i>
+                </div>
+                <div class="card-body">
+                    <div id="analytics-info">
+                        <!-- Аналитични данни -->
+                    </div>
+                </div>
+            </div>
+
+            <!-- Системна информация -->
+            <div class="card">
+                <div class="card-header" data-toggle="card">
+                    <h2><i class="fas fa-info-circle"></i> Системна Информация</h2>
+                    <i class="fas fa-chevron-down"></i>
+                </div>
+                <div class="card-body">
+                    <div id="system-info">
+                        <!-- Статус и системни данни -->
+                    </div>
+                </div>
+            </div>
+
+            <!-- Пълен JSON -->
+            <div class="card">
+                <div class="card-header" data-toggle="card">
+                    <h2><i class="fas fa-code"></i> Пълен JSON</h2>
+                    <i class="fas fa-chevron-down"></i>
+                </div>
+                <div class="card-body">
+                    <pre id="full-json" style="white-space: pre-wrap"></pre>
+                </div>
+            </div>
         </div>
     </div>
 
     <script type="module">
         import { apiEndpoints } from './js/config.js';
+        import { labelMap } from './js/labelMap.js';
+
+        function renderValue(val) {
+            if (Array.isArray(val)) {
+                const ul = document.createElement('ul');
+                val.forEach(v => {
+                    const li = document.createElement('li');
+                    li.appendChild(renderValue(v));
+                    ul.appendChild(li);
+                });
+                return ul;
+            }
+            if (val && typeof val === 'object') {
+                return renderObjectAsList(val);
+            }
+            const span = document.createElement('span');
+            span.textContent = val;
+            return span;
+        }
+
+        function renderObjectAsList(obj = {}) {
+            const dl = document.createElement('dl');
+            Object.entries(obj).forEach(([key, value]) => {
+                const dt = document.createElement('dt');
+                dt.textContent = labelMap[key] || key;
+                const dd = document.createElement('dd');
+                dd.appendChild(renderValue(value));
+                dl.appendChild(dt);
+                dl.appendChild(dd);
+            });
+            return dl;
+        }
+
+        function renderDetailedMetrics(metrics = []) {
+            const table = document.createElement('table');
+            table.className = 'menu-table';
+            const thead = document.createElement('thead');
+            thead.innerHTML = '<tr><th>Показател</th><th>Начална</th><th>Целева</th><th>Текуща</th></tr>';
+            table.appendChild(thead);
+            const tbody = document.createElement('tbody');
+            metrics.forEach(m => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${m.label || ''}</td><td>${m.initialValueText ?? ''}</td><td>${m.expectedValueText ?? ''}</td><td>${m.currentValueText ?? ''}</td>`;
+                tbody.appendChild(tr);
+            });
+            table.appendChild(tbody);
+            return table;
+        }
+
+        function setupCardToggles() {
+            document.querySelectorAll('.card').forEach(card => {
+                const header = card.querySelector('.card-header');
+                const body = card.querySelector('.card-body');
+                if (!header || !body) return;
+
+                header.classList.add('collapsed');
+                body.style.maxHeight = 0;
+                body.classList.remove('open');
+
+                header.addEventListener('click', () => {
+                    const isOpen = body.classList.toggle('open');
+                    header.classList.toggle('collapsed');
+                    body.style.maxHeight = isOpen ? body.scrollHeight + 'px' : 0;
+                });
+            });
+        }
+
+        function setupAccordions() {
+            document.querySelectorAll('.accordion-item').forEach(item => {
+                const header = item.querySelector('.accordion-header');
+                const body = item.querySelector('.accordion-body');
+                if (!header || !body) return;
+
+                item.classList.remove('active');
+                body.style.maxHeight = 0;
+
+                header.addEventListener('click', () => {
+                    const active = item.classList.toggle('active');
+                    body.style.maxHeight = active ? body.scrollHeight + 'px' : 0;
+                });
+            });
+        }
+
         document.addEventListener('DOMContentLoaded', async function() {
             const params = new URLSearchParams(window.location.search);
             const userId = params.get('userId');
@@ -745,8 +928,8 @@
                 try {
                     const resp = await fetch(`${apiEndpoints.dashboard}?userId=${encodeURIComponent(userId)}`);
                     const data = await resp.json();
-                    if (resp.ok && data.success && data.planData) {
-                        initialJson = JSON.stringify(data.planData, null, 2);
+                    if (resp.ok && data.success) {
+                        initialJson = JSON.stringify(data, null, 2);
                         document.getElementById('json-input').value = initialJson;
                     }
                 } catch (err) {
@@ -759,20 +942,6 @@
             } catch (e) {
                 console.error('Грешка при парсване на JSON:', e);
             }
-            
-            // Карта с разгръщащи се секции
-            document.querySelectorAll('.card-header').forEach(header => {
-                header.addEventListener('click', function() {
-                    const cardBody = this.nextElementSibling;
-                    this.classList.toggle('collapsed');
-                    
-                    if (cardBody.style.maxHeight) {
-                        cardBody.style.maxHeight = null;
-                    } else {
-                        cardBody.style.maxHeight = cardBody.scrollHeight + 'px';
-                    }
-                });
-            });
             
             // Табове за менюто
             document.querySelectorAll('.tab').forEach(tab => {
@@ -790,21 +959,8 @@
                 });
             });
             
-            // Аккордеони за принципите
-            document.querySelectorAll('.accordion-header').forEach(header => {
-                header.addEventListener('click', function() {
-                    const item = this.parentElement;
-                    const body = this.nextElementSibling;
-                    
-                    item.classList.toggle('active');
-                    
-                    if (body.style.maxHeight) {
-                        body.style.maxHeight = null;
-                    } else {
-                        body.style.maxHeight = body.scrollHeight + 'px';
-                    }
-                });
-            });
+            setupCardToggles();
+            setupAccordions();
             
             // Бутон за зареждане на JSON
             document.getElementById('load-btn').addEventListener('click', function() {
@@ -812,6 +968,8 @@
                 try {
                     const profileData = JSON.parse(jsonInput);
                     renderProfile(profileData);
+                    setupCardToggles();
+                    setupAccordions();
                 } catch (e) {
                     alert('Невалиден JSON формат! Моля, проверете данните.');
                     console.error('Грешка при парсване на JSON:', e);
@@ -819,16 +977,36 @@
             });
             
             // Функция за визуализация на профила
-            function renderProfile(data) {
+            function renderProfile(allData) {
+                document.getElementById('full-json').textContent = JSON.stringify(allData, null, 2);
+
+                const plan = allData.planData || allData;
+                const answers = allData.initialAnswers || allData.questionnaireAnswers || {};
+
                 // Обобщение на профила
-                if (data.profileSummary) {
-                    document.getElementById('profile-summary').innerHTML = 
-                        `<p>${data.profileSummary}</p>`;
+                if (plan.profileSummary) {
+                    document.getElementById('profile-summary').innerHTML =
+                        `<p>${plan.profileSummary}</p>`;
                 }
-                
+
+                // Лични данни
+                const personalInfo = { ...(plan.personalInfo || {}), ...answers };
+                if (Object.keys(personalInfo).length) {
+                    const cont = document.getElementById('personal-info');
+                    cont.innerHTML = '';
+                    cont.appendChild(renderObjectAsList(personalInfo));
+                }
+
+                // Отговори от въпросника
+                if (answers && typeof answers === 'object') {
+                    const qaCont = document.getElementById('questionnaire-info');
+                    qaCont.innerHTML = '';
+                    qaCont.appendChild(renderObjectAsList(answers));
+                }
+
                 // Калории и макронутриенти
-                if (data.caloriesMacros) {
-                    const macros = data.caloriesMacros;
+                if (plan.caloriesMacros) {
+                    const macros = plan.caloriesMacros;
                     document.getElementById('calories-value').textContent = macros.calories;
                     document.getElementById('protein-value').textContent = `${macros.protein_percent}%`;
                     document.getElementById('protein-grams').textContent = `${macros.protein_grams}g`;
@@ -839,12 +1017,12 @@
                 }
                 
                 // Седмично меню
-                if (data.week1Menu) {
-                    for (const day in data.week1Menu) {
+                if (plan.week1Menu) {
+                    for (const day in plan.week1Menu) {
                         const dayContainer = document.getElementById(day);
                         if (dayContainer) {
                             let html = '';
-                            data.week1Menu[day].forEach(meal => {
+                            plan.week1Menu[day].forEach(meal => {
                                 html += `<div class="meal-item">
                                     <div class="meal-title">
                                         <i class="fas fa-utensil-spoon"></i> ${meal.meal_name}
@@ -867,9 +1045,9 @@
                 }
                 
                 // Принципи за седмици 2-4
-                if (data.principlesWeek2_4) {
+                if (plan.principlesWeek2_4) {
                     let principlesHtml = '';
-                    data.principlesWeek2_4.forEach(principle => {
+                    plan.principlesWeek2_4.forEach(principle => {
                         principlesHtml += `<div class="accordion-item">
                             <div class="accordion-header">
                                 ${principle.title}
@@ -881,40 +1059,40 @@
                         </div>`;
                     });
                     document.getElementById('principles-container').innerHTML = principlesHtml;
-                    
-                    // Инициализиране на акордеоните
-                    document.querySelectorAll('.accordion-header').forEach(header => {
-                        header.addEventListener('click', function() {
-                            const item = this.parentElement;
-                            const body = this.nextElementSibling;
-                            
-                            item.classList.toggle('active');
-                            
-                            if (body.style.maxHeight) {
-                                body.style.maxHeight = null;
-                            } else {
-                                body.style.maxHeight = body.scrollHeight + 'px';
-                            }
-                        });
-                    });
+                    setupAccordions();
                 }
                 
-                // Хидратация
-                if (data.hydrationCookingSupplements && data.hydrationCookingSupplements.hydration_recommendations) {
-                    const hydration = data.hydrationCookingSupplements.hydration_recommendations;
-                    document.getElementById('hydration-liters').textContent = hydration.daily_liters;
-                    
-                    let tipsHtml = '<ul>';
-                    hydration.tips.forEach(tip => {
-                        tipsHtml += `<li><i class="fas fa-check-circle"></i> ${tip}</li>`;
-                    });
-                    tipsHtml += '</ul>';
-                    document.getElementById('hydration-tips').innerHTML = tipsHtml;
+                // Хидратация, готвене и добавки
+                if (plan.hydrationCookingSupplements) {
+                    const hcs = plan.hydrationCookingSupplements;
+                    if (hcs.hydration_recommendations) {
+                        const hydration = hcs.hydration_recommendations;
+                        document.getElementById('hydration-liters').textContent = hydration.daily_liters;
+
+                        let tipsHtml = '<ul>';
+                        hydration.tips.forEach(tip => {
+                            tipsHtml += `<li><i class="fas fa-check-circle"></i> ${tip}</li>`;
+                        });
+                        tipsHtml += '</ul>';
+                        document.getElementById('hydration-tips').innerHTML = tipsHtml;
+                    }
+                    if (Array.isArray(hcs.cooking_methods)) {
+                        let cHtml = '<ul>';
+                        hcs.cooking_methods.forEach(m => { cHtml += `<li>${m}</li>`; });
+                        cHtml += '</ul>';
+                        document.getElementById('cooking-methods').innerHTML = cHtml;
+                    }
+                    if (Array.isArray(hcs.supplements)) {
+                        let sHtml = '<ul>';
+                        hcs.supplements.forEach(s => { sHtml += `<li>${s}</li>`; });
+                        sHtml += '</ul>';
+                        document.getElementById('supplements-list').innerHTML = sHtml;
+                    }
                 }
                 
                 // Разрешени и забранени храни
-                if (data.allowedForbiddenFoods) {
-                    const foods = data.allowedForbiddenFoods;
+                if (plan.allowedForbiddenFoods) {
+                    const foods = plan.allowedForbiddenFoods;
                     
                     // Разрешени храни
                     let allowedHtml = '';
@@ -940,9 +1118,9 @@
                 }
                 
                 // Психологически насоки
-                if (data.psychologicalGuidance) {
-                    const guidance = data.psychologicalGuidance;
-                    
+                if (plan.psychologicalGuidance) {
+                    const guidance = plan.psychologicalGuidance;
+
                     // Стратегии за справяне
                     let strategiesHtml = '<ul>';
                     if (guidance.coping_strategies) {
@@ -952,11 +1130,18 @@
                     }
                     strategiesHtml += '</ul>';
                     document.getElementById('coping-strategies').innerHTML = strategiesHtml;
+
+                    if (Array.isArray(guidance.motivational_messages)) {
+                        let motHtml = '<ul>';
+                        guidance.motivational_messages.forEach(m => { motHtml += `<li>${m}</li>`; });
+                        motHtml += '</ul>';
+                        document.getElementById('motivational-messages').innerHTML = motHtml;
+                    }
                 }
                 
                 // Подробни цели
-                if (data.detailedTargets) {
-                    const targets = data.detailedTargets;
+                if (plan.detailedTargets) {
+                    const targets = plan.detailedTargets;
                     if (targets.sleep_quality_target_text) {
                         document.getElementById('sleep-target').textContent = targets.sleep_quality_target_text;
                     }
@@ -969,6 +1154,69 @@
                     if (targets.hydration_target_text) {
                         document.getElementById('hydration-target').textContent = targets.hydration_target_text;
                     }
+                }
+
+                // Допълнителни насоки
+                if (plan.additionalGuidelines) {
+                    const extra = document.getElementById('extra-guidelines');
+                    extra.innerHTML = '';
+                    const g = plan.additionalGuidelines;
+                    if (Array.isArray(g)) {
+                        g.forEach(item => {
+                            if (typeof item === 'string') {
+                                const p = document.createElement('p');
+                                p.textContent = item;
+                                extra.appendChild(p);
+                            } else if (item && typeof item === 'object') {
+                                const div = document.createElement('div');
+                                if (item.title) div.innerHTML = `<strong>${item.title}</strong>`;
+                                if (item.content) {
+                                    const p = document.createElement('p');
+                                    p.textContent = item.content;
+                                    div.appendChild(p);
+                                }
+                                extra.appendChild(div);
+                            }
+                        });
+                    } else if (typeof g === 'string') {
+                        extra.textContent = g;
+                    } else if (typeof g === 'object') {
+                        extra.appendChild(renderObjectAsList(g));
+                    }
+                }
+
+                // Аналитика
+                if (allData.analytics) {
+                    const cont = document.getElementById('analytics-info');
+                    cont.innerHTML = '';
+                    const a = allData.analytics;
+                    if (a.current) cont.appendChild(renderObjectAsList(a.current));
+                    if (a.textualAnalysis) {
+                        const p = document.createElement('p');
+                        p.textContent = a.textualAnalysis;
+                        cont.appendChild(p);
+                    }
+                    if (Array.isArray(a.detailed) && a.detailed.length) {
+                        cont.appendChild(renderDetailedMetrics(a.detailed));
+                    }
+                    if (a.streak) {
+                        const p = document.createElement('p');
+                        p.textContent = `${labelMap.streak || 'streak'}: ${a.streak.currentCount || 0} дни`;
+                        cont.appendChild(p);
+                    }
+                }
+
+                // Системна информация
+                const sysInfo = {};
+                ['userId','planStatus','message','showAdaptiveQuiz','isFirstLoginWithReadyPlan'].forEach(k => {
+                    if (allData[k] !== undefined) sysInfo[k] = allData[k];
+                });
+                if (allData.currentStatus) sysInfo.currentStatus = allData.currentStatus;
+                if (plan.generationMetadata) sysInfo.generationMetadata = plan.generationMetadata;
+                if (Object.keys(sysInfo).length) {
+                    const cont = document.getElementById('system-info');
+                    cont.innerHTML = '';
+                    cont.appendChild(renderObjectAsList(sysInfo));
                 }
             }
         });


### PR DESCRIPTION
## Summary
- show personal info and questionnaire data in Userdata.html
- display plan JSON and hydration details (cooking methods, supplements)
- parse dashboard response fully
- include extra guidelines, analytics and system info
- collapse sections by default and improve mobile layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68585deeda20832684f9b841a63be74a