### PR TITLE
Add questionnaire confirmation email

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,6 +772,8 @@ To send a test email задайте `WORKER_ADMIN_TOKEN`. Може да посо
 | `FROM_EMAIL` | Sender address used by `mailer.js` and the PHP backend. |
 | `WELCOME_EMAIL_SUBJECT` | Optional custom subject for welcome emails sent by `mailer.js`. |
 | `WELCOME_EMAIL_BODY` | Optional HTML body template for welcome emails. The string `{{name}}` will be replaced with the recipient's name. |
+| `QUESTIONNAIRE_EMAIL_SUBJECT` | Optional subject for the confirmation email sent след изпращане на въпросника. |
+| `QUESTIONNAIRE_EMAIL_BODY` | Optional HTML body template for the confirmation email. `{{name}}` ще бъде заменено с името на потребителя. |
 | `WORKER_URL` | Base URL of the main worker used by `mailer.js` to fetch email templates when no subject or body is provided. |
 
 Проверете стойностите така:

--- a/js/__tests__/submitQuestionnaireEmail.test.js
+++ b/js/__tests__/submitQuestionnaireEmail.test.js
@@ -1,0 +1,43 @@
+import { jest } from '@jest/globals'
+
+let handleSubmitQuestionnaire
+
+beforeEach(async () => {
+  jest.resetModules()
+  ;({ handleSubmitQuestionnaire } = await import('../../worker.js'))
+})
+
+afterEach(() => {
+  if (global.fetch && typeof global.fetch.mockRestore === 'function') {
+    global.fetch.mockRestore()
+  }
+})
+
+test('sends confirmation email when configured', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true })
+  const env = {
+    MAILER_ENDPOINT_URL: 'https://mail.example.com',
+    USER_METADATA_KV: {
+      get: jest.fn(async key => key === 'email_to_uuid_user@site.bg' ? 'u1' : null),
+      put: jest.fn()
+    }
+  }
+  const req = { json: async () => ({ email: 'user@site.bg', name: 'Иван' }) }
+  const res = await handleSubmitQuestionnaire(req, env)
+  expect(res.success).toBe(true)
+  expect(fetch).toHaveBeenCalledWith('https://mail.example.com', expect.any(Object))
+})
+
+test('works without email configuration', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true })
+  const env = {
+    USER_METADATA_KV: {
+      get: jest.fn(async key => key === 'email_to_uuid_x@x.bg' ? 'u1' : null),
+      put: jest.fn()
+    }
+  }
+  const req = { json: async () => ({ email: 'x@x.bg' }) }
+  const res = await handleSubmitQuestionnaire(req, env)
+  expect(res.success).toBe(true)
+  expect(fetch).toHaveBeenCalledWith('https://mybody.best/mailer/mail.php', expect.any(Object))
+})

--- a/preworker.js
+++ b/preworker.js
@@ -56,6 +56,13 @@ const WELCOME_BODY_TEMPLATE = '<h2>Здравей, {{name}} 👋</h2>' +
     '<p>Бъди здрав и вдъхновен!</p>' +
     '<p>– Екипът на MyBody</p>';
 
+const QUESTIONNAIRE_SUBJECT = 'Получихме вашите отговори';
+const QUESTIONNAIRE_BODY_TEMPLATE = '<p>Здравей, {{name}}.</p>' +
+    '<p>Благодарим за попълването на въпросника. Нашият екип ще изготви индивидуален план и ще се свърже с теб скоро.</p>' +
+    '<p>– Екипът на MyBody</p>';
+const QUESTIONNAIRE_EMAIL_SUBJECT_VAR_NAME = 'QUESTIONNAIRE_EMAIL_SUBJECT';
+const QUESTIONNAIRE_EMAIL_BODY_VAR_NAME = 'QUESTIONNAIRE_EMAIL_BODY';
+
 async function sendWelcomeEmail(to, name, env) {
     const sendEmail = await getSendEmail(env);
     if (sendEmail === defaultSendEmail) return;
@@ -64,6 +71,19 @@ async function sendWelcomeEmail(to, name, env) {
         await sendEmail(to, WELCOME_SUBJECT, html);
     } catch (err) {
         console.error('Failed to send welcome email:', err);
+    }
+}
+
+async function sendQuestionnaireConfirmationEmail(to, name, env) {
+    const sendEmail = await getSendEmail(env);
+    if (sendEmail === defaultSendEmail) return;
+    const subject = env?.[QUESTIONNAIRE_EMAIL_SUBJECT_VAR_NAME] || QUESTIONNAIRE_SUBJECT;
+    const tpl = env?.[QUESTIONNAIRE_EMAIL_BODY_VAR_NAME] || QUESTIONNAIRE_BODY_TEMPLATE;
+    const html = tpl.replace(/{{\s*name\s*}}/g, name);
+    try {
+        await sendEmail(to, subject, html);
+    } catch (err) {
+        console.error('Failed to send questionnaire confirmation email:', err);
     }
 }
 
