### PR TITLE
Allow email re-registration

### DIFF
--- a/js/__tests__/clientProfile.test.js
+++ b/js/__tests__/clientProfile.test.js
@@ -31,7 +31,8 @@ beforeEach(async () => {
   `;
   window.history.pushState({}, '', '/?userId=1');
 
-  const src = await fs.promises.readFile(new URL('../clientProfile.js', import.meta.url), 'utf8');
+  const clientProfilePath = path.join(path.dirname(jsonrepairMockPath), '../clientProfile.js');
+  const src = await fs.promises.readFile(clientProfilePath, 'utf8');
   const patched = src
     .replace("https://cdn.jsdelivr.net/npm/jsonrepair/+esm", jsonrepairMockPath)
     .replace('./config.js', '../config.js')


### PR DESCRIPTION
## Summary
- permit using the same email multiple times when registering
- keep tests working on Node 18 by avoiding URL arguments
- import `node:crypto` so the worker works in the test environment

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68786a60a0d88326a41f58a71cf0099e