### PR TITLE
Update README note on backend methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,14 @@ wrangler deploy worker-backend.js --name bodybest-backend
 
 Bind the `SETTINGS` KV namespace and provide `CF_AI_TOKEN`, `CF_ACCOUNT_ID` and model variables as secrets.
 
+Заявките към този работник трябва да са **само POST**. При опит с друг метод
+ще получите **HTTP 405 Method Not Allowed**:
+
+```bash
+curl -X GET https://<your-backend-url>
+# => HTTP/1.1 405 Method Not Allowed
+```
+
 
 ### Работа с KV
 


### PR DESCRIPTION
## Summary
- document 405 response for worker-backend.js in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861cc5607ec8326ab4759e393223e6e