### PR TITLE
Add analysis status tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,7 @@ curl -X POST https://<your-domain>/api/runImageModel \
 ### Персонален анализ (`analyze.html`)
 
 След попълване на въпросника Cloudflare worker-ът съхранява резултата като `<userId>_analysis` и го връща чрез `/api/getInitialAnalysis?userId=<ID>`.
+Статусът на изчисляването се пази отделно в ключ `<userId>_analysis_status` и може да се провери с `/api/analysisStatus?userId=<ID>`.
 Шаблонът `reganalize/analyze.html` визуализира тези данни.
 Когато анализът е генериран, потребителят получава имейл с линк към страницата,
 на който параметърът `userId` зарежда индивидуалния JSON.
@@ -677,6 +678,7 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
 - `GET /api/getAiPreset` – връща данните за конкретен пресет.
 - `POST /api/saveAiPreset` – съхранява нов пресет или обновява съществуващ.
 - `POST /api/testAiModel` – проверява връзката с конкретен AI модел.
+- `GET /api/analysisStatus` – връща текущия статус на персоналния анализ.
 - `POST /api/analyzeImage` – анализира качено изображение и връща резултат. Изпращайте поле `image` с пълен `data:` URL. Ендпойнтът не изисква `WORKER_ADMIN_TOKEN`, освен ако изрично не сте го добавили като защита.
 - `POST /api/runImageModel` – изпраща байтовете на изображение към избран Cloudflare AI модел. Заявката приема `{ "model": "@cf/llava-hf/llava-1.5-7b-hf", "prompt": "Описание", "image": [..] }` и връща JSON от `env.AI.run`. При заявки с друг метод се връща статус 405.
 - `POST /api/sendTestEmail` – изпраща тестов имейл. Изисква администраторски токен.

--- a/js/__tests__/initialAnalysis.test.js
+++ b/js/__tests__/initialAnalysis.test.js
@@ -32,6 +32,7 @@ describe('initial analysis handlers', () => {
     }
     await worker.handleAnalyzeInitialAnswers('u1', env)
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis', '{"ok":true}')
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_status', 'ready')
     expect(global.fetch).toHaveBeenCalledWith('https://mail.example.com', expect.any(Object))
   })
 
@@ -61,6 +62,7 @@ describe('initial analysis handlers', () => {
     }
     await worker.handleAnalyzeInitialAnswers('u1', env)
     expect(warnSpy).toHaveBeenCalledWith('ANALYSIS_EMAIL_BODY missing {{link}} placeholder')
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_status', 'ready')
     warnSpy.mockRestore()
   })
 
@@ -70,5 +72,13 @@ describe('initial analysis handlers', () => {
     const res = await worker.handleGetInitialAnalysisRequest(req, env)
     expect(res.success).toBe(true)
     expect(res.analysis).toEqual({ a: 1 })
+  })
+
+  test('handleAnalysisStatusRequest returns stored status', async () => {
+    const env = { USER_METADATA_KV: { get: jest.fn().mockResolvedValue('ready') } }
+    const req = { url: 'https://x/api/analysisStatus?userId=u1' }
+    const res = await worker.handleAnalysisStatusRequest(req, env)
+    expect(res.success).toBe(true)
+    expect(res.analysisStatus).toBe('ready')
   })
 })

--- a/js/__tests__/submitQuestionnaireAnalysis.test.js
+++ b/js/__tests__/submitQuestionnaireAnalysis.test.js
@@ -33,6 +33,7 @@ describe('submit questionnaire workflow', () => {
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_initial_answers', expect.any(String))
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('plan_status_u1', 'pending', { metadata: { status: 'pending' } })
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis', '{"score":1}')
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_status', 'pending')
     expect(global.fetch).toHaveBeenCalledWith('https://mail.example.com', expect.any(Object))
   })
 })


### PR DESCRIPTION
## Summary
- store analysis status when questionnaire is submitted
- update analysis generation to mark status ready or error
- expose `/api/analysisStatus` endpoint
- document new key and endpoint
- extend tests for new status flow

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a8b8a25b48326af183ecc657b3f46