### PR TITLE
Send images as base64

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,6 @@
 // app.js - Основен Файл на Приложението
 import { isLocalDevelopment, apiEndpoints } from './config.js';
-import { safeParseFloat, escapeHtml } from './utils.js';
+import { safeParseFloat, escapeHtml, fileToBase64 } from './utils.js';
 import { selectors, initializeSelectors, loadInfoTexts } from './uiElements.js';
 import {
     initializeTheme,
@@ -896,11 +896,13 @@ export async function handleChatImageUpload(file) { // Exported for chat.js
     selectors.chatUploadBtn?.setAttribute('disabled', 'true');
     displayChatTypingIndicator(true);
 
-    const formData = new FormData();
-    formData.append('userId', currentUserId);
-    formData.append('image', file);
     try {
-        const response = await fetch(apiEndpoints.analyzeImage, { method: 'POST', body: formData });
+        const imageData = await fileToBase64(file);
+        const response = await fetch(apiEndpoints.analyzeImage, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ userId: currentUserId, imageData })
+        });
         const result = await response.json();
         const text = result.result || result.message || 'Грешка';
         const isError = !response.ok || !result.success;

--- a/js/utils.js
+++ b/js/utils.js
@@ -47,3 +47,20 @@ export const escapeHtml = (text) => {
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;');
 };
+
+/**
+ * Преобразува File обект към base64 низ без data префикс.
+ * @param {File} file - Изображението за конвертиране.
+ * @returns {Promise<string>} Обещание с base64 съдържанието.
+ */
+export function fileToBase64(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            const result = reader.result || '';
+            resolve(result.split(',')[1] || '');
+        };
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(file);
+    });
+}


### PR DESCRIPTION
## Summary
- convert File objects to base64 in utils
- send base64 encoded images from assistantChat and app

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68589b5dc6fc8326a7c44eee6fc55362