### PR TITLE
Add unit tests for sanitizer and message utils

### DIFF
--- a/js/__tests__/htmlSanitizer.test.js
+++ b/js/__tests__/htmlSanitizer.test.js
@@ -1,0 +1,16 @@
+/** @jest-environment jsdom */
+import { sanitizeHTML } from '../htmlSanitizer.js';
+
+describe('sanitizeHTML', () => {
+  test('removes disallowed tags and event attributes', () => {
+    const html = '<div onclick="bad()">hi<script>alert(1)</script><a href="#" onmouseover="evil()">link</a></div>';
+    const result = sanitizeHTML(html, ['div','a']);
+    expect(result).toBe('<div>hi<a href="#">link</a></div>');
+  });
+
+  test('keeps allowed tags and attributes', () => {
+    const html = '<p class="x">T</p><span style="color:red">X</span>';
+    const result = sanitizeHTML(html, ['p','span']);
+    expect(result).toBe('<p class="x">T</p><span style="color:red">X</span>');
+  });
+});

--- a/js/__tests__/messageUtils.test.js
+++ b/js/__tests__/messageUtils.test.js
@@ -1,0 +1,25 @@
+/** @jest-environment jsdom */
+import { jest } from "@jest/globals";
+import { showMessage, hideMessage } from '../messageUtils.js';
+
+describe('messageUtils', () => {
+  test('showMessage sets text and success style', () => {
+    const el = document.createElement('div');
+    el.scrollIntoView = jest.fn();
+    showMessage(el, 'done', false);
+    expect(el.textContent).toBe('done');
+    expect(el.className).toBe('message success animate-success');
+    expect(el.style.display).toBe('block');
+    expect(el.scrollIntoView).toHaveBeenCalled();
+  });
+
+  test('hideMessage clears element', () => {
+    const el = document.createElement('div');
+    el.scrollIntoView = jest.fn();
+    showMessage(el, 'err');
+    hideMessage(el);
+    expect(el.textContent).toBe('');
+    expect(el.style.display).toBe('none');
+    expect(el.className).toBe('message');
+  });
+});

--- a/js/htmlSanitizer.js
+++ b/js/htmlSanitizer.js
@@ -1,4 +1,4 @@
-export function sanitizeHTML(html, allowedTags = ['a','b','i','u','p','div','span','ul','ol','li','br','hr','h1','h2','h3','h4','h5','h6','table','thead','tbody','tr','td','th','button','input','label','form','select','option','textarea','img','svg','use','path']) {
+export function sanitizeHTML(html, allowedTags = ['body','a','b','i','u','p','div','span','ul','ol','li','br','hr','h1','h2','h3','h4','h5','h6','table','thead','tbody','tr','td','th','button','input','label','form','select','option','textarea','img','svg','use','path']) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
   const walker = document.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT, null);
@@ -7,17 +7,16 @@ export function sanitizeHTML(html, allowedTags = ['a','b','i','u','p','div','spa
   let node = walker.currentNode;
   while (node) {
     const tag = node.tagName.toLowerCase();
-    if (!allowed.has(tag)) {
-      const toRemove = node;
-      node = walker.nextNode();
-      toRemove.remove();
-      continue;
+    const next = walker.nextNode();
+    if (node !== doc.body && !allowed.has(tag)) {
+      node.remove();
+    } else {
+      [...node.attributes].forEach(attr => {
+        const name = attr.name.toLowerCase();
+        if (name.startsWith('on') || /javascript:/i.test(attr.value)) node.removeAttribute(attr.name);
+      });
     }
-    [...node.attributes].forEach(attr => {
-      const name = attr.name.toLowerCase();
-      if (name.startsWith('on') || /javascript:/i.test(attr.value)) node.removeAttribute(attr.name);
-    });
-    node = walker.nextNode();
+    node = next;
   }
   return doc.body.innerHTML;
 }


### PR DESCRIPTION
## Summary
- refine `sanitizeHTML` to keep the body element and remove attributes safely
- add tests for `htmlSanitizer.js`
- add tests for `messageUtils.js`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876e5de2ff88326aaa2a6064936df5b