### PR TITLE
Add prompt support for Gemini Vision

### DIFF
--- a/js/__tests__/analyzeImage.test.js
+++ b/js/__tests__/analyzeImage.test.js
@@ -69,6 +69,22 @@ describe('handleAnalyzeImageRequest', () => {
     const body = JSON.parse(global.fetch.mock.calls[0][1].body);
     expect(body.contents[0].parts[0].inlineData.data).toBe('img');
     expect(body.contents[0].parts[0].inlineData.mimeType).toBe('image/png');
+    expect(body.contents[0].parts[1].text).toBe('Опиши съдържанието на това изображение.');
+  });
+
+  test('passes user prompt to Gemini vision API', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ candidates: [{ content: { parts: [{ text: 'ok' }] } }] })
+    });
+    const env = {
+      GEMINI_API_KEY: 'k',
+      RESOURCES_KV: { get: jest.fn().mockResolvedValue('gemini-pro-vision') }
+    };
+    const request = { json: async () => ({ userId: 'u1', imageData: 'img', mimeType: 'image/png', prompt: 'details' }) };
+    await handleAnalyzeImageRequest(request, env);
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.contents[0].parts[1].text).toBe('details');
   });
 
   test('sends prompt-image payload for llava models', async () => {

--- a/worker.js
+++ b/worker.js
@@ -1415,6 +1415,7 @@ async function handleAnalyzeImageRequest(request, env) {
             aiResp = await callGeminiVisionAPI(
                 imageData,
                 mimeType || 'image/jpeg',
+                prompt,
                 key,
                 { temperature: 0.2, maxOutputTokens: 200 },
                 modelName
@@ -2894,16 +2895,17 @@ async function callGeminiAPI(prompt, apiKey, generationConfig = {}, safetySettin
 // ------------- END FUNCTION: callGeminiAPI -------------
 
 // ------------- START FUNCTION: callGeminiVisionAPI -------------
-async function callGeminiVisionAPI(imageData, mimeType, apiKey, generationConfig = {}, model) {
+async function callGeminiVisionAPI(imageData, mimeType, prompt, apiKey, generationConfig = {}, model) {
     if (!model) {
         console.error('GEMINI_VISION_CALL_ERROR: Model name is missing!');
         throw new Error('Gemini model name is missing.');
     }
     const apiUrl = `${GEMINI_API_URL_BASE}${model}:generateContent?key=${apiKey}`;
+    const textPrompt = prompt || 'Опиши съдържанието на това изображение.';
     const requestBody = {
         contents: [{ parts: [
             { inlineData: { mimeType, data: imageData } },
-            { text: 'Опиши съдържанието на това изображение.' }
+            { text: textPrompt }
         ] }],
         ...(Object.keys(generationConfig).length > 0 && { generationConfig })
     };


### PR DESCRIPTION
## Summary
- allow `callGeminiVisionAPI` to accept a prompt
- forward custom prompts from `handleAnalyzeImageRequest`
- extend tests for Gemini Vision prompt handling

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68599a1b78288326abcdced7ed205acc