### PR TITLE
Remove unused import from profile template

### DIFF
--- a/profileTemplate.dev.js
+++ b/profileTemplate.dev.js
@@ -1,7 +1,6 @@
 // Development-only setup for profileTemplate.html
 // Import required functions
 import { initClientProfile } from './js/clientProfile.js';
-import { jsonrepair } from 'https://cdn.jsdelivr.net/npm/jsonrepair/+esm';
 
 // Initialize the profile with mock data
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- clean up `profileTemplate.dev.js` by removing the unused `jsonrepair` import

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68587f0411608326b88244c521df275f