### PR TITLE
Fix Cloudflare worker Buffer usage

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -26,7 +26,6 @@ async function defaultSendEmail(to, subject, body) {
     throw new Error('Email functionality is not configured.');
 }
 import { sendEmail as phpSendEmail } from './sendEmailWorker.js';
-import { Buffer } from 'buffer';
 
 /** @type {(to: string, subject: string, body: string) => Promise<void>} */
 let sendEmailFn = defaultSendEmail;


### PR DESCRIPTION
## Summary
- stop importing `Buffer` from Node in Cloudflare worker

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f304f5ba483268c03a83b839ca6b7