### PR TITLE
Remove MailChannels fallback

### DIFF
--- a/js/__tests__/sendTestEmailRequest.test.js
+++ b/js/__tests__/sendTestEmailRequest.test.js
@@ -71,16 +71,16 @@ test('supports alternate field names', async () => {
   expect(fetch).toHaveBeenCalledWith('https://mail.example.com', expect.any(Object));
 });
 
-test('falls back to MailChannels when endpoint missing', async () => {
+test('uses PHP mail endpoint when MAILER_ENDPOINT_URL missing', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })
   };
-  const env = { WORKER_ADMIN_TOKEN: 'secret', FROM_EMAIL: 'info@mybody.best' };
+  const env = { WORKER_ADMIN_TOKEN: 'secret', MAIL_PHP_URL: 'https://mybody.best/mail.php' };
   const res = await handleSendTestEmailRequest(request, env);
   expect(res.success).toBe(true);
-  expect(fetch).toHaveBeenCalledWith('https://api.mailchannels.net/tx/v1/send', expect.any(Object));
+  expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail.php', expect.any(Object));
 });
 
 test('records usage in USER_METADATA_KV', async () => {

--- a/worker.js
+++ b/worker.js
@@ -25,6 +25,8 @@
 async function defaultSendEmail(to, subject, body) {
     throw new Error('Email functionality is not configured.');
 }
+import { sendEmail as phpSendEmail } from './sendEmailWorker.js';
+
 /** @type {(to: string, subject: string, body: string) => Promise<void>} */
 let sendEmailFn = defaultSendEmail;
 const MAILER_ENDPOINT_URL_VAR_NAME = 'MAILER_ENDPOINT_URL';
@@ -41,25 +43,9 @@ async function getSendEmail(env) {
             });
             if (!resp.ok) throw new Error(`Mailer responded with ${resp.status}`);
         };
-        return sendEmailFn;
+    } else {
+        sendEmailFn = (to, subject, body) => phpSendEmail(to, subject, body, env);
     }
-
-    console.warn('MAILER_ENDPOINT_URL not configured; falling back to MailChannels');
-    const fromEmail = env?.[FROM_EMAIL_VAR_NAME] || 'info@mybody.best';
-    sendEmailFn = async (to, subject, body) => {
-        const payload = {
-            personalizations: [{ to: [{ email: to }] }],
-            from: { email: fromEmail },
-            subject,
-            content: [{ type: 'text/plain', value: body }]
-        };
-        const resp = await fetch('https://api.mailchannels.net/tx/v1/send', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload)
-        });
-        if (!resp.ok) throw new Error(`MailChannels responded with ${resp.status}`);
-    };
     return sendEmailFn;
 }
 


### PR DESCRIPTION
## Summary
- rely on `sendEmailWorker.js` when `MAILER_ENDPOINT_URL` is missing
- update tests for new behaviour
- clarify README around email delivery

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e00b28d4c8326b556ac32162e0d6c