### PR TITLE
Switch admin token to sessionStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,12 +313,12 @@ const result = await env.AI.run('@cf/llava-hf/llava-1.5-7b-hf', {
 ```
 
 Администраторският скрипт `admin.js` добавя автоматично тази
-заглавка, ако в `localStorage` съществува ключ `adminToken`.
+заглавка, ако в `sessionStorage` съществува ключ `adminToken`.
 Стойността може да зададете от панела в полето „Admin Token“,
-което я записва в `localStorage`. Може и ръчно да я зададете през конзолата:
+което я записва в `sessionStorage`. Може и ръчно да я зададете през конзолата:
 
 ```javascript
-localStorage.setItem('adminToken', '<вашият токен>');
+sessionStorage.setItem('adminToken', '<вашият токен>');
 ```
 
 Токените за моделите вече се задават единствено като *worker secrets*.

--- a/js/__tests__/saveAiConfig.test.js
+++ b/js/__tests__/saveAiConfig.test.js
@@ -29,8 +29,8 @@ beforeEach(async () => {
     <button id="showStats"></button>
     <button id="sendQuery"></button>
   `;
-  localStorage.clear();
-  localStorage.setItem('adminToken', 'secret');
+  sessionStorage.clear();
+  sessionStorage.setItem('adminToken', 'secret');
 
   const form = document.getElementById('aiConfigForm');
   form.addEventListener = (evt, handler) => {
@@ -50,7 +50,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   global.fetch && global.fetch.mockRestore();
-  localStorage.clear();
+  sessionStorage.clear();
 });
 
 test('saveAiConfig sends updates payload with Authorization header', async () => {
@@ -104,5 +104,5 @@ test('saveAiConfig sends updates payload with Authorization header', async () =>
       image_temperature: '0.4'
     }
   });
-  expect(localStorage.getItem('adminToken')).toBe('newSecret');
+  expect(sessionStorage.getItem('adminToken')).toBe('newSecret');
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -1050,7 +1050,14 @@ async function loadClientReplies(markRead = false) {
 
 function loadAdminToken() {
     if (!adminTokenInput) return;
-    adminTokenInput.value = localStorage.getItem('adminToken') || '';
+    const stored = sessionStorage.getItem('adminToken') || localStorage.getItem('adminToken');
+    if (stored) {
+        adminTokenInput.value = stored;
+        sessionStorage.setItem('adminToken', stored);
+        localStorage.removeItem('adminToken');
+    } else {
+        adminTokenInput.value = '';
+    }
 }
 
 async function loadAiConfig() {
@@ -1112,9 +1119,10 @@ async function saveAiConfig() {
         let adminToken = '';
         if (adminTokenInput) {
             adminToken = adminTokenInput.value.trim();
-            localStorage.setItem('adminToken', adminToken);
+            sessionStorage.setItem('adminToken', adminToken);
+            localStorage.removeItem('adminToken');
         } else {
-            adminToken = localStorage.getItem('adminToken') || '';
+            adminToken = sessionStorage.getItem('adminToken') || localStorage.getItem('adminToken') || '';
         }
         const headers = { 'Content-Type': 'application/json' };
         if (adminToken) headers.Authorization = `Bearer ${adminToken}`;
@@ -1221,7 +1229,7 @@ async function saveCurrentPreset() {
         }
     };
     try {
-        const adminToken = localStorage.getItem('adminToken') || '';
+        const adminToken = sessionStorage.getItem('adminToken') || localStorage.getItem('adminToken') || '';
         const headers = { 'Content-Type': 'application/json' };
         if (adminToken) headers.Authorization = `Bearer ${adminToken}`;
         const resp = await fetch(apiEndpoints.saveAiPreset, {
@@ -1254,7 +1262,7 @@ async function testAiModel(modelName) {
         return;
     }
     try {
-        const adminToken = adminTokenInput ? adminTokenInput.value.trim() : (localStorage.getItem('adminToken') || '');
+        const adminToken = adminTokenInput ? adminTokenInput.value.trim() : (sessionStorage.getItem('adminToken') || localStorage.getItem('adminToken') || '');
         const headers = { 'Content-Type': 'application/json' };
         if (adminToken) headers.Authorization = `Bearer ${adminToken}`;
         const resp = await fetch(apiEndpoints.testAiModel, {


### PR DESCRIPTION
## Summary
- store admin token in sessionStorage instead of localStorage
- migrate token on page load and update API calls
- adjust documentation about admin token storage
- update unit tests for sessionStorage use

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859fd275a50832695affffa30f0144c