### PR TITLE
Improve sendEmail JSON parsing

### DIFF
--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -24,7 +24,13 @@ test('rejects missing fields', async () => {
 });
 
 test('calls PHP endpoint on valid input', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  const resp = {
+    ok: true,
+    json: async () => ({ success: true }),
+    text: async () => JSON.stringify({ success: true }),
+    clone() { return { json: this.json }; }
+  };
+  global.fetch = jest.fn().mockResolvedValue(resp);
   const req = { json: async () => ({ to: 'a@b.bg', subject: 'S', text: 'B' }) };
   const res = await handleSendEmailRequest(req, { MAIL_PHP_URL: 'https://mybody.best/mail.php' });
   expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail.php', expect.any(Object));
@@ -33,7 +39,13 @@ test('calls PHP endpoint on valid input', async () => {
 });
 
 test('sendEmail forwards data to PHP endpoint', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  const resp = {
+    ok: true,
+    json: async () => ({ success: true }),
+    text: async () => JSON.stringify({ success: true }),
+    clone() { return { json: this.json }; }
+  };
+  global.fetch = jest.fn().mockResolvedValue(resp);
   await sendEmail('t@e.com', 'Hi', 'Body', { MAIL_PHP_URL: 'https://mybody.best/mail.php' });
   expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail.php', expect.any(Object));
   fetch.mockRestore();
@@ -41,9 +53,30 @@ test('sendEmail forwards data to PHP endpoint', async () => {
 
 test('sendEmail throws when backend reports failure', async () => {
   const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: false, error: 'bad' }) });
+  const resp = {
+    ok: true,
+    json: async () => ({ success: false, error: 'bad' }),
+    text: async () => JSON.stringify({ success: false, error: 'bad' }),
+    clone() { return { json: this.json }; }
+  };
+  global.fetch = jest.fn().mockResolvedValue(resp);
   await expect(sendEmail('x@y.z', 'S', 'B')).rejects.toThrow('bad');
   expect(errSpy).toHaveBeenCalledWith('sendEmail failed response:', { success: false, error: 'bad' });
+  errSpy.mockRestore();
+  fetch.mockRestore();
+});
+
+test('sendEmail throws descriptive error on non-JSON response', async () => {
+  const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const resp = {
+    ok: true,
+    json: async () => { throw new Error('parse'); },
+    text: async () => 'not-json',
+    clone() { return { json: this.json }; }
+  };
+  global.fetch = jest.fn().mockResolvedValue(resp);
+  await expect(sendEmail('x@y.z', 'S', 'B')).rejects.toThrow('Invalid JSON response from mailer');
+  expect(errSpy).toHaveBeenCalledWith('Failed to parse JSON response:', 'not-json');
   errSpy.mockRestore();
   fetch.mockRestore();
 });

--- a/js/__tests__/sendTestEmailRequest.test.js
+++ b/js/__tests__/sendTestEmailRequest.test.js
@@ -72,7 +72,13 @@ test('supports alternate field names', async () => {
 });
 
 test('uses PHP mail endpoint when MAILER_ENDPOINT_URL missing', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  const resp = {
+    ok: true,
+    json: async () => ({ success: true }),
+    text: async () => JSON.stringify({ success: true }),
+    clone() { return { json: this.json }; }
+  };
+  global.fetch = jest.fn().mockResolvedValue(resp);
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -13,7 +13,14 @@ export async function sendEmail(to, subject, text, env = {}) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
-  const result = await resp.json();
+  let result;
+  try {
+    result = await resp.clone().json();
+  } catch {
+    const bodyText = await resp.text();
+    console.error('Failed to parse JSON response:', bodyText);
+    throw new Error('Invalid JSON response from mailer');
+  }
   if (!resp.ok || result.success === false) {
     console.error('sendEmail failed response:', result);
     throw new Error(result.error || result.message || 'Failed to send');


### PR DESCRIPTION
## Summary
- handle non-JSON responses in `sendEmail`
- extend tests for `sendEmailWorker` to cover parse errors
- adjust sendTestEmailRequest mocks for new parsing logic

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed463bfdc832693b501c0a87c13c8