@@ -565,6 +585,8 @@ async function handleSubmitQuestionnaire(request, env, ctx) {
         await env.USER_METADATA_KV.put(`${userId}_initial_answers`, JSON.stringify(questionnaireData));
         await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'pending', { metadata: { status: 'pending' } });
         console.log(`SUBMIT_QUESTIONNAIRE (${userId}): Saved initial answers, status set to pending.`);
+        const confirmTask = sendQuestionnaireConfirmationEmail(userEmail, questionnaireData.name || 'Потребител', env);
+        if (ctx) ctx.waitUntil(confirmTask); else await confirmTask;
         return { success: true, message: 'Данните са приети. Вашият индивидуален план ще бъде генериран скоро.' };
     } catch (error) {
         console.error(`Error in handleSubmitQuestionnaire:`, error.message, error.stack);
@@ -3851,4 +3873,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, handleSubmitQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };

--- a/worker.js
+++ b/worker.js
@@ -56,6 +56,13 @@ const WELCOME_BODY_TEMPLATE = '<h2>Здравей, {{name}} 👋</h2>' +
     '<p>Бъди здрав и вдъхновен!</p>' +
     '<p>– Екипът на MyBody</p>';
 
+const QUESTIONNAIRE_SUBJECT = 'Получихме вашите отговори';
+const QUESTIONNAIRE_BODY_TEMPLATE = '<p>Здравей, {{name}}.</p>' +
+    '<p>Благодарим за попълването на въпросника. Нашият екип ще изготви индивидуален план и ще се свърже с теб скоро.</p>' +
+    '<p>– Екипът на MyBody</p>';
+const QUESTIONNAIRE_EMAIL_SUBJECT_VAR_NAME = 'QUESTIONNAIRE_EMAIL_SUBJECT';
+const QUESTIONNAIRE_EMAIL_BODY_VAR_NAME = 'QUESTIONNAIRE_EMAIL_BODY';
+
 async function sendWelcomeEmail(to, name, env) {
     const sendEmail = await getSendEmail(env);
     if (sendEmail === defaultSendEmail) return;
@@ -64,6 +71,19 @@ async function sendWelcomeEmail(to, name, env) {
         await sendEmail(to, WELCOME_SUBJECT, html);
     } catch (err) {
         console.error('Failed to send welcome email:', err);
+    }
+}
+
+async function sendQuestionnaireConfirmationEmail(to, name, env) {
+    const sendEmail = await getSendEmail(env);
+    if (sendEmail === defaultSendEmail) return;
+    const subject = env?.[QUESTIONNAIRE_EMAIL_SUBJECT_VAR_NAME] || QUESTIONNAIRE_SUBJECT;
+    const tpl = env?.[QUESTIONNAIRE_EMAIL_BODY_VAR_NAME] || QUESTIONNAIRE_BODY_TEMPLATE;
+    const html = tpl.replace(/{{\s*name\s*}}/g, name);
+    try {
+        await sendEmail(to, subject, html);
+    } catch (err) {
+        console.error('Failed to send questionnaire confirmation email:', err);
     }
 }
 
@@ -565,6 +585,8 @@ async function handleSubmitQuestionnaire(request, env, ctx) {
         await env.USER_METADATA_KV.put(`${userId}_initial_answers`, JSON.stringify(questionnaireData));
         await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'pending', { metadata: { status: 'pending' } });
         console.log(`SUBMIT_QUESTIONNAIRE (${userId}): Saved initial answers, status set to pending.`);
+        const confirmTask = sendQuestionnaireConfirmationEmail(userEmail, questionnaireData.name || 'Потребител', env);
+        if (ctx) ctx.waitUntil(confirmTask); else await confirmTask;
         return { success: true, message: 'Данните са приети. Вашият индивидуален план ще бъде генериран скоро.' };
     } catch (error) {
         console.error(`Error in handleSubmitQuestionnaire:`, error.message, error.stack);
@@ -3851,4 +3873,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, handleSubmitQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };


### PR DESCRIPTION
## Summary
- send email after questionnaire submission using the existing mailer logic
- allow custom subject and body via env vars `QUESTIONNAIRE_EMAIL_SUBJECT` and `QUESTIONNAIRE_EMAIL_BODY`
- document the new variables in README
- add unit tests covering the new behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68783cc04f408326bb7f4bf93c7c7b79