### PR TITLE
Ensure KV TTL never below 60s

### DIFF
--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -96,3 +96,28 @@ test('sendEmail throws on invalid JSON response', async () => {
   errSpy.mockRestore();
   fetch.mockRestore();
 });
+
+test('rate limit TTL never below 60 seconds', async () => {
+  const now = Date.now();
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true }),
+    clone: () => ({ text: async () => '{}' })
+  });
+  const put = jest.fn();
+  const req = {
+    headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
+    json: async () => ({ to: 't@e.com', subject: 'S', text: 'B' })
+  };
+  const env = {
+    MAIL_PHP_URL: 'https://mybody.best/mail_smtp.php',
+    WORKER_ADMIN_TOKEN: 'secret',
+    USER_METADATA_KV: {
+      get: jest.fn().mockResolvedValue(JSON.stringify({ ts: now - 59000, count: 1 })),
+      put
+    }
+  };
+  await handleSendEmailRequest(req, env);
+  expect(put.mock.calls[0][2].expirationTtl).toBe(60);
+  fetch.mockRestore();
+});

--- a/preworker.js
+++ b/preworker.js
@@ -2669,7 +2669,10 @@ async function checkRateLimit(env, type, identifier, limit = 3, windowMs = 60000
                 if (data.count >= limit) return true;
                 data.count++;
                 await env.USER_METADATA_KV.put(key, JSON.stringify(data), {
-                    expirationTtl: Math.ceil((windowMs - (now - data.ts)) / 1000)
+                    expirationTtl: Math.max(
+                        60,
+                        Math.ceil((windowMs - (now - data.ts)) / 1000)
+                    )
                 });
                 return false;
             }
@@ -2677,7 +2680,7 @@ async function checkRateLimit(env, type, identifier, limit = 3, windowMs = 60000
         await env.USER_METADATA_KV.put(
             key,
             JSON.stringify({ ts: now, count: 1 }),
-            { expirationTtl: Math.ceil(windowMs / 1000) }
+            { expirationTtl: Math.max(60, Math.ceil(windowMs / 1000)) }
         );
     } catch (err) {
         console.error('Failed to enforce rate limit:', err.message);

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -36,7 +36,10 @@ async function checkRateLimit(env, identifier, limit = 3, windowMs = 60000) {
         if (data.count >= limit) return true;
         data.count++;
         await env.USER_METADATA_KV.put(key, JSON.stringify(data), {
-          expirationTtl: Math.ceil((windowMs - (now - data.ts)) / 1000)
+          expirationTtl: Math.max(
+            60,
+            Math.ceil((windowMs - (now - data.ts)) / 1000)
+          )
         });
         return false;
       }
@@ -44,7 +47,7 @@ async function checkRateLimit(env, identifier, limit = 3, windowMs = 60000) {
     await env.USER_METADATA_KV.put(
       key,
       JSON.stringify({ ts: now, count: 1 }),
-      { expirationTtl: Math.ceil(windowMs / 1000) }
+      { expirationTtl: Math.max(60, Math.ceil(windowMs / 1000)) }
     );
   } catch (err) {
     console.error('Failed to enforce rate limit:', err.message);

--- a/worker.js
+++ b/worker.js
@@ -2669,7 +2669,10 @@ async function checkRateLimit(env, type, identifier, limit = 3, windowMs = 60000
                 if (data.count >= limit) return true;
                 data.count++;
                 await env.USER_METADATA_KV.put(key, JSON.stringify(data), {
-                    expirationTtl: Math.ceil((windowMs - (now - data.ts)) / 1000)
+                    expirationTtl: Math.max(
+                        60,
+                        Math.ceil((windowMs - (now - data.ts)) / 1000)
+                    )
                 });
                 return false;
             }
@@ -2677,7 +2680,7 @@ async function checkRateLimit(env, type, identifier, limit = 3, windowMs = 60000
         await env.USER_METADATA_KV.put(
             key,
             JSON.stringify({ ts: now, count: 1 }),
-            { expirationTtl: Math.ceil(windowMs / 1000) }
+            { expirationTtl: Math.max(60, Math.ceil(windowMs / 1000)) }
         );
     } catch (err) {
         console.error('Failed to enforce rate limit:', err.message);


### PR DESCRIPTION
## Summary
- clamp expiration TTL in `checkRateLimit` so Cloudflare KV keeps entries for at least 60s
- verify TTL floor via new tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f5bb8ea288326947491ef245ef677