### PR TITLE
Secure template loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ npm run docs
 ```
 The output is placed in the `docs/` folder.
 
+### Template Loading
+
+Client pages sometimes fetch HTML snippets at runtime. Templates such as
+`profileTemplate.html` and `extra-meal-entry-form.html` must reside in the same
+origin as the application. The helper `loadTemplateInto(url, containerId)`
+rejects cross-origin URLs and sanitizes the response before inserting it into
+the page.
+
 ## Deployment to Cloudflare
 
 A GitHub Action workflow at `.github/workflows/deploy.yml` automatically deploys the worker when you push to `main` or open a pull request that modifies `worker.js`. It runs `wrangler deploy` using the secret `CF_API_TOKEN` for authentication.

--- a/js/htmlSanitizer.js
+++ b/js/htmlSanitizer.js
@@ -1,0 +1,23 @@
+export function sanitizeHTML(html, allowedTags = ['a','b','i','u','p','div','span','ul','ol','li','br','hr','h1','h2','h3','h4','h5','h6','table','thead','tbody','tr','td','th','button','input','label','form','select','option','textarea','img','svg','use','path']) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  const walker = document.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT, null);
+  const allowed = new Set(allowedTags.map(t => t.toLowerCase()));
+
+  let node = walker.currentNode;
+  while (node) {
+    const tag = node.tagName.toLowerCase();
+    if (!allowed.has(tag)) {
+      const toRemove = node;
+      node = walker.nextNode();
+      toRemove.remove();
+      continue;
+    }
+    [...node.attributes].forEach(attr => {
+      const name = attr.name.toLowerCase();
+      if (name.startsWith('on') || /javascript:/i.test(attr.value)) node.removeAttribute(attr.name);
+    });
+    node = walker.nextNode();
+  }
+  return doc.body.innerHTML;
+}

--- a/js/templateLoader.js
+++ b/js/templateLoader.js
@@ -1,10 +1,17 @@
+import { sanitizeHTML } from './htmlSanitizer.js';
+
 export async function loadTemplateInto(url, containerId) {
   const container = document.getElementById(containerId);
   if (!container) return;
   try {
-    const resp = await fetch(url);
+    const resolved = new URL(url, window.location.href);
+    if (resolved.origin !== window.location.origin) {
+      throw new Error('Cross-origin template load blocked.');
+    }
+    const resp = await fetch(resolved);
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-    container.innerHTML = await resp.text();
+    const raw = await resp.text();
+    container.innerHTML = sanitizeHTML(raw);
   } catch (err) {
     console.error('Template load error:', err);
   }


### PR DESCRIPTION
## Summary
- sanitize HTML templates before injecting
- block cross-origin template loads
- reuse sanitizer for extra meal form
- document where templates must live

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859fd154a688326a5ff2b8e62380a1a