### PR TITLE
Enable direct MailChannels email fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ To set the token:
 
 The worker configuration is stored in `wrangler.toml`. Update `account_id` with your Cloudflare account if needed. For the `USER_METADATA_KV` namespace the file expects the environment variables `USER_METADATA_KV_ID` and `USER_METADATA_KV_PREVIEW_ID`. Configure them as GitHub secrets so the workflow can substitute the correct IDs before deployment. **Важно:** полето `compatibility_date` не може да сочи в бъдещето спрямо датата на деплой. Ако е зададена по-нова дата, Cloudflare ще откаже деплойването. Затова поддържайте стойност, която е днес или по-стара. Например:
 
-If mailing is required, set `MAILER_ENDPOINT_URL` to the URL of the standalone worker that sends emails. Omitting this variable disables email sending in the deployed worker. Without it the `/api/sendTestEmail` endpoint returns a 400 status indicating the feature is disabled.
+For email notifications you may set `MAILER_ENDPOINT_URL` to point to a standalone worker or service that performs the delivery. If the variable is omitted, the main worker still sends emails directly via MailChannels using the `FROM_EMAIL` address.
 
 ```toml
 compatibility_date = "2025-06-20"
@@ -260,6 +260,7 @@ Before deploying, configure the following secrets in Cloudflare (via the dashboa
 - `тут_ваш_php_api_token_secret_name`
 - `CF_AI_TOKEN` – API token used for Cloudflare AI requests
 - `OPENAI_API_KEY` – set via `wrangler secret put OPENAI_API_KEY`, used by `worker.js`
+- `FROM_EMAIL` – optional sender address for outgoing emails
 
 Без тази стойност част от AI функционалностите няма да работят.
 
@@ -568,8 +569,9 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
     -H "Content-Type: application/json" \
     --data '{"to":"someone@example.com","subject":"Тест","text":"Здравей"}'
   ```
-  Ако `MAILER_ENDPOINT_URL` не е конфигуриран, ендпойнтът връща **HTTP 400** с
-  `{ "success": false, "message": "Email functionality is not configured." }`.
+  Ако `MAILER_ENDPOINT_URL` не е зададен, работникът изпраща имейла директно
+  чрез MailChannels, използвайки адреса от `FROM_EMAIL` (по подразбиране
+  `info@mybody.best`).
 - **Дебъг логове** – при изпращане на заглавие `X-Debug: 1` към който и да е API
 ендпойнт, worker-ът записва в конзолата кратка информация за заявката.
 
@@ -600,11 +602,15 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
 
 ## Email Notifications
 
-The worker sends emails by calling a separate endpoint specified in the
-`MAILER_ENDPOINT_URL` environment variable. If this variable is not provided
-the worker falls back to a stub implementation and no emails are sent. In that
-case `/api/sendTestEmail` responds with status **400** and a message indicating
-the functionality is disabled.
+The worker can send emails in two ways:
+
+1. If `MAILER_ENDPOINT_URL` is set, requests are forwarded to that endpoint
+   (for example a standalone worker) which handles the actual delivery.
+2. Otherwise the worker sends messages directly via MailChannels using the
+   address from `FROM_EMAIL` (defaults to `info@mybody.best`).
+
+In both cases the `/api/sendTestEmail` endpoint behaves the same and returns a
+JSON response indicating success or failure.
 
 To enable real emails:
 

--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -13,20 +13,20 @@ afterEach(() => {
 
 test('rejects invalid JSON', async () => {
   const req = { json: async () => { throw new Error('bad'); } };
-  const res = await handleSendEmailRequest(req);
+  const res = await handleSendEmailRequest(req, { FROM_EMAIL: 'info@mybody.best' });
   expect(res.status).toBe(400);
 });
 
 test('rejects missing fields', async () => {
   const req = { json: async () => ({}) };
-  const res = await handleSendEmailRequest(req);
+  const res = await handleSendEmailRequest(req, { FROM_EMAIL: 'info@mybody.best' });
   expect(res.status).toBe(400);
 });
 
 test('calls MailChannels on valid input', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true });
   const req = { json: async () => ({ to: 'a@b.bg', subject: 'S', text: 'B' }) };
-  const res = await handleSendEmailRequest(req);
+  const res = await handleSendEmailRequest(req, { FROM_EMAIL: 'info@mybody.best' });
   expect(fetch).toHaveBeenCalledWith('https://api.mailchannels.net/tx/v1/send', expect.any(Object));
   expect(res.status).toBe(200);
   fetch.mockRestore();
@@ -34,7 +34,7 @@ test('calls MailChannels on valid input', async () => {
 
 test('sendEmail forwards data to MailChannels', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true });
-  await sendEmail('t@e.com', 'Hi', 'Body');
+  await sendEmail('t@e.com', 'Hi', 'Body', { FROM_EMAIL: 'info@mybody.best' });
   expect(fetch).toHaveBeenCalledWith('https://api.mailchannels.net/tx/v1/send', expect.any(Object));
   fetch.mockRestore();
 });

