### PR TITLE
Send welcome email on registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Include the common registration logic by importing `setupRegistration`:
 </script>
 ```
 
+Successful registration triggers a welcome email. The worker loads the
+`registration_email_html` template from `RESOURCES_KV` and passes it to
+`sendWelcomeEmail`.
+
 
 ### Отстраняване на проблеми
 
@@ -315,6 +319,9 @@ wrangler kv key put model_image_analysis "@cf/llava-hf/llava-v1.6b" --binding=RE
 Оттам можете да редактирате HTML текста на писмото, изпращано при нова регистрация.
 Наличен е бутон **Изпрати тест**, който използва `/api/sendTestEmail` за изпращане
 на пробен имейл до посочен адрес.
+
+При реална регистрация същият шаблон се взема от `RESOURCES_KV` и се изпраща
+чрез `sendWelcomeEmail` на новия потребител.
 
 При деплой на worker-а задайте секрет `SENDGRID_API_KEY`, който съдържа вашия
 SendGrid API ключ. Той се използва от функцията `sendWelcomeEmail` за

--- a/js/__tests__/registerEmailTrigger.test.js
+++ b/js/__tests__/registerEmailTrigger.test.js
@@ -1,0 +1,56 @@
+import { jest } from '@jest/globals';
+
+const PHP_FILE_MANAGER_API_URL_SECRET_NAME = 'тут_ваш_php_api_url_secret_name';
+const PHP_API_STATIC_TOKEN_SECRET_NAME = 'тут_ваш_php_api_token_secret_name';
+
+let fetchHandler, sendWelcomeEmail;
+
+beforeEach(async () => {
+  jest.resetModules();
+  const emailMock = jest.fn();
+  jest.unstable_mockModule('../../mailer.js', () => ({
+    sendWelcomeEmail: emailMock
+  }));
+  const mod = await import('../../worker.js');
+  fetchHandler = mod.default.fetch;
+  ({ sendWelcomeEmail } = await import('../../mailer.js'));
+  sendWelcomeEmail.mockClear();
+});
+
+test('registration triggers sendWelcomeEmail', async () => {
+  const env = {
+    USER_METADATA_KV: {
+      get: jest.fn().mockResolvedValue(null),
+      put: jest.fn().mockResolvedValue(undefined)
+    },
+    RESOURCES_KV: {
+      get: jest.fn().mockResolvedValue('<p>welcome</p>')
+    },
+    [PHP_FILE_MANAGER_API_URL_SECRET_NAME]: 'https://php.test',
+    [PHP_API_STATIC_TOKEN_SECRET_NAME]: 'token'
+  };
+
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ message: 'ok', file: 'f.json' })
+  });
+
+  const req = new Request('https://x/api/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'user@example.com',
+      password: '12345678',
+      confirm_password: '12345678'
+    })
+  });
+
+  await fetchHandler(req, env, {});
+
+  expect(sendWelcomeEmail).toHaveBeenCalledWith(
+    'user@example.com',
+    'user@example.com',
+    '<p>welcome</p>',
+    env
+  );
+});


### PR DESCRIPTION
## Summary
- notify new users with welcome email template in worker
- verify registration sends welcome email
- document welcome email behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b40fa6c6883269737ab9a5c3c4782