### PR TITLE
Fix sendEmail type declaration

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -14,6 +14,7 @@
 function defaultSendEmail() {
     throw new Error('Email functionality is not configured.');
 }
+/** @type {(to: string, subject: string, body: string) => Promise<void>} */
 let sendEmailFn = defaultSendEmail;
 async function getSendEmail() {
     if (sendEmailFn && sendEmailFn !== defaultSendEmail) return sendEmailFn;


### PR DESCRIPTION
## Summary
- specify function signature for `sendEmailFn` in `worker.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c95030b3c8326a28a792dedbc31c6