### PR TITLE
Add email debugging and PHPMailer example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules/
 dist/
 .eslintcache
 docs/
+!docs/mail_smtp.php
 .env

--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ an external provider.
 | `WELCOME_EMAIL_BODY` | Optional HTML body template for welcome emails. The string `{{name}}` will be replaced with the recipient's name. |
 | `WORKER_URL` | Base URL of the main worker used by `mailer.js` to fetch email templates when no subject or body is provided. |
 Примерен PHP скрипт за изпращане на писма е наличен в [docs/mail.php](docs/mail.php). Настройте `MAIL_PHP_URL` да сочи към същия или сходен адрес.
+За изпращане през SMTP може да използвате и варианта с PHPMailer в [docs/mail_smtp.php](docs/mail_smtp.php), който приема същите полета (`to`, `subject`, `body`).
 
 ## Cron configuration
 

--- a/docs/mail.php
+++ b/docs/mail.php
@@ -14,6 +14,8 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 
 // Извлечи и декодирай JSON от заявката
 $data = json_decode(file_get_contents("php://input"), true);
+$logFile = __DIR__ . '/mail_debug.log';
+file_put_contents($logFile, date('c') . " INPUT: " . json_encode($data) . PHP_EOL, FILE_APPEND);
 
 // Валидация
 $to = $data['to'] ?? '';
@@ -47,12 +49,25 @@ $headers .= "Reply-To: info@mybody.best\r\n";
 
 // Изпращане
 $success = mail($to, $subject, $body, $headers);
+file_put_contents($logFile, date('c') . " RESULT: " . json_encode(['success' => $success]) . PHP_EOL, FILE_APPEND);
 
 // Отговор
 if ($success) {
     http_response_code(200);
-    echo json_encode(["success" => true, "message" => "Email sent successfully."]);
+    echo json_encode([
+        "success" => true,
+        "message" => "Email sent successfully.",
+        "to" => $to,
+        "subject" => $subject,
+        "body" => $body
+    ]);
 } else {
     http_response_code(500);
-    echo json_encode(["success" => false, "error" => "Failed to send email."]);
+    echo json_encode([
+        "success" => false,
+        "error" => "Failed to send email.",
+        "to" => $to,
+        "subject" => $subject,
+        "body" => $body
+    ]);
 }

--- a/docs/mail_smtp.php
+++ b/docs/mail_smtp.php
@@ -1,0 +1,56 @@
+<?php
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+require __DIR__ . '/vendor/autoload.php';
+
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: POST');
+header('Access-Control-Allow-Headers: Content-Type');
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Only POST method allowed']);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true) ?? [];
+$to = $input['to'] ?? '';
+$subject = $input['subject'] ?? '(No subject)';
+$body = $input['body'] ?? '';
+
+if (!filter_var($to, FILTER_VALIDATE_EMAIL)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid recipient email']);
+    exit;
+}
+if (empty($body)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing email body']);
+    exit;
+}
+
+$mail = new PHPMailer(true);
+try {
+    $mail->isSMTP();
+    $mail->Host = 'mail.mybody.best';
+    $mail->SMTPAuth = true;
+    $mail->Username = 'info@mybody.best';
+    $mail->Password = 'YOUR_SMTP_PASSWORD';
+    $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;
+    $mail->Port = 465;
+
+    $mail->setFrom('info@mybody.best', 'MyBody');
+    $mail->addAddress($to);
+    $mail->isHTML(true);
+    $mail->Subject = $subject;
+    $mail->Body = $body;
+    $mail->send();
+    http_response_code(200);
+    echo json_encode(['success' => true, 'message' => 'Email sent.']);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => $mail->ErrorInfo]);
+}
+

--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -24,7 +24,7 @@ test('rejects missing fields', async () => {
 });
 
 test('calls PHP endpoint on valid input', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   const req = { json: async () => ({ to: 'a@b.bg', subject: 'S', text: 'B' }) };
   const res = await handleSendEmailRequest(req, { MAIL_PHP_URL: 'https://mybody.best/mail.php' });
   expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail.php', expect.any(Object));
@@ -33,8 +33,14 @@ test('calls PHP endpoint on valid input', async () => {
 });
 
 test('sendEmail forwards data to PHP endpoint', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   await sendEmail('t@e.com', 'Hi', 'Body', { MAIL_PHP_URL: 'https://mybody.best/mail.php' });
   expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail.php', expect.any(Object));
+  fetch.mockRestore();
+});
+
+test('sendEmail throws on unsuccessful PHP response', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: false }) });
+  await expect(sendEmail('t@e.com', 'Hi', 'Body', { MAIL_PHP_URL: 'https://mybody.best/mail.php' })).rejects.toThrow();
   fetch.mockRestore();
 });

--- a/js/__tests__/sendTestEmailRequest.test.js
+++ b/js/__tests__/sendTestEmailRequest.test.js
@@ -48,7 +48,7 @@ test('rejects invalid json', async () => {
 });
 
 test('sends email on valid data', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 'test@example.com', subject: 'Hi', body: 'b' })
@@ -60,7 +60,7 @@ test('sends email on valid data', async () => {
 });
 
 test('supports alternate field names', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ to: 'alt@example.com', subject: 'Hi', text: 'b' })
@@ -72,7 +72,7 @@ test('supports alternate field names', async () => {
 });
 
 test('uses PHP mail endpoint when MAILER_ENDPOINT_URL missing', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })
@@ -84,7 +84,7 @@ test('uses PHP mail endpoint when MAILER_ENDPOINT_URL missing', async () => {
 });
 
 test('records usage in USER_METADATA_KV', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -8,12 +8,20 @@
 export async function sendEmail(to, subject, text, env = {}) {
   const endpoint = env.MAIL_PHP_URL || 'https://mybody.best/mail.php';
   const payload = { to, subject, body: text };
+  console.log('sendEmail payload', payload);
   const resp = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
-  if (!resp.ok) throw new Error('Failed to send');
+  let data = {};
+  try {
+    data = await resp.json();
+  } catch {
+    // ignore malformed JSON
+  }
+  console.log('sendEmail response', resp.status, data);
+  if (!resp.ok || data.success !== true) throw new Error('Failed to send');
 }
 
 export async function handleSendEmailRequest(request, env = {}) {


### PR DESCRIPTION
## Summary
- log payload and response in `sendEmailWorker`
- add logging and echo details in PHP mailer
- provide `mail_smtp.php` sample using PHPMailer
- document SMTP option in README
- update tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb9885b3883269f72c109c7cf4bf8