### PR TITLE
Make email sender configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,8 @@ Before deploying, configure the following secrets in Cloudflare (via the dashboa
 - `тут_ваш_php_api_token_secret_name`
 - `CF_AI_TOKEN` – API token used for Cloudflare AI requests
 - `OPENAI_API_KEY` – set via `wrangler secret put OPENAI_API_KEY`, used by `worker.js`
-- `FROM_EMAIL` – optional sender address for outgoing emails
+- `FROM_EMAIL` – optional sender address for outgoing emails. PHP scripts read
+  this value to populate the `From` header dynamically.
 
 Без тази стойност част от AI функционалностите няма да работят.
 

--- a/docs/mail.php
+++ b/docs/mail.php
@@ -43,8 +43,9 @@ if (preg_match("/[\r\n]/", $to) || preg_match("/[\r\n]/", $subject)) {
 // Имейл заглавки за HTML
 $headers = "MIME-Version: 1.0\r\n";
 $headers .= "Content-type: text/html; charset=UTF-8\r\n";
-$headers .= "From: info@mybody.best\r\n";
-$headers .= "Reply-To: info@mybody.best\r\n";
+$from = $_ENV['FROM_EMAIL'] ?? 'info@mybody.best';
+$headers .= "From: $from\r\n";
+$headers .= "Reply-To: $from\r\n";
 
 // Изпращане
 $success = mail($to, $subject, $body, $headers);

--- a/docs/mail_smtp.php
+++ b/docs/mail_smtp.php
@@ -50,7 +50,8 @@ try {
     $mail->Username = 'info@mybody.best';
     $mail->Password = getenv('EMAIL_PASSWORD');
 
-    $mail->setFrom('info@mybody.best');
+    $from = $_ENV['FROM_EMAIL'] ?? 'info@mybody.best';
+    $mail->setFrom($from);
     $mail->addAddress($to);
     $mail->Subject = $subject;
     $mail->isHTML(true);

--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -13,29 +13,40 @@ afterEach(() => {
 
 test('rejects invalid JSON', async () => {
   const req = { json: async () => { throw new Error('bad'); } };
-  const res = await handleSendEmailRequest(req, { FROM_EMAIL: 'info@mybody.best' });
+  const res = await handleSendEmailRequest(req, {});
   expect(res.status).toBe(400);
 });
 
 test('rejects missing fields', async () => {
   const req = { json: async () => ({}) };
-  const res = await handleSendEmailRequest(req, { FROM_EMAIL: 'info@mybody.best' });
+  const res = await handleSendEmailRequest(req, {});
   expect(res.status).toBe(400);
 });
 
 test('calls PHP endpoint on valid input', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   const req = { json: async () => ({ to: 'a@b.bg', subject: 'S', text: 'B' }) };
-  const res = await handleSendEmailRequest(req, { MAIL_PHP_URL: 'https://mybody.best/mail.php' });
-  expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail.php', expect.any(Object));
+  const env = { MAIL_PHP_URL: 'https://mybody.best/mail.php', FROM_EMAIL: 'admin@example.com' };
+  const res = await handleSendEmailRequest(req, env);
+  expect(fetch).toHaveBeenCalledWith(
+    'https://mybody.best/mail.php',
+    expect.objectContaining({
+      body: JSON.stringify({ to: 'a@b.bg', subject: 'S', body: 'B', from: 'admin@example.com' })
+    })
+  );
   expect(res.status).toBe(200);
   fetch.mockRestore();
 });
 
 test('sendEmail forwards data to PHP endpoint', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
-  await sendEmail('t@e.com', 'Hi', 'Body', { MAIL_PHP_URL: 'https://mybody.best/mail.php' });
-  expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail.php', expect.any(Object));
+  await sendEmail('t@e.com', 'Hi', 'Body', { MAIL_PHP_URL: 'https://mybody.best/mail.php', FROM_EMAIL: 'admin@example.com' });
+  expect(fetch).toHaveBeenCalledWith(
+    'https://mybody.best/mail.php',
+    expect.objectContaining({
+      body: JSON.stringify({ to: 't@e.com', subject: 'Hi', body: 'Body', from: 'admin@example.com' })
+    })
+  );
   fetch.mockRestore();
 });
 

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -5,9 +5,13 @@
  * @param {string} subject email subject line
  * @param {string} text plain text body
  */
+const FROM_EMAIL_VAR_NAME = 'FROM_EMAIL';
+
 export async function sendEmail(to, subject, text, env = {}) {
   const endpoint = env.MAIL_PHP_URL || 'https://mybody.best/mail.php';
+  const from = env[FROM_EMAIL_VAR_NAME];
   const payload = { to, subject, body: text };
+  if (from) payload.from = from;
   const resp = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/worker.js
+++ b/worker.js
@@ -37,10 +37,13 @@ async function getSendEmail(env) {
     const endpoint = env?.[MAILER_ENDPOINT_URL_VAR_NAME];
     if (endpoint) {
         sendEmailFn = async (to, subject, body) => {
+            const from = env?.[FROM_EMAIL_VAR_NAME];
+            const payload = { to, subject, text: body };
+            if (from) payload.from = from;
             const resp = await fetch(endpoint, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ to, subject, text: body })
+                body: JSON.stringify(payload)
             });
             if (!resp.ok) throw new Error(`Mailer responded with ${resp.status}`);
         };


### PR DESCRIPTION
## Summary
- allow JS workers to forward FROM_EMAIL to PHP
- read FROM_EMAIL from env in PHP scripts
- test that FROM_EMAIL is respected

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed44a4d288326932cc465e0e1f76d