### PR TITLE
Add auth header test for sendEmail

### DIFF
--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -85,6 +85,27 @@ test('sendEmail forwards data to MailChannels endpoint', async () => {
   fetch.mockRestore();
 });
 
+test('sendEmail includes Authorization header when key provided', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true }),
+    clone: () => ({ text: async () => '{}' }),
+    headers: { get: () => 'application/json' }
+  });
+  await sendEmail('t@e.com', 'Hi', 'Body', {
+    MAILCHANNELS_KEY: 'k',
+    MAILCHANNELS_DOMAIN: 'mybody.best',
+    FROM_EMAIL: 'info@mybody.best'
+  });
+  expect(fetch).toHaveBeenCalledWith(
+    'https://api.mailchannels.net/tx/v1/send',
+    expect.objectContaining({
+      headers: expect.objectContaining({ Authorization: 'Bearer k' })
+    })
+  );
+  fetch.mockRestore();
+});
+
 test('sendEmail throws when backend reports failure', async () => {
   const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   global.fetch = jest.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- add unit test ensuring `sendEmail` includes Authorization header when MAILCHANNELS_KEY is provided

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f782d48dc8326a8ad8f69ee723e8d