### PR TITLE
Replace CF_API_TOKEN references

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check required secrets
         run: |
           missing=0
-          for var in CF_API_TOKEN USER_METADATA_KV_ID USER_METADATA_KV_PREVIEW_ID; do
+          for var in CLOUDFLARE_API_TOKEN USER_METADATA_KV_ID USER_METADATA_KV_PREVIEW_ID; do
             if [ -z "${!var}" ]; then
               echo "❌ Missing secret: $var"
               missing=1
@@ -31,7 +31,7 @@ jobs:
             exit 1
           fi
         env:
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           USER_METADATA_KV_ID: ${{ secrets.USER_METADATA_KV_ID }}
           USER_METADATA_KV_PREVIEW_ID: ${{ secrets.USER_METADATA_KV_PREVIEW_ID }}
 
@@ -49,9 +49,9 @@ jobs:
         env:
           USER_METADATA_KV_ID: ${{ secrets.USER_METADATA_KV_ID }}
           USER_METADATA_KV_PREVIEW_ID: ${{ secrets.USER_METADATA_KV_PREVIEW_ID }}
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Deploy to Cloudflare Workers
         run: wrangler deploy
         env:
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ the page.
 
 ## Deployment to Cloudflare
 
-A GitHub Action workflow at `.github/workflows/deploy.yml` automatically deploys the worker when you push to `main` or open a pull request. It runs `wrangler deploy` using the secret `CF_API_TOKEN` for authentication. Pull requests from forks cannot access the secrets, so those builds will skip deployment.
+A GitHub Action workflow at `.github/workflows/deploy.yml` automatically deploys the worker when you push to `main` or open a pull request. It runs `wrangler deploy` using the secret `CLOUDFLARE_API_TOKEN` for authentication. Pull requests from forks cannot access the secrets, so those builds will skip deployment.
 
 To set the token:
 
 1. Generate an API token with **Edit Cloudflare Workers** permissions.
-2. In your repository settings, create a GitHub secret named `CF_API_TOKEN` containing the token value.
+2. In your repository settings, create a GitHub secret named `CLOUDFLARE_API_TOKEN` containing the token value.
 
 The worker configuration is stored in `wrangler.toml`. Update `account_id` with your Cloudflare account if needed. For the `USER_METADATA_KV` namespace the file expects the environment variables `USER_METADATA_KV_ID` and `USER_METADATA_KV_PREVIEW_ID`. Configure them as GitHub secrets so the workflow can substitute the correct IDs before deployment. **Важно:** полето `compatibility_date` не може да сочи в бъдещето спрямо датата на деплой. Ако е зададена по-нова дата, Cloudflare ще откаже деплойването. Затова поддържайте стойност, която е днес или по-стара. Например:
 
@@ -162,7 +162,7 @@ You can verify this setup locally by running:
 ```bash
 node scripts/validate-wrangler.js
 ```
-This script checks for placeholder values and for a provided `CF_API_TOKEN`.
+This script checks for placeholder values and for a provided `CLOUDFLARE_API_TOKEN`.
 
 
 ### Работа с KV
@@ -175,7 +175,7 @@ wrangler kv key get <ключ> --binding=RESOURCES_KV
 wrangler kv key delete <ключ> --binding=RESOURCES_KV
 ```
 
-> За работа с тези команди трябва да имате зададен `CF_API_TOKEN` или да сте изпълнили `wrangler login`.
+> За работа с тези команди трябва да имате зададен `CLOUDFLARE_API_TOKEN` или да сте изпълнили `wrangler login`.
 
 Заменете `RESOURCES_KV` с `USER_METADATA_KV` при нужда. В директорията `scripts` има примерен Node скрипт `manage-kv.js`, който изпълнява същите операции:
 
@@ -271,7 +271,7 @@ This list is combined with the defaults when building the CORS headers.
 The PHP helper scripts expect the following variables set in the server environment:
 
 - `STATIC_TOKEN` – shared secret token used for authentication in `file_manager_api.php`.
-- `CF_API_TOKEN` – token used by `save-questions.php` to update the Cloudflare KV store.
+- `CLOUDFLARE_API_TOKEN` – token used by `save-questions.php` to update the Cloudflare KV store.
 - `ALLOWED_ORIGINS` – optional comma-separated list of origins allowed to
   access the PHP scripts and `worker-backend.js`. Defaults match the worker
   configuration when not provided.

--- a/save-questions.php
+++ b/save-questions.php
@@ -2,7 +2,7 @@
 header("Content-Type: application/json; charset=utf-8");
 
 // ----- Конфигурация чрез променливи на средата -----
-$cloudflareApiToken = getenv('CF_API_TOKEN');
+$cloudflareApiToken = getenv('CLOUDFLARE_API_TOKEN');
 $cloudflareAccountId = getenv('CF_ACCOUNT_ID') ?: 'c2015f4060e04bc3c414f78a9946668e';
 $kvNamespaceId = getenv('RESOURCES_KV_ID') ?: '8ebf65a6ed0a44e7b7d1b4bc6f24465e';
 $kvKeyName = 'question_definitions';
@@ -27,8 +27,8 @@ function respondAndExit($code, $success, $message) {
 
 // Проверка дали конфигурацията е попълнена (проста проверка)
 if (empty($cloudflareApiToken) || empty($cloudflareAccountId) || empty($kvNamespaceId)) {
-    error_log("save-questions.php: Липсва CF_API_TOKEN или друга конфигурация.");
-    respondAndExit(500, false, "Сървърът няма достъп до Cloudflare (липсва CF_API_TOKEN).");
+    error_log("save-questions.php: Липсва CLOUDFLARE_API_TOKEN или друга конфигурация.");
+    respondAndExit(500, false, "Сървърът няма достъп до Cloudflare (липсва CLOUDFLARE_API_TOKEN).");
 }
 
 

--- a/scripts/validate-wrangler.js
+++ b/scripts/validate-wrangler.js
@@ -15,8 +15,8 @@ try {
     process.exit(1);
   }
 
-  if (!process.env.CF_API_TOKEN) {
-    console.error('Липсва променливата на средата CF_API_TOKEN.');
+  if (!process.env.CLOUDFLARE_API_TOKEN) {
+    console.error('Липсва променливата на средата CLOUDFLARE_API_TOKEN.');
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- rename environment variable `CF_API_TOKEN` to `CLOUDFLARE_API_TOKEN`
- update validation script and helper PHP script
- adjust deploy workflow to use the new secret
- refresh documentation accordingly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c9ff2fa008326abff78b554acf534