### PR TITLE
Log admin requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,14 @@ node scripts/repair-log.js <userId> <YYYY-MM-DD>
 Скриптът изтегля стойността от `USER_METADATA_KV`, опитва да я поправи с помощта
 на `jsonrepair` и я записва обратно, ако корекцията е успешна.
 
+За преглед на логовете от администраторските операции използвайте `view-usage-logs.js`:
+
+```bash
+node scripts/view-usage-logs.js sendTestEmail 5
+```
+
+Скриптът показва последните N записа за зададения тип (`sendTestEmail` или `analyzeImage`).
+
 ### Задължителни ключове в `RESOURCES_KV`
 
 Следните ключове трябва да са налични в KV пространството `RESOURCES_KV`, за да

--- a/js/__tests__/analyzeImage.test.js
+++ b/js/__tests__/analyzeImage.test.js
@@ -246,4 +246,26 @@ describe('handleAnalyzeImageRequest', () => {
     expect(res.message).toBe('Невалидни или повредени данни на изображението.');
     expect(res.statusHint).toBe(400);
   });
+
+  test('records usage in USER_METADATA_KV', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { response: 'ok' } })
+    });
+    const env = {
+      CF_ACCOUNT_ID: 'acc',
+      CF_AI_TOKEN: 'token',
+      RESOURCES_KV: { get: jest.fn().mockResolvedValue(null) },
+      USER_METADATA_KV: { put: jest.fn() }
+    };
+    const request = {
+      headers: { get: () => null },
+      json: async () => ({ userId: 'u1', image: `data:image/png;base64,${validPng}` })
+    };
+    await handleAnalyzeImageRequest(request, env);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
+      expect.stringMatching(/^usage_analyzeImage_/),
+      expect.any(String)
+    );
+  });
 });

--- a/preworker.js
+++ b/preworker.js
@@ -1446,6 +1446,12 @@ async function handleAnalyzeImageRequest(request, env) {
     } catch {
         return { success: false, message: 'Невалиден JSON.', statusHint: 400 };
     }
+    await recordUsage(
+        env,
+        'analyzeImage',
+        (request.headers?.get?.('Authorization') || '').replace(/^Bearer\s+/i, '').trim() ||
+            request.headers?.get?.('CF-Connecting-IP') || ''
+    );
     try {
         const { userId, image, imageData, mimeType, prompt } = payloadData;
         if (!userId || (!image && !imageData)) {
@@ -1851,8 +1857,13 @@ async function handleTestAiModelRequest(request, env) {
 // ------------- START FUNCTION: handleSendTestEmailRequest -------------
 async function handleSendTestEmailRequest(request, env) {
     try {
-        const auth = request.headers.get('Authorization') || '';
+        const auth = request.headers?.get?.('Authorization') || '';
         const token = auth.replace(/^Bearer\s+/i, '').trim();
+        await recordUsage(
+            env,
+            'sendTestEmail',
+            token || request.headers?.get?.('CF-Connecting-IP') || ''
+        );
         const expected = env[WORKER_ADMIN_TOKEN_SECRET_NAME];
         if (expected && token !== expected) {
             return { success: false, message: 'Невалиден токен.', statusHint: 403 };
@@ -2636,6 +2647,20 @@ const safeGet = (obj, path, defaultValue = null) => { try { const keys = Array.i
 // ------------- START FUNCTION: safeParseFloat -------------
 const safeParseFloat = (val, defaultVal = null) => { if (val === null || val === undefined || String(val).trim() === '') return defaultVal; const num = parseFloat(String(val).replace(',', '.')); return isNaN(num) ? defaultVal : num; };
 // ------------- END FUNCTION: safeParseFloat -------------
+
+// ------------- START FUNCTION: recordUsage -------------
+async function recordUsage(env, type, identifier = '') {
+    try {
+        if (env.USER_METADATA_KV && typeof env.USER_METADATA_KV.put === 'function') {
+            const key = `usage_${type}_${Date.now()}`;
+            const entry = { ts: new Date().toISOString(), id: identifier };
+            await env.USER_METADATA_KV.put(key, JSON.stringify(entry));
+        }
+    } catch (err) {
+        console.error('Failed to record usage:', err.message);
+    }
+}
+// ------------- END FUNCTION: recordUsage -------------
 
 // ------------- START FUNCTION: safeParseJson -------------
 const safeParseJson = (jsonString, defaultValue = null) => {

--- a/scripts/view-usage-logs.js
+++ b/scripts/view-usage-logs.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { spawnSync } from 'child_process';
+
+const [type = 'sendTestEmail', limit = '10', binding = 'USER_METADATA_KV'] = process.argv.slice(2);
+const prefix = `usage_${type}_`;
+
+function run(cmd, args) {
+  return spawnSync(cmd, args, { encoding: 'utf8' });
+}
+
+const list = run('wrangler', ['kv', 'key', 'list', '--binding', binding, '--prefix', prefix]);
+if (list.error) {
+  console.error('Failed to list keys:', list.error.message);
+  process.exit(1);
+}
+const keys = JSON.parse(list.stdout || '{}').keys || [];
+keys.sort((a, b) => a.name.localeCompare(b.name));
+const recent = keys.slice(-parseInt(limit, 10));
+for (const k of recent) {
+  const get = run('wrangler', ['kv', 'key', 'get', k.name, '--binding', binding]);
+  if (get.error) {
+    console.error('Failed to get', k.name, get.error.message);
+    continue;
+  }
+  const val = get.stdout.trim();
+  try {
+    const obj = JSON.parse(val);
+    console.log(`${k.name}:`, obj);
+  } catch {
+    console.log(`${k.name}:`, val);
+  }
+}


### PR DESCRIPTION
## Summary
- track admin test email and image analysis requests
- add `recordUsage` helper
- create `view-usage-logs.js` CLI tool
- test usage logging
- document usage log viewer in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685df32948a4832685d4141f95404c25