### PR TITLE
Add MailChannels email support

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
     --data '{"to":"someone@example.com","subject":"Тест","text":"Здравей"}'
   ```
   Ако `MAILER_ENDPOINT_URL` не е зададен, работникът използва `sendEmailWorker.js`
-  и изпраща данните към `MAIL_PHP_URL` (по подразбиране `https://mybody.best/mail_smtp.php`).
+  и изпраща данните чрез MailChannels.
 - **Дебъг логове** – при изпращане на заглавие `X-Debug: 1` към който и да е API
 ендпойнт, worker-ът записва в конзолата кратка информация за заявката.
 
@@ -673,8 +673,8 @@ The worker can send emails in two ways:
 
 1. If `MAILER_ENDPOINT_URL` is set, requests are forwarded to that endpoint
    (for example a standalone worker) which handles the actual delivery.
-2. Otherwise the worker posts to `MAIL_PHP_URL` via the helper from
-   `sendEmailWorker.js` (defaults to `https://mybody.best/mail_smtp.php`).
+2. Otherwise the worker calls `sendEmailWorker.js`, which now uses
+   MailChannels to deliver the message.
 
 In both cases the `/api/sendTestEmail` endpoint behaves the same and returns a
 JSON response indicating success or failure.
@@ -692,6 +692,8 @@ Example `.env` snippet:
 
 ```env
 MAILER_ENDPOINT_URL=https://send-email-worker.example.workers.dev
+MAILCHANNELS_KEY=your-mailchannels-key
+MAILCHANNELS_DOMAIN=mybody.best
 ```
 
 Example in `wrangler.toml`:
@@ -699,12 +701,14 @@ Example in `wrangler.toml`:
 ```toml
 [vars]
 MAILER_ENDPOINT_URL = "https://send-email-worker.example.workers.dev"
+MAILCHANNELS_KEY = "your-mailchannels-key"
+MAILCHANNELS_DOMAIN = "mybody.best"
 ```
 
 For a simple setup deploy `sendEmailWorker.js`, which exposes `/api/sendEmail`
-and sends messages via a PHP backend. Point `MAILER_ENDPOINT_URL` to the URL of
-this worker so the main service can dispatch emails without relying on Node.js. Requests to this endpoint also require the admin token and are rate limited.
-`sendEmailWorker.js` logs an error if the PHP endpoint returns invalid JSON.
+and sends messages through **MailChannels**. Point `MAILER_ENDPOINT_URL` to the URL of
+this worker so the main service can dispatch emails without relying on Node.js.
+Requests to this endpoint also require the admin token and are rate limited.
 
 The included `mailer.js` relies on `nodemailer` and therefore requires a Node.js
 environment. Run it as a separate service or replace it with a script that calls
@@ -713,13 +717,16 @@ an external provider.
 ### Email Environment Variables
 
 To send a test email you must set `WORKER_ADMIN_TOKEN` and either
-`MAILER_ENDPOINT_URL` or `MAIL_PHP_URL`. The optional `FROM_EMAIL` variable
-overrides the default sender address used by the PHP script.
+`MAILER_ENDPOINT_URL` or `MAILCHANNELS_KEY` (use `MAIL_PHP_URL` only for legacy
+PHP setups). The optional `FROM_EMAIL` variable overrides the default sender
+address.
 
 | Variable | Purpose |
 |----------|---------|
-| `MAILER_ENDPOINT_URL` | Endpoint called by `worker.js` when sending emails. If omitted, the worker posts to `MAIL_PHP_URL` via `sendEmailWorker.js`. |
-| `MAIL_PHP_URL` | Endpoint used by `sendEmailWorker.js` to deliver messages. Defaults to `https://mybody.best/mail_smtp.php`. Set this to the public URL of the script from [docs/mail_smtp.php](docs/mail_smtp.php). |
+| `MAILER_ENDPOINT_URL` | Endpoint called by `worker.js` when sending emails. If omitted, the worker posts to `sendEmailWorker.js`. |
+| `MAILCHANNELS_KEY` | API key for MailChannels. Required when using the HTTP API. |
+| `MAILCHANNELS_DOMAIN` | Optional domain used for the `mail_from` address. |
+| `MAIL_PHP_URL` | Legacy PHP endpoint if you prefer your own backend. Defaults to `https://mybody.best/mail_smtp.php`. |
 | `EMAIL_PASSWORD` | Password used by `mailer.js` when authenticating with the SMTP server. |
 | `FROM_EMAIL` | Sender address used by `mailer.js` and the PHP backend. |
 | `WELCOME_EMAIL_SUBJECT` | Optional custom subject for welcome emails sent by `mailer.js`. |

