### PR TITLE
Improve Cloudflare worker deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    paths:
-      - 'worker.js'
+    branches: [ '*' ]
   workflow_dispatch:
 
 jobs:
@@ -20,6 +19,12 @@ jobs:
           env:
             USER_METADATA_KV_ID: ${{ secrets.USER_METADATA_KV_ID }}
             USER_METADATA_KV_PREVIEW_ID: ${{ secrets.USER_METADATA_KV_PREVIEW_ID }}
+        - name: Update compatibility date
+          run: node scripts/update-compat-date.js
+        - name: Check required secrets
+          if: ${{ !secrets.CF_API_TOKEN }}
+          run: |
+            echo "Missing CF_API_TOKEN secret. Deployment cannot continue." && exit 1
         - name: Validate configuration
           run: node scripts/validate-wrangler.js
           env:

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ the page.
 
 ## Deployment to Cloudflare
 
-A GitHub Action workflow at `.github/workflows/deploy.yml` automatically deploys the worker when you push to `main` or open a pull request that modifies `worker.js`. It runs `wrangler deploy` using the secret `CF_API_TOKEN` for authentication.
+A GitHub Action workflow at `.github/workflows/deploy.yml` automatically deploys the worker when you push to `main` or open a pull request. It runs `wrangler deploy` using the secret `CF_API_TOKEN` for authentication. Pull requests from forks cannot access the secrets, so those builds will skip deployment.
 
 To set the token:
 
@@ -148,6 +148,7 @@ The worker configuration is stored in `wrangler.toml`. Update `account_id` with 
 compatibility_date = "2025-06-20"
 ```
 Препоръчително е периодично (например веднъж годишно) да обновявате тази дата до последна валидна стойност, за да се възползва worker-ът от новите възможности на Cloudflare.
+В workflow-а има стъпка `update-compat-date`, която автоматично я коригира, ако е зададена по-нова от днешната.
 
 Пример за промяна в `wrangler.toml`:
 

--- a/scripts/update-compat-date.js
+++ b/scripts/update-compat-date.js
@@ -1,0 +1,26 @@
+import fs from 'fs';
+
+const today = new Date().toISOString().split('T')[0];
+
+let toml;
+try {
+  toml = fs.readFileSync('wrangler.toml', 'utf8');
+} catch (err) {
+  console.error('Cannot read wrangler.toml:', err.message);
+  process.exit(1);
+}
+
+const match = toml.match(/compatibility_date\s*=\s*"(\d{4}-\d{2}-\d{2})"/);
+if (!match) {
+  console.error('compatibility_date not found in wrangler.toml');
+  process.exit(1);
+}
+
+const [, current] = match;
+if (current > today) {
+  const updated = toml.replace(match[0], `compatibility_date = "${today}"`);
+  fs.writeFileSync('wrangler.toml', updated);
+  console.log(`compatibility_date updated to ${today}`);
+} else {
+  console.log('compatibility_date is valid');
+}


### PR DESCRIPTION
## Summary
- trigger CF worker deployment on any PR
- update compatibility date automatically
- check for missing secrets and document new workflow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685bedc95df88326885eabca2e66ec3b