### PR TITLE
Update analyzeImage return format

### DIFF
--- a/js/__tests__/analyzeImage.test.js
+++ b/js/__tests__/analyzeImage.test.js
@@ -24,7 +24,7 @@ describe('handleAnalyzeImageRequest', () => {
     const request = { json: async () => ({ userId: 'u1', imageData: 'imgdata', mimeType: 'image/png', prompt: 'hi' }) };
     const res = await handleAnalyzeImageRequest(request, env);
     expect(res.success).toBe(true);
-    expect(res.aiResponse).toBe('ok');
+    expect(res.result).toBe('ok');
     const expectedUrl =
       'https://api.cloudflare.com/client/v4/accounts/acc/ai/run/@cf/stabilityai/clip';
     expect(global.fetch).toHaveBeenCalledWith(
@@ -65,7 +65,7 @@ describe('handleAnalyzeImageRequest', () => {
     const request = { json: async () => ({ userId: 'u1', imageData: 'img', mimeType: 'image/png' }) };
     const res = await handleAnalyzeImageRequest(request, env);
     expect(res.success).toBe(true);
-    expect(res.aiResponse).toBe('ok');
+    expect(res.result).toBe('ok');
     const body = JSON.parse(global.fetch.mock.calls[0][1].body);
     expect(body.contents[0].parts[0].inlineData.data).toBe('img');
     expect(body.contents[0].parts[0].inlineData.mimeType).toBe('image/png');

--- a/worker.js
+++ b/worker.js
@@ -1424,7 +1424,7 @@ async function handleAnalyzeImageRequest(request, env) {
             aiResp = await callModel(modelName, textPrompt, env, { temperature: 0.2, maxTokens: 200 });
         }
 
-        return { success: true, aiResponse: aiResp };
+        return { success: true, result: aiResp };
     } catch (error) {
         console.error('Error in handleAnalyzeImageRequest:', error.message, error.stack);
         return { success: false, message: 'Грешка при анализа на изображението.', statusHint: 500 };


### PR DESCRIPTION
## Summary
- rename `aiResponse` to `result` in `handleAnalyzeImageRequest`
- align analyze image unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859989557a0832685a7d8d9c7b879cd