### PR TITLE
Improve week menu rendering

### DIFF
--- a/Userdata.html
+++ b/Userdata.html
@@ -1113,12 +1113,28 @@
                 }
                 
                 // Седмично меню
-                if (plan.week1Menu) {
-                    const days = ['monday','tuesday','wednesday','thursday','friday','saturday','sunday'];
-                    days.forEach(day => {
-                        const dayContainer = document.getElementById(day);
+                const weekMenu = plan.week1Menu || plan.weekMenu;
+                if (weekMenu) {
+                    const dayMap = {
+                        monday: 'monday',
+                        tuesday: 'tuesday',
+                        wednesday: 'wednesday',
+                        thursday: 'thursday',
+                        friday: 'friday',
+                        saturday: 'saturday',
+                        sunday: 'sunday',
+                        'понеделник': 'monday',
+                        'вторник': 'tuesday',
+                        'сряда': 'wednesday',
+                        'четвъртък': 'thursday',
+                        'петък': 'friday',
+                        'събота': 'saturday',
+                        'неделя': 'sunday'
+                    };
+                    Object.entries(dayMap).forEach(([key, id]) => {
+                        const dayContainer = document.getElementById(id);
                         if (!dayContainer) return;
-                        const meals = plan.week1Menu[day];
+                        const meals = weekMenu[key] || weekMenu[id];
                         if (Array.isArray(meals) && meals.length) {
                             let html = '';
                             meals.forEach(meal => {

--- a/js/labelMap.js
+++ b/js/labelMap.js
@@ -87,7 +87,21 @@ export const labelMap = {
   fat_grams: 'Мазнини (g)',
   protein_percent: 'Протеини (%)',
   carbs_percent: 'Въглехидрати (%)',
-  fat_percent: 'Мазнини (%)'
+  fat_percent: 'Мазнини (%)',
+  monday: 'Понеделник',
+  tuesday: 'Вторник',
+  wednesday: 'Сряда',
+  thursday: 'Четвъртък',
+  friday: 'Петък',
+  saturday: 'Събота',
+  sunday: 'Неделя',
+  'понеделник': 'Понеделник',
+  'вторник': 'Вторник',
+  'сряда': 'Сряда',
+  'четвъртък': 'Четвъртък',
+  'петък': 'Петък',
+  'събота': 'Събота',
+  'неделя': 'Неделя'
 };
 
 export const statusMap = {


### PR DESCRIPTION
## Summary
- support Bulgarian day labels in label map
- handle `weekMenu` or Bulgarian day keys in `Userdata.html`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858895d3d748326a022c6de84cc33fe