### PR TITLE
Handle model agreement errors in assistant chat

### DIFF
--- a/js/__tests__/assistantChatModelAgreement.test.js
+++ b/js/__tests__/assistantChatModelAgreement.test.js
@@ -1,0 +1,47 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let sendMessage, sendImage;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <input id="userId" value="u1">
+    <input id="chat-input">
+    <input id="chat-image" type="file">
+    <div id="chat-messages"></div>
+    <button id="chat-send"></button>
+    <button id="chat-clear"></button>
+    <button id="chat-upload"></button>`;
+
+  jest.unstable_mockModule('../config.js', () => ({
+    apiEndpoints: { chat: '/chat', analyzeImage: '/img' },
+    cloudflareAccountId: 'c'
+  }));
+  jest.unstable_mockModule('../utils.js', () => ({
+    fileToBase64: jest.fn(async () => 'imgdata')
+  }));
+
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    json: async () => ({ message: 'CF AI error: Model Agreement required' })
+  });
+
+  const mod = await import('../assistantChat.js');
+  sendMessage = mod.sendMessage;
+  sendImage = mod.sendImage;
+});
+
+test('shows agreement hint on message error', async () => {
+  document.getElementById('chat-input').value = 'hi';
+  await sendMessage();
+  expect(document.getElementById('chat-messages').textContent)
+    .toContain('Моделът изисква потвърждение');
+});
+
+test('shows agreement hint on image error', async () => {
+  const file = new File(['x'], 'a.png');
+  await sendImage(file);
+  expect(document.getElementById('chat-messages').textContent)
+    .toContain('Моделът изисква потвърждение');
+});

--- a/js/assistantChat.js
+++ b/js/assistantChat.js
@@ -64,10 +64,17 @@ async function sendImage(file) {
             body: JSON.stringify({ userId, imageData })
         });
         const data = await res.json();
-        const text = data.result || data.message || 'Грешка';
-        addMessage(text, 'bot', !res.ok || !data.success);
-        chatHistory.push({ text, sender: 'bot', isError: !res.ok || !data.success });
-        saveHistory();
+        if (data.message && data.message.includes('Model Agreement') && !sessionStorage.getItem('modelAgreement')) {
+            const warn = 'Моделът изисква потвърждение. Изпратете `agree` като първо съобщение.';
+            addMessage(warn, 'bot', true);
+            chatHistory.push({ text: warn, sender: 'bot', isError: true });
+            saveHistory();
+        } else {
+            const text = data.result || data.message || 'Грешка';
+            addMessage(text, 'bot', !res.ok || !data.success);
+            chatHistory.push({ text, sender: 'bot', isError: !res.ok || !data.success });
+            saveHistory();
+        }
     } catch (e) {
         addMessage('Грешка при изпращане на изображението.', 'bot', true);
         chatHistory.push({ text: 'Грешка при изпращане на изображението.', sender: 'bot', isError: true });
@@ -84,6 +91,9 @@ async function sendMessage() {
     const userId = userIdEl.value.trim();
     const message = inputEl.value.trim();
     if (!userId || !message) return;
+    if (message.toLowerCase() === 'agree') {
+        sessionStorage.setItem('modelAgreement', 'true');
+    }
 
     addMessage(message, 'user');
     chatHistory.push({ text: message, sender: 'user', isError: false });
@@ -99,7 +109,12 @@ async function sendMessage() {
             body: JSON.stringify({ userId, message, history: chatHistory.slice(-10) })
         });
         const data = await res.json();
-        if (res.ok && data.success) {
+        if (data.message && data.message.includes('Model Agreement') && !sessionStorage.getItem('modelAgreement')) {
+            const warn = 'Моделът изисква потвърждение. Изпратете `agree` като първо съобщение.';
+            addMessage(warn, 'bot', true);
+            chatHistory.push({ text: warn, sender: 'bot', isError: true });
+            saveHistory();
+        } else if (res.ok && data.success) {
             addMessage(data.reply, 'bot');
             chatHistory.push({ text: data.reply, sender: 'bot', isError: false });
             saveHistory();
@@ -152,3 +167,5 @@ document.addEventListener('DOMContentLoaded', () => {
         if (e.target.files[0]) sendImage(e.target.files[0]);
     });
 });
+
+export { sendMessage, sendImage, clearChat };


### PR DESCRIPTION
## Summary
- detect model agreement error messages in assistant chat
- remind users to send `agree`
- remember agreement in sessionStorage
- export helpers for testing and add unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858b38ea7bc83268ca8e476d5c32547