### PR TITLE
Add admin test email feature

### DIFF
--- a/js/__tests__/adminSendEmail.test.js
+++ b/js/__tests__/adminSendEmail.test.js
@@ -1,0 +1,43 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+
+let sendTestEmail
+
+beforeEach(async () => {
+  jest.resetModules()
+  document.body.innerHTML = `
+    <button id="showStats"></button>
+    <button id="sendQuery"></button>
+    <input id="adminToken" />`
+  jest.unstable_mockModule('../config.js', () => ({
+    apiEndpoints: { sendTestEmail: '/api/sendTestEmail' }
+  }))
+  const mod = await import('../admin.js')
+  sendTestEmail = mod.sendTestEmail
+})
+
+afterEach(() => {
+  global.fetch && global.fetch.mockRestore()
+  window.alert && window.alert.mockRestore && window.alert.mockRestore()
+})
+
+test('sends POST request with auth header and shows success alert', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) })
+  window.alert = jest.fn()
+  document.getElementById('adminToken').value = 'tok'
+  await sendTestEmail('a@b.com')
+  expect(global.fetch).toHaveBeenCalledWith('/api/sendTestEmail', expect.objectContaining({
+    method: 'POST',
+    headers: expect.objectContaining({ Authorization: 'Bearer tok' })
+  }))
+  const body = JSON.parse(global.fetch.mock.calls[0][1].body)
+  expect(body).toEqual({ email: 'a@b.com' })
+  expect(window.alert).toHaveBeenCalledWith('Тестовият имейл е изпратен.')
+})
+
+test('shows error alert on failure response', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: false, json: async () => ({ success: false, message: 'fail' }) })
+  window.alert = jest.fn()
+  await sendTestEmail('a@b.com')
+  expect(window.alert).toHaveBeenCalledWith('fail')
+})

--- a/js/admin.js
+++ b/js/admin.js
@@ -880,6 +880,32 @@ async function generatePraise() {
     }
 }
 
+async function sendTestEmail(email) {
+    if (!email) {
+        alert('Въведете имейл адрес.');
+        return;
+    }
+    try {
+        const adminToken = adminTokenInput ? adminTokenInput.value.trim() : (sessionStorage.getItem('adminToken') || localStorage.getItem('adminToken') || '');
+        const headers = { 'Content-Type': 'application/json' };
+        if (adminToken) headers.Authorization = `Bearer ${adminToken}`;
+        const resp = await fetch(apiEndpoints.sendTestEmail, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ email })
+        });
+        const data = await resp.json();
+        if (resp.ok && data.success) {
+            alert('Тестовият имейл е изпратен.');
+        } else {
+            alert(data.message || 'Грешка при изпращане на имейла.');
+        }
+    } catch (err) {
+        console.error('Error sending test email:', err);
+        alert('Грешка при изпращане на имейла.');
+    }
+}
+
 if (generatePraiseBtn) {
     generatePraiseBtn.addEventListener('click', generatePraise);
 }
@@ -1379,5 +1405,6 @@ export {
     showNotificationDot,
     checkForNotifications,
     showClient,
-    unreadClients
+    unreadClients,
+    sendTestEmail
 };

--- a/js/config.js
+++ b/js/config.js
@@ -43,6 +43,7 @@ export const apiEndpoints = {
     getAiPreset: `${workerBaseUrl}/api/getAiPreset`,
     saveAiPreset: `${workerBaseUrl}/api/saveAiPreset`,
     testAiModel: `${workerBaseUrl}/api/testAiModel`,
+    sendTestEmail: `${workerBaseUrl}/api/sendTestEmail`,
     analyzeImage: `${workerBaseUrl}/api/analyzeImage`
 };
 


### PR DESCRIPTION
## Summary
- provide endpoint for sending test emails
- support sending test messages from admin panel
- cover sendTestEmail with Jest

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b67fe6d488326bdc7134aabd7400d