### PR TITLE
Fix registration email handling

### DIFF
--- a/js/register.js
+++ b/js/register.js
@@ -51,8 +51,8 @@ export function setupRegistration(formSelector, messageElSelector) {
       const data = await res.json();
       if (!res.ok || !data.success) throw new Error(data.message || 'Грешка при регистрацията. Моля, опитайте отново.');
       showMessage(messageEl, data.message || 'Регистрацията успешна!', false);
+      form.dispatchEvent(new CustomEvent('registrationSuccess', { detail: { ...data, email } }));
       form.reset();
-      form.dispatchEvent(new CustomEvent('registrationSuccess', { detail: data }));
     } catch (err) {
       console.error('Registration failed:', err);
       showMessage(messageEl, err.message, true);

--- a/quest.html
+++ b/quest.html
@@ -274,8 +274,8 @@
       showPage(regIndex - 1);
     });
     setupRegistration("#register-form-q", "#register-message-q");
-    pageDiv.querySelector("#register-form-q").addEventListener("registrationSuccess", () => {
-      responses.email = emailInput.value.trim().toLowerCase();
+    pageDiv.querySelector("#register-form-q").addEventListener("registrationSuccess", (event) => {
+      responses.email = event.detail.email;
       saveProgress();
       showPage(regIndex + 1);
     });


### PR DESCRIPTION
## Summary
- dispatch registrationSuccess with email included
- reset registration form only after dispatching event
- update quest.html to store email from event detail

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878428318f88326b7d2ff60ef33df57