### PR TITLE
Move parseJsonSafe util

### DIFF
--- a/preworker.js
+++ b/preworker.js
@@ -26,6 +26,7 @@ async function defaultSendEmail(to, subject, body) {
     throw new Error('Email functionality is not configured.');
 }
 import { sendEmail as phpSendEmail } from './sendEmailWorker.js';
+import { parseJsonSafe } from './utils/parseJsonSafe.js';
 
 /** @type {(to: string, subject: string, body: string) => Promise<void>} */
 let sendEmailFn = defaultSendEmail;
@@ -2700,23 +2701,6 @@ const safeParseJson = (jsonString, defaultValue = null) => {
 };
 // ------------- END FUNCTION: safeParseJson -------------
 
-// ------------- START FUNCTION: parseJsonSafe -------------
-/**
- * Parse JSON from a Response object with extra error handling.
- * Logs the raw response text when JSON parsing fails.
- * @param {Response} resp
- * @returns {Promise<any>}
- */
-async function parseJsonSafe(resp, label = 'response') {
-    try {
-        return await resp.json();
-    } catch (err) {
-        const bodyText = await resp.clone().text().catch(() => '[unavailable]');
-        console.error(`Failed to parse JSON from ${label}:`, bodyText);
-        throw new Error('Invalid JSON response');
-    }
-}
-// ------------- END FUNCTION: parseJsonSafe -------------
 
 // ------------- START FUNCTION: createFallbackPrincipleSummary -------------
 function createFallbackPrincipleSummary(principlesText) {
@@ -3881,4 +3865,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, parseJsonSafe };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -5,7 +5,7 @@
  * @param {string} subject email subject line
  * @param {string} text plain text body
  */
-import { parseJsonSafe } from './worker.js';
+import { parseJsonSafe } from './utils/parseJsonSafe.js';
 const WORKER_ADMIN_TOKEN_SECRET_NAME = 'WORKER_ADMIN_TOKEN';
 const FROM_EMAIL_VAR_NAME = 'FROM_EMAIL';
 const MAILCHANNELS_KEY_VAR_NAME = 'MAILCHANNELS_KEY';

--- a/utils/parseJsonSafe.js
+++ b/utils/parseJsonSafe.js
@@ -1,0 +1,16 @@
+/**
+ * Parse JSON from a Response object with extra error handling.
+ * Logs the raw response text when JSON parsing fails.
+ * @param {Response} resp
+ * @param {string} [label='response'] label used in the log message
+ * @returns {Promise<any>}
+ */
+export async function parseJsonSafe(resp, label = 'response') {
+    try {
+        return await resp.json();
+    } catch {
+        const bodyText = await resp.clone().text().catch(() => '[unavailable]');
+        console.error(`Failed to parse JSON from ${label}:`, bodyText);
+        throw new Error('Invalid JSON response');
+    }
+}

--- a/worker.js
+++ b/worker.js
@@ -26,6 +26,7 @@ async function defaultSendEmail(to, subject, body) {
     throw new Error('Email functionality is not configured.');
 }
 import { sendEmail as phpSendEmail } from './sendEmailWorker.js';
+import { parseJsonSafe } from './utils/parseJsonSafe.js';
 
 /** @type {(to: string, subject: string, body: string) => Promise<void>} */
 let sendEmailFn = defaultSendEmail;
@@ -2700,23 +2701,6 @@ const safeParseJson = (jsonString, defaultValue = null) => {
 };
 // ------------- END FUNCTION: safeParseJson -------------
 
-// ------------- START FUNCTION: parseJsonSafe -------------
-/**
- * Parse JSON from a Response object with extra error handling.
- * Logs the raw response text when JSON parsing fails.
- * @param {Response} resp
- * @returns {Promise<any>}
- */
-async function parseJsonSafe(resp, label = 'response') {
-    try {
-        return await resp.json();
-    } catch (err) {
-        const bodyText = await resp.clone().text().catch(() => '[unavailable]');
-        console.error(`Failed to parse JSON from ${label}:`, bodyText);
-        throw new Error('Invalid JSON response');
-    }
-}
-// ------------- END FUNCTION: parseJsonSafe -------------
 
 // ------------- START FUNCTION: createFallbackPrincipleSummary -------------
 function createFallbackPrincipleSummary(principlesText) {
@@ -3881,4 +3865,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, parseJsonSafe };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };


### PR DESCRIPTION
## Summary
- split `parseJsonSafe` into a dedicated module in `utils`
- import the new util in `worker.js` and `sendEmailWorker.js`
- keep `worker.js` and `preworker.js` synchronized
- remove unused export to break circular dependency

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f6c669db48326bfc0bafc0a05c50a