--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -28,44 +28,58 @@ test('rejects invalid token', async () => {
     headers: { get: h => (h === 'Authorization' ? 'Bearer bad' : null) },
     json: async () => ({ to: 'a@b.bg', subject: 'S', text: 'B' })
   };
-  const env = { WORKER_ADMIN_TOKEN: 'secret', MAIL_PHP_URL: 'https://mybody.best/mail_smtp.php' };
+  const env = { WORKER_ADMIN_TOKEN: 'secret', MAILCHANNELS_KEY: 'k' };
   const res = await handleSendEmailRequest(req, env);
   expect(res.status).toBe(403);
 });
 
-test('calls PHP endpoint on valid input', async () => {
+test('calls MailChannels endpoint on valid input', async () => {
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => ({ success: true }),
-    clone: () => ({ text: async () => '{}' })
+    clone: () => ({ text: async () => '{}' }),
+    headers: { get: () => 'application/json' }
   });
   const req = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ to: 'a@b.bg', subject: 'S', text: 'B' })
   };
-  const env = { MAIL_PHP_URL: 'https://mybody.best/mail_smtp.php', WORKER_ADMIN_TOKEN: 'secret', FROM_EMAIL: 'info@mybody.best' };
+  const env = { MAILCHANNELS_KEY: 'k', MAILCHANNELS_DOMAIN: 'mybody.best', WORKER_ADMIN_TOKEN: 'secret', FROM_EMAIL: 'info@mybody.best' };
   const res = await handleSendEmailRequest(req, env);
   expect(fetch).toHaveBeenCalledWith(
-    'https://mybody.best/mail_smtp.php',
+    'https://api.mailchannels.net/tx/v1/send',
     expect.objectContaining({
-      body: JSON.stringify({ to: 'a@b.bg', subject: 'S', body: 'B', from: 'info@mybody.best' })
+      body: JSON.stringify({
+        personalizations: [{ to: [{ email: 'a@b.bg' }] }],
+        from: { email: 'info@mybody.best' },
+        subject: 'S',
+        content: [{ type: 'text/plain', value: 'B' }],
+        mail_from: { email: 'no-reply@mybody.best' }
+      })
     })
   );
   expect(res.status).toBe(200);
   fetch.mockRestore();
 });
 
-test('sendEmail forwards data to PHP endpoint', async () => {
+test('sendEmail forwards data to MailChannels endpoint', async () => {
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => ({ success: true }),
-    clone: () => ({ text: async () => '{}' })
+    clone: () => ({ text: async () => '{}' }),
+    headers: { get: () => 'application/json' }
   });
-  await sendEmail('t@e.com', 'Hi', 'Body', { MAIL_PHP_URL: 'https://mybody.best/mail_smtp.php', FROM_EMAIL: 'info@mybody.best' });
+  await sendEmail('t@e.com', 'Hi', 'Body', { MAILCHANNELS_KEY: 'k', MAILCHANNELS_DOMAIN: 'mybody.best', FROM_EMAIL: 'info@mybody.best' });
   expect(fetch).toHaveBeenCalledWith(
-    'https://mybody.best/mail_smtp.php',
+    'https://api.mailchannels.net/tx/v1/send',
     expect.objectContaining({
-      body: JSON.stringify({ to: 't@e.com', subject: 'Hi', body: 'Body', from: 'info@mybody.best' })
+      body: JSON.stringify({
+        personalizations: [{ to: [{ email: 't@e.com' }] }],
+        from: { email: 'info@mybody.best' },
+        subject: 'Hi',
+        content: [{ type: 'text/plain', value: 'Body' }],
+        mail_from: { email: 'no-reply@mybody.best' }
+      })
     })
   );
   fetch.mockRestore();
@@ -75,11 +89,12 @@ test('sendEmail throws when backend reports failure', async () => {
   const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
-    json: async () => ({ success: false, error: 'bad' }),
-    clone: () => ({ text: async () => '{"success":false}' })
+    json: async () => ({ errors: [{ message: 'bad' }] }),
+    clone: () => ({ text: async () => '{"errors":[{"message":"bad"}]}' }),
+    headers: { get: () => 'application/json' }
   });
   await expect(sendEmail('x@y.z', 'S', 'B')).rejects.toThrow('bad');
-  expect(errSpy).toHaveBeenCalledWith('sendEmail failed response:', { success: false, error: 'bad' });
+  expect(errSpy).toHaveBeenCalledWith('sendEmail failed response:', { errors: [{ message: 'bad' }] });
   errSpy.mockRestore();
   fetch.mockRestore();
 });
@@ -89,10 +104,11 @@ test('sendEmail throws on invalid JSON response', async () => {
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => { throw new SyntaxError('bad json'); },
-    clone: () => ({ text: async () => 'not-json' })
+    clone: () => ({ text: async () => 'not-json' }),
+    headers: { get: () => 'application/json' }
   });
