### PR TITLE
Add Buffer import to workers

### DIFF
--- a/preworker.js
+++ b/preworker.js
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 // Cloudflare Worker Script (index.js) - Версия 2.3
 // Добавен е режим за дебъг чрез HTTP заглавие `X-Debug: 1`
 // Също така са запазени всички функционалности от предходните версии

--- a/worker.js
+++ b/worker.js
@@ -1,4 +1,5 @@
 /// <reference types="node" />
+import { Buffer } from 'buffer';
 // Cloudflare Worker Script (index.js) - Версия 2.3
 // Добавен е режим за дебъг чрез HTTP заглавие `X-Debug: 1`
 // Също така са запазени всички функционалности от предходните версии


### PR DESCRIPTION
## Summary
- ensure Buffer is imported in both worker.js and preworker.js
- keep Node type definitions in tsconfig.json

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685df509c6e083268a18402167bc03b1