### PR TITLE
Fix email worker default URL

### DIFF
--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -28,7 +28,7 @@ test('rejects invalid token', async () => {
     headers: { get: h => (h === 'Authorization' ? 'Bearer bad' : null) },
     json: async () => ({ to: 'a@b.bg', subject: 'S', text: 'B' })
   };
-  const env = { WORKER_ADMIN_TOKEN: 'secret', MAIL_PHP_URL: 'https://mybody.best/mail.php' };
+  const env = { WORKER_ADMIN_TOKEN: 'secret', MAIL_PHP_URL: 'https://mybody.best/mail_smtp.php' };
   const res = await handleSendEmailRequest(req, env);
   expect(res.status).toBe(403);
 });
@@ -43,10 +43,10 @@ test('calls PHP endpoint on valid input', async () => {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ to: 'a@b.bg', subject: 'S', text: 'B' })
   };
-  const env = { MAIL_PHP_URL: 'https://mybody.best/mail.php', WORKER_ADMIN_TOKEN: 'secret', FROM_EMAIL: 'info@mybody.best' };
+  const env = { MAIL_PHP_URL: 'https://mybody.best/mail_smtp.php', WORKER_ADMIN_TOKEN: 'secret', FROM_EMAIL: 'info@mybody.best' };
   const res = await handleSendEmailRequest(req, env);
   expect(fetch).toHaveBeenCalledWith(
-    'https://mybody.best/mail.php',
+    'https://mybody.best/mail_smtp.php',
     expect.objectContaining({
       body: JSON.stringify({ to: 'a@b.bg', subject: 'S', body: 'B', from: 'info@mybody.best' })
     })
@@ -61,9 +61,9 @@ test('sendEmail forwards data to PHP endpoint', async () => {
     json: async () => ({ success: true }),
     clone: () => ({ text: async () => '{}' })
   });
-  await sendEmail('t@e.com', 'Hi', 'Body', { MAIL_PHP_URL: 'https://mybody.best/mail.php', FROM_EMAIL: 'info@mybody.best' });
+  await sendEmail('t@e.com', 'Hi', 'Body', { MAIL_PHP_URL: 'https://mybody.best/mail_smtp.php', FROM_EMAIL: 'info@mybody.best' });
   expect(fetch).toHaveBeenCalledWith(
-    'https://mybody.best/mail.php',
+    'https://mybody.best/mail_smtp.php',
     expect.objectContaining({
       body: JSON.stringify({ to: 't@e.com', subject: 'Hi', body: 'Body', from: 'info@mybody.best' })
     })

--- a/js/__tests__/sendTestEmailRequest.test.js
+++ b/js/__tests__/sendTestEmailRequest.test.js
@@ -89,10 +89,10 @@ test('uses PHP mail endpoint when MAILER_ENDPOINT_URL missing', async () => {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })
   };
-  const env = { WORKER_ADMIN_TOKEN: 'secret', MAIL_PHP_URL: 'https://mybody.best/mail.php' };
+  const env = { WORKER_ADMIN_TOKEN: 'secret', MAIL_PHP_URL: 'https://mybody.best/mail_smtp.php' };
   const res = await handleSendTestEmailRequest(request, env);
   expect(res.success).toBe(true);
-  expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail.php', expect.any(Object));
+  expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail_smtp.php', expect.any(Object));
 });
 
 test('records usage in USER_METADATA_KV', async () => {
@@ -109,7 +109,7 @@ test('records usage in USER_METADATA_KV', async () => {
     WORKER_ADMIN_TOKEN: 'secret',
     FROM_EMAIL: 'info@mybody.best',
     USER_METADATA_KV: { put: jest.fn() },
-    MAIL_PHP_URL: 'https://mybody.best/mail.php'
+    MAIL_PHP_URL: 'https://mybody.best/mail_smtp.php'
   };
   await handleSendTestEmailRequest(request, env);
   expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
@@ -117,7 +117,7 @@ test('records usage in USER_METADATA_KV', async () => {
     expect.any(String)
   );
   expect(fetch).toHaveBeenCalledWith(
-    'https://mybody.best/mail.php',
+    'https://mybody.best/mail_smtp.php',
     expect.objectContaining({
       body: JSON.stringify({ to: 't@e.com', subject: 's', body: 'b', from: 'info@mybody.best' })
     })

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -53,7 +53,8 @@ async function checkRateLimit(env, identifier, limit = 3, windowMs = 60000) {
 }
 
 export async function sendEmail(to, subject, text, env = {}) {
-  const endpoint = env.MAIL_PHP_URL || 'https://mybody.best/mail.php';
+  // Fallback URL when MAIL_PHP_URL is not provided
+  const endpoint = env.MAIL_PHP_URL || 'https://mybody.best/mail_smtp.php';
   const fromEmail = env[FROM_EMAIL_VAR_NAME];
   const payload = { to, subject, body: text };
   if (fromEmail) payload.from = fromEmail;


### PR DESCRIPTION
## Summary
- update `sendEmailWorker.js` fallback endpoint to `mail_smtp.php`
- adjust tests to match new default URL
- note the fallback URL in `sendEmailWorker.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f55e6a7008326ae91991d277a380a