### PR TITLE
Add MAILCHANNELS_KEY validation

### DIFF
--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -85,6 +85,15 @@ test('sendEmail forwards data to MailChannels endpoint', async () => {
   fetch.mockRestore();
 });
 
+test('sendEmail returns error when MAILCHANNELS_KEY missing', async () => {
+  const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const result = await sendEmail('x@y.z', 'S', 'B', {});
+  expect(result).toBeInstanceOf(Error);
+  expect(result.message).toBe('Missing MAILCHANNELS_KEY');
+  expect(errSpy).toHaveBeenCalledWith('Missing MAILCHANNELS_KEY environment variable');
+  errSpy.mockRestore();
+});
+
 test('sendEmail throws when backend reports failure', async () => {
   const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   global.fetch = jest.fn().mockResolvedValue({
@@ -93,7 +102,7 @@ test('sendEmail throws when backend reports failure', async () => {
     clone: () => ({ text: async () => '{"errors":[{"message":"bad"}]}' }),
     headers: { get: () => 'application/json' }
   });
-  await expect(sendEmail('x@y.z', 'S', 'B')).rejects.toThrow('bad');
+  await expect(sendEmail('x@y.z', 'S', 'B', { MAILCHANNELS_KEY: 'k' })).rejects.toThrow('bad');
   expect(errSpy).toHaveBeenCalledWith('sendEmail failed response:', { errors: [{ message: 'bad' }] });
   errSpy.mockRestore();
   fetch.mockRestore();
@@ -107,7 +116,7 @@ test('sendEmail throws on invalid JSON response', async () => {
     clone: () => ({ text: async () => 'not-json' }),
     headers: { get: () => 'application/json' }
   });
-  await expect(sendEmail('x@y.z', 'S', 'B')).rejects.toThrow('Invalid JSON response from MailChannels');
+  await expect(sendEmail('x@y.z', 'S', 'B', { MAILCHANNELS_KEY: 'k' })).rejects.toThrow('Invalid JSON response from MailChannels');
   expect(errSpy).toHaveBeenCalledWith('Failed to parse JSON from MailChannels response:', 'not-json');
   errSpy.mockRestore();
   fetch.mockRestore();

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -56,6 +56,10 @@ async function checkRateLimit(env, identifier, limit = 3, windowMs = 60000) {
 }
 
 async function sendViaMailChannels(to, subject, text, env = {}) {
+  if (!env[MAILCHANNELS_KEY_VAR_NAME]) {
+    console.error('Missing MAILCHANNELS_KEY environment variable');
+    return new Error('Missing MAILCHANNELS_KEY');
+  }
   const from = env[FROM_EMAIL_VAR_NAME] || `no-reply@${env[MAILCHANNELS_DOMAIN_VAR_NAME] || 'example.com'}`;
   const payload = {
     personalizations: [{ to: [{ email: to }] }],
@@ -97,7 +101,7 @@ async function sendViaMailChannels(to, subject, text, env = {}) {
 }
 
 export async function sendEmail(to, subject, text, env = {}) {
-  await sendViaMailChannels(to, subject, text, env);
+  return await sendViaMailChannels(to, subject, text, env);
 }
 
 export async function handleSendEmailRequest(request, env = {}) {


### PR DESCRIPTION
## Summary
- ensure `MAILCHANNELS_KEY` is present before sending mail
- return result of `sendViaMailChannels`
- cover missing `MAILCHANNELS_KEY` case and update tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f783558dc8326abc6dfa61285b0b7