### PR TITLE
Detect missing PHP secrets on register

### DIFF
--- a/js/__tests__/registerEmail.test.js
+++ b/js/__tests__/registerEmail.test.js
@@ -33,3 +33,19 @@ test('sends welcome email when mailer configured', async () => {
   expect(res.success).toBe(true)
   expect(global.fetch.mock.calls[1][0]).toBe('https://mail.example.com')
 })
+
+test('returns message when PHP API secrets missing', async () => {
+  const env = {
+    USER_METADATA_KV: {
+      get: jest.fn().mockResolvedValue(null),
+      put: jest.fn()
+    }
+  }
+  const req = {
+    json: async () => ({ email: 'u@e.bg', password: '12345678', confirm_password: '12345678' })
+  }
+  const res = await handleRegisterRequest(req, env)
+  expect(res.success).toBe(false)
+  expect(res.message).toBe('PHP API не е конфигуриран.')
+  expect(res.statusHint).toBe(500)
+})

--- a/preworker.js
+++ b/preworker.js
@@ -519,7 +519,16 @@ async function handleRegisterRequest(request, env, ctx) {
         const emailTask = sendWelcomeEmail(trimmedEmail, userId, env);
         if (ctx) ctx.waitUntil(emailTask); else await emailTask;
         return { success: true, message: 'Регистрацията успешна!' };
-     } catch (error) { console.error('Error in handleRegisterRequest:', error.message, error.stack); let userMessage = 'Вътрешна грешка при регистрация.'; if (error.message.includes('Failed to fetch')) userMessage = 'Грешка при свързване със сървъра.'; else if (error instanceof SyntaxError) userMessage = 'Грешка в отговора от сървъра.'; return { success: false, message: userMessage, statusHint: 500 }; }
+     } catch (error) {
+        console.error('Error in handleRegisterRequest:', error.message, error.stack);
+        if (error.message.includes('PHP API URL or Token not configured')) {
+            return { success: false, message: 'PHP API не е конфигуриран.', statusHint: 500 };
+        }
+        let userMessage = 'Вътрешна грешка при регистрация.';
+        if (error.message.includes('Failed to fetch')) userMessage = 'Грешка при свързване със сървъра.';
+        else if (error instanceof SyntaxError) userMessage = 'Грешка в отговора от сървъра.';
+        return { success: false, message: userMessage, statusHint: 500 };
+     }
 }
 // ------------- END FUNCTION: handleRegisterRequest -------------
 

--- a/worker.js
+++ b/worker.js
@@ -519,7 +519,16 @@ async function handleRegisterRequest(request, env, ctx) {
         const emailTask = sendWelcomeEmail(trimmedEmail, userId, env);
         if (ctx) ctx.waitUntil(emailTask); else await emailTask;
         return { success: true, message: 'Регистрацията успешна!' };
-     } catch (error) { console.error('Error in handleRegisterRequest:', error.message, error.stack); let userMessage = 'Вътрешна грешка при регистрация.'; if (error.message.includes('Failed to fetch')) userMessage = 'Грешка при свързване със сървъра.'; else if (error instanceof SyntaxError) userMessage = 'Грешка в отговора от сървъра.'; return { success: false, message: userMessage, statusHint: 500 }; }
+     } catch (error) {
+        console.error('Error in handleRegisterRequest:', error.message, error.stack);
+        if (error.message.includes('PHP API URL or Token not configured')) {
+            return { success: false, message: 'PHP API не е конфигуриран.', statusHint: 500 };
+        }
+        let userMessage = 'Вътрешна грешка при регистрация.';
+        if (error.message.includes('Failed to fetch')) userMessage = 'Грешка при свързване със сървъра.';
+        else if (error instanceof SyntaxError) userMessage = 'Грешка в отговора от сървъра.';
+        return { success: false, message: userMessage, statusHint: 500 };
+     }
 }
 // ------------- END FUNCTION: handleRegisterRequest -------------
 


### PR DESCRIPTION
## Summary
- show specific error when PHP API secrets are missing
- add coverage for missing secrets in register email handler

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68771db70e108326bf18a956188f30b9