### PR TITLE
Improve sendEmail JSON error handling

### DIFF
--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -88,11 +88,23 @@ test('sendEmail throws on invalid JSON response', async () => {
   const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
+    status: 200,
     json: async () => { throw new SyntaxError('bad json'); },
     clone: () => ({ text: async () => 'not-json' })
   });
-  await expect(sendEmail('x@y.z', 'S', 'B')).rejects.toThrow('Invalid JSON response from email service');
-  expect(errSpy).toHaveBeenCalledWith('Failed to parse JSON from sendEmail response:', 'not-json');
+  await expect(sendEmail('x@y.z', 'S', 'B')).rejects.toThrow(
+    'Invalid JSON response from email service (status 200)'
+  );
+  expect(errSpy).toHaveBeenNthCalledWith(
+    1,
+    'Failed to parse JSON from sendEmail response:',
+    'not-json'
+  );
+  expect(errSpy).toHaveBeenNthCalledWith(
+    2,
+    'Invalid JSON response from email service (status 200):',
+    'not-json'
+  );
   errSpy.mockRestore();
   fetch.mockRestore();
 });

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -68,7 +68,15 @@ export async function sendEmail(to, subject, text, env = {}) {
   try {
     result = await parseJsonSafe(resp, 'sendEmail response');
   } catch {
-    throw new Error('Invalid JSON response from email service');
+    const bodyText = await resp.clone().text().catch(() => '[unavailable]');
+    const snippet = bodyText.slice(0, 200);
+    console.error(
+      `Invalid JSON response from email service (status ${resp.status}):`,
+      snippet
+    );
+    throw new Error(
+      `Invalid JSON response from email service (status ${resp.status})`
+    );
   }
   if (!resp.ok || result.success === false) {
     console.error('sendEmail failed response:', result);


### PR DESCRIPTION
## Summary
- handle invalid JSON responses in `sendEmailWorker.js` by logging status and a body snippet
- include status code in the thrown error
- expect these details in `sendEmailWorker` tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f647a116883268d6f53b8224ba967