### PR TITLE
Fix Buffer global usage in worker source

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ Check that `tsconfig.json` includes `"node"` in the `types` array.
 compatibility_flags = ["nodejs_compat"]
 ```
 
-Then import `Buffer` explicitly when needed:
+When `nodejs_compat` is enabled, Cloudflare Workers expose `Buffer` globally,
+so you can use it directly:
 
 ```ts
-import { Buffer } from 'buffer';
 const encoded = Buffer.from('hello').toString('base64');
 ```
 
@@ -173,7 +173,7 @@ file test.jpg
 The `file` output should recognize an image format like JPEG or PNG.
 Cloudflare returns `Tensor error: failed to decode u8` when the data isn't a valid image.
 
-> **Note**: За Node функции като `Buffer` активирайте `nodejs_compat` в `wrangler.toml` (вижте по-горе) и импортирайте от `'buffer'` при нужда.
+> **Note**: При активирано `nodejs_compat` Cloudflare Workers предоставят `Buffer` и други Node функции като глобални, така че няма нужда от `import`.
 
 ### Generate Documentation
 

--- a/preworker.js
+++ b/preworker.js
@@ -26,7 +26,6 @@ async function defaultSendEmail(to, subject, body) {
     throw new Error('Email functionality is not configured.');
 }
 import { sendEmail as phpSendEmail } from './sendEmailWorker.js';
-import { Buffer } from 'buffer';
 
 /** @type {(to: string, subject: string, body: string) => Promise<void>} */
 let sendEmailFn = defaultSendEmail;

--- a/worker.js
+++ b/worker.js
@@ -26,7 +26,6 @@ async function defaultSendEmail(to, subject, body) {
     throw new Error('Email functionality is not configured.');
 }
 import { sendEmail as phpSendEmail } from './sendEmailWorker.js';
-import { Buffer } from 'buffer';
 
 /** @type {(to: string, subject: string, body: string) => Promise<void>} */
 let sendEmailFn = defaultSendEmail;


### PR DESCRIPTION
## Summary
- remove Buffer import from `preworker.js`
- clarify Buffer availability in Cloudflare Workers in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f304f5ba483268c03a83b839ca6b7