### PR TITLE
Add reusable registration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ npm config delete https-proxy
 `loglevel=error` и е включен в репозиторито.
 Тези стъпки намаляват предупрежденията и потенциално ускоряват старта на
 тестовете.
+### Registration Module Example
+
+Include the common registration logic by importing `setupRegistration`:
+
+```html
+<script type="module">
+  import { setupRegistration } from "./js/register.js";
+  setupRegistration("#register-form", "#register-message");
+</script>
+```
+
 
 ### Отстраняване на проблеми
 

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
 
     <script type="module">
         import { showMessage, hideMessage } from './js/messageUtils.js';
+        import { setupRegistration } from './js/register.js';
         import { workerBaseUrl, isLocalDevelopment } from './js/config.js';
         // Селектори
         const loginSection = document.getElementById('login-section');
@@ -173,69 +174,13 @@
                 loginButton.textContent = originalButtonText;
             }
         });
-
-        // Обработка на РЕГИСТРАЦИОННАТА формата
-        registerForm.addEventListener('submit', async (event) => {
-            event.preventDefault();
-            hideMessage(registerMessage);
-            const registerButton = registerForm.querySelector('button[type="submit"]');
-            const originalButtonText = registerButton.textContent;
-            registerButton.disabled = true;
-            registerButton.textContent = 'Обработка...';
-
-            const emailInput = document.getElementById('register-email');
-            const passwordInput = document.getElementById('register-password');
-            const confirmPasswordInput = document.getElementById('confirm-password');
-            const email = emailInput.value.trim().toLowerCase(); // Винаги с малки букви
-            const password = passwordInput.value;
-            const confirmPassword = confirmPasswordInput.value;
-
-            // Клиентска валидация
-            if (!email || !password || !confirmPassword) {
-                 showMessage(registerMessage, 'Моля, попълнете всички полета.', true);
-                 registerButton.disabled = false; registerButton.textContent = originalButtonText; return;
-             }
-            if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-                showMessage(registerMessage, 'Моля, въведете валиден имейл адрес.', true);
-                 registerButton.disabled = false; registerButton.textContent = originalButtonText; return;
-            }
-             if (password.length < 8) {
-                 showMessage(registerMessage, 'Паролата трябва да е поне 8 знака.', true);
-                 registerButton.disabled = false; registerButton.textContent = originalButtonText; return;
-             }
-            if (password !== confirmPassword) {
-                showMessage(registerMessage, 'Паролите не съвпадат.', true);
-                 registerButton.disabled = false; registerButton.textContent = originalButtonText; return;
-            }
-
-            try {
-                const response = await fetch(registerEndpoint, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ email, password, confirm_password: confirmPassword })
-                });
-                const data = await response.json();
-
-                if (!response.ok || !data.success) {
-                    throw new Error(data.message || 'Грешка при регистрацията. Моля, опитайте отново.');
-                }
-
-                // УСПЕШНА РЕГИСТРАЦИЯ
-                showMessage(registerMessage, 'Регистрацията успешна! Пренасочване към формата за вход...', false);
-                registerForm.reset();
-                 setTimeout(() => {
-                     showLoginLink.click(); // Превключваме към логин формата
-                     hideMessage(registerMessage); // Скриваме съобщението за успех след превключване
-                 }, 2500); // Изчакваме 2.5 секунди преди превключване
-
-            } catch (error) {
-                console.error('Registration failed:', error);
-                showMessage(registerMessage, error.message, true);
-                 registerButton.disabled = false;
-                 registerButton.textContent = originalButtonText;
-            }
+        setupRegistration("#register-form", "#register-message");
+        document.getElementById("register-form").addEventListener("registrationSuccess", () => {
+            setTimeout(() => {
+                document.getElementById("show-login").click();
+                hideMessage(document.getElementById("register-message"));
+            }, 2500);
         });
-
     </script>
 </body>
 </html>

