### PR TITLE
Remove nodemailer from deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,9 +708,10 @@ and sends messages through **MailChannels**. Point `MAILER_ENDPOINT_URL` to the 
 this worker so the main service can dispatch emails without relying on Node.js.
 Requests to this endpoint also require the admin token and are rate limited.
 
-The included `mailer.js` relies on `nodemailer` and therefore requires a Node.js
-environment. Run it as a separate service or replace it with a script that calls
-an external provider.
+The included `mailer.js` relies on `nodemailer`, which is not installed by
+default. Add it manually if you wish to use this Node.js script. You can run the
+mailer as a separate service or replace it with a script that calls an external
+provider.
 
 ### Email Environment Variables
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.5.0",
-        "jsonrepair": "^3.12.0",
-        "nodemailer": "^7.0.3"
+        "jsonrepair": "^3.12.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250627.0",
@@ -21,6 +20,7 @@
         "globals": "^16.2.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0",
+        "nodemailer": "^7.0.3",
         "typedoc": "^0.28.5",
         "vite": "^6.3.5"
       },
@@ -5334,6 +5334,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
       "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
+      "dev": true,
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0",
     "typedoc": "^0.28.5",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "nodemailer": "^7.0.3"
   },
   "dependencies": {
     "dotenv": "^16.5.0",
-    "jsonrepair": "^3.12.0",
-    "nodemailer": "^7.0.3"
+    "jsonrepair": "^3.12.0"
   }
 }


### PR DESCRIPTION
## Summary
- move `nodemailer` from dependencies to devDependencies
- regenerate package-lock
- clarify in README that nodemailer must be installed manually

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68609ebae9408326b369cc6f619eff3c