### PR TITLE
Add TypeScript check instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Check the source code with ESLint (see `eslint.config.js` for configuration):
 npm run lint
 ```
 
+### Type Check
+
+Make sure dependencies are installed (`npm ci` or `npm install`) before running the TypeScript compiler in check mode:
+
+```bash
+npx tsc --noEmit
+```
+
 ### Инсталация на зависимости
 
 Преди да стартирате тестовете, инсталирайте необходимите зависимости, за да бъде
@@ -154,12 +162,6 @@ Create API documentation using Typedoc:
 npm run docs
 ```
 The output is placed in the `docs/` folder.
-
-Type-check the source with:
-
-```bash
-npx tsc --noEmit
-```
 
 ### Template Loading
 


### PR DESCRIPTION
## Summary
- document how to verify TypeScript types
- remove duplicated `tsc` snippet

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685dfab7d8d0832683d292b7b2f2e07c