### PR TITLE
Fix analysis data check & add injection helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,12 @@ curl -X POST https://<your-domain>/api/runImageModel \
 node -e "const fs=require('fs');const data=require('./analysis.json');const html=fs.readFileSync('reganalize/analyze.html','utf8').replace('/*---JSON_DATA_PLACEHOLDER---*/',JSON.stringify(data));fs.writeFileSync('analysis.html',html);"
 ```
 
+По-удобно може да използвате `scripts/injectAnalysis.js`, който автоматично извлича анализа и го вгражда:
+
+```bash
+node scripts/injectAnalysis.js https://<your-domain> <userId>
+```
+
 
 ### Промяна на началното съобщение в чата
 

--- a/reganalize/analyze.html
+++ b/reganalize/analyze.html
@@ -176,7 +176,7 @@
         const analysisData = {/*---JSON_DATA_PLACEHOLDER---*/};
 
         document.addEventListener('DOMContentLoaded', function() {
-            if (!analysisData || Object.keys(analysisData).length === 1) {
+            if (!analysisData || !analysisData.client) {
                 document.body.innerHTML = '<h1>Грешка при зареждане на данните за анализ.</h1>';
                 document.body.classList.add('loaded');
                 return;

--- a/scripts/injectAnalysis.js
+++ b/scripts/injectAnalysis.js
@@ -1,0 +1,25 @@
+import { readFileSync, writeFileSync } from 'fs';
+
+const [apiUrl, userId, source = 'reganalize/analyze.html', output = 'analysis.html'] = process.argv.slice(2);
+
+if (!apiUrl || !userId) {
+  console.log('Usage: node scripts/injectAnalysis.js <apiUrl> <userId> [sourceHtml] [outputHtml]');
+  process.exit(1);
+}
+
+const res = await fetch(`${apiUrl}/api/getInitialAnalysis?userId=${userId}`);
+if (!res.ok) {
+  console.error('Failed to fetch analysis:', res.status, res.statusText);
+  process.exit(1);
+}
+
+const data = await res.json();
+if (!data.analysis) {
+  console.error('Invalid response from API');
+  process.exit(1);
+}
+
+const html = readFileSync(source, 'utf8').replace('/*---JSON_DATA_PLACEHOLDER---*/', JSON.stringify(data.analysis));
+writeFileSync(output, html);
+console.log(`Saved analysis to ${output}`);
+


### PR DESCRIPTION
## Summary
- fix `analysisData` validation in `analyze.html`
- add a helper script to inject analysis JSON from the API
- document the script usage in `README.md`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879c949ac8c8326b89e37c389f313a7