### PR TITLE
Add MailChannels email worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
 - `POST /api/testAiModel` – проверява връзката с конкретен AI модел.
 - `POST /api/analyzeImage` – анализира качено изображение и връща резултат. Ендпойнтът не изисква `WORKER_ADMIN_TOKEN`, освен ако изрично не сте го добавили като защита.
 - `POST /api/sendTestEmail` – изпраща тестов имейл. Изисква администраторски токен.
+- `POST /api/sendEmail` – изпраща имейл чрез MailChannels. Приема JSON `{ "to": "user@example.com", "subject": "Тема", "text": "Съобщение" }`.
 
   ```bash
   curl -X POST https://<your-domain>/api/testAiModel \
@@ -581,6 +582,10 @@ The worker loads mailing logic only at runtime. Specify a module URL in the
 the worker falls back to a stub implementation and no emails are sent. In that
 case `/api/sendTestEmail` responds with status **400** and a message indicating
 the functionality is disabled.
+
+For a simple setup deploy `sendEmailWorker.js`, which exposes `/api/sendEmail`
+and sends messages via MailChannels. Point `MAILER_MODULE_URL` to the URL of
+this worker so the main service can dispatch emails without relying on Node.js.
 
 The included `mailer.js` relies on `nodemailer` and therefore requires a Node.js
 environment. Run it as a separate service or replace it with a script that calls

--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -1,0 +1,33 @@
+import { jest } from '@jest/globals';
+
+let handleSendEmailRequest;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ handleSendEmailRequest } = await import('../../sendEmailWorker.js'));
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+test('rejects invalid JSON', async () => {
+  const req = { json: async () => { throw new Error('bad'); } };
+  const res = await handleSendEmailRequest(req);
+  expect(res.status).toBe(400);
+});
+
+test('rejects missing fields', async () => {
+  const req = { json: async () => ({}) };
+  const res = await handleSendEmailRequest(req);
+  expect(res.status).toBe(400);
+});
+
+test('calls MailChannels on valid input', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  const req = { json: async () => ({ to: 'a@b.bg', subject: 'S', text: 'B' }) };
+  const res = await handleSendEmailRequest(req);
+  expect(fetch).toHaveBeenCalledWith('https://api.mailchannels.net/tx/v1/send', expect.any(Object));
+  expect(res.status).toBe(200);
+  fetch.mockRestore();
+});

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -1,0 +1,47 @@
+export async function handleSendEmailRequest(request) {
+  try {
+    let data;
+    try {
+      data = await request.json();
+    } catch {
+      return { status: 400, body: { success: false, message: 'Invalid JSON' } };
+    }
+    const { to, subject, text } = data || {};
+    if (
+      typeof to !== 'string' || !to ||
+      typeof subject !== 'string' || !subject ||
+      typeof text !== 'string' || !text
+    ) {
+      return { status: 400, body: { success: false, message: 'Invalid input' } };
+    }
+    const payload = {
+      personalizations: [{ to: [{ email: to }] }],
+      from: { email: 'info@mybody.best' },
+      subject,
+      content: [{ type: 'text/plain', value: text }]
+    };
+    const resp = await fetch('https://api.mailchannels.net/tx/v1/send', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!resp.ok) {
+      return { status: 500, body: { success: false, message: 'Failed to send' } };
+    }
+    return { status: 200, body: { success: true } };
+  } catch (err) {
+    console.error('Error in handleSendEmailRequest:', err);
+    return { status: 500, body: { success: false, message: 'Internal error' } };
+  }
+}
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (request.method === 'POST' && url.pathname === '/api/sendEmail') {
+      const { status, body } = await handleSendEmailRequest(request);
+      return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+    }
+    return new Response('Not Found', { status: 404 });
+  }
+};


### PR DESCRIPTION
## Summary
- create `sendEmailWorker.js` for MailChannels
- document `/api/sendEmail` endpoint and worker setup
- test new worker logic

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cb6a9abc88326801d78164f961cf5