### PR TITLE
Remove mandatory MailChannels key

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,7 +692,6 @@ Example `.env` snippet:
 
 ```env
 MAILER_ENDPOINT_URL=https://send-email-worker.example.workers.dev
-MAILCHANNELS_KEY=your-mailchannels-key
 MAILCHANNELS_DOMAIN=mybody.best
 ```
 
@@ -701,7 +700,6 @@ Example in `wrangler.toml`:
 ```toml
 [vars]
 MAILER_ENDPOINT_URL = "https://send-email-worker.example.workers.dev"
-MAILCHANNELS_KEY = "your-mailchannels-key"
 MAILCHANNELS_DOMAIN = "mybody.best"
 ```
 
@@ -717,14 +715,14 @@ an external provider.
 ### Email Environment Variables
 
 To send a test email you must set `WORKER_ADMIN_TOKEN` and either
-`MAILER_ENDPOINT_URL` or `MAILCHANNELS_KEY` (use `MAIL_PHP_URL` only for legacy
-PHP setups). The optional `FROM_EMAIL` variable overrides the default sender
+`MAILER_ENDPOINT_URL` or `MAILCHANNELS_KEY` when using a dedicated account
+(use `MAIL_PHP_URL` only for legacy PHP setups). The optional `FROM_EMAIL` variable overrides the default sender
 address.
 
 | Variable | Purpose |
 |----------|---------|
 | `MAILER_ENDPOINT_URL` | Endpoint called by `worker.js` when sending emails. If omitted, the worker posts to `sendEmailWorker.js`. |
-| `MAILCHANNELS_KEY` | API key for MailChannels. Required when using the HTTP API. |
+| `MAILCHANNELS_KEY` | Optional API key for MailChannels. Provide it only if you use a dedicated account. |
 | `MAILCHANNELS_DOMAIN` | Optional domain used for the `mail_from` address. |
 | `MAIL_PHP_URL` | Legacy PHP endpoint if you prefer your own backend. Defaults to `https://mybody.best/mail_smtp.php`. |
 | `EMAIL_PASSWORD` | Password used by `mailer.js` when authenticating with the SMTP server. |
@@ -732,7 +730,7 @@ address.
 | `WELCOME_EMAIL_SUBJECT` | Optional custom subject for welcome emails sent by `mailer.js`. |
 | `WELCOME_EMAIL_BODY` | Optional HTML body template for welcome emails. The string `{{name}}` will be replaced with the recipient's name. |
 | `WORKER_URL` | Base URL of the main worker used by `mailer.js` to fetch email templates when no subject or body is provided. |
-> **Бележка**: MailChannels връща HTTP 401 при грешен или липсващ `MAILCHANNELS_KEY`, както и когато домейнът в `MAILCHANNELS_DOMAIN` не е разрешен.
+> **Бележка**: MailChannels връща HTTP 401 при невалиден ключ или когато домейнът в `MAILCHANNELS_DOMAIN` не е разрешен.
 
 Проверете стойностите така:
 

--- a/js/__tests__/sendTestEmailRequest.test.js
+++ b/js/__tests__/sendTestEmailRequest.test.js
@@ -92,7 +92,7 @@ test('uses MailChannels when MAILER_ENDPOINT_URL missing', async () => {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
     json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })
   };
-  const env = { WORKER_ADMIN_TOKEN: 'secret', MAILCHANNELS_KEY: 'k', MAILCHANNELS_DOMAIN: 'mybody.best', FROM_EMAIL: 'info@mybody.best' };
+  const env = { WORKER_ADMIN_TOKEN: 'secret', MAILCHANNELS_DOMAIN: 'mybody.best', FROM_EMAIL: 'info@mybody.best' };
   const res = await handleSendTestEmailRequest(request, env);
   expect(res.success).toBe(true);
   expect(fetch).toHaveBeenCalledWith('https://api.mailchannels.net/tx/v1/send', expect.any(Object));
@@ -113,7 +113,6 @@ test('records usage in USER_METADATA_KV', async () => {
     WORKER_ADMIN_TOKEN: 'secret',
     FROM_EMAIL: 'info@mybody.best',
     USER_METADATA_KV: { put: jest.fn() },
-    MAILCHANNELS_KEY: 'k',
     MAILCHANNELS_DOMAIN: 'mybody.best'
   };
   await handleSendTestEmailRequest(request, env);

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -56,10 +56,6 @@ async function checkRateLimit(env, identifier, limit = 3, windowMs = 60000) {
 }
 
 async function sendViaMailChannels(to, subject, text, env = {}) {
-  if (!env[MAILCHANNELS_KEY_VAR_NAME]) {
-    console.error('Missing MAILCHANNELS_KEY environment variable');
-    return new Error('Missing MAILCHANNELS_KEY');
-  }
   const from = env[FROM_EMAIL_VAR_NAME] || `no-reply@${env[MAILCHANNELS_DOMAIN_VAR_NAME] || 'example.com'}`;
   const payload = {
     personalizations: [{ to: [{ email: to }] }],


### PR DESCRIPTION
## Summary
- drop MAILCHANNELS_KEY requirement from sendEmailWorker
- update email tests for optional key
- adjust test data for sendTestEmailRequest
- document optional MailChannels API key

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f7c8fd8148326943d56036574d54d