### PR TITLE
Remove unused FROM_EMAIL variable

### DIFF
--- a/preworker.js
+++ b/preworker.js
@@ -29,7 +29,6 @@ import { sendEmail as phpSendEmail } from './sendEmailWorker.js';
 /** @type {(to: string, subject: string, body: string) => Promise<void>} */
 let sendEmailFn = defaultSendEmail;
 const MAILER_ENDPOINT_URL_VAR_NAME = 'MAILER_ENDPOINT_URL';
-const FROM_EMAIL_VAR_NAME = 'FROM_EMAIL';
 async function getSendEmail(env) {
     if (sendEmailFn && sendEmailFn !== defaultSendEmail) return sendEmailFn;
     const endpoint = env?.[MAILER_ENDPOINT_URL_VAR_NAME];

--- a/worker.js
+++ b/worker.js
@@ -31,7 +31,6 @@ import { Buffer } from 'buffer';
 /** @type {(to: string, subject: string, body: string) => Promise<void>} */
 let sendEmailFn = defaultSendEmail;
 const MAILER_ENDPOINT_URL_VAR_NAME = 'MAILER_ENDPOINT_URL';
-const FROM_EMAIL_VAR_NAME = 'FROM_EMAIL';
 async function getSendEmail(env) {
     if (sendEmailFn && sendEmailFn !== defaultSendEmail) return sendEmailFn;
     const endpoint = env?.[MAILER_ENDPOINT_URL_VAR_NAME];


### PR DESCRIPTION
## Summary
- remove `FROM_EMAIL_VAR_NAME` from worker.js and preworker.js

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ee32893f88326bf8afffba0fa738d