### PR TITLE
Add supplement suggestions rendering

### DIFF
--- a/Userdata.html
+++ b/Userdata.html
@@ -1172,11 +1172,22 @@
                         cHtml += '</ul>';
                         document.getElementById('cooking-methods').innerHTML = cHtml;
                     }
-                    if (Array.isArray(hcs.supplements)) {
+                    const suppCont = document.getElementById('supplements-list');
+                    if (Array.isArray(hcs.supplement_suggestions) && hcs.supplement_suggestions.length > 0) {
+                        let sHtml = '<ul>';
+                        hcs.supplement_suggestions.forEach(s => {
+                            sHtml += `<li><strong>${s.supplement_name || '?'}</strong>${s.reasoning ? ` - ${s.reasoning}` : ''}` +
+                                     `${s.caution ? `<br><em>${s.caution}</em>` : ''}</li>`;
+                        });
+                        sHtml += '</ul>';
+                        suppCont.innerHTML = sHtml;
+                    } else if (Array.isArray(hcs.supplements) && hcs.supplements.length > 0) {
                         let sHtml = '<ul>';
                         hcs.supplements.forEach(s => { sHtml += `<li>${s}</li>`; });
                         sHtml += '</ul>';
-                        document.getElementById('supplements-list').innerHTML = sHtml;
+                        suppCont.innerHTML = sHtml;
+                    } else {
+                        suppCont.textContent = 'Няма данни';
                     }
                 } else {
                     ['hydration-liters','hydration-tips','cooking-methods','supplements-list']


### PR DESCRIPTION
## Summary
- extend `renderProfile` in **Userdata.html** to support `supplement_suggestions`
- fall back to legacy `hcs.supplements`
- show "Няма данни" when no suggestions exist

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858850fdd4483268b3e9cfdd6b302f9