### PR TITLE
Add test email capability

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -209,6 +209,16 @@
     </form>
   </details>
 
+  <details id="testEmailSection" class="card">
+    <summary>Тестов имейл</summary>
+    <form id="testEmailForm">
+      <label>До:<br><input id="testEmailTo" type="email"></label>
+      <label>Тема:<br><input id="testEmailSubject" type="text"></label>
+      <label>Съдържание:<br><textarea id="testEmailBody" rows="5"></textarea></label>
+      <button type="submit">Изпрати</button>
+    </form>
+  </details>
+
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="js/admin.js"></script>
 </body>

--- a/js/__tests__/sendTestEmail.test.js
+++ b/js/__tests__/sendTestEmail.test.js
@@ -1,0 +1,51 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let send;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <form id="testEmailForm">
+      <input id="testEmailTo">
+      <input id="testEmailSubject">
+      <textarea id="testEmailBody"></textarea>
+    </form>
+    <button id="showStats"></button>
+    <button id="sendQuery"></button>`;
+
+  jest.unstable_mockModule('../config.js', () => ({
+    apiEndpoints: { sendTestEmail: '/api/sendTestEmail' }
+  }));
+
+  const mod = await import('../admin.js');
+  send = mod.sendTestEmail;
+});
+
+afterEach(() => {
+  global.fetch && global.fetch.mockRestore();
+});
+
+test('sendTestEmail posts form data', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  document.getElementById('testEmailTo').value = 'a@b.bg';
+  document.getElementById('testEmailSubject').value = 'Sub';
+  document.getElementById('testEmailBody').value = 'Body';
+  await send();
+  expect(global.fetch).toHaveBeenCalledWith('/api/sendTestEmail', expect.objectContaining({
+    method: 'POST',
+    headers: expect.any(Object),
+    body: JSON.stringify({ to: 'a@b.bg', subject: 'Sub', body: 'Body' })
+  }));
+});
+
+test('alert shown on error', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: false, json: async () => ({ success: false, message: 'err' }) });
+  const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+  document.getElementById('testEmailTo').value = 'x';
+  document.getElementById('testEmailSubject').value = 's';
+  document.getElementById('testEmailBody').value = 'b';
+  await send();
+  expect(alertSpy).toHaveBeenCalled();
+  alertSpy.mockRestore();
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -88,6 +88,10 @@ const testImageBtn = document.getElementById('testImageModel');
 const emailSettingsForm = document.getElementById('emailSettingsForm');
 const welcomeEmailSubjectInput = document.getElementById('welcomeEmailSubject');
 const welcomeEmailBodyInput = document.getElementById('welcomeEmailBody');
+const testEmailForm = document.getElementById('testEmailForm');
+const testEmailToInput = document.getElementById('testEmailTo');
+const testEmailSubjectInput = document.getElementById('testEmailSubject');
+const testEmailBodyInput = document.getElementById('testEmailBody');
 const clientNameHeading = document.getElementById('clientName');
 const closeProfileBtn = document.getElementById('closeProfile');
 const notificationsList = document.getElementById('notificationsList');
@@ -1195,6 +1199,29 @@ async function saveEmailSettings() {
     }
 }
 
+async function sendTestEmail() {
+    if (!testEmailForm) return;
+    const to = testEmailToInput ? testEmailToInput.value.trim() : '';
+    const subject = testEmailSubjectInput ? testEmailSubjectInput.value.trim() : '';
+    const body = testEmailBodyInput ? testEmailBodyInput.value.trim() : '';
+    try {
+        const adminToken = sessionStorage.getItem('adminToken') || localStorage.getItem('adminToken') || '';
+        const headers = { 'Content-Type': 'application/json' };
+        if (adminToken) headers.Authorization = `Bearer ${adminToken}`;
+        const resp = await fetch(apiEndpoints.sendTestEmail, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ to, subject, body })
+        });
+        const data = await resp.json();
+        if (!resp.ok || !data.success) throw new Error(data.message || 'Error');
+        alert('Имейлът е изпратен успешно.');
+    } catch (err) {
+        console.error('Error sending test email:', err);
+        alert(err.message || 'Грешка при изпращане на имейла.');
+    }
+}
+
 async function loadAiPresets() {
     if (!presetSelect) return;
     try {
@@ -1372,6 +1399,13 @@ if (emailSettingsForm) {
     });
 }
 
+if (testEmailForm) {
+    testEmailForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        await sendTestEmail();
+    });
+}
+
 export {
     allClients,
     loadClients,
@@ -1379,5 +1413,6 @@ export {
     showNotificationDot,
     checkForNotifications,
     showClient,
-    unreadClients
+    unreadClients,
+    sendTestEmail
 };

--- a/js/config.js
+++ b/js/config.js
@@ -43,7 +43,8 @@ export const apiEndpoints = {
     getAiPreset: `${workerBaseUrl}/api/getAiPreset`,
     saveAiPreset: `${workerBaseUrl}/api/saveAiPreset`,
     testAiModel: `${workerBaseUrl}/api/testAiModel`,
-    analyzeImage: `${workerBaseUrl}/api/analyzeImage`
+    analyzeImage: `${workerBaseUrl}/api/analyzeImage`,
+    sendTestEmail: `${workerBaseUrl}/api/sendTestEmail`
 };
 
 // Cloudflare Account ID за използване в чат асистента


### PR DESCRIPTION
## Summary
- add Test Email section in admin page
- support sending test emails via new `sendTestEmail` function
- expose endpoint in config
- cover email sending with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b5ebb41bc8326ad4421d75f1bf137