### PR TITLE
Switch email worker to php backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,7 +648,7 @@ MAILER_ENDPOINT_URL = "https://send-email-worker.example.workers.dev"
 ```
 
 For a simple setup deploy `sendEmailWorker.js`, which exposes `/api/sendEmail`
-and sends messages via MailChannels. Point `MAILER_ENDPOINT_URL` to the URL of
+and sends messages via a PHP backend. Point `MAILER_ENDPOINT_URL` to the URL of
 this worker so the main service can dispatch emails without relying on Node.js.
 
 The included `mailer.js` relies on `nodemailer` and therefore requires a Node.js
@@ -661,6 +661,7 @@ an external provider such as Cloudflare
 | Variable | Purpose |
 |----------|---------|
 | `MAILER_ENDPOINT_URL` | Endpoint called by `worker.js` when sending emails. If omitted, the worker sends via MailChannels using `FROM_EMAIL`. |
+| `MAIL_PHP_URL` | Endpoint used by `sendEmailWorker.js` to deliver messages. Defaults to `https://mybody.best/mail.php`. |
 | `EMAIL_PASSWORD` | Password used by `mailer.js` when authenticating with the SMTP server. |
 | `WELCOME_EMAIL_SUBJECT` | Optional custom subject for welcome emails sent by `mailer.js`. |
 | `WELCOME_EMAIL_BODY` | Optional HTML body template for welcome emails. The string `{{name}}` will be replaced with the recipient's name. |

--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -23,18 +23,18 @@ test('rejects missing fields', async () => {
   expect(res.status).toBe(400);
 });
 
-test('calls MailChannels on valid input', async () => {
+test('calls PHP endpoint on valid input', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true });
   const req = { json: async () => ({ to: 'a@b.bg', subject: 'S', text: 'B' }) };
-  const res = await handleSendEmailRequest(req, { FROM_EMAIL: 'info@mybody.best' });
-  expect(fetch).toHaveBeenCalledWith('https://api.mailchannels.net/tx/v1/send', expect.any(Object));
+  const res = await handleSendEmailRequest(req, { MAIL_PHP_URL: 'https://mybody.best/mail.php' });
+  expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail.php', expect.any(Object));
   expect(res.status).toBe(200);
   fetch.mockRestore();
 });
 
-test('sendEmail forwards data to MailChannels', async () => {
+test('sendEmail forwards data to PHP endpoint', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true });
-  await sendEmail('t@e.com', 'Hi', 'Body', { FROM_EMAIL: 'info@mybody.best' });
-  expect(fetch).toHaveBeenCalledWith('https://api.mailchannels.net/tx/v1/send', expect.any(Object));
+  await sendEmail('t@e.com', 'Hi', 'Body', { MAIL_PHP_URL: 'https://mybody.best/mail.php' });
+  expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail.php', expect.any(Object));
   fetch.mockRestore();
 });

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -1,19 +1,14 @@
 /**
- * Send an email via MailChannels.
+ * Send an email via a PHP backend.
  * Exported so other modules can reuse the same logic.
  * @param {string} to recipient address
  * @param {string} subject email subject line
  * @param {string} text plain text body
  */
 export async function sendEmail(to, subject, text, env = {}) {
-  const fromEmail = env.FROM_EMAIL || 'info@mybody.best';
-  const payload = {
-    personalizations: [{ to: [{ email: to }] }],
-    from: { email: fromEmail },
-    subject,
-    content: [{ type: 'text/plain', value: text }]
-  };
-  const resp = await fetch('https://api.mailchannels.net/tx/v1/send', {
+  const endpoint = env.MAIL_PHP_URL || 'https://mybody.best/mail.php';
+  const payload = { to, subject, body: text };
+  const resp = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- update email worker to post to `https://mybody.best/mail.php`
- adjust email worker tests for new endpoint
- document `MAIL_PHP_URL` environment variable

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ddc92dbd08326aa4c5f4d41fb8614