### PR TITLE
Add registration validation tests

### DIFF
--- a/js/__tests__/register.test.js
+++ b/js/__tests__/register.test.js
@@ -2,6 +2,7 @@
 import { jest } from '@jest/globals';
 
 let setupRegistration;
+let showMessage;
 
 beforeEach(async () => {
   jest.resetModules();
@@ -14,6 +15,7 @@ beforeEach(async () => {
   }));
   jest.unstable_mockModule('../config.js', () => ({ workerBaseUrl: 'https://api' }));
   ({ setupRegistration } = await import('../register.js'));
+  ({ showMessage } = await import('../messageUtils.js'));
   global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
 });
 
@@ -39,4 +41,39 @@ test('accepts invalid email', async () => {
   form.dispatchEvent(new Event('submit', { bubbles: true }));
   await Promise.resolve();
   expect(global.fetch).toHaveBeenCalledWith('https://api/api/register', expect.any(Object));
+});
+
+test('shows message for empty fields', async () => {
+  const form = document.getElementById('reg');
+  setupRegistration('#reg', '#msg');
+  form.dispatchEvent(new Event('submit', { bubbles: true }));
+  await Promise.resolve();
+  expect(showMessage).toHaveBeenCalledWith(document.getElementById('msg'), 'Моля, попълнете всички полета.', true);
+  expect(global.fetch).not.toHaveBeenCalled();
+});
+
+test('shows message for short password', async () => {
+  const form = document.getElementById('reg');
+  form.querySelector('input[type="email"]').value = 'a@b.com';
+  const pw = form.querySelectorAll('input[type="password"]');
+  pw[0].value = '123';
+  pw[1].value = '123';
+  setupRegistration('#reg', '#msg');
+  form.dispatchEvent(new Event('submit', { bubbles: true }));
+  await Promise.resolve();
+  expect(showMessage).toHaveBeenCalledWith(document.getElementById('msg'), 'Паролата трябва да е поне 8 знака.', true);
+  expect(global.fetch).not.toHaveBeenCalled();
+});
+
+test('shows message for mismatched passwords', async () => {
+  const form = document.getElementById('reg');
+  form.querySelector('input[type="email"]').value = 'a@b.com';
+  const pw = form.querySelectorAll('input[type="password"]');
+  pw[0].value = '12345678';
+  pw[1].value = '87654321';
+  setupRegistration('#reg', '#msg');
+  form.dispatchEvent(new Event('submit', { bubbles: true }));
+  await Promise.resolve();
+  expect(showMessage).toHaveBeenCalledWith(document.getElementById('msg'), 'Паролите не съвпадат.', true);
+  expect(global.fetch).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- expand register unit tests
- mock messageUtils and assert error messages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876f51fc2e08326a0e6a41540dd14b6