### PR TITLE
Unify profile edit endpoints

### DIFF
--- a/js/profileEdit.js
+++ b/js/profileEdit.js
@@ -1,5 +1,6 @@
 import { safeParseFloat, safeGet } from './utils.js';
 import { currentUserId } from './app.js';
+import { apiEndpoints } from './config.js';
 
 // Apply saved theme so the page matches the dashboard
 (function applySavedTheme() {
@@ -15,7 +16,7 @@ const form = document.getElementById('profileEditForm');
 if (form) {
   const prefillProfileData = async () => {
     try {
-      const res = await fetch(`/api/getProfile?userId=${currentUserId}`);
+      const res = await fetch(`${apiEndpoints.getProfile}?userId=${currentUserId}`);
       if (!res.ok) throw new Error('Server error');
       const data = await res.json();
 
@@ -51,7 +52,7 @@ if (form) {
     };
 
     try {
-      await fetch("/api/updateProfile", {
+      await fetch(apiEndpoints.updateProfile, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ ...data, userId: currentUserId }),

--- a/quest.html
+++ b/quest.html
@@ -888,7 +888,7 @@
      ============================================================================ */
 
   const phpFileManagerUrl = "http://mybody.best/wp-content/uploads/file_manager_api.php";
-  const workerSubmitUrl = "https://openapichatbot.radilov-k.workers.dev/api/submitQuestionnaire";
+  const workerSubmitUrl = `${workerBaseUrl}/api/submitQuestionnaire`;
   const phpApiToken = window.FILE_API_TOKEN || "";
 
    // Преместваме ги извън функцията, за да са достъпни, ако е нужно


### PR DESCRIPTION
## Summary
- import API endpoints in `profileEdit.js`
- use `apiEndpoints` for fetching profile data and updates
- update `quest.html` to use `workerBaseUrl` for questionnaire submission

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876eee165f483269073f07f97aaf5e1