### PR TITLE
Update README with MailChannels note

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,17 @@ address.
 | `WELCOME_EMAIL_SUBJECT` | Optional custom subject for welcome emails sent by `mailer.js`. |
 | `WELCOME_EMAIL_BODY` | Optional HTML body template for welcome emails. The string `{{name}}` will be replaced with the recipient's name. |
 | `WORKER_URL` | Base URL of the main worker used by `mailer.js` to fetch email templates when no subject or body is provided. |
+> **Бележка**: MailChannels връща HTTP 401 при грешен или липсващ `MAILCHANNELS_KEY`, както и когато домейнът в `MAILCHANNELS_DOMAIN` не е разрешен.
+
+Проверете стойностите така:
+
+```bash
+# показва тайните записани за работника
+wrangler secret list
+
+# или прегледайте локалния .env файл
+grep MAILCHANNELS .env
+```
 Примерен PHP скрипт за изпращане на писма е наличен в [docs/mail_smtp.php](docs/mail_smtp.php). Настройте `MAIL_PHP_URL` да сочи към същия или сходен адрес.
 
 ### PHP script requirements


### PR DESCRIPTION
## Summary
- add a note that MailChannels returns 401 for invalid `MAILCHANNELS_KEY` or domain
- show how to check env variables using `wrangler secret` and `.env`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f783683c88326bfbcb5f228866641