### PR TITLE
Fix email persistence after registration

### DIFF
--- a/quest.html
+++ b/quest.html
@@ -441,6 +441,7 @@
     setupRegistration("#register-form-q", "#register-message-q");
     pageDiv.querySelector("#register-form-q").addEventListener("registrationSuccess", () => {
       responses.email = emailInput.value.trim().toLowerCase();
+      saveProgress();
       showPage(regIndex + 1);
     });
 


### PR DESCRIPTION
## Summary
- save progress when registration succeeds so `responses.email` survives reloads

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859f49b745c8326be7ca4d61cfb1a84