### PR TITLE
Add chat image upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ localStorage.setItem('adminToken', '<вашият токен>');
 The standalone page `assistant.html` allows you to send direct commands to the worker.
 Open the file in a browser, enter your message and it will call the `/api/chat` endpoint.
 The Cloudflare account ID is filled automatically from `config.js`.
+Use the small image button next to the send icon to upload a picture. The file is sent to `/api/analyzeImage` and the analysis appears as a bot reply.
 
 Example test request with `curl`:
 
@@ -336,6 +337,7 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
 - `GET /api/getAiPreset` – връща данните за конкретен пресет.
 - `POST /api/saveAiPreset` – съхранява нов пресет или обновява съществуващ.
 - `POST /api/testAiModel` – проверява връзката с конкретен AI модел.
+- `POST /api/analyzeImage` – анализира качено изображение и връща резултат.
 
   ```bash
   curl -X POST https://<your-domain>/api/testAiModel \

--- a/assistant.html
+++ b/assistant.html
@@ -14,6 +14,9 @@
     <symbol id="icon-send" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
         <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"></path>
     </symbol>
+    <symbol id="icon-upload" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v13m0 0l-5-5m5 5l5-5M3 16v5h18v-5" />
+    </symbol>
 </svg>
 <div id="chat-widget" class="chat-widget visible" role="log" aria-live="polite">
     <div class="chat-header">
@@ -26,6 +29,10 @@
         <input type="text" id="userId" placeholder="Вашият ID" style="max-width:120px;">
         <small id="id-note" style="margin-left:0.5rem;">ID се попълва автоматично (Cloudflare Account ID) и се запазва за текущата сесия.</small>
         <textarea id="chat-input" placeholder="Вашето съобщение..." rows="2"></textarea>
+        <input type="file" id="chat-image" accept="image/*" hidden>
+        <button id="chat-upload" aria-label="Качи изображение">
+            <svg class="icon"><use href="#icon-upload"></use></svg>
+        </button>
         <button id="chat-send" aria-label="Изпрати съобщение">
             <svg class="icon"><use href="#icon-send"></use></svg>
         </button>

--- a/code.html
+++ b/code.html
@@ -33,6 +33,7 @@
         <symbol id="icon-menu-burger" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5"> <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"></path> </symbol>
         <symbol id="icon-close" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5"> <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"></path> </symbol>
         <symbol id="icon-send" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"></path></symbol>
+        <symbol id="icon-upload" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v13m0 0l-5-5m5 5l5-5M3 16v5h18v-5"/></symbol>
         <symbol id="icon-spinner" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"></path></symbol>
         <symbol id="icon-chevron-right" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5"> <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"></path> </symbol>
         <symbol id="icon-feedback" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 12H5.17L4 15.17V4h16v10zm-6-5.41L14.59 8 12 10.59 9.41 8 8 9.41 10.59 12 8 14.59 9.41 16 12 13.41 14.59 16 16 14.59 13.41 12 16 9.41z"/></symbol>
@@ -638,6 +639,10 @@
             </div>
             <div class="chat-input-area">
                 <textarea id="chat-input" placeholder="Вашето съобщение..." rows="2" aria-label="Поле за въвеждане на съобщение в чата"></textarea>
+                <input type="file" id="chat-image" accept="image/*" hidden>
+                <button id="chat-upload" aria-label="Качи изображение">
+                    <svg class="icon"><use href="#icon-upload"></use></svg>
+                </button>
                 <button id="chat-send" aria-label="Изпрати съобщение">
                     <svg class="icon"><use href="#icon-send"></use></svg>
                 </button>

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -241,9 +241,16 @@ body.dark-theme .chat-messages .message.bot { color: #e0e0e0; }
   max-height: 90px; overflow-y: auto;
 }
 #chat-send {
-  background-color: var(--primary-color); color: var(--fab-icon); 
+  background-color: var(--primary-color); color: var(--fab-icon);
   border-radius: var(--radius-round); width: 44px; height: 44px;
   flex-shrink: 0; padding: 0;
 }
-#chat-send svg { width: 20px; height: 20px; } 
+#chat-send svg { width: 20px; height: 20px; }
 #chat-send:hover { background-color: var(--secondary-color); }
+#chat-upload {
+  background-color: var(--primary-color); color: var(--fab-icon);
+  border-radius: var(--radius-round); width: 44px; height: 44px;
+  flex-shrink: 0; padding: 0;
+}
+#chat-upload svg { width: 20px; height: 20px; }
+#chat-upload:hover { background-color: var(--secondary-color); }

--- a/js/app.js
+++ b/js/app.js
@@ -886,6 +886,36 @@ export async function handleChatSend() { // Exported for eventListeners.js
         if(selectors.chatSend) selectors.chatSend.disabled = false;
     }
 }
+
+export async function handleChatImageUpload(file) { // Exported for chat.js
+    if (!file || !currentUserId) return;
+
+    displayChatMessage('Изпратено изображение', 'user');
+    chatHistory.push({ text: '[image]', sender: 'user', isError: false });
+
+    selectors.chatUploadBtn?.setAttribute('disabled', 'true');
+    displayChatTypingIndicator(true);
+
+    const formData = new FormData();
+    formData.append('userId', currentUserId);
+    formData.append('image', file);
+    try {
+        const response = await fetch(apiEndpoints.analyzeImage, { method: 'POST', body: formData });
+        const result = await response.json();
+        const text = result.result || result.message || 'Грешка';
+        const isError = !response.ok || !result.success;
+        displayChatMessage(text, 'bot', isError);
+        chatHistory.push({ text, sender: 'bot', isError });
+    } catch (e) {
+        const msg = `Грешка при изпращане на изображението: ${e.message}`;
+        displayChatMessage(msg, 'bot', true);
+        chatHistory.push({ text: msg, sender: 'bot', isError: true });
+    } finally {
+        displayChatTypingIndicator(false);
+        selectors.chatUploadBtn?.removeAttribute('disabled');
+        if (selectors.chatImageInput) selectors.chatImageInput.value = '';
+    }
+}
 export function handleChatInputKeypress(e){ if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();handleChatSend();}} // Exported for eventListeners
 
 // ==========================================================================

--- a/js/chat.js
+++ b/js/chat.js
@@ -1,7 +1,7 @@
 
 // chat.js - Логика за Чат
 import { selectors } from './uiElements.js';
-import { chatHistory, currentUserId } from './app.js'; // Access chatHistory and userId
+import { chatHistory, currentUserId, handleChatImageUpload } from './app.js'; // Access chatHistory and userId
 import { apiEndpoints, initialBotMessage } from './config.js';
 import { escapeHtml } from './utils.js';
 
@@ -75,5 +75,14 @@ export function displayTypingIndicator(show) {
 }
 
 export function scrollToChatBottom() { if (selectors.chatMessages) selectors.chatMessages.scrollTop = selectors.chatMessages.scrollHeight; }
+
+export function openChatImageDialog() {
+    selectors.chatImageInput?.click();
+}
+
+export function handleChatImageSelected() {
+    const file = selectors.chatImageInput?.files[0];
+    if (file) handleChatImageUpload(file);
+}
 
 // handleChatSend and handleChatInputKeypress remain in app.js as they modify chatHistory and call API

--- a/js/config.js
+++ b/js/config.js
@@ -42,7 +42,8 @@ export const apiEndpoints = {
     listAiPresets: `${workerBaseUrl}/api/listAiPresets`,
     getAiPreset: `${workerBaseUrl}/api/getAiPreset`,
     saveAiPreset: `${workerBaseUrl}/api/saveAiPreset`,
-    testAiModel: `${workerBaseUrl}/api/testAiModel`
+    testAiModel: `${workerBaseUrl}/api/testAiModel`,
+    analyzeImage: `${workerBaseUrl}/api/analyzeImage`
 };
 
 // Cloudflare Account ID за използване в чат асистента

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -24,6 +24,7 @@ import {
     handlePlanModChatInputKeypress
 } from './planModChat.js';
 import { toggleChatWidget, closeChatWidget, clearChat } from './chat.js';
+import * as chatUpload from './chat.js';
 import { computeSwipeTargetIndex } from './swipeUtils.js';
 import { handleAchievementClick } from './achievements.js';
 
@@ -164,6 +165,8 @@ export function setupStaticEventListeners() {
     if (selectors.chatClear) selectors.chatClear.addEventListener('click', clearChat);
     if (selectors.chatSend) selectors.chatSend.addEventListener('click', handleChatSend);
     if (selectors.chatInput) selectors.chatInput.addEventListener('keypress', handleChatInputKeypress);
+    if (selectors.chatUploadBtn) selectors.chatUploadBtn.addEventListener('click', chatUpload.openChatImageDialog);
+    if (selectors.chatImageInput) selectors.chatImageInput.addEventListener('change', chatUpload.handleChatImageSelected);
 
     if (selectors.planModChatClose) selectors.planModChatClose.addEventListener('click', () => {
         setChatModelOverride(null);

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -47,7 +47,8 @@ export function initializeSelectors() {
         tooltipTracker: 'tooltip-tracker',
         toast: 'toast', chatFab: 'chat-fab', chatWidget: 'chat-widget', chatClose: 'chat-close',
         chatClear: 'chat-clear',
-        chatMessages: 'chat-messages', chatInput: 'chat-input', chatSend: 'chat-send'
+        chatMessages: 'chat-messages', chatInput: 'chat-input', chatSend: 'chat-send',
+        chatImageInput: 'chat-image', chatUploadBtn: 'chat-upload'
     };
     let missingCriticalCount = 0;
     const criticalSelectors = ['appWrapper', 'loadingOverlay', 'tabsContainer', 'dailyTracker', 'mainMenu', 'dailyMealList', 'saveLogBtn'];


### PR DESCRIPTION
## Summary
- allow uploading images in chat widgets
- wire up selectors for the new button/input
- style the upload button same as send
- send file to `/api/analyzeImage` and display analysis
- document image upload in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68588ef093e48326a09f66ba2775ceb3