### PR TITLE
Support prompt-image payload for certain CF models

### DIFF
--- a/js/__tests__/analyzeImage.test.js
+++ b/js/__tests__/analyzeImage.test.js
@@ -70,4 +70,23 @@ describe('handleAnalyzeImageRequest', () => {
     expect(body.contents[0].parts[0].inlineData.data).toBe('img');
     expect(body.contents[0].parts[0].inlineData.mimeType).toBe('image/png');
   });
+
+  test('sends prompt-image payload for llava models', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { response: 'ok' } })
+    });
+    const env = {
+      CF_ACCOUNT_ID: 'acc',
+      CF_AI_TOKEN: 'token',
+      RESOURCES_KV: { get: jest.fn().mockResolvedValue('@cf/llava-hf/llava-1.5-7b-hf') }
+    };
+    const request = { json: async () => ({ userId: 'u1', imageData: 'img', mimeType: 'image/png', prompt: 'desc' }) };
+    await handleAnalyzeImageRequest(request, env);
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body).toEqual({
+      prompt: 'desc',
+      image: 'data:image/png;base64,img'
+    });
+  });
 });

--- a/worker.js
+++ b/worker.js
@@ -1380,7 +1380,18 @@ async function handleAnalyzeImageRequest(request, env) {
         const defaultText = 'Опиши съдържанието на това изображение.';
         let aiResp;
         if (provider === 'cf') {
-            if (modelName.startsWith('@cf/')) {
+            const promptImageNeeded =
+                modelName.includes('llava-1.5') || modelName.endsWith('-hf');
+            if (promptImageNeeded) {
+                aiResp = await callCfAi(
+                    modelName,
+                    {
+                        prompt: prompt || defaultText,
+                        image: `data:${mimeType || 'image/jpeg'};base64,${imageData}`
+                    },
+                    env
+                );
+            } else if (modelName.startsWith('@cf/')) {
                 const msgContent = [
                     {
                         type: 'image_url',


### PR DESCRIPTION
## Summary
- detect LLaVA/huggingface models in `handleAnalyzeImageRequest`
- send `{prompt, image}` payload to `callCfAi` for these models
- test new behaviour for `@cf/llava-hf/llava-1.5-7b-hf`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858d698a4f48326a42949e3ad67fef6