-  await expect(sendEmail('x@y.z', 'S', 'B')).rejects.toThrow('Invalid JSON response from email service');
-  expect(errSpy).toHaveBeenCalledWith('Failed to parse JSON from sendEmail response:', 'not-json');
+  await expect(sendEmail('x@y.z', 'S', 'B')).rejects.toThrow('Invalid JSON response from MailChannels');
+  expect(errSpy).toHaveBeenCalledWith('Failed to parse JSON from MailChannels response:', 'not-json');
   errSpy.mockRestore();
   fetch.mockRestore();
 });

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -1,5 +1,5 @@
 /**
- * Send an email via a PHP backend.
+ * Send an email via MailChannels.
  * Exported so other modules can reuse the same logic.
  * @param {string} to recipient address
  * @param {string} subject email subject line
@@ -8,6 +8,8 @@
 import { parseJsonSafe } from './worker.js';
 const WORKER_ADMIN_TOKEN_SECRET_NAME = 'WORKER_ADMIN_TOKEN';
 const FROM_EMAIL_VAR_NAME = 'FROM_EMAIL';
+const MAILCHANNELS_KEY_VAR_NAME = 'MAILCHANNELS_KEY';
+const MAILCHANNELS_DOMAIN_VAR_NAME = 'MAILCHANNELS_DOMAIN';
 
 async function recordUsage(env, identifier = '') {
   try {
@@ -53,27 +55,49 @@ async function checkRateLimit(env, identifier, limit = 3, windowMs = 60000) {
   return false;
 }
 
-export async function sendEmail(to, subject, text, env = {}) {
-  // Fallback URL when MAIL_PHP_URL is not provided
-  const endpoint = env.MAIL_PHP_URL || 'https://mybody.best/mail_smtp.php';
-  const fromEmail = env[FROM_EMAIL_VAR_NAME];
-  const payload = { to, subject, body: text };
-  if (fromEmail) payload.from = fromEmail;
-  const resp = await fetch(endpoint, {
+async function sendViaMailChannels(to, subject, text, env = {}) {
+  const from = env[FROM_EMAIL_VAR_NAME] || `no-reply@${env[MAILCHANNELS_DOMAIN_VAR_NAME] || 'example.com'}`;
+  const payload = {
+    personalizations: [{ to: [{ email: to }] }],
+    from: { email: from },
+    subject,
+    content: [{ type: 'text/plain', value: text }]
+  };
+  if (env[MAILCHANNELS_DOMAIN_VAR_NAME]) {
+    payload.mail_from = { email: `no-reply@${env[MAILCHANNELS_DOMAIN_VAR_NAME]}` };
+  }
+  const headers = { 'Content-Type': 'application/json' };
+  if (env[MAILCHANNELS_KEY_VAR_NAME]) {
+    headers.Authorization = `Bearer ${env[MAILCHANNELS_KEY_VAR_NAME]}`;
+  }
+  const resp = await fetch('https://api.mailchannels.net/tx/v1/send', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify(payload)
   });
-  let result;
-  try {
-    result = await parseJsonSafe(resp, 'sendEmail response');
-  } catch {
-    throw new Error('Invalid JSON response from email service');
+
+  const contentType = resp.headers.get('content-type') || '';
+  let result = null;
+  if (contentType.includes('application/json')) {
+    try {
+      result = await parseJsonSafe(resp, 'MailChannels response');
+    } catch {
+      throw new Error('Invalid JSON response from MailChannels');
+    }
+  } else if (!resp.ok) {
+    const bodyText = await resp.text().catch(() => '[unavailable]');
+    console.error('Unexpected MailChannels response:', bodyText);
+    throw new Error(`MailChannels error ${resp.status}`);
   }
-  if (!resp.ok || result.success === false) {
+
+  if (!resp.ok || result?.errors) {
     console.error('sendEmail failed response:', result);
-    throw new Error(result.error || result.message || 'Failed to send');
+    throw new Error(result?.errors?.[0]?.message || result?.message || 'Failed to send');
   }
+}
+
+export async function sendEmail(to, subject, text, env = {}) {
+  await sendViaMailChannels(to, subject, text, env);
 }
 
 export async function handleSendEmailRequest(request, env = {}) {


### PR DESCRIPTION
## Summary
- send emails through MailChannels instead of PHP
- document new `MAILCHANNELS_KEY` and `MAILCHANNELS_DOMAIN` variables
- update tests for MailChannels flow
- handle unexpected MailChannels responses and ensure JSON parsing only when appropriate

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f64b8e61c8326898bae4f13cf2b7c