### PR TITLE
Handle analyzeImage method

### DIFF
--- a/js/__tests__/workerFetchAnalyzeImage.test.js
+++ b/js/__tests__/workerFetchAnalyzeImage.test.js
@@ -1,0 +1,11 @@
+import worker from '../../worker.js';
+
+// Test GET request for analyzeImage returns 405
+
+test('GET /api/analyzeImage returns 405 via worker.fetch', async () => {
+  const req = new Request('https://example.com/api/analyzeImage', { method: 'GET' });
+  const res = await worker.fetch(req, {});
+  expect(res.status).toBe(405);
+  const json = await res.json();
+  expect(json).toEqual({ success: false, message: 'Method Not Allowed' });
+});

--- a/preworker.js
+++ b/preworker.js
@@ -231,6 +231,8 @@ export default {
                 responseBody = await handleAiHelperRequest(request, env);
             } else if (method === 'POST' && path === '/api/analyzeImage') {
                 responseBody = await handleAnalyzeImageRequest(request, env);
+            } else if (path === '/api/analyzeImage') {
+                responseBody = { success: false, message: 'Method Not Allowed', statusHint: 405 };
             } else if (method === 'GET' && path === '/api/listClients') {
                 responseBody = await handleListClientsRequest(request, env);
             } else if (method === 'POST' && path === '/api/addAdminQuery') {

--- a/worker.js
+++ b/worker.js
@@ -231,6 +231,8 @@ export default {
                 responseBody = await handleAiHelperRequest(request, env);
             } else if (method === 'POST' && path === '/api/analyzeImage') {
                 responseBody = await handleAnalyzeImageRequest(request, env);
+            } else if (path === '/api/analyzeImage') {
+                responseBody = { success: false, message: 'Method Not Allowed', statusHint: 405 };
             } else if (method === 'GET' && path === '/api/listClients') {
                 responseBody = await handleListClientsRequest(request, env);
             } else if (method === 'POST' && path === '/api/addAdminQuery') {


### PR DESCRIPTION
## Summary
- guard `/api/analyzeImage` for non-POST requests
- keep `preworker.js` in sync with `worker.js`
- cover the new 405 case with a unit test

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861cc5d734483268f977e537dd9a74e