### PR TITLE
Exclude tests from TypeDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Create API documentation using Typedoc:
 npm run docs
 ```
 The output is placed in the `docs/` folder.
+Тестовите файлове се изключват чрез `"exclude": ["**/__tests__/**"]` в `typedoc.json`.
 
 ### Template Loading
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,5 +3,6 @@
   "out": "docs",
   "excludePrivate": true,
   "tsconfig": "typedoc.tsconfig.json",
-  "highlightLanguages": ["toml", "shell", "bash", "html", "typescript", "json"]
+  "highlightLanguages": ["toml", "shell", "bash", "html", "typescript", "json"],
+  "exclude": ["**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary
- ignore `__tests__` when generating API docs
- note this exclusion in the README

## Testing
- `npm run lint`
- `npm test`
- `npm run docs`


------
https://chatgpt.com/codex/tasks/task_e_6876f77b54d08326bc034c8fb21bd90d