### PR TITLE
Update mailer URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ means the Node dependencies haven't been installed. Run `npm install` and then
 try again. Recent versions of the worker rely on the `MAILER_ENDPOINT_URL`
 environment variable instead of dynamic imports. If this variable is missing, the
 worker uses the helper from `sendEmailWorker.js` and posts directly to
-`MAIL_PHP_URL` (defaults to `https://mybody.best/mail_smtp.php`). A **500** error from
+`MAIL_PHP_URL` (defaults to `https://mybody.best/mailer/mail.php`). A **500** error from
 `/api/sendTestEmail` usually indicates a problem with the PHP backend. Inspect
 the worker logs for details.
 
@@ -732,7 +732,7 @@ To send a test email задайте `WORKER_ADMIN_TOKEN`. Може да посо
 | Variable | Purpose |
 |----------|---------|
 | `MAILER_ENDPOINT_URL` | Endpoint called by `worker.js` when sending emails. If omitted, the worker posts to `sendEmailWorker.js`. |
-| `MAIL_PHP_URL` | Legacy PHP endpoint if you prefer your own backend. Defaults to `https://mybody.best/mail_smtp.php`. |
+| `MAIL_PHP_URL` | Legacy PHP endpoint if you prefer your own backend. Defaults to `https://mybody.best/mailer/mail.php`. |
 | `EMAIL_PASSWORD` | Password used by `mailer.js` when authenticating with the SMTP server. |
 | `FROM_EMAIL` | Sender address used by `mailer.js` and the PHP backend. |
 | `WELCOME_EMAIL_SUBJECT` | Optional custom subject for welcome emails sent by `mailer.js`. |

--- a/docs/mail.php
+++ b/docs/mail.php
@@ -19,7 +19,7 @@ error_log('Input: '.json_encode($data));
 // Валидация
 $to = $data['to'] ?? '';
 $subject = $data['subject'] ?? '(Без тема)';
-$body = $data['body'] ?? '';
+$body = $data['body'] ?? ($data['message'] ?? '');
 
 if (!filter_var($to, FILTER_VALIDATE_EMAIL)) {
     http_response_code(400);

--- a/docs/mail_smtp.php
+++ b/docs/mail_smtp.php
@@ -17,7 +17,7 @@ $data = json_decode(file_get_contents('php://input'), true);
 
 $to = $data['to'] ?? '';
 $subject = $data['subject'] ?? '(Без тема)';
-$body = $data['body'] ?? '';
+$body = $data['body'] ?? ($data['message'] ?? '');
 
 if (!filter_var($to, FILTER_VALIDATE_EMAIL)) {
     http_response_code(400);

--- a/mailer.js
+++ b/mailer.js
@@ -64,7 +64,7 @@ async function getEmailTemplate() {
  * @returns {Promise<void>} resolves when the message is sent
  */
 export async function sendEmail(toEmail, subject, html) {
-    const url = process.env.MAIL_PHP_URL || 'https://mybody.best/mail_smtp.php'
+    const url = process.env.MAIL_PHP_URL || 'https://mybody.best/mailer/mail.php'
     const resp = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- change mailer default URL to `https://mybody.best/mailer/mail.php`
- allow PHP mail scripts to accept `message` when `body` is absent
- document new default URL in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860a95adf308326b00b86df6ac136cb