### PR TITLE
Fix image model method handling

### DIFF
--- a/js/__tests__/runImageModelMethod.test.js
+++ b/js/__tests__/runImageModelMethod.test.js
@@ -1,0 +1,9 @@
+import worker from '../../worker.js';
+
+describe('fetch handler for /api/runImageModel', () => {
+  test('GET returns 405', async () => {
+    const req = new Request('https://example.com/api/runImageModel', { method: 'GET' });
+    const res = await worker.fetch(req, {}, {});
+    expect(res.status).toBe(405);
+  });
+});

--- a/preworker.js
+++ b/preworker.js
@@ -233,6 +233,8 @@ export default {
                 responseBody = await handleAnalyzeImageRequest(request, env);
             } else if (method === 'POST' && path === '/api/runImageModel') {
                 responseBody = await handleRunImageModelRequest(request, env);
+            } else if (path === '/api/runImageModel') {
+                responseBody = { success: false, message: 'Method Not Allowed', statusHint: 405 };
             } else if (method === 'GET' && path === '/api/listClients') {
                 responseBody = await handleListClientsRequest(request, env);
             } else if (method === 'POST' && path === '/api/addAdminQuery') {

--- a/worker.js
+++ b/worker.js
@@ -233,6 +233,8 @@ export default {
                 responseBody = await handleAnalyzeImageRequest(request, env);
             } else if (method === 'POST' && path === '/api/runImageModel') {
                 responseBody = await handleRunImageModelRequest(request, env);
+            } else if (path === '/api/runImageModel') {
+                responseBody = { success: false, message: 'Method Not Allowed', statusHint: 405 };
             } else if (method === 'GET' && path === '/api/listClients') {
                 responseBody = await handleListClientsRequest(request, env);
             } else if (method === 'POST' && path === '/api/addAdminQuery') {


### PR DESCRIPTION
## Summary
- enforce 405 status when calling /api/runImageModel with wrong method
- keep worker and preworker scripts in sync
- test fetch handler for /api/runImageModel using GET

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861c89b29dc8326ba22690aa5980cca