### PR TITLE
Add email validity check in registration

### DIFF
--- a/js/__tests__/register.test.js
+++ b/js/__tests__/register.test.js
@@ -29,7 +29,7 @@ test('sends request on valid input', async () => {
   expect(global.fetch).toHaveBeenCalledWith('https://api/api/register', expect.any(Object));
 });
 
-test('accepts invalid email', async () => {
+test('shows error on invalid email', async () => {
   const form = document.getElementById('reg');
   form.querySelector('input[type="email"]').value = 'bad';
   const pw = form.querySelectorAll('input[type="password"]');
@@ -38,5 +38,11 @@ test('accepts invalid email', async () => {
   setupRegistration('#reg', '#msg');
   form.dispatchEvent(new Event('submit', { bubbles: true }));
   await Promise.resolve();
-  expect(global.fetch).toHaveBeenCalledWith('https://api/api/register', expect.any(Object));
+  expect(global.fetch).not.toHaveBeenCalled();
+  const { showMessage } = await import('../messageUtils.js');
+  expect(showMessage).toHaveBeenCalledWith(
+    document.getElementById('msg'),
+    'Невалиден e-mail адрес.',
+    true
+  );
 });

--- a/js/register.js
+++ b/js/register.js
@@ -32,7 +32,10 @@ export function setupRegistration(formSelector, messageElSelector) {
       showMessage(messageEl, msg, true);
       resetBtn();
     };
-    if (!email || !password || !confirmPassword) return showErr('Моля, попълнете всички полета.');
+    if (!email || !password || !confirmPassword)
+      return showErr('Моля, попълнете всички полета.');
+    if (!emailInput.validity.valid)
+      return showErr('Невалиден e-mail адрес.');
     if (password.length < 8) return showErr('Паролата трябва да е поне 8 знака.');
     if (password !== confirmPassword) return showErr('Паролите не съвпадат.');
     if (submitBtn) {


### PR DESCRIPTION
## Summary
- validate email field in register.js
- update register tests for new check

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876f508a93c8326b9d93729f72c18ea