### PR TITLE
Exclude tests from TypeDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ Create API documentation using Typedoc:
 npm run docs
 ```
 The output is placed in `docs/api`. Open `docs/api/index.html` in your browser to view the API documentation.
+Тестовите файлове се пропускат чрез настройката
+
+```json
+"exclude": ["**/__tests__/**"]
+```
+така че документацията съдържа само продукционни модули.
 
 ### Template Loading
 

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -119,7 +119,7 @@ Cloudflare returns <code>Tensor error: failed to decode u8</code> when the data 
 <pre><code class="bash"><span class="hl-0">npm</span><span class="hl-1"> </span><span class="hl-2">run</span><span class="hl-1"> </span><span class="hl-2">docs</span>
 </code><button type="button">Copy</button></pre>
 
-<p>The output is placed in the <code>docs/</code> folder.</p>
+<p>The output is placed in <code>docs/api</code>. Open <code>docs/api/index.html</code> in your browser to view the API documentation.</p>
 <h3 id="template-loading" class="tsd-anchor-link">Template Loading<a href="#template-loading" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="assets/icons.svg#icon-anchor"></use></svg></a></h3><p>Client pages sometimes fetch HTML snippets at runtime. Templates such as
 <code>profileTemplate.html</code> and <code>extra-meal-entry-form.html</code> must reside in the same
 origin as the application. The helper <code>loadTemplateInto(url, containerId)</code>

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,6 +2,7 @@
   "entryPoints": ["worker.js", "js"],
   "out": "docs/api",
   "excludePrivate": true,
+  "exclude": ["**/__tests__/**"],
   "tsconfig": "typedoc.tsconfig.json",
   "highlightLanguages": ["toml", "shell", "bash", "html", "typescript", "json"]
 }


### PR DESCRIPTION
## Summary
- skip `__tests__` when generating docs
- document this in README
- regenerate API docs

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876f92509c08326b56c2e640b7eb8f6