### PR TITLE
Improve email error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ The worker can send emails in two ways:
 
 In both cases the `/api/sendTestEmail` endpoint behaves the same and returns a
 JSON response indicating success or failure.
-A status **500** typically means MailChannels or your external service failed and should be investigated via the worker logs.
+A status **500** typically means MailChannels or your external service failed and should be investigated via the worker logs. When this occurs the worker includes the underlying error message (or the HTTP status) in the response so you can see exactly why the request failed.
 
 To enable real emails:
 

--- a/js/__tests__/sendTestEmailRequest.test.js
+++ b/js/__tests__/sendTestEmailRequest.test.js
@@ -119,3 +119,16 @@ test('rate limits excessive requests', async () => {
   expect(res.success).toBe(false);
   expect(res.statusHint).toBe(429);
 });
+
+test('returns error details when sendEmail fails', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 502 });
+  const request = {
+    headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
+    json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })
+  };
+  const env = { WORKER_ADMIN_TOKEN: 'secret', MAILER_ENDPOINT_URL: 'https://mail.example.com' };
+  const res = await handleSendTestEmailRequest(request, env);
+  expect(res.success).toBe(false);
+  expect(res.message).toMatch('502');
+  expect(res.statusHint).toBe(502);
+});

--- a/worker.js
+++ b/worker.js
@@ -1905,8 +1905,18 @@ async function handleSendTestEmailRequest(request, env) {
                 statusHint: 400
             };
         }
-        await sendEmail(recipient, subject, body);
-        return { success: true };
+        try {
+            await sendEmail(recipient, subject, body);
+            return { success: true };
+        } catch (err) {
+            const statusMatch = /\d{3}/.exec(err?.message ?? '');
+            const hint = err?.status || err?.statusCode || (statusMatch ? Number(statusMatch[0]) : 500);
+            return {
+                success: false,
+                message: `Грешка при изпращане: ${err?.message ?? hint}`,
+                statusHint: hint
+            };
+        }
     } catch (error) {
         console.error('Error in handleSendTestEmailRequest:', error.message, error.stack);
         return { success: false, message: 'Грешка при изпращане.', statusHint: 500 };


### PR DESCRIPTION
## Summary
- improve `handleSendTestEmailRequest` so failed email attempts return the underlying error or HTTP status
- test that the function exposes failure details
- document the returned error message in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e06a53cb08326bae61a887e842d8a