### PR TITLE
Send welcome email after registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Include the common registration logic by importing `setupRegistration`:
 </script>
 ```
 
+Upon successful registration the worker fetches an HTML template from
+`RESOURCES_KV` and sends a welcome email using `sendWelcomeEmail`.
+
 
 ### Отстраняване на проблеми
 

--- a/js/__tests__/registrationEmail.test.js
+++ b/js/__tests__/registrationEmail.test.js
@@ -1,0 +1,40 @@
+import { jest } from '@jest/globals';
+
+let handleRegisterRequest, sendWelcomeEmailMock;
+
+beforeEach(async () => {
+  jest.resetModules();
+  sendWelcomeEmailMock = jest.fn();
+  jest.unstable_mockModule('../../mailer.js', () => ({
+    sendWelcomeEmail: sendWelcomeEmailMock
+  }));
+  ({ handleRegisterRequest } = await import('../../worker.js'));
+});
+
+afterEach(() => {
+  global.fetch = undefined;
+});
+
+test('calls sendWelcomeEmail after successful registration', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ message: 'ok', file: 'cred.json' })
+  });
+  const env = {
+    USER_METADATA_KV: {
+      get: jest.fn().mockResolvedValue(null),
+      put: jest.fn()
+    },
+    RESOURCES_KV: {
+      get: jest.fn().mockResolvedValue('<p>tmpl</p>')
+    },
+    'тут_ваш_php_api_url_secret_name': 'https://api',
+    'тут_ваш_php_api_token_secret_name': 'tok',
+  };
+  const request = {
+    json: async () => ({ email: 'a@b.com', password: '12345678', confirm_password: '12345678' })
+  };
+  const res = await handleRegisterRequest(request, env);
+  expect(res.success).toBe(true);
+  expect(sendWelcomeEmailMock).toHaveBeenCalledWith('a@b.com', 'a@b.com', '<p>tmpl</p>', env);
+});

--- a/mailer.js
+++ b/mailer.js
@@ -3,28 +3,29 @@ import dotenv from 'dotenv'
 
 dotenv.config()
 
-const transporter = nodemailer.createTransport({
-    host: 'mybody.best',
-    port: 465,
-    secure: true,
-    auth: {
-        user: 'info@mybody.best',
-        pass: process.env.EMAIL_PASSWORD
-    }
-})
 
 /**
  * Send a welcome email to a newly registered user.
  * @param {string} toEmail recipient address
  * @param {string} userName user name for greeting
  */
-export async function sendWelcomeEmail(toEmail, userName) {
-    const html = `<h2>Здравей, ${userName} 👋</h2>
+export async function sendWelcomeEmail(toEmail, userName, template, env = process.env) {
+    const defaultHtml = `<h2>Здравей, ${userName} 👋</h2>
 <p>Благодарим ти, че се регистрира в <strong>MyBody</strong> – твоето пространство за здраве, балансирано хранене и осъзнат живот.</p>
 <p>Нашата мисия е да ти помогнем да постигнеш целите си с яснота, подкрепа и научно обоснован подход.</p>
 <p>Очаквай още полезни ресурси и съвети съвсем скоро.</p>
 <p>Бъди здрав и вдъхновен!</p>
 <p>– Екипът на MyBody</p>`
+    const html = template || defaultHtml
+    const transporter = nodemailer.createTransport({
+        host: 'mybody.best',
+        port: 465,
+        secure: true,
+        auth: {
+            user: 'info@mybody.best',
+            pass: env.EMAIL_PASSWORD
+        }
+    })
 
     try {
         await transporter.sendMail({
@@ -37,3 +38,4 @@ export async function sendWelcomeEmail(toEmail, userName) {
         console.error('Failed to send welcome email:', error)
     }
 }
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "esnext",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
-    "allowJs": true
+    "allowJs": true,
+    "resolveJsonModule": true
   },
   "include": ["worker.js", "mailer.js", "js/**/*"]
 }

--- a/worker.js
+++ b/worker.js
@@ -1,4 +1,5 @@
 // Cloudflare Worker Script (index.js) - Версия 2.3
+import { sendWelcomeEmail } from './mailer.js'
 // Добавен е режим за дебъг чрез HTTP заглавие `X-Debug: 1`
 // Също така са запазени всички функционалности от предходните версии
 // Включва:
@@ -413,6 +414,13 @@ async function handleRegisterRequest(request, env) {
         const phpApiResult = await phpApiResponse.json(); if (!phpApiResult.message || !phpApiResult.file) { console.warn(`REGISTER_INFO (${userId}): PHP API unexpected success response for POST:`, phpApiResult); } else { console.log(`REGISTER_SUCCESS (${userId}): PHP API: Credential file created successfully for ${userId}:`, phpApiResult); }
         await env.USER_METADATA_KV.put(`email_to_uuid_${trimmedEmail}`, userId);
         await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'pending', { metadata: { status: 'pending' } });
+        let template;
+        try {
+            template = await env.RESOURCES_KV.get('registration_email_template');
+            await sendWelcomeEmail(trimmedEmail, trimmedEmail, template, env);
+        } catch (emailErr) {
+            console.error(`REGISTER_EMAIL_ERROR (${userId}):`, emailErr.message);
+        }
         return { success: true, message: 'Регистрацията успешна!' };
      } catch (error) { console.error('Error in handleRegisterRequest:', error.message, error.stack); let userMessage = 'Вътрешна грешка при регистрация.'; if (error.message.includes('Failed to fetch')) userMessage = 'Грешка при свързване със сървъра.'; else if (error instanceof SyntaxError) userMessage = 'Грешка в отговора от сървъра.'; return { success: false, message: userMessage, statusHint: 500 }; }
 }
@@ -3614,4 +3622,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, handleRegisterRequest };


### PR DESCRIPTION
## Summary
- extend `sendWelcomeEmail` to accept template and env
- send registration email from worker using template stored in `RESOURCES_KV`
- export `handleRegisterRequest` for tests
- test that registration triggers welcome email
- document email step in README
- set `nodenext` module mode in TypeScript config

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b44d87a2483268610c01eabf0400a