### PR TITLE
Add welcome email integration and stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ Include the common registration logic by importing `setupRegistration`:
 </script>
 ```
 
+### Email Notifications
+
+Automatic welcome emails are sent after a successful registration. The function
+`sendWelcomeEmail` in `mailer.js` uses `nodemailer` to deliver the message.
+Set the environment variable `EMAIL_PASSWORD` with the mailbox password before
+running the server or tests. When `handleRegisterRequest` completes, it triggers
+`sendWelcomeEmail` and records the timestamp under `welcome_email_ts_<userId>`
+in KV storage. The admin panel can display these stats via the new endpoint
+`/api/getEmailStats`.
+
 
 ### Отстраняване на проблеми
 

--- a/admin.html
+++ b/admin.html
@@ -36,6 +36,7 @@
     </select>
     <p id="clientsCount"></p>
     <button id="showStats">Покажи статистика</button>
+    <button id="showEmailStats">Изпратени имейли</button>
     <ul id="clientsList"></ul>
   </aside>
 
@@ -147,6 +148,11 @@
     <h2>Статистика</h2>
     <pre id="statsOutput"></pre>
     <canvas id="statusChart" width="300" height="200"></canvas>
+  </section>
+
+  <section id="emailStatsSection" class="hidden card">
+    <h2>Изпратени имейли</h2>
+    <pre id="emailStatsOutput"></pre>
   </section>
 
   <details id="aiConfigSection" class="card">

--- a/js/__tests__/registerWelcome.test.js
+++ b/js/__tests__/registerWelcome.test.js
@@ -1,0 +1,32 @@
+import { jest } from '@jest/globals';
+
+let handleRegisterRequest, sendWelcomeEmailMock;
+
+beforeEach(async () => {
+  jest.resetModules();
+  sendWelcomeEmailMock = jest.fn().mockResolvedValue(undefined);
+  jest.unstable_mockModule('../../mailer.js', () => ({ sendWelcomeEmail: sendWelcomeEmailMock }));
+  ({ handleRegisterRequest } = await import('../../worker.js'));
+});
+
+test('welcome email is sent on successful registration', async () => {
+  const env = {
+    USER_METADATA_KV: {
+      get: jest.fn().mockResolvedValueOnce(null),
+      put: jest.fn()
+    },
+    'тут_ваш_php_api_url_secret_name': 'https://php.example.com',
+    'тут_ваш_php_api_token_secret_name': 'tok'
+  };
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ message: 'ok', file: 'f' })
+  });
+  const req = {
+    json: async () => ({ email: 'a@b.com', password: '12345678', confirm_password: '12345678' })
+  };
+  const res = await handleRegisterRequest(req, env);
+  expect(res.success).toBe(true);
+  expect(sendWelcomeEmailMock).toHaveBeenCalledWith('a@b.com', 'a');
+  expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(expect.stringMatching(/^welcome_email_ts_/), expect.any(String));
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -34,6 +34,8 @@ const clientRepliesList = document.getElementById('clientRepliesList');
 const feedbackList = document.getElementById('feedbackList');
 const statsOutput = document.getElementById('statsOutput');
 const showStatsBtn = document.getElementById('showStats');
+const emailStatsOutput = document.getElementById('emailStatsOutput');
+const showEmailStatsBtn = document.getElementById('showEmailStats');
 const sortOrderSelect = document.getElementById('sortOrder');
 const initialAnswersPre = document.getElementById('initialAnswers');
 const planMenuPre = document.getElementById('planMenu');
@@ -497,6 +499,22 @@ async function loadClients() {
     }
 }
 
+async function loadEmailStats() {
+    try {
+        const resp = await fetch(apiEndpoints.getEmailStats);
+        const data = await resp.json();
+        if (resp.ok && data.success) {
+            if (emailStatsOutput)
+                emailStatsOutput.textContent = JSON.stringify(data, null, 2);
+        } else if (emailStatsOutput) {
+            emailStatsOutput.textContent = 'Грешка при зареждане.';
+        }
+    } catch (err) {
+        console.error('Error loading email stats:', err);
+        if (emailStatsOutput) emailStatsOutput.textContent = 'Грешка при връзка.';
+    }
+}
+
 function renderClients() {
     const search = (clientSearch.value || '').toLowerCase();
     const filter = statusFilter.value;
@@ -701,6 +719,14 @@ showStatsBtn.addEventListener('click', () => {
     const sec = document.getElementById('statsSection');
     sec.classList.toggle('hidden');
 });
+
+if (showEmailStatsBtn) {
+    showEmailStatsBtn.addEventListener('click', async () => {
+        const sec = document.getElementById('emailStatsSection');
+        sec.classList.toggle('hidden');
+        if (!sec.classList.contains('hidden')) await loadEmailStats();
+    });
+}
 
 if (toggleWeightChartBtn) {
     toggleWeightChartBtn.addEventListener('click', () => {
@@ -1321,6 +1347,7 @@ if (aiConfigForm) {
 export {
     allClients,
     loadClients,
+    loadEmailStats,
     renderClients,
     showNotificationDot,
     checkForNotifications,

--- a/js/config.js
+++ b/js/config.js
@@ -43,7 +43,8 @@ export const apiEndpoints = {
     getAiPreset: `${workerBaseUrl}/api/getAiPreset`,
     saveAiPreset: `${workerBaseUrl}/api/saveAiPreset`,
     testAiModel: `${workerBaseUrl}/api/testAiModel`,
-    analyzeImage: `${workerBaseUrl}/api/analyzeImage`
+    analyzeImage: `${workerBaseUrl}/api/analyzeImage`,
+    getEmailStats: `${workerBaseUrl}/api/getEmailStats`
 };
 
 // Cloudflare Account ID за използване в чат асистента


### PR DESCRIPTION
## Summary
- send welcome email in `handleRegisterRequest`
- store timestamp in KV and expose `/api/getEmailStats`
- show email stats in admin panel
- document email notifications
- test registration email logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b4b9091208326af670827672dc949