### PR TITLE
Add Authorization header test for sendEmail

### DIFF
--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -85,6 +85,25 @@ test('sendEmail forwards data to MailChannels endpoint', async () => {
   fetch.mockRestore();
 });
 
+test('sendEmail sets Authorization header when key provided', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true }),
+    clone: () => ({ text: async () => '{}' }),
+    headers: { get: () => 'application/json' }
+  });
+
+  await sendEmail('t@e.com', 'Hi', 'Body', { MAILCHANNELS_KEY: 'k' });
+
+  expect(fetch).toHaveBeenCalledWith(
+    'https://api.mailchannels.net/tx/v1/send',
+    expect.objectContaining({
+      headers: expect.objectContaining({ Authorization: 'Bearer k' })
+    })
+  );
+  fetch.mockRestore();
+});
+
 test('sendEmail returns error when MAILCHANNELS_KEY missing', async () => {
   const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   const result = await sendEmail('x@y.z', 'S', 'B', {});


### PR DESCRIPTION
## Summary
- ensure `sendEmail` attaches MailChannels auth header

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f79cab7ac8326b7a27d838db91f88