--- a/js/__tests__/sendTestEmailRequest.test.js
+++ b/js/__tests__/sendTestEmailRequest.test.js
@@ -71,13 +71,14 @@ test('supports alternate field names', async () => {
   expect(fetch).toHaveBeenCalledWith('https://mail.example.com', expect.any(Object));
 });
 
-test('returns 400 when mailer is not configured', async () => {
+test('falls back to MailChannels when endpoint missing', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })
   };
-  const env = { WORKER_ADMIN_TOKEN: 'secret' };
+  const env = { WORKER_ADMIN_TOKEN: 'secret', FROM_EMAIL: 'info@mybody.best' };
   const res = await handleSendTestEmailRequest(request, env);
-  expect(res.success).toBe(false);
-  expect(res.statusHint).toBe(400);
+  expect(res.success).toBe(true);
+  expect(fetch).toHaveBeenCalledWith('https://api.mailchannels.net/tx/v1/send', expect.any(Object));
 });

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -5,10 +5,11 @@
  * @param {string} subject email subject line
  * @param {string} text plain text body
  */
-export async function sendEmail(to, subject, text) {
+export async function sendEmail(to, subject, text, env = {}) {
+  const fromEmail = env.FROM_EMAIL || 'info@mybody.best';
   const payload = {
     personalizations: [{ to: [{ email: to }] }],
-    from: { email: 'info@mybody.best' },
+    from: { email: fromEmail },
     subject,
     content: [{ type: 'text/plain', value: text }]
   };
@@ -20,7 +21,7 @@ export async function sendEmail(to, subject, text) {
   if (!resp.ok) throw new Error('Failed to send');
 }
 
-export async function handleSendEmailRequest(request) {
+export async function handleSendEmailRequest(request, env = {}) {
   try {
     let data;
     try {
@@ -36,7 +37,7 @@ export async function handleSendEmailRequest(request) {
     ) {
       return { status: 400, body: { success: false, message: 'Invalid input' } };
     }
-    await sendEmail(to, subject, text);
+    await sendEmail(to, subject, text, env);
     return { status: 200, body: { success: true } };
   } catch (err) {
     console.error('Error in handleSendEmailRequest:', err);
@@ -45,12 +46,45 @@ export async function handleSendEmailRequest(request) {
 }
 
 export default {
-  async fetch(request) {
+  async fetch(request, env) {
+    const defaultAllowedOrigins = [
+      'https://radilovk.github.io',
+      'https://radilov-k.github.io',
+      'http://localhost:5173',
+      'http://localhost:3000',
+      'null'
+    ];
+    const allowedOrigins = Array.from(new Set(
+      (env.ALLOWED_ORIGINS
+        ? env.ALLOWED_ORIGINS.split(',').map(o => o.trim()).filter(Boolean)
+        : [])
+        .concat(defaultAllowedOrigins)
+    ));
+    const requestOrigin = request.headers.get('Origin');
+    const originToSend = requestOrigin === null
+      ? 'null'
+      : allowedOrigins.includes(requestOrigin) ? requestOrigin : allowedOrigins[0];
+    const corsHeaders = {
+      'Access-Control-Allow-Origin': originToSend,
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      'Vary': 'Origin'
+    };
+
     const url = new URL(request.url);
-    if (request.method === 'POST' && url.pathname === '/api/sendEmail') {
-      const { status, body } = await handleSendEmailRequest(request);
-      return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders });
     }
-    return new Response('Not Found', { status: 404 });
+
+    if (request.method === 'POST' && url.pathname === '/api/sendEmail') {
+      const { status, body } = await handleSendEmailRequest(request, env);
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders }
+      });
+    }
+
+    return new Response('Not Found', { status: 404, headers: corsHeaders });
   }
 };


### PR DESCRIPTION
## Summary
- allow `worker.js` to send emails directly via MailChannels when `MAILER_ENDPOINT_URL` isn't set
- make `FROM_EMAIL` configurable and reuse it in `sendEmailWorker.js`
- add dynamic CORS headers to `sendEmailWorker.js`
- update email-related tests for the new behaviour
- document the new environment variable and behaviour in `README`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cc1d386cc8326bd3618a77056d241