### PR TITLE
Improve error handling for image analysis

### DIFF
--- a/js/__tests__/analyzeImage.test.js
+++ b/js/__tests__/analyzeImage.test.js
@@ -184,4 +184,24 @@ describe('handleAnalyzeImageRequest', () => {
     expect(res.message).toBe('Невалиден Base64 стринг.');
     expect(res.statusHint).toBe(400);
   });
+
+  test('returns friendly message on Cloudflare decode error', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ errors: [{ message: 'failed to decode u8' }] })
+    });
+    const env = {
+      CF_ACCOUNT_ID: 'acc',
+      CF_AI_TOKEN: 'token',
+      RESOURCES_KV: { get: jest.fn().mockResolvedValue(null) }
+    };
+    const request = {
+      json: async () => ({ userId: 'u1', imageData: 'img', mimeType: 'image/png' })
+    };
+    const res = await handleAnalyzeImageRequest(request, env);
+    expect(res.success).toBe(false);
+    expect(res.message).toBe('Невалидни или повредени данни на изображението.');
+    expect(res.statusHint).toBe(400);
+  });
 });

--- a/worker.js
+++ b/worker.js
@@ -1507,7 +1507,18 @@ async function handleAnalyzeImageRequest(request, env) {
         return { success: true, result: aiResp };
     } catch (error) {
         console.error('Error in handleAnalyzeImageRequest:', error.message, error.stack);
-        return { success: false, message: `Грешка при анализа на изображението: ${error.message}`, statusHint: 500 };
+        if (/failed to decode u8|Tensor error/i.test(error.message)) {
+            return {
+                success: false,
+                message: 'Невалидни или повредени данни на изображението.',
+                statusHint: 400
+            };
+        }
+        return {
+            success: false,
+            message: `Грешка при анализа на изображението: ${error.message}`,
+            statusHint: 500
+        };
     }
 }
 // ------------- END FUNCTION: handleAnalyzeImageRequest -------------


### PR DESCRIPTION
## Summary
- return helpful message for image decode errors
- test cloudflare failure case in image analysis handler

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cc2c312b0832686b7ef6067305d9b