--- a/js/__tests__/register.test.js
+++ b/js/__tests__/register.test.js
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let setupRegistration;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <form id="reg"><input type="email"><input type="password"><input type="password"><button type="submit">Ok</button></form>
+    <div id="msg"></div>`;
+  jest.unstable_mockModule('../messageUtils.js', () => ({
+    showMessage: jest.fn(),
+    hideMessage: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({ workerBaseUrl: 'https://api' }));
+  ({ setupRegistration } = await import('../register.js'));
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+});
+
+test('sends request on valid input', async () => {
+  const form = document.getElementById('reg');
+  form.querySelector('input[type="email"]').value = 'a@b.com';
+  const pw = form.querySelectorAll('input[type="password"]');
+  pw[0].value = '12345678';
+  pw[1].value = '12345678';
+  setupRegistration('#reg', '#msg');
+  form.dispatchEvent(new Event('submit', { bubbles: true }));
+  await Promise.resolve();
+  expect(global.fetch).toHaveBeenCalledWith('https://api/api/register', expect.any(Object));
+});
+
+test('shows error on invalid email', async () => {
+  const form = document.getElementById('reg');
+  form.querySelector('input[type="email"]').value = 'bad';
+  const pw = form.querySelectorAll('input[type="password"]');
+  pw[0].value = '12345678';
+  pw[1].value = '12345678';
+  const utils = await import('../messageUtils.js');
+  setupRegistration('#reg', '#msg');
+  form.dispatchEvent(new Event('submit', { bubbles: true }));
+  await Promise.resolve();
+  expect(global.fetch).not.toHaveBeenCalled();
+  expect(utils.showMessage).toHaveBeenCalled();
+});

--- a/js/register.js
+++ b/js/register.js
@@ -1,0 +1,62 @@
+import { showMessage, hideMessage } from "./messageUtils.js";
+import { workerBaseUrl } from "./config.js";
+
+export function setupRegistration(formSelector, messageElSelector) {
+  const form = document.querySelector(formSelector);
+  const messageEl = document.querySelector(messageElSelector);
+  if (!form || !messageEl) {
+    console.error('setupRegistration: elements not found');
+    return;
+  }
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    hideMessage(messageEl);
+    const emailInput = form.querySelector('input[type="email"]');
+    const [passInput, confirmInput] = form.querySelectorAll('input[type="password"]');
+    if (!emailInput || !passInput || !confirmInput) {
+      console.error('setupRegistration: missing input fields');
+      return;
+    }
+    const email = emailInput.value.trim().toLowerCase();
+    const password = passInput.value;
+    const confirmPassword = confirmInput.value;
+    const submitBtn = form.querySelector('button[type="submit"]');
+    const btnText = submitBtn ? submitBtn.textContent : '';
+    const resetBtn = () => {
+      if (submitBtn) {
+        submitBtn.disabled = false;
+        submitBtn.textContent = btnText;
+      }
+    };
+    const showErr = (msg) => {
+      showMessage(messageEl, msg, true);
+      resetBtn();
+    };
+    if (!email || !password || !confirmPassword) return showErr('Моля, попълнете всички полета.');
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return showErr('Моля, въведете валиден имейл адрес.');
+    if (password.length < 8) return showErr('Паролата трябва да е поне 8 знака.');
+    if (password !== confirmPassword) return showErr('Паролите не съвпадат.');
+    if (submitBtn) {
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Обработка...';
+    }
+    try {
+      const res = await fetch(`${workerBaseUrl}/api/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password, confirm_password: confirmPassword })
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) throw new Error(data.message || 'Грешка при регистрацията. Моля, опитайте отново.');
+      showMessage(messageEl, data.message || 'Регистрацията успешна!', false);
+      form.reset();
+      form.dispatchEvent(new CustomEvent('registrationSuccess', { detail: data }));
+    } catch (err) {
+      console.error('Registration failed:', err);
+      showMessage(messageEl, err.message, true);
+      form.dispatchEvent(new CustomEvent('registrationError', { detail: err }));
+    } finally {
+      resetBtn();
+    }
+  });
+}

--- a/quest.html
+++ b/quest.html
@@ -150,6 +150,7 @@
 
 <script type="module">
   import { workerBaseUrl } from './js/config.js';
+  import { setupRegistration } from "./js/register.js";
   /***** Глобални променливи *****/
   let rawQuestions = [];     // Суровият масив от questions.json (йерархичен)
   let flatPages = [];        // Плосък масив от всички въпроси (след рекурсивно сплескване)
@@ -379,51 +380,12 @@
     pageDiv.querySelector('#regBackBtn').addEventListener('click', () => {
       showPage(regIndex - 1);
     });
-
-    pageDiv.querySelector('#register-form-q').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const msgEl = pageDiv.querySelector('#register-message-q');
-      msgEl.style.display = 'none';
-      const email = emailInput.value.trim().toLowerCase();
-      const pass = pageDiv.querySelector('#register-password-q').value;
-      const confirm = pageDiv.querySelector('#confirm-password-q').value;
-      if (!email || !pass || !confirm) {
-        msgEl.textContent = 'Моля, попълнете всички полета.';
-        msgEl.className = 'message error';
-        msgEl.style.display = 'block';
-        return;
-      }
-      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-        msgEl.textContent = 'Невалиден имейл.';
-        msgEl.className = 'message error';
-        msgEl.style.display = 'block';
-        return;
-      }
-      if (pass.length < 8 || pass !== confirm) {
-        msgEl.textContent = 'Провери паролата.';
-        msgEl.className = 'message error';
-        msgEl.style.display = 'block';
-        return;
-      }
-      try {
-        const res = await fetch(`${workerBaseUrl}/api/register`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email, password: pass, confirm_password: confirm })
-        });
-        const data = await res.json();
-        if (!res.ok || !data.success) throw new Error(data.message || 'Грешка при регистрация.');
-        responses.email = email; // обновяваме имейла ако е различен
-        msgEl.textContent = 'Регистрацията успешна!';
-        msgEl.className = 'message success';
-        msgEl.style.display = 'block';
-        showPage(regIndex + 1);
-      } catch (err) {
-        msgEl.textContent = err.message;
-        msgEl.className = 'message error';
-        msgEl.style.display = 'block';
-      }
+    setupRegistration("#register-form-q", "#register-message-q");
+    pageDiv.querySelector("#register-form-q").addEventListener("registrationSuccess", () => {
+      responses.email = emailInput.value.trim().toLowerCase();
+      showPage(regIndex + 1);
     });
+
   }
 
   /***** Създаване на финална страница *****/


### PR DESCRIPTION
## Summary
- factor registration logic into `js/register.js`
- import and use the new module in `index.html` and `quest.html`
- remove duplicated code in both pages
- document `setupRegistration` usage in README
- add Jest tests for the module

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859da9f0f748326b2d5efb13635ac8b