### PR TITLE
Add MailChannels email worker

### DIFF
--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -1,0 +1,40 @@
+import { jest } from '@jest/globals';
+
+let handleSendEmailRequest, sendEmail;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ handleSendEmailRequest, sendEmail } = await import('../../sendEmailWorker.js'));
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+test('rejects invalid JSON', async () => {
+  const req = { json: async () => { throw new Error('bad'); } };
+  const res = await handleSendEmailRequest(req);
+  expect(res.status).toBe(400);
+});
+
+test('rejects missing fields', async () => {
+  const req = { json: async () => ({}) };
+  const res = await handleSendEmailRequest(req);
+  expect(res.status).toBe(400);
+});
+
+test('calls MailChannels on valid input', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  const req = { json: async () => ({ to: 'a@b.bg', subject: 'S', text: 'B' }) };
+  const res = await handleSendEmailRequest(req);
+  expect(fetch).toHaveBeenCalledWith('https://api.mailchannels.net/tx/v1/send', expect.any(Object));
+  expect(res.status).toBe(200);
+  fetch.mockRestore();
+});
+
+test('sendEmail forwards data to MailChannels', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  await sendEmail('t@e.com', 'Hi', 'Body');
+  expect(fetch).toHaveBeenCalledWith('https://api.mailchannels.net/tx/v1/send', expect.any(Object));
+  fetch.mockRestore();
+});

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -1,0 +1,56 @@
+/**
+ * Send an email via MailChannels.
+ * Exported so other modules can reuse the same logic.
+ * @param {string} to recipient address
+ * @param {string} subject email subject line
+ * @param {string} text plain text body
+ */
+export async function sendEmail(to, subject, text) {
+  const payload = {
+    personalizations: [{ to: [{ email: to }] }],
+    from: { email: 'info@mybody.best' },
+    subject,
+    content: [{ type: 'text/plain', value: text }]
+  };
+  const resp = await fetch('https://api.mailchannels.net/tx/v1/send', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!resp.ok) throw new Error('Failed to send');
+}
+
+export async function handleSendEmailRequest(request) {
+  try {
+    let data;
+    try {
+      data = await request.json();
+    } catch {
+      return { status: 400, body: { success: false, message: 'Invalid JSON' } };
+    }
+    const { to, subject, text } = data || {};
+    if (
+      typeof to !== 'string' || !to ||
+      typeof subject !== 'string' || !subject ||
+      typeof text !== 'string' || !text
+    ) {
+      return { status: 400, body: { success: false, message: 'Invalid input' } };
+    }
+    await sendEmail(to, subject, text);
+    return { status: 200, body: { success: true } };
+  } catch (err) {
+    console.error('Error in handleSendEmailRequest:', err);
+    return { status: 500, body: { success: false, message: 'Internal error' } };
+  }
+}
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (request.method === 'POST' && url.pathname === '/api/sendEmail') {
+      const { status, body } = await handleSendEmailRequest(request);
+      return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+    }
+    return new Response('Not Found', { status: 404 });
+  }
+};


### PR DESCRIPTION
## Summary
- create `sendEmailWorker.js` for MailChannels
- wire main worker to call `MAILER_ENDPOINT_URL`
- update docs for the new endpoint
- adjust tests for the email worker

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cb6a9abc88326801d78164f961cf5