### PR TITLE
Add prompt to image analysis API

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ Replace the placeholders with your own values and keep the token secret.
 
 In addition to text messages you can upload an image for automatic analysis.
 Open `assistant.html`, choose a file and it will be converted to a Base64 string
-and sent to `/api/analyzeImage` as JSON with fields `userId`, `imageData` and
-`mimeType`.
+and sent to `/api/analyzeImage` as JSON with fields `userId`, `imageData`,
+`mimeType` and an optional `prompt` describing what you want to see.
 The worker forwards the image data to the configured vision model and returns a
 JSON summary describing the detected objects or text.
 
@@ -353,11 +353,20 @@ Example `curl` request:
 curl -X POST https://<your-domain>/api/analyzeImage \
   -H "Authorization: Bearer <WORKER_ADMIN_TOKEN>" \
   -H "Content-Type: application/json" \
-  --data '{"userId":"123","imageData":"<base64>","mimeType":"image/jpeg"}'
+  --data '{"userId":"123","imageData":"<base64>","mimeType":"image/jpeg","prompt":"Намери текст"}'
 ```
 
 For Cloudflare models set `CF_AI_TOKEN`. When using Gemini Vision provide
 `GEMINI_API_KEY`. Without these secrets the endpoint will respond with an error.
+
+Example with the Cloudflare LLaVA model (KV key `model_image_analysis=@cf/llava-hf/llava-v1.6b`):
+
+```bash
+curl -X POST https://<your-domain>/api/analyzeImage \
+  -H "Authorization: Bearer <WORKER_ADMIN_TOKEN>" \
+  -H "Content-Type: application/json" \
+  --data '{"userId":"123","imageData":"<base64>","mimeType":"image/png","prompt":"Опиши подробно"}'
+```
 
 ### Промяна на началното съобщение в чата
 

--- a/js/app.js
+++ b/js/app.js
@@ -898,10 +898,11 @@ export async function handleChatImageUpload(file) { // Exported for chat.js
 
     try {
         const imageData = await fileToBase64(file);
+        const prompt = selectors.chatInput?.value.trim() || '';
         const response = await fetch(apiEndpoints.analyzeImage, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ userId: currentUserId, imageData, mimeType: file.type })
+            body: JSON.stringify({ userId: currentUserId, imageData, mimeType: file.type, prompt })
         });
         const result = await response.json();
         const text = result.result || result.message || 'Грешка';

--- a/js/assistantChat.js
+++ b/js/assistantChat.js
@@ -73,10 +73,11 @@ async function sendImage(file) {
     showTyping();
     try {
         const imageData = await fileToBase64(file);
+        const prompt = document.getElementById('chat-input').value.trim();
         const res = await fetch(apiEndpoints.analyzeImage, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ userId, imageData, mimeType: file.type })
+            body: JSON.stringify({ userId, imageData, mimeType: file.type, prompt })
         });
         const data = await res.json();
         if (handleModelAgreement(data)) {


### PR DESCRIPTION
## Summary
- allow `handleAnalyzeImageRequest` to accept an optional text prompt
- pass the prompt from the chat interfaces
- support Cloudflare LLaVA style messages when the model name begins with `@cf/`
- update the corresponding unit tests
- document the new parameter with an example in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858c94ac0808326a262360ce70ef5be