### PR TITLE
Fix sendTestEmail request body

### DIFF
--- a/js/__tests__/sendTestEmail.test.js
+++ b/js/__tests__/sendTestEmail.test.js
@@ -35,7 +35,7 @@ test('sendTestEmail posts form data', async () => {
   expect(global.fetch).toHaveBeenCalledWith('/api/sendTestEmail', expect.objectContaining({
     method: 'POST',
     headers: expect.any(Object),
-    body: JSON.stringify({ to: 'a@b.bg', subject: 'Sub', body: 'Body' })
+    body: JSON.stringify({ recipient: 'a@b.bg', subject: 'Sub', body: 'Body' })
   }));
 });
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -1201,7 +1201,7 @@ async function saveEmailSettings() {
 
 async function sendTestEmail() {
     if (!testEmailForm) return;
-    const to = testEmailToInput ? testEmailToInput.value.trim() : '';
+    const recipient = testEmailToInput ? testEmailToInput.value.trim() : '';
     const subject = testEmailSubjectInput ? testEmailSubjectInput.value.trim() : '';
     const body = testEmailBodyInput ? testEmailBodyInput.value.trim() : '';
     try {
@@ -1211,7 +1211,7 @@ async function sendTestEmail() {
         const resp = await fetch(apiEndpoints.sendTestEmail, {
             method: 'POST',
             headers,
-            body: JSON.stringify({ to, subject, body })
+            body: JSON.stringify({ recipient, subject, body })
         });
         const data = await resp.json();
         if (!resp.ok || !data.success) throw new Error(data.message || 'Error');


### PR DESCRIPTION
## Summary
- update `sendTestEmail` to send `{ recipient }` instead of `{ to }`
- adjust unit test accordingly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ca5e9f92c83268ac1c034f6999dfe