### PR TITLE
Add questionnaire analysis configuration

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -187,6 +187,11 @@
         <label>Temperature: <input id="imageTemperature" type="number" min="0" max="1" step="0.1"></label>
         <small id="imageHints" class="text-muted"></small>
       </fieldset>
+      <fieldset>
+        <legend>Анализ на въпросник</legend>
+        <label>Модел: <input id="analysisModel" type="text"> <button type="button" id="testAnalysisModel">Тествай</button></label>
+        <label>Промпт:<br><textarea id="analysisPrompt" rows="2"></textarea></label>
+      </fieldset>
       <div class="preset-controls">
         <label>Запазени настройки:
           <select id="aiPresetSelect"></select>

--- a/js/__tests__/aiConfig.test.js
+++ b/js/__tests__/aiConfig.test.js
@@ -13,11 +13,19 @@ function createStore(initial = {}) {
 
 describe('AI config handlers', () => {
   test('handleGetAiConfig returns all KV values', async () => {
-    const kv = createStore({ model_chat: 'base' });
+    const kv = createStore({
+      model_chat: 'base',
+      model_questionnaire_analysis: 'qa',
+      prompt_questionnaire_analysis: 'qp'
+    });
     const env = { RESOURCES_KV: kv };
     const res = await handleGetAiConfig({}, env);
     expect(res.success).toBe(true);
-    expect(res.config).toEqual({ model_chat: 'base' });
+    expect(res.config).toEqual({
+      model_chat: 'base',
+      model_questionnaire_analysis: 'qa',
+      prompt_questionnaire_analysis: 'qp'
+    });
   });
 
   test('handleSetAiConfig updates values and subsequent chat uses them', async () => {

--- a/js/__tests__/saveAiConfig.test.js
+++ b/js/__tests__/saveAiConfig.test.js
@@ -24,6 +24,8 @@ beforeEach(async () => {
       <textarea id="imagePrompt"></textarea>
       <input id="imageTokens" />
       <input id="imageTemperature" />
+      <input id="analysisModel" />
+      <textarea id="analysisPrompt"></textarea>
       <input id="adminToken" />
     </form>
     <button id="showStats"></button>
@@ -75,6 +77,8 @@ test('saveAiConfig sends updates payload with Authorization header', async () =>
   document.getElementById('imagePrompt').value = 'ip';
   document.getElementById('imageTokens').value = '4';
   document.getElementById('imageTemperature').value = '0.4';
+  document.getElementById('analysisModel').value = 'am';
+  document.getElementById('analysisPrompt').value = 'ap';
 
   await submitHandler(new Event('submit'));
 
@@ -91,6 +95,8 @@ test('saveAiConfig sends updates payload with Authorization header', async () =>
       model_principle_adjustment: 'mm',
       model_image_analysis: 'im',
       prompt_image_analysis: 'ip',
+      model_questionnaire_analysis: 'am',
+      prompt_questionnaire_analysis: 'ap',
       prompt_unified_plan_generation_v2: 'pp',
       plan_token_limit: '1',
       plan_temperature: '0.1',

--- a/js/admin.js
+++ b/js/admin.js
@@ -86,6 +86,9 @@ const testPlanBtn = document.getElementById('testPlanModel');
 const testChatBtn = document.getElementById('testChatModel');
 const testModBtn = document.getElementById('testModModel');
 const testImageBtn = document.getElementById('testImageModel');
+const analysisModelInput = document.getElementById('analysisModel');
+const analysisPromptInput = document.getElementById('analysisPrompt');
+const testAnalysisBtn = document.getElementById('testAnalysisModel');
 const emailSettingsForm = document.getElementById('emailSettingsForm');
 const welcomeEmailSubjectInput = document.getElementById('welcomeEmailSubject');
 const welcomeEmailBodyInput = document.getElementById('welcomeEmailBody');
@@ -1092,6 +1095,8 @@ async function loadAiConfig() {
         modModelInput.value = cfg.model_principle_adjustment || '';
         if (imageModelInput) imageModelInput.value = cfg.model_image_analysis || '';
         if (imagePromptInput) imagePromptInput.value = cfg.prompt_image_analysis || '';
+        if (analysisModelInput) analysisModelInput.value = cfg.model_questionnaire_analysis || '';
+        if (analysisPromptInput) analysisPromptInput.value = cfg.prompt_questionnaire_analysis || '';
         if (planPromptInput) planPromptInput.value = cfg.prompt_unified_plan_generation_v2 || '';
         if (planTokensInput) planTokensInput.value = cfg.plan_token_limit || '';
         if (planTemperatureInput) planTemperatureInput.value = cfg.plan_temperature || '';
@@ -1124,6 +1129,8 @@ async function saveAiConfig() {
             model_principle_adjustment: modModelInput.value.trim(),
             model_image_analysis: imageModelInput ? imageModelInput.value.trim() : '',
             prompt_image_analysis: imagePromptInput ? imagePromptInput.value.trim() : '',
+            model_questionnaire_analysis: analysisModelInput ? analysisModelInput.value.trim() : '',
+            prompt_questionnaire_analysis: analysisPromptInput ? analysisPromptInput.value.trim() : '',
             prompt_unified_plan_generation_v2: planPromptInput ? planPromptInput.value.trim() : '',
             plan_token_limit: planTokensInput ? planTokensInput.value.trim() : '',
             plan_temperature: planTemperatureInput ? planTemperatureInput.value.trim() : '',
@@ -1317,6 +1324,8 @@ async function applySelectedPreset() {
         modModelInput.value = cfg.modModel || cfg.model_principle_adjustment || '';
         if (imageModelInput) imageModelInput.value = cfg.imageModel || cfg.model_image_analysis || '';
         if (imagePromptInput) imagePromptInput.value = cfg.imagePrompt || cfg.prompt_image_analysis || '';
+        if (analysisModelInput) analysisModelInput.value = cfg.analysisModel || cfg.model_questionnaire_analysis || '';
+        if (analysisPromptInput) analysisPromptInput.value = cfg.analysisPrompt || cfg.prompt_questionnaire_analysis || '';
         if (planPromptInput) planPromptInput.value = cfg.planPrompt || cfg.prompt_unified_plan_generation_v2 || '';
         if (planTokensInput) planTokensInput.value = cfg.planTokens || cfg.plan_token_limit || '';
         if (planTemperatureInput) planTemperatureInput.value = cfg.planTemperature || cfg.plan_temperature || '';
@@ -1352,6 +1361,8 @@ async function saveCurrentPreset() {
             model_principle_adjustment: modModelInput.value.trim(),
             model_image_analysis: imageModelInput ? imageModelInput.value.trim() : '',
             prompt_image_analysis: imagePromptInput ? imagePromptInput.value.trim() : '',
+            model_questionnaire_analysis: analysisModelInput ? analysisModelInput.value.trim() : '',
+            prompt_questionnaire_analysis: analysisPromptInput ? analysisPromptInput.value.trim() : '',
             prompt_unified_plan_generation_v2: planPromptInput ? planPromptInput.value.trim() : '',
             plan_token_limit: planTokensInput ? planTokensInput.value.trim() : '',
             plan_temperature: planTemperatureInput ? planTemperatureInput.value.trim() : '',
@@ -1450,6 +1461,7 @@ if (aiConfigForm) {
     testChatBtn?.addEventListener('click', () => testAiModel(chatModelInput.value.trim()));
     testModBtn?.addEventListener('click', () => testAiModel(modModelInput.value.trim()));
     testImageBtn?.addEventListener('click', () => testAiModel(imageModelInput.value.trim()));
+    testAnalysisBtn?.addEventListener('click', () => testAiModel(analysisModelInput.value.trim()));
     planModelInput?.addEventListener('input', () => updateHints(planModelInput, planHints));
     chatModelInput?.addEventListener('input', () => updateHints(chatModelInput, chatHints));
     modModelInput?.addEventListener('input', () => updateHints(modModelInput, modHints));

--- a/preworker.js
+++ b/preworker.js
@@ -114,6 +114,28 @@ const ADAPTIVE_QUIZ_ANSWERS_LOOKBACK_DAYS = 35; // Колко назад да т
 const PREVIOUS_QUIZZES_FOR_CONTEXT_COUNT = 2; // Брой предишни въпросници за контекст при генериране на нов
 const AUTOMATED_FEEDBACK_TRIGGER_DAYS = 3; // След толкова дни предлагаме автоматичен чат
 const PRAISE_INTERVAL_DAYS = 3; // Интервал за нова похвала/значка
+const AI_CONFIG_KEYS = [
+    'model_plan_generation',
+    'model_chat',
+    'model_principle_adjustment',
+    'model_image_analysis',
+    'prompt_image_analysis',
+    'model_questionnaire_analysis',
+    'prompt_questionnaire_analysis',
+    'prompt_unified_plan_generation_v2',
+    'plan_token_limit',
+    'plan_temperature',
+    'prompt_chat',
+    'chat_token_limit',
+    'chat_temperature',
+    'prompt_plan_modification',
+    'mod_token_limit',
+    'mod_temperature',
+    'image_token_limit',
+    'image_temperature',
+    'welcome_email_subject',
+    'welcome_email_body'
+];
 // ------------- END BLOCK: GlobalConstantsAndBindings -------------
 
 // ------------- START BLOCK: HelperFunctions -------------
@@ -1869,10 +1891,10 @@ async function handleGetPlanModificationPrompt(request, env) {
 // ------------- START FUNCTION: handleGetAiConfig -------------
 async function handleGetAiConfig(request, env) {
     try {
-        const list = await env.RESOURCES_KV.list();
         const config = {};
-        for (const { name } of list.keys) {
-            config[name] = await env.RESOURCES_KV.get(name);
+        for (const key of AI_CONFIG_KEYS) {
+            const val = await env.RESOURCES_KV.get(key);
+            if (val !== null) config[key] = val;
         }
         return { success: true, config };
     } catch (error) {
@@ -1901,7 +1923,9 @@ async function handleSetAiConfig(request, env) {
             return { success: false, message: 'Липсват данни.', statusHint: 400 };
         }
         for (const [key, value] of Object.entries(updates)) {
-            await env.RESOURCES_KV.put(key, String(value));
+            if (AI_CONFIG_KEYS.includes(key)) {
+                await env.RESOURCES_KV.put(key, String(value));
+            }
         }
         return { success: true };
     } catch (error) {

--- a/worker.js
+++ b/worker.js
@@ -114,6 +114,28 @@ const ADAPTIVE_QUIZ_ANSWERS_LOOKBACK_DAYS = 35; // Колко назад да т
 const PREVIOUS_QUIZZES_FOR_CONTEXT_COUNT = 2; // Брой предишни въпросници за контекст при генериране на нов
 const AUTOMATED_FEEDBACK_TRIGGER_DAYS = 3; // След толкова дни предлагаме автоматичен чат
 const PRAISE_INTERVAL_DAYS = 3; // Интервал за нова похвала/значка
+const AI_CONFIG_KEYS = [
+    'model_plan_generation',
+    'model_chat',
+    'model_principle_adjustment',
+    'model_image_analysis',
+    'prompt_image_analysis',
+    'model_questionnaire_analysis',
+    'prompt_questionnaire_analysis',
+    'prompt_unified_plan_generation_v2',
+    'plan_token_limit',
+    'plan_temperature',
+    'prompt_chat',
+    'chat_token_limit',
+    'chat_temperature',
+    'prompt_plan_modification',
+    'mod_token_limit',
+    'mod_temperature',
+    'image_token_limit',
+    'image_temperature',
+    'welcome_email_subject',
+    'welcome_email_body'
+];
 // ------------- END BLOCK: GlobalConstantsAndBindings -------------
 
 // ------------- START BLOCK: HelperFunctions -------------
@@ -1869,10 +1891,10 @@ async function handleGetPlanModificationPrompt(request, env) {
 // ------------- START FUNCTION: handleGetAiConfig -------------
 async function handleGetAiConfig(request, env) {
     try {
-        const list = await env.RESOURCES_KV.list();
         const config = {};
-        for (const { name } of list.keys) {
-            config[name] = await env.RESOURCES_KV.get(name);
+        for (const key of AI_CONFIG_KEYS) {
+            const val = await env.RESOURCES_KV.get(key);
+            if (val !== null) config[key] = val;
         }
         return { success: true, config };
     } catch (error) {
@@ -1901,7 +1923,9 @@ async function handleSetAiConfig(request, env) {
             return { success: false, message: 'Липсват данни.', statusHint: 400 };
         }
         for (const [key, value] of Object.entries(updates)) {
-            await env.RESOURCES_KV.put(key, String(value));
+            if (AI_CONFIG_KEYS.includes(key)) {
+                await env.RESOURCES_KV.put(key, String(value));
+            }
         }
         return { success: true };
     } catch (error) {


### PR DESCRIPTION
## Summary
- extend admin UI to configure questionnaire analysis
- handle new analysis model in admin.js
- support extra AI config keys in worker
- cover questionnaire analysis in tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879bb3401b48326a1b941c973210a9a