### PR TITLE
Update sendTestEmail body handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,13 +629,13 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
     --data '{"recipient":"user@example.com","subject":"Test","body":"Hello"}'
   ```
   Полетата `recipient`, `subject` и `body` са задължителни. Като алтернатива
-  могат да се използват имената `to` и `text`.
+  могат да се използват имената `to`, `text` или `message`.
 
   ```bash
   curl -X POST https://<your-domain>/api/sendTestEmail \
     -H "Authorization: Bearer <WORKER_ADMIN_TOKEN>" \
     -H "Content-Type: application/json" \
-    --data '{"to":"someone@example.com","subject":"Тест","text":"Здравей"}'
+    --data '{"to":"someone@example.com","subject":"Тест","message":"Здравей"}'
   ```
   ```javascript
   await fetch('/api/sendTestEmail', {
@@ -647,7 +647,7 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
     body: JSON.stringify({
       to: 'someone@example.com',
       subject: 'Тест',
-      text: 'Здравей'
+      message: 'Здравей'
     })
   });
   ```

--- a/js/__tests__/sendTestEmail.test.js
+++ b/js/__tests__/sendTestEmail.test.js
@@ -45,7 +45,7 @@ test('sendTestEmail posts form data', async () => {
   expect(global.fetch).toHaveBeenCalledWith('/api/sendTestEmail', expect.objectContaining({
     method: 'POST',
     headers: expect.any(Object),
-    body: JSON.stringify({ recipient: 'a@b.bg', subject: 'Sub', message: 'Body' })
+    body: JSON.stringify({ recipient: 'a@b.bg', subject: 'Sub', body: 'Body' })
   }));
 });
 

--- a/js/__tests__/sendTestEmailRequest.test.js
+++ b/js/__tests__/sendTestEmailRequest.test.js
@@ -73,7 +73,7 @@ test('supports alternate field names', async () => {
   });
   const request = {
     headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
-    json: async () => ({ to: 'alt@example.com', subject: 'Hi', text: 'b' })
+    json: async () => ({ to: 'alt@example.com', subject: 'Hi', message: 'b' })
   };
   const env = { WORKER_ADMIN_TOKEN: 'secret', MAILER_ENDPOINT_URL: 'https://mail.example.com' };
   const res = await handleSendTestEmailRequest(request, env);

--- a/js/admin.js
+++ b/js/admin.js
@@ -1228,7 +1228,7 @@ async function sendTestEmail() {
         const resp = await fetch(apiEndpoints.sendTestEmail, {
             method: 'POST',
             headers,
-            body: JSON.stringify({ recipient, subject, message: body })
+            body: JSON.stringify({ recipient, subject, body })
         });
 
         const ct = resp.headers.get('Content-Type') || '';

--- a/preworker.js
+++ b/preworker.js
@@ -1871,7 +1871,7 @@ async function handleSendTestEmailRequest(request, env) {
 
         const recipient = data.recipient ?? data.to;
         const subject = data.subject;
-        const body = data.body ?? data.text;
+        const body = data.body ?? data.text ?? data.message;
 
         if (typeof recipient !== 'string' || !recipient) {
             return { success: false, message: 'Missing field: recipient (use "recipient" or "to")', statusHint: 400 };
@@ -1880,7 +1880,7 @@ async function handleSendTestEmailRequest(request, env) {
             return { success: false, message: 'Missing field: subject', statusHint: 400 };
         }
         if (typeof body !== 'string' || !body) {
-            return { success: false, message: 'Missing field: body (use "body" or "text")', statusHint: 400 };
+            return { success: false, message: 'Missing field: body (use "body", "text" or "message")', statusHint: 400 };
         }
 
         const sendEmail = await getSendEmail(env);

--- a/worker.js
+++ b/worker.js
@@ -1871,7 +1871,7 @@ async function handleSendTestEmailRequest(request, env) {
 
         const recipient = data.recipient ?? data.to;
         const subject = data.subject;
-        const body = data.body ?? data.text;
+        const body = data.body ?? data.text ?? data.message;
 
         if (typeof recipient !== 'string' || !recipient) {
             return { success: false, message: 'Missing field: recipient (use "recipient" or "to")', statusHint: 400 };
@@ -1880,7 +1880,7 @@ async function handleSendTestEmailRequest(request, env) {
             return { success: false, message: 'Missing field: subject', statusHint: 400 };
         }
         if (typeof body !== 'string' || !body) {
-            return { success: false, message: 'Missing field: body (use "body" or "text")', statusHint: 400 };
+            return { success: false, message: 'Missing field: body (use "body", "text" or "message")', statusHint: 400 };
         }
 
         const sendEmail = await getSendEmail(env);


### PR DESCRIPTION
## Summary
- ensure `body` is resolved from `body`, `text` or `message`
- adjust admin panel to send `{ body }`
- update docs and unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860a95f9a388326a12f0cc3594c0a7b