### PR TITLE
Add FROM_EMAIL support to mail API

### DIFF
--- a/docs/mail.php
+++ b/docs/mail.php
@@ -43,8 +43,9 @@ if (preg_match("/[\r\n]/", $to) || preg_match("/[\r\n]/", $subject)) {
 // Имейл заглавки за HTML
 $headers = "MIME-Version: 1.0\r\n";
 $headers .= "Content-type: text/html; charset=UTF-8\r\n";
-$headers .= "From: info@mybody.best\r\n";
-$headers .= "Reply-To: info@mybody.best\r\n";
+$fromEmail = getenv('FROM_EMAIL') ?: 'info@mybody.best';
+$headers .= "From: {$fromEmail}\r\n";
+$headers .= "Reply-To: {$fromEmail}\r\n";
 
 // Изпращане
 $success = mail($to, $subject, $body, $headers);

--- a/docs/mail_smtp.php
+++ b/docs/mail_smtp.php
@@ -47,10 +47,11 @@ try {
     $mail->Port = 465;
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;
     $mail->SMTPAuth = true;
-    $mail->Username = 'info@mybody.best';
+    $mail->Username = getenv('FROM_EMAIL') ?: 'info@mybody.best';
     $mail->Password = getenv('EMAIL_PASSWORD');
 
-    $mail->setFrom('info@mybody.best');
+    $fromEmail = getenv('FROM_EMAIL') ?: 'info@mybody.best';
+    $mail->setFrom($fromEmail);
     $mail->addAddress($to);
     $mail->Subject = $subject;
     $mail->isHTML(true);

--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -13,13 +13,13 @@ afterEach(() => {
 
 test('rejects invalid JSON', async () => {
   const req = { json: async () => { throw new Error('bad'); } };
-  const res = await handleSendEmailRequest(req, { FROM_EMAIL: 'info@mybody.best' });
+  const res = await handleSendEmailRequest(req, {});
   expect(res.status).toBe(400);
 });
 
 test('rejects missing fields', async () => {
   const req = { json: async () => ({}) };
-  const res = await handleSendEmailRequest(req, { FROM_EMAIL: 'info@mybody.best' });
+  const res = await handleSendEmailRequest(req, {});
   expect(res.status).toBe(400);
 });
 
@@ -43,8 +43,14 @@ test('calls PHP endpoint on valid input', async () => {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ to: 'a@b.bg', subject: 'S', text: 'B' })
   };
-  const res = await handleSendEmailRequest(req, { MAIL_PHP_URL: 'https://mybody.best/mail.php', WORKER_ADMIN_TOKEN: 'secret' });
-  expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail.php', expect.any(Object));
+  const env = { MAIL_PHP_URL: 'https://mybody.best/mail.php', WORKER_ADMIN_TOKEN: 'secret', FROM_EMAIL: 'info@mybody.best' };
+  const res = await handleSendEmailRequest(req, env);
+  expect(fetch).toHaveBeenCalledWith(
+    'https://mybody.best/mail.php',
+    expect.objectContaining({
+      body: JSON.stringify({ to: 'a@b.bg', subject: 'S', body: 'B', from: 'info@mybody.best' })
+    })
+  );
   expect(res.status).toBe(200);
   fetch.mockRestore();
 });
@@ -55,8 +61,13 @@ test('sendEmail forwards data to PHP endpoint', async () => {
     json: async () => ({ success: true }),
     clone: () => ({ text: async () => '{}' })
   });
-  await sendEmail('t@e.com', 'Hi', 'Body', { MAIL_PHP_URL: 'https://mybody.best/mail.php' });
-  expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail.php', expect.any(Object));
+  await sendEmail('t@e.com', 'Hi', 'Body', { MAIL_PHP_URL: 'https://mybody.best/mail.php', FROM_EMAIL: 'info@mybody.best' });
+  expect(fetch).toHaveBeenCalledWith(
+    'https://mybody.best/mail.php',
+    expect.objectContaining({
+      body: JSON.stringify({ to: 't@e.com', subject: 'Hi', body: 'Body', from: 'info@mybody.best' })
+    })
+  );
   fetch.mockRestore();
 });
 

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -6,6 +6,7 @@
  * @param {string} text plain text body
  */
 const WORKER_ADMIN_TOKEN_SECRET_NAME = 'WORKER_ADMIN_TOKEN';
+const FROM_EMAIL_VAR_NAME = 'FROM_EMAIL';
 
 async function recordUsage(env, identifier = '') {
   try {
@@ -53,7 +54,9 @@ async function checkRateLimit(env, identifier, limit = 3, windowMs = 60000) {
 
 export async function sendEmail(to, subject, text, env = {}) {
   const endpoint = env.MAIL_PHP_URL || 'https://mybody.best/mail.php';
+  const fromEmail = env[FROM_EMAIL_VAR_NAME];
   const payload = { to, subject, body: text };
+  if (fromEmail) payload.from = fromEmail;
   const resp = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- support configurable `FROM_EMAIL` in `sendEmailWorker.js`
- send `from` value to PHP mail API
- adjust PHP scripts to use `FROM_EMAIL`
- verify `FROM_EMAIL` logic in tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eda44b5cc83268613fef065dfa8d1