### PR TITLE
Add image header validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,8 @@ Open `assistant.html`, choose a file and it will be converted to a Base64 string
 and sent to `/api/analyzeImage` as JSON with fields `userId`, `imageData`,
 `mimeType` and an optional `prompt` describing what you want to see.
 The `imageData` value may contain either the raw Base64 string or a complete
-`data:` URL. Malformed Base64 will return "Невалиден Base64 стринг.". For raw
+`data:` URL. Malformed Base64 will return "Невалиден Base64 стринг.". Invalid
+file headers yield "Невалиден файлов хедър.". For raw
 strings you can convert a file in the browser using FileReader:
 ```javascript
 const reader = new FileReader();

--- a/js/__tests__/analyzeImage.test.js
+++ b/js/__tests__/analyzeImage.test.js
@@ -1,6 +1,8 @@
 import { jest } from '@jest/globals';
 import { handleAnalyzeImageRequest } from '../../worker.js';
 
+const samplePng = 'iVBORw0KGgo=';
+
 const originalFetch = global.fetch;
 
 describe('handleAnalyzeImageRequest', () => {
@@ -29,7 +31,7 @@ describe('handleAnalyzeImageRequest', () => {
       json: async () => ({ result: { response: 'ok' } })
     });
     const env = { CF_ACCOUNT_ID: 'acc', CF_AI_TOKEN: 'token', RESOURCES_KV: { get: jest.fn().mockResolvedValue(null) } };
-    const request = { json: async () => ({ userId: 'u1', imageData: 'imgdata', mimeType: 'image/png', prompt: 'hi' }) };
+    const request = { json: async () => ({ userId: 'u1', imageData: samplePng, mimeType: 'image/png', prompt: 'hi' }) };
     const res = await handleAnalyzeImageRequest(request, env);
     expect(res.success).toBe(true);
     expect(res.result).toBe('ok');
@@ -42,7 +44,7 @@ describe('handleAnalyzeImageRequest', () => {
     const body = JSON.parse(global.fetch.mock.calls[0][1].body);
     expect(body).toEqual({
       prompt: 'hi',
-      image: 'data:image/png;base64,imgdata'
+      image: `data:image/png;base64,${samplePng}`
     });
   });
 
@@ -56,7 +58,7 @@ describe('handleAnalyzeImageRequest', () => {
       CF_AI_TOKEN: 'token',
       RESOURCES_KV: { get: jest.fn().mockResolvedValue('@cf/custom') }
     };
-    const request = { json: async () => ({ userId: 'u1', imageData: 'img', mimeType: 'image/png', prompt: 'desc' }) };
+    const request = { json: async () => ({ userId: 'u1', imageData: samplePng, mimeType: 'image/png', prompt: 'desc' }) };
     await handleAnalyzeImageRequest(request, env);
     const url = global.fetch.mock.calls[0][0];
     expect(url).toContain('@cf/custom');
@@ -71,12 +73,12 @@ describe('handleAnalyzeImageRequest', () => {
       GEMINI_API_KEY: 'k',
       RESOURCES_KV: { get: jest.fn().mockResolvedValue('gemini-pro-vision') }
     };
-    const request = { json: async () => ({ userId: 'u1', imageData: 'img', mimeType: 'image/png', prompt: 'desc' }) };
+    const request = { json: async () => ({ userId: 'u1', imageData: samplePng, mimeType: 'image/png', prompt: 'desc' }) };
     const res = await handleAnalyzeImageRequest(request, env);
     expect(res.success).toBe(true);
     expect(res.result).toBe('ok');
     const body = JSON.parse(global.fetch.mock.calls[0][1].body);
-    expect(body.contents[0].parts[0].inlineData.data).toBe('img');
+    expect(body.contents[0].parts[0].inlineData.data).toBe(samplePng);
     expect(body.contents[0].parts[0].inlineData.mimeType).toBe('image/png');
     expect(body.contents[0].parts[1].text).toBe('desc');
   });
@@ -90,7 +92,7 @@ describe('handleAnalyzeImageRequest', () => {
       GEMINI_API_KEY: 'k',
       RESOURCES_KV: { get: jest.fn().mockResolvedValue('gemini-pro-vision') }
     };
-    const request = { json: async () => ({ userId: 'u1', imageData: 'img', mimeType: 'image/png' }) };
+    const request = { json: async () => ({ userId: 'u1', imageData: samplePng, mimeType: 'image/png' }) };
     await handleAnalyzeImageRequest(request, env);
     const body = JSON.parse(global.fetch.mock.calls[0][1].body);
     expect(body.contents[0].parts[1].text).toBe('Опиши съдържанието на това изображение.');
@@ -106,18 +108,18 @@ describe('handleAnalyzeImageRequest', () => {
       CF_AI_TOKEN: 'token',
       RESOURCES_KV: { get: jest.fn().mockResolvedValue('@cf/llava-hf/llava-1.5-7b-hf') }
     };
-    const request = { json: async () => ({ userId: 'u1', imageData: 'img', mimeType: 'image/png', prompt: 'desc' }) };
+    const request = { json: async () => ({ userId: 'u1', imageData: samplePng, mimeType: 'image/png', prompt: 'desc' }) };
     await handleAnalyzeImageRequest(request, env);
     const body = JSON.parse(global.fetch.mock.calls[0][1].body);
     expect(body).toEqual({
       prompt: 'desc',
-      image: 'data:image/png;base64,img'
+      image: `data:image/png;base64,${samplePng}`
     });
   });
 
   test('fails when both CF secrets missing', async () => {
     const env = { RESOURCES_KV: { get: jest.fn().mockResolvedValue(null) } };
-    const request = { json: async () => ({ userId: 'u1', imageData: 'img' }) };
+    const request = { json: async () => ({ userId: 'u1', imageData: samplePng }) };
     const res = await handleAnalyzeImageRequest(request, env);
     expect(res.success).toBe(false);
     expect(res.message).toBe('Липсват CF_AI_TOKEN и CF_ACCOUNT_ID.');
@@ -126,7 +128,7 @@ describe('handleAnalyzeImageRequest', () => {
 
   test('fails when only CF_AI_TOKEN missing', async () => {
     const env = { CF_ACCOUNT_ID: 'acc', RESOURCES_KV: { get: jest.fn().mockResolvedValue(null) } };
-    const request = { json: async () => ({ userId: 'u1', imageData: 'img' }) };
+    const request = { json: async () => ({ userId: 'u1', imageData: samplePng }) };
     const res = await handleAnalyzeImageRequest(request, env);
     expect(res.success).toBe(false);
     expect(res.message).toBe('Липсва CF_AI_TOKEN.');
@@ -135,7 +137,7 @@ describe('handleAnalyzeImageRequest', () => {
 
   test('fails when only CF_ACCOUNT_ID missing', async () => {
     const env = { CF_AI_TOKEN: 't', RESOURCES_KV: { get: jest.fn().mockResolvedValue(null) } };
-    const request = { json: async () => ({ userId: 'u1', imageData: 'img' }) };
+    const request = { json: async () => ({ userId: 'u1', imageData: samplePng }) };
     const res = await handleAnalyzeImageRequest(request, env);
     expect(res.success).toBe(false);
     expect(res.message).toBe('Липсва CF_ACCOUNT_ID.');
@@ -144,7 +146,7 @@ describe('handleAnalyzeImageRequest', () => {
 
   test('fails when GEMINI_API_KEY missing', async () => {
     const env = { RESOURCES_KV: { get: jest.fn().mockResolvedValue('gemini-pro-vision') } };
-    const request = { json: async () => ({ userId: 'u1', imageData: 'img' }) };
+    const request = { json: async () => ({ userId: 'u1', imageData: samplePng }) };
     const res = await handleAnalyzeImageRequest(request, env);
     expect(res.success).toBe(false);
     expect(res.message).toBe('Липсва GEMINI_API_KEY.');
@@ -171,10 +173,10 @@ describe('handleAnalyzeImageRequest', () => {
       json: async () => ({ result: { response: 'ok' } })
     });
     const env = { CF_ACCOUNT_ID: 'acc', CF_AI_TOKEN: 'token', RESOURCES_KV: { get: jest.fn().mockResolvedValue(null) } };
-    const request = { json: async () => ({ userId: 'u1', imageData: 'data:image/png;base64,aGVsbG8=' }) };
+    const request = { json: async () => ({ userId: 'u1', imageData: `data:image/png;base64,${samplePng}` }) };
     await handleAnalyzeImageRequest(request, env);
     const body = JSON.parse(global.fetch.mock.calls[0][1].body);
-    expect(body.image).toBe('data:image/png;base64,aGVsbG8=');
+    expect(body.image).toBe(`data:image/png;base64,${samplePng}`);
   });
 
   test('returns 400 on invalid base64', async () => {
@@ -182,6 +184,14 @@ describe('handleAnalyzeImageRequest', () => {
     const res = await handleAnalyzeImageRequest(request, {});
     expect(res.success).toBe(false);
     expect(res.message).toBe('Невалиден Base64 стринг.');
+    expect(res.statusHint).toBe(400);
+  });
+
+  test('returns 400 on invalid image header', async () => {
+    const bad = Buffer.from('hello').toString('base64');
+    const request = { json: async () => ({ userId: 'u1', imageData: bad }) };
+    const res = await handleAnalyzeImageRequest(request, {});
+    expect(res.success).toBe(false);
     expect(res.statusHint).toBe(400);
   });
 });

--- a/worker.js
+++ b/worker.js
@@ -1453,6 +1453,14 @@ async function handleAnalyzeImageRequest(request, env) {
             return { success: false, message: 'Невалиден Base64 стринг.', statusHint: 400 };
         }
 
+        const buf = Buffer.from(base64, 'base64');
+        const isJpeg = buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff;
+        const pngHeader = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+        const isPng = pngHeader.every((b, i) => buf[i] === b);
+        if (!isJpeg && !isPng) {
+            return { success: false, message: 'Невалиден файлов хедър.', statusHint: 400 };
+        }
+
         const modelFromKv = env.RESOURCES_KV ? await env.RESOURCES_KV.get('model_image_analysis') : null;
         let kvPrompt = null;
         if (env.RESOURCES_KV) {


### PR DESCRIPTION
## Summary
- validate JPEG/PNG headers after decoding uploaded images
- update README with new validation error
- fix analyzeImage tests to use real base64 data and cover invalid header

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cc2bb74c8832699251178dd114dc4