### PR TITLE
Add initial questionnaire analysis

### DIFF
--- a/js/__tests__/initialAnalysis.test.js
+++ b/js/__tests__/initialAnalysis.test.js
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals'
+import * as worker from '../../worker.js'
+
+const originalFetch = global.fetch
+
+describe('initial analysis handlers', () => {
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  test('handleAnalyzeInitialAnswers saves result', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { response: '{"ok":true}' } })
+    })
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(key => key === 'u1_initial_answers' ? Promise.resolve('{"name":"A"}') : Promise.resolve(null)),
+        put: jest.fn()
+      },
+      RESOURCES_KV: {
+        get: jest.fn(key => {
+          if (key === 'prompt_initial_analysis') return 'Analyze %%ANSWERS_JSON%%'
+          if (key === 'model_chat') return '@cf/test-model'
+          return null
+        })
+      },
+      CF_ACCOUNT_ID: 'acc',
+      CF_AI_TOKEN: 't'
+    }
+    await worker.handleAnalyzeInitialAnswers('u1', env)
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis', '{"ok":true}')
+  })
+
+  test('handleGetInitialAnalysisRequest returns parsed analysis', async () => {
+    const env = { USER_METADATA_KV: { get: jest.fn().mockResolvedValue('{"a":1}') } }
+    const req = { url: 'https://x/api/getInitialAnalysis?userId=u1' }
+    const res = await worker.handleGetInitialAnalysisRequest(req, env)
+    expect(res.success).toBe(true)
+    expect(res.analysis).toEqual({ a: 1 })
+  })
+})


### PR DESCRIPTION
## Summary
- implement `handleAnalyzeInitialAnswers` for AI-based questionnaire analysis
- store analysis JSON in `USER_METADATA_KV`
- trigger analysis after questionnaire submission and expose `/api/getInitialAnalysis`
- keep preworker in sync
- add tests for new handlers

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879a631883083268e19edb6d53a4b99