### PR TITLE
Add PHP mail example and doc note

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,11 +661,12 @@ an external provider such as Cloudflare
 | Variable | Purpose |
 |----------|---------|
 | `MAILER_ENDPOINT_URL` | Endpoint called by `worker.js` when sending emails. If omitted, the worker sends via MailChannels using `FROM_EMAIL`. |
-| `MAIL_PHP_URL` | Endpoint used by `sendEmailWorker.js` to deliver messages. Defaults to `https://mybody.best/mail.php`. |
+| `MAIL_PHP_URL` | Endpoint used by `sendEmailWorker.js` to deliver messages. Defaults to `https://mybody.best/mail.php`. Set this to the public URL of the script from [docs/mail.php](docs/mail.php). |
 | `EMAIL_PASSWORD` | Password used by `mailer.js` when authenticating with the SMTP server. |
 | `WELCOME_EMAIL_SUBJECT` | Optional custom subject for welcome emails sent by `mailer.js`. |
 | `WELCOME_EMAIL_BODY` | Optional HTML body template for welcome emails. The string `{{name}}` will be replaced with the recipient's name. |
 | `WORKER_URL` | Base URL of the main worker used by `mailer.js` to fetch email templates when no subject or body is provided. |
+Примерен PHP скрипт за изпращане на писма е наличен в [docs/mail.php](docs/mail.php). Настройте `MAIL_PHP_URL` да сочи към същия или сходен адрес.
 
 ## Cron configuration
 

--- a/docs/mail.php
+++ b/docs/mail.php
@@ -1,0 +1,24 @@
+<?php
+// docs/mail.php - example endpoint used by sendEmailWorker.js
+// Accepts JSON {to, subject, body} and sends the email.
+// Adjust authentication and SMTP settings as needed.
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!isset($input['to'], $input['subject'], $input['body'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Invalid input']);
+    exit;
+}
+
+$to = $input['to'];
+$subject = $input['subject'];
+$body = $input['body'];
+$headers = "Content-Type: text/plain; charset=UTF-8\r\n";
+
+if (mail($to, $subject, $body, $headers)) {
+    echo json_encode(['success' => true]);
+} else {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Failed to send']);
+}
+


### PR DESCRIPTION
## Summary
- add PHP script example for sending emails
- link to the PHP example in README
- mention MAIL_PHP_URL must point to that script

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685dee9ec7a883268499344c911e03ac