### PR TITLE
Improve sendTestEmail validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,13 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
   ```
   Полетата `recipient`, `subject` и `body` са задължителни. Като алтернатива
   могат да се използват имената `to` и `text`.
+
+  ```bash
+  curl -X POST https://<your-domain>/api/sendTestEmail \
+    -H "Authorization: Bearer <WORKER_ADMIN_TOKEN>" \
+    -H "Content-Type: application/json" \
+    --data '{"to":"someone@example.com","subject":"Тест","text":"Здравей"}'
+  ```
   Ако `MAILER_MODULE_URL` не е конфигуриран, ендпойнтът връща **HTTP 400** с
   `{ "success": false, "message": "Email functionality is not configured." }`.
 - **Дебъг логове** – при изпращане на заглавие `X-Debug: 1` към който и да е API

--- a/admin.html
+++ b/admin.html
@@ -212,9 +212,9 @@
   <details id="testEmailSection" class="card">
     <summary>Тестов имейл</summary>
     <form id="testEmailForm">
-      <label>До:<br><input id="testEmailTo" type="email"></label>
-      <label>Тема:<br><input id="testEmailSubject" type="text"></label>
-      <label>Съдържание:<br><textarea id="testEmailBody" rows="5"></textarea></label>
+      <label>До:<br><input id="testEmailTo" type="email" required></label>
+      <label>Тема:<br><input id="testEmailSubject" type="text" required></label>
+      <label>Съдържание:<br><textarea id="testEmailBody" rows="5" required></textarea></label>
       <button type="submit">Изпрати</button>
     </form>
   </details>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1209,6 +1209,10 @@ async function sendTestEmail() {
     const recipient = testEmailToInput ? testEmailToInput.value.trim() : '';
     const subject = testEmailSubjectInput ? testEmailSubjectInput.value.trim() : '';
     const body = testEmailBodyInput ? testEmailBodyInput.value.trim() : '';
+    if (!recipient || !subject || !body) {
+        alert('Моля попълнете всички полета.');
+        return;
+    }
     try {
         const adminToken = sessionStorage.getItem('adminToken') || localStorage.getItem('adminToken') || '';
         const headers = { 'Content-Type': 'application/json' };

--- a/worker.js
+++ b/worker.js
@@ -1744,13 +1744,13 @@ async function handleSendTestEmailRequest(request, env) {
         const body = data.body ?? data.text;
 
         if (typeof recipient !== 'string' || !recipient) {
-            return { success: false, message: 'Missing field: recipient', statusHint: 400 };
+            return { success: false, message: 'Missing field: recipient (use "recipient" or "to")', statusHint: 400 };
         }
         if (typeof subject !== 'string' || !subject) {
             return { success: false, message: 'Missing field: subject', statusHint: 400 };
         }
         if (typeof body !== 'string' || !body) {
-            return { success: false, message: 'Missing field: body', statusHint: 400 };
+            return { success: false, message: 'Missing field: body (use "body" or "text")', statusHint: 400 };
         }
 
         const sendEmail = await getSendEmail(env);


### PR DESCRIPTION
## Summary
- refine validation errors in `handleSendTestEmailRequest`
- require all test email fields in admin form and client JS
- document alternate field names in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cb0e837bc8326957ce849fe7dc262