### PR TITLE
Support new Cloudflare image payload

### DIFF
--- a/js/__tests__/analyzeImage.test.js
+++ b/js/__tests__/analyzeImage.test.js
@@ -32,9 +32,10 @@ describe('handleAnalyzeImageRequest', () => {
       expect.objectContaining({ method: 'POST' })
     );
     const body = JSON.parse(global.fetch.mock.calls[0][1].body);
-    expect(body.messages[0].content[0].image_url.url)
-      .toBe('data:image/png;base64,imgdata');
-    expect(body.messages[0].content[1].text).toBe('hi');
+    expect(body).toEqual({
+      prompt: 'hi',
+      image: 'data:image/png;base64,imgdata'
+    });
   });
 
   test('uses model from KV when provided', async () => {
@@ -87,7 +88,7 @@ describe('handleAnalyzeImageRequest', () => {
     expect(body.contents[0].parts[1].text).toBe('Опиши съдържанието на това изображение.');
   });
 
-  test('sends prompt-image payload for llava models', async () => {
+  test('sends prompt-image payload for cf models', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ result: { response: 'ok' } })

--- a/worker.js
+++ b/worker.js
@@ -3091,21 +3091,8 @@ async function callModel(model, prompt, env, { temperature = 0.7, maxTokens = 80
 
 // ------------- START FUNCTION: buildCfImagePayload -------------
 function buildCfImagePayload(model, imageUrl, promptText) {
-    const needsPromptImage = model.includes('llava-1.5') || model.endsWith('-hf');
-    if (needsPromptImage) {
-        return { prompt: promptText, image: imageUrl };
-    }
     if (model.startsWith('@cf/')) {
-        return {
-            messages: [{
-                role: 'user',
-                content: [
-                    { type: 'image_url', image_url: { url: imageUrl } },
-                    { type: 'text', text: promptText }
-                ]
-            }],
-            stream: false
-        };
+        return { prompt: promptText, image: imageUrl };
     }
     return { image: imageUrl };
 }


### PR DESCRIPTION
## Summary
- simplify `buildCfImagePayload` to always send `{prompt, image}` for Cloudflare models
- adjust image analysis tests accordingly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ca6d918388326aa13238acecb08dd