### PR TITLE
Improve sendTestEmail response handling

### DIFF
--- a/js/__tests__/sendTestEmail.test.js
+++ b/js/__tests__/sendTestEmail.test.js
@@ -76,3 +76,24 @@ test('confirmation wrapper aborts when cancelled', async () => {
   expect(global.fetch).not.toHaveBeenCalled();
   confirmSpy.mockRestore();
 });
+
+test('logs snippet when response is not JSON', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: { get: () => 'text/plain' },
+    text: async () => 'plain text error body'
+  });
+  const logSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+  document.getElementById('testEmailTo').value = 'a@b.bg';
+  document.getElementById('testEmailSubject').value = 'Sub';
+  document.getElementById('testEmailBody').value = 'Body';
+  await send();
+  expect(logSpy).toHaveBeenCalledWith(
+    'Non-JSON response from sendTestEmail:',
+    'plain text error body'
+  );
+  expect(alertSpy).toHaveBeenCalled();
+  logSpy.mockRestore();
+  alertSpy.mockRestore();
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -1222,12 +1222,26 @@ async function sendTestEmail() {
             headers,
             body: JSON.stringify({ recipient, subject, body })
         });
-        const data = await resp.json();
+
+        const ct = resp.headers.get('Content-Type') || '';
+        let data;
+        let raw = '';
+        if (ct.includes('application/json')) {
+            data = await resp.json();
+        } else {
+            raw = await resp.text();
+        }
+
+        if (!ct.includes('application/json')) {
+            console.error('Non-JSON response from sendTestEmail:', raw.slice(0, 200));
+            throw new Error('Unexpected server response');
+        }
+
         if (!resp.ok || !data.success) throw new Error(data.message || 'Error');
         alert('Имейлът е изпратен успешно.');
     } catch (err) {
         console.error('Error sending test email:', err);
-        alert(err.message || 'Грешка при изпращане на имейла.');
+        alert('Грешка при изпращане.');
     }
 }
 


### PR DESCRIPTION
## Summary
- log a snippet if `/api/sendTestEmail` returns non‑JSON
- surface failure via concise alert message
- test non‑JSON handling in admin module

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f55eb5b6483269b8d801ef7d8d6a4