### PR TITLE
Add configurable image analysis model

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ node scripts/repair-log.js <userId> <YYYY-MM-DD>
 | `model_chat` | Модел за чат асистента |
 | `model_plan_generation` | Модел за първоначално генериране на план |
 | `model_principle_adjustment` | Модел за корекция на принципите |
+| `model_image_analysis` | Модел за анализ на изображения |
 | `prompt_adaptive_quiz_generation` | Шаблон за създаване на адаптивен въпросник |
 | `prompt_analytics_textual_summary` | Шаблон за текстов анализ на прогреса |
 | `prompt_analyze_quiz_and_suggest_changes` | Шаблон за анализ на отговорите и предложения за промяна |

--- a/admin.html
+++ b/admin.html
@@ -168,6 +168,10 @@
         <legend>Модификация на плана</legend>
         <label>Модел: <input id="modModel" type="text"> <button type="button" id="testModModel">Тествай</button></label>
       </fieldset>
+      <fieldset>
+        <legend>Анализ на изображение</legend>
+        <label>Модел: <input id="imageModel" type="text"> <button type="button" id="testImageModel">Тествай</button></label>
+      </fieldset>
       <div class="preset-controls">
         <label>Запазени настройки:
           <select id="aiPresetSelect"></select>

--- a/js/__tests__/analyzeImage.test.js
+++ b/js/__tests__/analyzeImage.test.js
@@ -20,7 +20,7 @@ describe('handleAnalyzeImageRequest', () => {
       ok: true,
       json: async () => ({ result: { response: 'ok' } })
     });
-    const env = { CF_ACCOUNT_ID: 'acc', CF_AI_TOKEN: 'token' };
+    const env = { CF_ACCOUNT_ID: 'acc', CF_AI_TOKEN: 'token', RESOURCES_KV: { get: jest.fn().mockResolvedValue(null) } };
     const request = { json: async () => ({ userId: 'u1', imageData: 'imgdata' }) };
     const res = await handleAnalyzeImageRequest(request, env);
     expect(res.success).toBe(true);
@@ -34,5 +34,21 @@ describe('handleAnalyzeImageRequest', () => {
         body: JSON.stringify({ image: 'imgdata' })
       })
     );
+  });
+
+  test('uses model from KV when provided', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { response: 'ok' } })
+    });
+    const env = {
+      CF_ACCOUNT_ID: 'acc',
+      CF_AI_TOKEN: 'token',
+      RESOURCES_KV: { get: jest.fn().mockResolvedValue('@cf/custom') }
+    };
+    const request = { json: async () => ({ userId: 'u1', imageData: 'img' }) };
+    await handleAnalyzeImageRequest(request, env);
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toContain('@cf/custom');
   });
 });

--- a/js/__tests__/saveAiConfig.test.js
+++ b/js/__tests__/saveAiConfig.test.js
@@ -11,6 +11,7 @@ beforeEach(async () => {
       <input id="planModel" />
       <input id="chatModel" />
       <input id="modModel" />
+      <input id="imageModel" />
       <input id="adminToken" />
     </form>
     <button id="showStats"></button>
@@ -49,6 +50,7 @@ test('saveAiConfig sends updates payload with Authorization header', async () =>
   document.getElementById('planModel').value = 'pm';
   document.getElementById('chatModel').value = 'cm';
   document.getElementById('modModel').value = 'mm';
+  document.getElementById('imageModel').value = 'im';
 
   await submitHandler(new Event('submit'));
 
@@ -62,7 +64,8 @@ test('saveAiConfig sends updates payload with Authorization header', async () =>
     updates: {
       model_plan_generation: 'pm',
       model_chat: 'cm',
-      model_principle_adjustment: 'mm'
+      model_principle_adjustment: 'mm',
+      model_image_analysis: 'im'
     }
   });
   expect(localStorage.getItem('adminToken')).toBe('newSecret');

--- a/js/admin.js
+++ b/js/admin.js
@@ -59,6 +59,7 @@ const aiConfigForm = document.getElementById('aiConfigForm');
 const planModelInput = document.getElementById('planModel');
 const chatModelInput = document.getElementById('chatModel');
 const modModelInput = document.getElementById('modModel');
+const imageModelInput = document.getElementById('imageModel');
 const adminTokenInput = document.getElementById('adminToken');
 const presetSelect = document.getElementById('aiPresetSelect');
 const savePresetBtn = document.getElementById('savePreset');
@@ -67,6 +68,7 @@ const presetNameInput = document.getElementById('presetName');
 const testPlanBtn = document.getElementById('testPlanModel');
 const testChatBtn = document.getElementById('testChatModel');
 const testModBtn = document.getElementById('testModModel');
+const testImageBtn = document.getElementById('testImageModel');
 const clientNameHeading = document.getElementById('clientName');
 const closeProfileBtn = document.getElementById('closeProfile');
 const notificationsList = document.getElementById('notificationsList');
@@ -1030,6 +1032,7 @@ async function loadAiConfig() {
         planModelInput.value = cfg.model_plan_generation || '';
         chatModelInput.value = cfg.model_chat || '';
         modModelInput.value = cfg.model_principle_adjustment || '';
+        if (imageModelInput) imageModelInput.value = cfg.model_image_analysis || '';
     } catch (err) {
         console.error('Error loading AI config:', err);
         alert('Грешка при зареждане на AI конфигурацията.');
@@ -1042,7 +1045,8 @@ async function saveAiConfig() {
         updates: {
             model_plan_generation: planModelInput.value.trim(),
             model_chat: chatModelInput.value.trim(),
-            model_principle_adjustment: modModelInput.value.trim()
+            model_principle_adjustment: modModelInput.value.trim(),
+            model_image_analysis: imageModelInput ? imageModelInput.value.trim() : ''
         }
     };
     try {
@@ -1107,6 +1111,7 @@ async function applySelectedPreset() {
         planModelInput.value = cfg.planModel || cfg.model_plan_generation || '';
         chatModelInput.value = cfg.chatModel || cfg.model_chat || '';
         modModelInput.value = cfg.modModel || cfg.model_principle_adjustment || '';
+        if (imageModelInput) imageModelInput.value = cfg.imageModel || cfg.model_image_analysis || '';
     } catch (err) {
         console.error('Error applying preset:', err);
         alert('Грешка при зареждане на пресета.');
@@ -1124,7 +1129,8 @@ async function saveCurrentPreset() {
         config: {
             model_plan_generation: planModelInput.value.trim(),
             model_chat: chatModelInput.value.trim(),
-            model_principle_adjustment: modModelInput.value.trim()
+            model_principle_adjustment: modModelInput.value.trim(),
+            model_image_analysis: imageModelInput ? imageModelInput.value.trim() : ''
         }
     };
     try {
@@ -1210,6 +1216,7 @@ if (aiConfigForm) {
     testPlanBtn?.addEventListener('click', () => testAiModel(planModelInput.value.trim()));
     testChatBtn?.addEventListener('click', () => testAiModel(chatModelInput.value.trim()));
     testModBtn?.addEventListener('click', () => testAiModel(modModelInput.value.trim()));
+    testImageBtn?.addEventListener('click', () => testAiModel(imageModelInput.value.trim()));
 }
 
 export {


### PR DESCRIPTION
## Summary
- document new `model_image_analysis` key for RESOURCES_KV
- choose image analysis model from KV in `worker.js`
- extend admin panel with field for configuring image model
- keep admin JS in sync and update tests
- test that API uses the configured model

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589ec031c483269fdeccb9c98b2683