### PR TITLE
Implement image analysis endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,17 +303,18 @@ curl https://api.cloudflare.com/client/v4/accounts/<CF_ACCOUNT_ID>/ai/run/@cf/me
 Replace the placeholders with your own values and keep the token secret.
 
 In addition to text messages you can upload an image for automatic analysis.
-Open `assistant.html`, choose a file and it will be sent to `/api/analyzeImage`
-with `multipart/form-data` (field name `image`). The worker forwards the image
-to the configured vision model and returns a JSON summary describing the
-detected objects or text.
+Open `assistant.html`, choose a file and it will be converted to a Base64 string
+and sent to `/api/analyzeImage` as JSON with fields `userId` and `imageData`.
+The worker forwards the image data to the configured vision model and returns a
+JSON summary describing the detected objects or text.
 
 Example `curl` request:
 
 ```bash
 curl -X POST https://<your-domain>/api/analyzeImage \
   -H "Authorization: Bearer <WORKER_ADMIN_TOKEN>" \
-  -F image=@/path/to/photo.jpg
+  -H "Content-Type: application/json" \
+  --data '{"userId":"123","imageData":"<base64>"}'
 ```
 
 For Cloudflare models set `CF_AI_TOKEN`. When using Gemini Vision provide

--- a/js/__tests__/analyzeImage.test.js
+++ b/js/__tests__/analyzeImage.test.js
@@ -21,15 +21,18 @@ describe('handleAnalyzeImageRequest', () => {
       json: async () => ({ result: { response: 'ok' } })
     });
     const env = { CF_ACCOUNT_ID: 'acc', CF_AI_TOKEN: 'token' };
-    const request = { json: async () => ({ userId: 'u1', imageUrl: 'img' }) };
+    const request = { json: async () => ({ userId: 'u1', imageData: 'imgdata' }) };
     const res = await handleAnalyzeImageRequest(request, env);
     expect(res.success).toBe(true);
     expect(res.aiResponse).toBe('ok');
     const expectedUrl =
-      'https://api.cloudflare.com/client/v4/accounts/acc/ai/run/@cf/analysis-image';
+      'https://api.cloudflare.com/client/v4/accounts/acc/ai/run/@cf/stabilityai/clip';
     expect(global.fetch).toHaveBeenCalledWith(
       expectedUrl,
-      expect.objectContaining({ method: 'POST' })
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ image: 'imgdata' })
+      })
     );
   });
 });

--- a/worker.js
+++ b/worker.js
@@ -1368,13 +1368,13 @@ async function handleAiHelperRequest(request, env) {
 // ------------- START FUNCTION: handleAnalyzeImageRequest -------------
 async function handleAnalyzeImageRequest(request, env) {
     try {
-        const { userId, imageUrl } = await request.json();
-        if (!userId || !imageUrl) {
-            return { success: false, message: 'Липсва imageUrl или userId.', statusHint: 400 };
+        const { userId, imageData } = await request.json();
+        if (!userId || !imageData) {
+            return { success: false, message: 'Липсват imageData или userId.', statusHint: 400 };
         }
         const aiResp = await callCfAi(
-            '@cf/analysis-image',
-            { imageUrl },
+            '@cf/stabilityai/clip',
+            { image: imageData },
             env
         );
         return { success: true, aiResponse: aiResp };


### PR DESCRIPTION
## Summary
- add new /api/analyzeImage route handler for visual AI analysis
- expect `{userId, imageData}` JSON payload
- update accompanying unit test and README documentation

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685894b96b108326b492b7fb61c71b40