### PR TITLE
Update tsconfig libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "nodemailer": "^7.0.3"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250627.0",
         "@eslint/js": "^8.57.1",
         "@types/node": "latest",
         "eslint": "^8.57.1",
@@ -557,6 +558,13 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20250627.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250627.0.tgz",
+      "integrity": "sha512-1il2InPF6NwucUwDl9RL6KLUfJuqaLazGTa9IZRO/XqMFggtGOXuc9X9wZ+IH1PTOWkdJ+jN+woyjj0W2CcTKg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -19,14 +19,15 @@
     "node": ">=18"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250627.0",
     "@eslint/js": "^8.57.1",
+    "@types/node": "latest",
     "eslint": "^8.57.1",
     "globals": "^16.2.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0",
     "typedoc": "^0.28.5",
-    "vite": "^6.3.5",
-    "@types/node": "latest"
+    "vite": "^6.3.5"
   },
   "dependencies": {
     "dotenv": "^16.5.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "moduleResolution": "nodenext",
     "allowJs": true,
     "resolveJsonModule": true,
-    "types": ["node"]
+    "types": ["@cloudflare/workers-types", "node"],
+    "lib": ["es2020", "dom"],
+    "skipLibCheck": true
   },
   "include": [
     "worker.js",


### PR DESCRIPTION
## Summary
- support Cloudflare Workers by adding lib and types configuration
- include workers type definitions as a dev dependency

## Testing
- `npm run lint`
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685dfab0bb2c8326baca8c097df7fb21