### PR TITLE
Remove email format checks

### DIFF
--- a/js/__tests__/register.test.js
+++ b/js/__tests__/register.test.js
@@ -29,16 +29,14 @@ test('sends request on valid input', async () => {
   expect(global.fetch).toHaveBeenCalledWith('https://api/api/register', expect.any(Object));
 });
 
-test('shows error on invalid email', async () => {
+test('accepts invalid email', async () => {
   const form = document.getElementById('reg');
   form.querySelector('input[type="email"]').value = 'bad';
   const pw = form.querySelectorAll('input[type="password"]');
   pw[0].value = '12345678';
   pw[1].value = '12345678';
-  const utils = await import('../messageUtils.js');
   setupRegistration('#reg', '#msg');
   form.dispatchEvent(new Event('submit', { bubbles: true }));
   await Promise.resolve();
-  expect(global.fetch).not.toHaveBeenCalled();
-  expect(utils.showMessage).toHaveBeenCalled();
+  expect(global.fetch).toHaveBeenCalledWith('https://api/api/register', expect.any(Object));
 });

--- a/js/register.js
+++ b/js/register.js
@@ -33,7 +33,6 @@ export function setupRegistration(formSelector, messageElSelector) {
       resetBtn();
     };
     if (!email || !password || !confirmPassword) return showErr('Моля, попълнете всички полета.');
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return showErr('Моля, въведете валиден имейл адрес.');
     if (password.length < 8) return showErr('Паролата трябва да е поне 8 знака.');
     if (password !== confirmPassword) return showErr('Паролите не съвпадат.');
     if (submitBtn) {

--- a/quest.html
+++ b/quest.html
@@ -799,8 +799,6 @@
         if (element) value = element.value.trim();
         if (isRequired && !value) {
             isValid = false; errorMessage = "Моля, попълнете това поле.";
-        } else if (question.type === 'email' && value && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
-            isValid = false; errorMessage = "Моля, въведете валиден имейл адрес.";
         } else if (question.type === 'number') {
             const num = Number(value);
             if (value && isNaN(num)) {
@@ -910,17 +908,7 @@
       let userEmail = responses.email || (emailInputEl ? emailInputEl.value : '');
       userEmail = String(userEmail).trim().toLowerCase();
 
-      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(userEmail)) {
-          console.error("Validation Error: Invalid or missing email.", responses.email);
-          delete responses.submissionDate;
-          const msgEl = document.getElementById('register-message-q');
-          if (msgEl) showMessage(msgEl, 'Моля, въведете валиден имейл адрес.', true);
-          showPage(registrationPageIndex);
-          throw new Error('Невалиден имейл');
-      }
-
       responses.email = userEmail;
-      console.log("Email validation passed:", userEmail);
        // ------------------------------------------
 
        // --- Изпращане към Worker (Критична част) ---


### PR DESCRIPTION
## Summary
- drop email validation regex in register.js
- skip email validation in questionnaire flow
- adjust tests for relaxed behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a0fc43bd88326945a0e11e55e0d73