### PR TITLE
Add check for scrollIntoView

### DIFF
--- a/js/__tests__/messageUtils.test.js
+++ b/js/__tests__/messageUtils.test.js
@@ -9,6 +9,7 @@ test('showMessage sets text and styles', () => {
   expect(el.textContent).toBe('ok');
   expect(el.className).toBe('message success animate-success');
   expect(el.style.display).toBe('block');
+  expect(el.scrollIntoView).toHaveBeenCalled();
 });
 
 test('hideMessage clears element', () => {


### PR DESCRIPTION
## Summary
- extend `showMessage` tests to verify scrollIntoView is invoked

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876f513d3f483268db9bcea18ccce01