### PR TITLE
Add JSON parse error feedback

### DIFF
--- a/Userdata.html
+++ b/Userdata.html
@@ -1003,6 +1003,8 @@
                 renderProfile(profileData);
             } catch (e) {
                 console.error('Грешка при парсване на JSON:', e);
+                errorEl.textContent = 'Невалиден JSON формат';
+                document.getElementById('profile-container').innerHTML = '';
             }
             
             // Табове за менюто


### PR DESCRIPTION
## Summary
- notify users when the initial JSON in `Userdata.html` cannot be parsed
- clear profile container to avoid stale data

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68587b30a7c083269061ec4f0a433b7e