### PR TITLE
Clarify analyzeImage imageData format

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,17 @@ In addition to text messages you can upload an image for automatic analysis.
 Open `assistant.html`, choose a file and it will be converted to a Base64 string
 and sent to `/api/analyzeImage` as JSON with fields `userId`, `imageData`,
 `mimeType` and an optional `prompt` describing what you want to see.
+The `imageData` field must contain only the raw Base64 string without a `data:` prefix.
+For example, convert a file in the browser using FileReader:
+```javascript
+const reader = new FileReader();
+reader.onload = () => send({imageData: reader.result.split(",")[1]});
+reader.readAsDataURL(file);
+```
+You can also generate a Base64 string via shell:
+```bash
+base64 -w0 image.jpg > base64.txt
+```
 The worker forwards the image data together with your text prompt to the
 configured vision model and returns a JSON summary describing the detected
 objects or text.


### PR DESCRIPTION
## Summary
- clarify that `/api/analyzeImage` expects `imageData` without a `data:` prefix
- show how to convert a file to Base64 in JS or shell

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cb138a00c8326b8392b053145f594