### PR TITLE
Improve env var checks for analyzeImage

### DIFF
--- a/js/__tests__/analyzeImage.test.js
+++ b/js/__tests__/analyzeImage.test.js
@@ -115,12 +115,30 @@ describe('handleAnalyzeImageRequest', () => {
     });
   });
 
-  test('fails when CF secrets missing', async () => {
+  test('fails when both CF secrets missing', async () => {
     const env = { RESOURCES_KV: { get: jest.fn().mockResolvedValue(null) } };
     const request = { json: async () => ({ userId: 'u1', imageData: 'img' }) };
     const res = await handleAnalyzeImageRequest(request, env);
     expect(res.success).toBe(false);
-    expect(res.message).toBe('Липсва CF_AI_TOKEN или CF_ACCOUNT_ID.');
+    expect(res.message).toBe('Липсват CF_AI_TOKEN и CF_ACCOUNT_ID.');
+    expect(res.statusHint).toBe(500);
+  });
+
+  test('fails when only CF_AI_TOKEN missing', async () => {
+    const env = { CF_ACCOUNT_ID: 'acc', RESOURCES_KV: { get: jest.fn().mockResolvedValue(null) } };
+    const request = { json: async () => ({ userId: 'u1', imageData: 'img' }) };
+    const res = await handleAnalyzeImageRequest(request, env);
+    expect(res.success).toBe(false);
+    expect(res.message).toBe('Липсва CF_AI_TOKEN.');
+    expect(res.statusHint).toBe(500);
+  });
+
+  test('fails when only CF_ACCOUNT_ID missing', async () => {
+    const env = { CF_AI_TOKEN: 't', RESOURCES_KV: { get: jest.fn().mockResolvedValue(null) } };
+    const request = { json: async () => ({ userId: 'u1', imageData: 'img' }) };
+    const res = await handleAnalyzeImageRequest(request, env);
+    expect(res.success).toBe(false);
+    expect(res.message).toBe('Липсва CF_ACCOUNT_ID.');
     expect(res.statusHint).toBe(500);
   });
 

--- a/worker.js
+++ b/worker.js
@@ -1444,8 +1444,12 @@ async function handleAnalyzeImageRequest(request, env) {
         const provider = getModelProvider(modelName);
 
         if (provider === 'cf') {
-            if (!env[CF_AI_TOKEN_SECRET_NAME] || !(env[CF_ACCOUNT_ID_VAR_NAME] || env.accountId || env.ACCOUNT_ID)) {
-                return { success: false, message: 'Липсва CF_AI_TOKEN или CF_ACCOUNT_ID.', statusHint: 500 };
+            const missing = [];
+            if (!env[CF_AI_TOKEN_SECRET_NAME]) missing.push('CF_AI_TOKEN');
+            if (!(env[CF_ACCOUNT_ID_VAR_NAME] || env.accountId || env.ACCOUNT_ID)) missing.push('CF_ACCOUNT_ID');
+            if (missing.length) {
+                const verb = missing.length > 1 ? 'Липсват' : 'Липсва';
+                return { success: false, message: `${verb} ${missing.join(' и ')}.`, statusHint: 500 };
             }
         } else if (provider === 'gemini') {
             if (!env[GEMINI_API_KEY_SECRET_NAME]) {


### PR DESCRIPTION
## Summary
- detect specific missing secrets in `handleAnalyzeImageRequest`
- return tailored error messages for CF_AI_TOKEN and CF_ACCOUNT_ID
- cover new cases in analyzeImage unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cbe5e130c8326830ccdd83f17d2a8