### PR TITLE
Configure allowed origins via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ These names are referenced in `worker.js` and must exist for the worker to funct
 
 ### Allowed Origins
 
-The worker supports a custom list of allowed origins for CORS via the
+The worker and PHP scripts support a custom list of allowed origins for CORS via the
 `ALLOWED_ORIGINS` environment variable. Provide a comma-separated list of
 domains from which the application (for example the admin panel) will be
 loaded. If the variable is not set, the default list includes
@@ -243,6 +243,9 @@ The PHP helper scripts expect the following variables set in the server environm
 
 - `STATIC_TOKEN` – shared secret token used for authentication in `file_manager_api.php`.
 - `CF_API_TOKEN` – token used by `save-questions.php` to update the Cloudflare KV store.
+- `ALLOWED_ORIGINS` – optional comma-separated list of origins allowed to
+  access the PHP scripts and `worker-backend.js`. Defaults match the worker
+  configuration when not provided.
 
 The admin panel по подразбиране използва фиксирани данни за вход – потребителско име `admin` и парола `6131`.
 Ако е зададенa променлива `ADMIN_PASS_HASH`, паролата се проверява по нейния bcrypt хеш. Празни стойности на `ADMIN_PASS_HASH` или `ADMIN_USERNAME` се игнорират и се използват стандартните данни.

--- a/file_manager_api.php
+++ b/file_manager_api.php
@@ -14,9 +14,22 @@ if ($envToken === false) {
 define('STATIC_TOKEN', $envToken); // API ключ за удостоверяване
 
 // Задаване на CORS заглавки
-header("Access-Control-Allow-Origin: *"); // Може да се ограничи до твоя Worker или домейни
+$defaultAllowedOrigins = [
+    'https://radilovk.github.io',
+    'https://radilov-k.github.io',
+    'http://localhost:5173',
+    'http://localhost:3000',
+    'null'
+];
+$envOrigins = getenv('ALLOWED_ORIGINS');
+$allowedOrigins = $envOrigins ? array_filter(array_map('trim', explode(',', $envOrigins))) : [];
+$allowedOrigins = array_unique(array_merge($allowedOrigins, $defaultAllowedOrigins));
+$requestOrigin = $_SERVER['HTTP_ORIGIN'] ?? 'null';
+$originToSend = in_array($requestOrigin, $allowedOrigins, true) ? $requestOrigin : $allowedOrigins[0];
+header("Access-Control-Allow-Origin: $originToSend");
 header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
+header("Vary: Origin");
 header("Content-Type: application/json");
 
 // Създаване на директорията за качване, ако не съществува (Остава без промяна)

--- a/login.php
+++ b/login.php
@@ -1,7 +1,21 @@
 <?php
 session_start();
 header('Content-Type: application/json; charset=utf-8');
-header('Access-Control-Allow-Origin: *');
+// Configure allowed origins
+$defaultAllowedOrigins = [
+    'https://radilovk.github.io',
+    'https://radilov-k.github.io',
+    'http://localhost:5173',
+    'http://localhost:3000',
+    'null'
+];
+$envOrigins = getenv('ALLOWED_ORIGINS');
+$allowedOrigins = $envOrigins ? array_filter(array_map('trim', explode(',', $envOrigins))) : [];
+$allowedOrigins = array_unique(array_merge($allowedOrigins, $defaultAllowedOrigins));
+$requestOrigin = $_SERVER['HTTP_ORIGIN'] ?? 'null';
+$originToSend = in_array($requestOrigin, $allowedOrigins, true) ? $requestOrigin : $allowedOrigins[0];
+header('Access-Control-Allow-Origin: ' . $originToSend);
+header('Vary: Origin');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     echo json_encode(["success"=>false, "message"=>"Only POST allowed"]);


### PR DESCRIPTION
## Summary
- configure allowed CORS origins in `login.php` and `file_manager_api.php`
- make the backend worker respect `ALLOWED_ORIGINS`
- document the new environment variable usage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859fbbb8abc8326be0b8ce843f7b9ae