### PR TITLE
Fix worker email helper type

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -11,7 +11,15 @@
 // - Попълнени липсващи части от предходни версии.
 // - Запазени всички предходни функционалности.
 
-function defaultSendEmail() {
+/**
+ * Fallback email sender used when `mailer.js` is unavailable.
+ * Matches the signature of the real implementation to satisfy TypeScript.
+ * @param {string} to
+ * @param {string} subject
+ * @param {string} body
+ * @returns {Promise<void>}
+ */
+async function defaultSendEmail(to, subject, body) {
     throw new Error('Email functionality is not configured.');
 }
 /** @type {(to: string, subject: string, body: string) => Promise<void>} */


### PR DESCRIPTION
## Summary
- align the default fallback `sendEmail` implementation with the expected async signature

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c98d934dc8326903806acfefbc4d9