### PR TITLE
Improve sendEmail worker error handling

### DIFF
--- a/js/__tests__/sendTestEmailRequest.test.js
+++ b/js/__tests__/sendTestEmailRequest.test.js
@@ -48,7 +48,7 @@ test('rejects invalid json', async () => {
 });
 
 test('sends email on valid data', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 'test@example.com', subject: 'Hi', body: 'b' })
@@ -60,7 +60,7 @@ test('sends email on valid data', async () => {
 });
 
 test('supports alternate field names', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ to: 'alt@example.com', subject: 'Hi', text: 'b' })
@@ -72,7 +72,7 @@ test('supports alternate field names', async () => {
 });
 
 test('uses PHP mail endpoint when MAILER_ENDPOINT_URL missing', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })
@@ -84,7 +84,7 @@ test('uses PHP mail endpoint when MAILER_ENDPOINT_URL missing', async () => {
 });
 
 test('records usage in USER_METADATA_KV', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -13,7 +13,11 @@ export async function sendEmail(to, subject, text, env = {}) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
-  if (!resp.ok) throw new Error('Failed to send');
+  const result = await resp.json();
+  if (!resp.ok || result.success === false) {
+    console.error('sendEmail failed response:', result);
+    throw new Error(result.error || result.message || 'Failed to send');
+  }
 }
 
 export async function handleSendEmailRequest(request, env = {}) {


### PR DESCRIPTION
## Summary
- parse JSON after sending emails
- throw when PHP response indicates failure
- log failing responses
- update unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eba72169c8326881ae382491e1b45