### PR TITLE
Add parseJsonSafe helper and refactor API calls

### DIFF
--- a/preworker.js
+++ b/preworker.js
@@ -2700,6 +2700,24 @@ const safeParseJson = (jsonString, defaultValue = null) => {
 };
 // ------------- END FUNCTION: safeParseJson -------------
 
+// ------------- START FUNCTION: parseJsonSafe -------------
+/**
+ * Parse JSON from a Response object with extra error handling.
+ * Logs the raw response text when JSON parsing fails.
+ * @param {Response} resp
+ * @returns {Promise<any>}
+ */
+async function parseJsonSafe(resp, label = 'response') {
+    try {
+        return await resp.json();
+    } catch (err) {
+        const bodyText = await resp.clone().text().catch(() => '[unavailable]');
+        console.error(`Failed to parse JSON from ${label}:`, bodyText);
+        throw new Error('Invalid JSON response');
+    }
+}
+// ------------- END FUNCTION: parseJsonSafe -------------
+
 // ------------- START FUNCTION: createFallbackPrincipleSummary -------------
 function createFallbackPrincipleSummary(principlesText) {
     const changeLines = principlesText
@@ -3083,7 +3101,7 @@ async function callGeminiAPI(prompt, apiKey, generationConfig = {}, safetySettin
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(requestBody)
             });
-            const data = await response.json();
+            const data = await parseJsonSafe(response);
 
             const errDet = data?.error;
             const msg = errDet?.message || `HTTP Error ${response.status}`;
@@ -3181,7 +3199,7 @@ async function callGeminiVisionAPI(
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(requestBody)
             });
-            const data = await response.json();
+            const data = await parseJsonSafe(response);
 
             const errDet = data?.error;
             const msg = errDet?.message || `HTTP Error ${response.status}`;
@@ -3863,4 +3881,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, parseJsonSafe };

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -5,6 +5,7 @@
  * @param {string} subject email subject line
  * @param {string} text plain text body
  */
+import { parseJsonSafe } from './worker.js';
 const WORKER_ADMIN_TOKEN_SECRET_NAME = 'WORKER_ADMIN_TOKEN';
 const FROM_EMAIL_VAR_NAME = 'FROM_EMAIL';
 
@@ -63,13 +64,10 @@ export async function sendEmail(to, subject, text, env = {}) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
-  const respClone = resp.clone();
   let result;
   try {
-    result = await resp.json();
-  } catch (err) {
-    const bodyText = await respClone.text().catch(() => '[unavailable]');
-    console.error('Failed to parse JSON from sendEmail response:', bodyText);
+    result = await parseJsonSafe(resp, 'sendEmail response');
+  } catch {
     throw new Error('Invalid JSON response from email service');
   }
   if (!resp.ok || result.success === false) {

--- a/worker.js
+++ b/worker.js
@@ -2700,6 +2700,24 @@ const safeParseJson = (jsonString, defaultValue = null) => {
 };
 // ------------- END FUNCTION: safeParseJson -------------
 
+// ------------- START FUNCTION: parseJsonSafe -------------
+/**
+ * Parse JSON from a Response object with extra error handling.
+ * Logs the raw response text when JSON parsing fails.
+ * @param {Response} resp
+ * @returns {Promise<any>}
+ */
+async function parseJsonSafe(resp, label = 'response') {
+    try {
+        return await resp.json();
+    } catch (err) {
+        const bodyText = await resp.clone().text().catch(() => '[unavailable]');
+        console.error(`Failed to parse JSON from ${label}:`, bodyText);
+        throw new Error('Invalid JSON response');
+    }
+}
+// ------------- END FUNCTION: parseJsonSafe -------------
+
 // ------------- START FUNCTION: createFallbackPrincipleSummary -------------
 function createFallbackPrincipleSummary(principlesText) {
     const changeLines = principlesText
@@ -3083,7 +3101,7 @@ async function callGeminiAPI(prompt, apiKey, generationConfig = {}, safetySettin
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(requestBody)
             });
-            const data = await response.json();
+            const data = await parseJsonSafe(response);
 
             const errDet = data?.error;
             const msg = errDet?.message || `HTTP Error ${response.status}`;
@@ -3181,7 +3199,7 @@ async function callGeminiVisionAPI(
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(requestBody)
             });
-            const data = await response.json();
+            const data = await parseJsonSafe(response);
 
             const errDet = data?.error;
             const msg = errDet?.message || `HTTP Error ${response.status}`;
@@ -3863,4 +3881,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, parseJsonSafe };


### PR DESCRIPTION
## Summary
- introduce `parseJsonSafe` utility for consistent response parsing
- handle Gemini JSON parsing through helper
- update email worker to use new helper

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f605969148326beba78c9593c4915