### PR TITLE
Add admin test email endpoint

### DIFF
--- a/js/__tests__/sendTestEmailRequest.test.js
+++ b/js/__tests__/sendTestEmailRequest.test.js
@@ -1,0 +1,47 @@
+import { jest } from '@jest/globals';
+
+let handleSendTestEmailRequest, sendEmailMock;
+
+beforeEach(async () => {
+  jest.resetModules();
+  sendEmailMock = jest.fn().mockResolvedValue();
+  jest.unstable_mockModule('../../mailer.js', () => ({ sendEmail: sendEmailMock }));
+  ({ handleSendTestEmailRequest } = await import('../../worker.js'));
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+test('rejects invalid token', async () => {
+  const request = {
+    headers: { get: h => (h === 'Authorization' ? 'Bearer bad' : null) },
+    json: async () => ({ recipient: 'test@example.com', subject: 's', body: 'b' })
+  };
+  const env = { WORKER_ADMIN_TOKEN: 'secret' };
+  const res = await handleSendTestEmailRequest(request, env);
+  expect(res.success).toBe(false);
+  expect(res.statusHint).toBe(403);
+});
+
+test('rejects missing fields', async () => {
+  const request = {
+    headers: { get: () => null },
+    json: async () => ({})
+  };
+  const env = {};
+  const res = await handleSendTestEmailRequest(request, env);
+  expect(res.success).toBe(false);
+  expect(res.statusHint).toBe(400);
+});
+
+test('sends email on valid data', async () => {
+  const request = {
+    headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
+    json: async () => ({ recipient: 'test@example.com', subject: 'Hi', body: 'b' })
+  };
+  const env = { WORKER_ADMIN_TOKEN: 'secret' };
+  const res = await handleSendTestEmailRequest(request, env);
+  expect(res.success).toBe(true);
+  expect(sendEmailMock).toHaveBeenCalledWith('test@example.com', 'Hi', 'b');
+});

--- a/mailer.js
+++ b/mailer.js
@@ -65,17 +65,22 @@ async function getEmailTemplate() {
     }
 }
 
+export async function sendEmail(toEmail, subject, html) {
+    await transporter.sendMail({
+        from: 'info@mybody.best',
+        to: toEmail,
+        subject,
+        html
+    })
+}
+
 export async function sendWelcomeEmail(toEmail, userName) {
     const tpl = await getEmailTemplate()
     const html = tpl.body.replace(/{{\s*name\s*}}/g, userName)
     try {
-        await transporter.sendMail({
-            from: 'info@mybody.best',
-            to: toEmail,
-            subject: tpl.subject,
-            html
-        })
+        await sendEmail(toEmail, tpl.subject, html)
     } catch (error) {
         console.error('Failed to send welcome email:', error)
     }
 }
+

--- a/worker.js
+++ b/worker.js
@@ -11,6 +11,8 @@
 // - Попълнени липсващи части от предходни версии.
 // - Запазени всички предходни функционалности.
 
+import { sendEmail } from './mailer.js';
+
 // ------------- START BLOCK: GlobalConstantsAndBindings -------------
 const PHP_FILE_MANAGER_API_URL_SECRET_NAME = 'тут_ваш_php_api_url_secret_name';
 const PHP_API_STATIC_TOKEN_SECRET_NAME = 'тут_ваш_php_api_token_secret_name';
@@ -201,6 +203,8 @@ export default {
                 responseBody = await handleSaveAiPreset(request, env);
             } else if (method === 'POST' && path === '/api/testAiModel') {
                 responseBody = await handleTestAiModelRequest(request, env);
+            } else if (method === 'POST' && path === '/api/sendTestEmail') {
+                responseBody = await handleSendTestEmailRequest(request, env);
             } else if (method === 'GET' && path === '/api/getFeedbackMessages') {
                 responseBody = await handleGetFeedbackMessagesRequest(request, env);
             } else {
@@ -1708,6 +1712,30 @@ async function handleTestAiModelRequest(request, env) {
     }
 }
 // ------------- END FUNCTION: handleTestAiModelRequest -------------
+
+// ------------- START FUNCTION: handleSendTestEmailRequest -------------
+async function handleSendTestEmailRequest(request, env) {
+    try {
+        const auth = request.headers.get('Authorization') || '';
+        const token = auth.replace(/^Bearer\s+/i, '').trim();
+        const expected = env[WORKER_ADMIN_TOKEN_SECRET_NAME];
+        if (expected && token !== expected) {
+            return { success: false, message: 'Невалиден токен.', statusHint: 403 };
+        }
+
+        const { recipient, subject, body } = await request.json();
+        if (!recipient || !subject || !body) {
+            return { success: false, message: 'Липсват данни.', statusHint: 400 };
+        }
+
+        await sendEmail(recipient, subject, body);
+        return { success: true };
+    } catch (error) {
+        console.error('Error in handleSendTestEmailRequest:', error.message, error.stack);
+        return { success: false, message: 'Грешка при изпращане.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleSendTestEmailRequest -------------
 
 
 // ------------- START BLOCK: PlanGenerationHeaderComment -------------
@@ -3614,4 +3642,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements };


### PR DESCRIPTION
## Summary
- extend `mailer.js` with generic `sendEmail` helper
- add `/api/sendTestEmail` handler in `worker.js`
- test the new handler

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b5eb1a47c8326ac5b3c689a780cab