### PR TITLE
Add alerts for profile loading errors

### DIFF
--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -51,10 +51,14 @@ async function loadData() {
     const dashData = await dashRes.json();
     if (profileRes.ok && profileData.success) {
       fillProfile(profileData, dashData.initialAnswers);
+    } else if (!profileRes.ok) {
+      alert(profileData.message || 'Грешка при зареждане на профила.');
     }
     if (dashRes.ok && dashData.success) {
       fillDashboard(dashData);
       fillAdminNotes(dashData.currentStatus);
+    } else if (!dashRes.ok) {
+      alert(dashData.message || 'Грешка при зареждане на таблото.');
     }
   } catch (err) {
     console.error('Load error', err);


### PR DESCRIPTION
## Summary
- show alerts in `loadData` when profile or dashboard fetch calls fail

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876f521cd7883268a480f83a78f8c96