### PR TITLE
Add MailChannels email support

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
     --data '{"to":"someone@example.com","subject":"Тест","text":"Здравей"}'
   ```
   Ако `MAILER_ENDPOINT_URL` не е зададен, работникът използва `sendEmailWorker.js`
-  и изпраща данните към `MAIL_PHP_URL` (по подразбиране `https://mybody.best/mail_smtp.php`).
+  и изпраща данните чрез MailChannels.
 - **Дебъг логове** – при изпращане на заглавие `X-Debug: 1` към който и да е API
 ендпойнт, worker-ът записва в конзолата кратка информация за заявката.
 
@@ -673,8 +673,8 @@ The worker can send emails in two ways:
 
 1. If `MAILER_ENDPOINT_URL` is set, requests are forwarded to that endpoint
    (for example a standalone worker) which handles the actual delivery.
-2. Otherwise the worker posts to `MAIL_PHP_URL` via the helper from
-   `sendEmailWorker.js` (defaults to `https://mybody.best/mail_smtp.php`).
+2. Otherwise the worker calls `sendEmailWorker.js`, which now uses
+   MailChannels to deliver the message.
 
 In both cases the `/api/sendTestEmail` endpoint behaves the same and returns a
 JSON response indicating success or failure.
@@ -692,6 +692,8 @@ Example `.env` snippet:
 
 ```env
 MAILER_ENDPOINT_URL=https://send-email-worker.example.workers.dev
+MAILCHANNELS_KEY=your-mailchannels-key
+MAILCHANNELS_DOMAIN=mybody.best
 ```
 
 Example in `wrangler.toml`:
@@ -699,12 +701,14 @@ Example in `wrangler.toml`:
 ```toml
 [vars]
 MAILER_ENDPOINT_URL = "https://send-email-worker.example.workers.dev"
+MAILCHANNELS_KEY = "your-mailchannels-key"
+MAILCHANNELS_DOMAIN = "mybody.best"
 ```
 
 For a simple setup deploy `sendEmailWorker.js`, which exposes `/api/sendEmail`
-and sends messages via a PHP backend. Point `MAILER_ENDPOINT_URL` to the URL of
-this worker so the main service can dispatch emails without relying on Node.js. Requests to this endpoint also require the admin token and are rate limited.
-`sendEmailWorker.js` logs an error if the PHP endpoint returns invalid JSON.
+and sends messages through **MailChannels**. Point `MAILER_ENDPOINT_URL` to the URL of
+this worker so the main service can dispatch emails without relying on Node.js.
+Requests to this endpoint also require the admin token and are rate limited.
 
 The included `mailer.js` relies on `nodemailer` and therefore requires a Node.js
 environment. Run it as a separate service or replace it with a script that calls
@@ -713,13 +717,16 @@ an external provider.
 ### Email Environment Variables
 
 To send a test email you must set `WORKER_ADMIN_TOKEN` and either
-`MAILER_ENDPOINT_URL` or `MAIL_PHP_URL`. The optional `FROM_EMAIL` variable
-overrides the default sender address used by the PHP script.
+`MAILER_ENDPOINT_URL` or `MAILCHANNELS_KEY` (use `MAIL_PHP_URL` only for legacy
+PHP setups). The optional `FROM_EMAIL` variable overrides the default sender
+address.
 
 | Variable | Purpose |
 |----------|---------|
-| `MAILER_ENDPOINT_URL` | Endpoint called by `worker.js` when sending emails. If omitted, the worker posts to `MAIL_PHP_URL` via `sendEmailWorker.js`. |
-| `MAIL_PHP_URL` | Endpoint used by `sendEmailWorker.js` to deliver messages. Defaults to `https://mybody.best/mail_smtp.php`. Set this to the public URL of the script from [docs/mail_smtp.php](docs/mail_smtp.php). |
+| `MAILER_ENDPOINT_URL` | Endpoint called by `worker.js` when sending emails. If omitted, the worker posts to `sendEmailWorker.js`. |
+| `MAILCHANNELS_KEY` | API key for MailChannels. Required when using the HTTP API. |
+| `MAILCHANNELS_DOMAIN` | Optional domain used for the `mail_from` address. |
+| `MAIL_PHP_URL` | Legacy PHP endpoint if you prefer your own backend. Defaults to `https://mybody.best/mail_smtp.php`. |
 | `EMAIL_PASSWORD` | Password used by `mailer.js` when authenticating with the SMTP server. |
 | `FROM_EMAIL` | Sender address used by `mailer.js` and the PHP backend. |
 | `WELCOME_EMAIL_SUBJECT` | Optional custom subject for welcome emails sent by `mailer.js`. |

--- a/js/__tests__/sendTestEmailRequest.test.js
+++ b/js/__tests__/sendTestEmailRequest.test.js
@@ -79,7 +79,7 @@ test('supports alternate field names', async () => {
   expect(fetch).toHaveBeenCalledWith('https://mail.example.com', expect.any(Object));
 });
 
-test('uses PHP mail endpoint when MAILER_ENDPOINT_URL missing', async () => {
+test('uses MailChannels when MAILER_ENDPOINT_URL missing', async () => {
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => ({ success: true }),
@@ -89,10 +89,10 @@ test('uses PHP mail endpoint when MAILER_ENDPOINT_URL missing', async () => {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })
   };
-  const env = { WORKER_ADMIN_TOKEN: 'secret', MAIL_PHP_URL: 'https://mybody.best/mail_smtp.php' };
+  const env = { WORKER_ADMIN_TOKEN: 'secret', MAILCHANNELS_KEY: 'k', MAILCHANNELS_DOMAIN: 'mybody.best', FROM_EMAIL: 'info@mybody.best' };
   const res = await handleSendTestEmailRequest(request, env);
   expect(res.success).toBe(true);
-  expect(fetch).toHaveBeenCalledWith('https://mybody.best/mail_smtp.php', expect.any(Object));
+  expect(fetch).toHaveBeenCalledWith('https://api.mailchannels.net/tx/v1/send', expect.any(Object));
 });
 
 test('records usage in USER_METADATA_KV', async () => {
@@ -109,7 +109,8 @@ test('records usage in USER_METADATA_KV', async () => {
     WORKER_ADMIN_TOKEN: 'secret',
     FROM_EMAIL: 'info@mybody.best',
     USER_METADATA_KV: { put: jest.fn() },
-    MAIL_PHP_URL: 'https://mybody.best/mail_smtp.php'
+    MAILCHANNELS_KEY: 'k',
+    MAILCHANNELS_DOMAIN: 'mybody.best'
   };
   await handleSendTestEmailRequest(request, env);
   expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
@@ -117,9 +118,15 @@ test('records usage in USER_METADATA_KV', async () => {
     expect.any(String)
   );
   expect(fetch).toHaveBeenCalledWith(
-    'https://mybody.best/mail_smtp.php',
+    'https://api.mailchannels.net/tx/v1/send',
     expect.objectContaining({
-      body: JSON.stringify({ to: 't@e.com', subject: 's', body: 'b', from: 'info@mybody.best' })
+      body: JSON.stringify({
+        personalizations: [{ to: [{ email: 't@e.com' }] }],
+        from: { email: 'info@mybody.best' },
+        subject: 's',
+        content: [{ type: 'text/plain', value: 'b' }],
+        mail_from: { email: 'no-reply@mybody.best' }
+      })
     })
   );
 });


### PR DESCRIPTION
## Summary
- send emails through MailChannels instead of PHP
- document new `MAILCHANNELS_KEY` and `MAILCHANNELS_DOMAIN` variables
- update tests for MailChannels flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f64b8e61c8326898bae4f13cf2b7c