### PR TITLE
Replace Nodemailer with fetch-based mailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,9 +708,8 @@ and sends messages through **MailChannels**. Point `MAILER_ENDPOINT_URL` to the 
 this worker so the main service can dispatch emails without relying on Node.js.
 Requests to this endpoint also require the admin token and are rate limited.
 
-The included `mailer.js` relies on `nodemailer` and therefore requires a Node.js
-environment. Run it as a separate service or replace it with a script that calls
-an external provider.
+`mailer.js` sends requests to `MAIL_PHP_URL` via `fetch`. Run it as a Node script
+when using the PHP backend or adjust it to suit your setup.
 
 ### Email Environment Variables
 
@@ -725,7 +724,7 @@ address.
 | `MAILCHANNELS_KEY` | Optional API key for MailChannels. Provide it only if you use a dedicated account. |
 | `MAILCHANNELS_DOMAIN` | Optional domain used for the `mail_from` address. |
 | `MAIL_PHP_URL` | Legacy PHP endpoint if you prefer your own backend. Defaults to `https://mybody.best/mail_smtp.php`. |
-| `EMAIL_PASSWORD` | Password used by `mailer.js` when authenticating with the SMTP server. |
+| `EMAIL_PASSWORD` | Password used by the PHP backend when authenticating with the SMTP server. |
 | `FROM_EMAIL` | Sender address used by `mailer.js` and the PHP backend. |
 | `WELCOME_EMAIL_SUBJECT` | Optional custom subject for welcome emails sent by `mailer.js`. |
 | `WELCOME_EMAIL_BODY` | Optional HTML body template for welcome emails. The string `{{name}}` will be replaced with the recipient's name. |

--- a/js/__tests__/mailer.test.js
+++ b/js/__tests__/mailer.test.js
@@ -1,45 +1,48 @@
 import { jest } from '@jest/globals'
 
-let sendWelcomeEmail, createTransportMock, sendMailMock
+let sendWelcomeEmail
 
 beforeEach(async () => {
     jest.resetModules()
-    process.env.EMAIL_PASSWORD = 'pass'
     process.env.WORKER_URL = 'https://api'
-    sendMailMock = jest.fn().mockResolvedValue(undefined)
-    createTransportMock = jest.fn(() => ({ sendMail: sendMailMock }))
-    global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ success: true, config: { welcome_email_subject: 'Тест', welcome_email_body: '<p>Hello {{name}}</p>' } })
-    })
-    jest.unstable_mockModule('nodemailer', () => ({ default: { createTransport: createTransportMock } }))
+    process.env.MAIL_PHP_URL = 'https://php/send'
+    global.fetch = jest.fn()
+    global.fetch
+        .mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ success: true, config: { welcome_email_subject: 'Тест', welcome_email_body: '<p>Hello {{name}}</p>' } })
+        })
+        .mockResolvedValueOnce({ ok: true })
     ;({ sendWelcomeEmail } = await import('../../mailer.js'))
 })
 
 afterEach(() => {
     global.fetch.mockRestore()
     delete process.env.WORKER_URL
+    delete process.env.MAIL_PHP_URL
 })
 
 test('sends welcome email with correct options', async () => {
     await sendWelcomeEmail('client@example.com', 'Иван')
-    expect(createTransportMock).toHaveBeenCalledWith({
-        host: 'mybody.best',
-        port: 465,
-        secure: true,
-        auth: { user: 'info@mybody.best', pass: 'pass' }
-    })
-    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({
-        from: 'info@mybody.best',
-        to: 'client@example.com',
-        subject: 'Тест'
-    }))
-    expect(sendMailMock.mock.calls[0][0].html).toContain('Hello Иван')
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+    expect(global.fetch).toHaveBeenNthCalledWith(1, 'https://api/api/getAiConfig')
+    const [, options] = global.fetch.mock.calls[1]
+    expect(global.fetch.mock.calls[1][0]).toBe('https://php/send')
+    const body = JSON.parse(options.body)
+    expect(body.to).toBe('client@example.com')
+    expect(body.subject).toBe('Тест')
+    expect(body.message).toContain('Hello Иван')
 })
 
 test('logs error on failure', async () => {
     const error = new Error('fail')
-    sendMailMock.mockRejectedValueOnce(error)
+    global.fetch.mockReset()
+    global.fetch
+        .mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ success: true, config: { welcome_email_subject: 'Тест', welcome_email_body: '<p>Hello {{name}}</p>' } })
+        })
+        .mockRejectedValueOnce(error)
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
     await sendWelcomeEmail('client@example.com', 'Иван')
     expect(spy).toHaveBeenCalled()

--- a/mailer.d.ts
+++ b/mailer.d.ts
@@ -1,2 +1,3 @@
+/** Send an email through the PHP backend configured by `MAIL_PHP_URL`. */
 export function sendEmail(to: string, subject: string, html: string): Promise<void>;
 export function sendWelcomeEmail(to: string, name: string): Promise<void>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.5.0",
-        "jsonrepair": "^3.12.0",
-        "nodemailer": "^7.0.3"
+        "jsonrepair": "^3.12.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250627.0",
@@ -5329,15 +5328,6 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nodemailer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
-      "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "dotenv": "^16.5.0",
-    "jsonrepair": "^3.12.0",
-    "nodemailer": "^7.0.3"
+    "jsonrepair": "^3.12.0"
   }
 }


### PR DESCRIPTION
## Summary
- switch `mailer.js` to POST email data to `MAIL_PHP_URL`
- update type declaration and tests for the new implementation
- drop nodemailer from dependencies
- refresh docs to explain the new mailer and env var

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68609eb1b0948326a2c595cca1137208