### PR TITLE
Add image bytes AI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,15 @@ curl -X POST https://<your-domain>/api/analyzeImage \
 ```
 Добавете `Authorization` заглавка само при активен `WORKER_ADMIN_TOKEN`.
 
+Пример с новия ендпойнт за байтов масив:
+
+```bash
+curl -X POST https://<your-domain>/api/runImageModel \
+  -H "Content-Type: application/json" \
+  --data '{"model":"@cf/llava-hf/llava-1.5-7b-hf","prompt":"Какво има?","image":[1,2,3]}'
+```
+
+
 ### Промяна на началното съобщение в чата
 
 Текстът, който се показва при първо отваряне на чата, се намира в `js/config.js`
@@ -608,6 +617,7 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
 - `POST /api/saveAiPreset` – съхранява нов пресет или обновява съществуващ.
 - `POST /api/testAiModel` – проверява връзката с конкретен AI модел.
 - `POST /api/analyzeImage` – анализира качено изображение и връща резултат. Изпращайте поле `image` с пълен `data:` URL. Ендпойнтът не изисква `WORKER_ADMIN_TOKEN`, освен ако изрично не сте го добавили като защита.
+- `POST /api/runImageModel` – изпраща байтовете на изображение към избран Cloudflare AI модел. Заявката приема `{ "model": "@cf/llava-hf/llava-1.5-7b-hf", "prompt": "Описание", "image": [..] }` и връща JSON от `env.AI.run`.
 - `POST /api/sendTestEmail` – изпраща тестов имейл. Изисква администраторски токен.
 - `POST /api/sendEmail` – изпраща имейл чрез PHP бекенда. Изисква HTTP заглавка `Authorization: Bearer <WORKER_ADMIN_TOKEN>` и приема JSON `{ "to": "user@example.com", "subject": "Тема", "text": "Съобщение" }`. Заявките са ограничени до няколко на минута.
 

--- a/js/__tests__/runImageModel.test.js
+++ b/js/__tests__/runImageModel.test.js
@@ -1,0 +1,28 @@
+import { jest } from '@jest/globals';
+import { handleRunImageModelRequest } from '../../worker.js';
+
+describe('handleRunImageModelRequest', () => {
+  test('returns 400 on invalid JSON', async () => {
+    const req = { json: async () => { throw new Error('bad'); } };
+    const res = await handleRunImageModelRequest(req, {});
+    expect(res.success).toBe(false);
+    expect(res.statusHint).toBe(400);
+  });
+
+  test('validates required fields', async () => {
+    const req = { json: async () => ({}) };
+    const res = await handleRunImageModelRequest(req, {});
+    expect(res.success).toBe(false);
+    expect(res.statusHint).toBe(400);
+  });
+
+  test('calls env.AI.run and returns result', async () => {
+    const aiRun = jest.fn().mockResolvedValue('ok');
+    const env = { AI: { run: aiRun } };
+    const req = { json: async () => ({ model: '@cf/test', prompt: 'hi', image: [1,2] }) };
+    const res = await handleRunImageModelRequest(req, env);
+    expect(res.success).toBe(true);
+    expect(res.result).toBe('ok');
+    expect(aiRun).toHaveBeenCalledWith('@cf/test', { prompt: 'hi', image: new Uint8Array([1,2]) });
+  });
+});

--- a/preworker.js
+++ b/preworker.js
@@ -231,6 +231,8 @@ export default {
                 responseBody = await handleAiHelperRequest(request, env);
             } else if (method === 'POST' && path === '/api/analyzeImage') {
                 responseBody = await handleAnalyzeImageRequest(request, env);
+            } else if (method === 'POST' && path === '/api/runImageModel') {
+                responseBody = await handleRunImageModelRequest(request, env);
             } else if (method === 'GET' && path === '/api/listClients') {
                 responseBody = await handleListClientsRequest(request, env);
             } else if (method === 'POST' && path === '/api/addAdminQuery') {
@@ -1573,6 +1575,28 @@ async function handleAnalyzeImageRequest(request, env) {
     }
 }
 // ------------- END FUNCTION: handleAnalyzeImageRequest -------------
+// ------------- START FUNCTION: handleRunImageModelRequest -------------
+async function handleRunImageModelRequest(request, env) {
+    let data;
+    try {
+        data = await request.json();
+    } catch {
+        return { success: false, message: 'Невалиден JSON.', statusHint: 400 };
+    }
+    const { model, prompt, image } = data || {};
+    if (typeof model !== 'string' || !model || typeof prompt !== 'string' || !prompt || !Array.isArray(image)) {
+        return { success: false, message: 'Липсват данни за модел, описание или изображение.', statusHint: 400 };
+    }
+    try {
+        const bytes = new Uint8Array(image);
+        const result = await env.AI.run(model, { prompt, image: bytes });
+        return { success: true, result };
+    } catch (error) {
+        console.error('Error in handleRunImageModelRequest:', error.message, error.stack);
+        return { success: false, message: 'Грешка при анализа на изображението.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleRunImageModelRequest -------------
 
 // ------------- START FUNCTION: handleListClientsRequest -------------
 async function handleListClientsRequest(request, env) {
@@ -3865,4 +3889,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };

--- a/worker.js
+++ b/worker.js
@@ -231,6 +231,8 @@ export default {
                 responseBody = await handleAiHelperRequest(request, env);
             } else if (method === 'POST' && path === '/api/analyzeImage') {
                 responseBody = await handleAnalyzeImageRequest(request, env);
+            } else if (method === 'POST' && path === '/api/runImageModel') {
+                responseBody = await handleRunImageModelRequest(request, env);
             } else if (method === 'GET' && path === '/api/listClients') {
                 responseBody = await handleListClientsRequest(request, env);
             } else if (method === 'POST' && path === '/api/addAdminQuery') {
@@ -1573,6 +1575,28 @@ async function handleAnalyzeImageRequest(request, env) {
     }
 }
 // ------------- END FUNCTION: handleAnalyzeImageRequest -------------
+// ------------- START FUNCTION: handleRunImageModelRequest -------------
+async function handleRunImageModelRequest(request, env) {
+    let data;
+    try {
+        data = await request.json();
+    } catch {
+        return { success: false, message: 'Невалиден JSON.', statusHint: 400 };
+    }
+    const { model, prompt, image } = data || {};
+    if (typeof model !== 'string' || !model || typeof prompt !== 'string' || !prompt || !Array.isArray(image)) {
+        return { success: false, message: 'Липсват данни за модел, описание или изображение.', statusHint: 400 };
+    }
+    try {
+        const bytes = new Uint8Array(image);
+        const result = await env.AI.run(model, { prompt, image: bytes });
+        return { success: true, result };
+    } catch (error) {
+        console.error('Error in handleRunImageModelRequest:', error.message, error.stack);
+        return { success: false, message: 'Грешка при анализа на изображението.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleRunImageModelRequest -------------
 
 // ------------- START FUNCTION: handleListClientsRequest -------------
 async function handleListClientsRequest(request, env) {
@@ -3865,4 +3889,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };


### PR DESCRIPTION
## Summary
- add new `handleRunImageModelRequest` helper to invoke `env.AI.run`
- expose `/api/runImageModel` route
- document new endpoint and example usage
- keep `worker.js` and `preworker.js` in sync
- test the handler

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861b9e59d608326a7993e2d1b6c7885