### PR TITLE
Improve email worker sender handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,9 @@ Before deploying, configure the following secrets in Cloudflare (via the dashboa
 - `тут_ваш_php_api_token_secret_name`
 - `CF_AI_TOKEN` – API token used for Cloudflare AI requests
 - `OPENAI_API_KEY` – set via `wrangler secret put OPENAI_API_KEY`, used by `worker.js`
-- `FROM_EMAIL` – optional sender address for outgoing emails
+ - `FROM_EMAIL` – optional sender address for outgoing emails. When set, this
+   value is passed to the PHP mail scripts and used in the `From` and
+   `Reply-To` headers.
 
 Без тази стойност част от AI функционалностите няма да работят.
 

--- a/docs/mail.php
+++ b/docs/mail.php
@@ -43,8 +43,9 @@ if (preg_match("/[\r\n]/", $to) || preg_match("/[\r\n]/", $subject)) {
 // Имейл заглавки за HTML
 $headers = "MIME-Version: 1.0\r\n";
 $headers .= "Content-type: text/html; charset=UTF-8\r\n";
-$headers .= "From: info@mybody.best\r\n";
-$headers .= "Reply-To: info@mybody.best\r\n";
+$fromAddr = $data['from'] ?? getenv('FROM_EMAIL') ?: 'info@mybody.best';
+$headers .= "From: {$fromAddr}\r\n";
+$headers .= "Reply-To: {$fromAddr}\r\n";
 
 // Изпращане
 $success = mail($to, $subject, $body, $headers);

--- a/docs/mail_smtp.php
+++ b/docs/mail_smtp.php
@@ -47,10 +47,11 @@ try {
     $mail->Port = 465;
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;
     $mail->SMTPAuth = true;
-    $mail->Username = 'info@mybody.best';
-    $mail->Password = getenv('EMAIL_PASSWORD');
+$mail->Username = 'info@mybody.best';
+$mail->Password = getenv('EMAIL_PASSWORD');
 
-    $mail->setFrom('info@mybody.best');
+    $fromAddr = $data['from'] ?? getenv('FROM_EMAIL') ?: 'info@mybody.best';
+    $mail->setFrom($fromAddr);
     $mail->addAddress($to);
     $mail->Subject = $subject;
     $mail->isHTML(true);

--- a/js/__tests__/sendTestEmailRequest.test.js
+++ b/js/__tests__/sendTestEmailRequest.test.js
@@ -48,7 +48,7 @@ test('rejects invalid json', async () => {
 });
 
 test('sends email on valid data', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, text: async () => JSON.stringify({ success: true }) });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 'test@example.com', subject: 'Hi', body: 'b' })
@@ -60,7 +60,7 @@ test('sends email on valid data', async () => {
 });
 
 test('supports alternate field names', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, text: async () => JSON.stringify({ success: true }) });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ to: 'alt@example.com', subject: 'Hi', text: 'b' })
@@ -72,7 +72,7 @@ test('supports alternate field names', async () => {
 });
 
 test('uses PHP mail endpoint when MAILER_ENDPOINT_URL missing', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, text: async () => JSON.stringify({ success: true }) });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })
@@ -84,7 +84,7 @@ test('uses PHP mail endpoint when MAILER_ENDPOINT_URL missing', async () => {
 });
 
 test('records usage in USER_METADATA_KV', async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, text: async () => JSON.stringify({ success: true }) });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })


### PR DESCRIPTION
## Summary
- allow `sendEmailWorker` to pass `FROM_EMAIL` in request payload
- handle invalid JSON responses from the mail backend
- update PHP mail scripts to respect `FROM_EMAIL`
- document sender variable in README
- extend tests for new behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ed23148e48326bb8f43492ba6f65a