### PR TITLE
Update login/register endpoints

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
     <script type="module">
         import { showMessage, hideMessage } from './js/messageUtils.js';
         import { setupRegistration } from './js/register.js';
-        import { workerBaseUrl, isLocalDevelopment } from './js/config.js';
+        import { workerBaseUrl, apiEndpoints, isLocalDevelopment } from './js/config.js';
         // Селектори
         const loginSection = document.getElementById('login-section');
         const registerSection = document.getElementById('register-section');
@@ -85,8 +85,8 @@
         // Базов URL на Worker-а е дефиниран в config.js
 
         // API Endpoints
-        const loginEndpoint = `${workerBaseUrl}/api/login`;
-        const registerEndpoint = `${workerBaseUrl}/api/register`;
+        const loginEndpoint = apiEndpoints.login;
+        const registerEndpoint = apiEndpoints.register;
         // const forgotPasswordEndpoint = `${workerBaseUrl}/api/forgotPassword`; // Placeholder за бъдещ endpoint
 
         // URL за пренасочване след логин

--- a/js/__tests__/login.test.js
+++ b/js/__tests__/login.test.js
@@ -1,0 +1,19 @@
+import { jest } from '@jest/globals';
+
+const importConfig = async (hostname) => {
+  jest.resetModules();
+  global.window = { location: { hostname } };
+  return import('../config.js');
+};
+
+test('login endpoint in local development', async () => {
+  const { apiEndpoints } = await importConfig('localhost');
+  expect(apiEndpoints.login).toBe('/api/login');
+});
+
+test('login endpoint in production', async () => {
+  const { apiEndpoints } = await importConfig('example.com');
+  expect(apiEndpoints.login).toBe(
+    'https://openapichatbot.radilov-k.workers.dev/api/login'
+  );
+});

--- a/js/__tests__/register.test.js
+++ b/js/__tests__/register.test.js
@@ -13,7 +13,9 @@ beforeEach(async () => {
     showMessage: jest.fn(),
     hideMessage: jest.fn()
   }));
-  jest.unstable_mockModule('../config.js', () => ({ workerBaseUrl: 'https://api' }));
+  jest.unstable_mockModule('../config.js', () => ({
+    apiEndpoints: { register: 'https://api/api/register' }
+  }));
   ({ setupRegistration } = await import('../register.js'));
   ({ showMessage } = await import('../messageUtils.js'));
   global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });

--- a/js/config.js
+++ b/js/config.js
@@ -5,11 +5,13 @@ export const isLocalDevelopment = window.location.hostname === 'localhost' ||
                                window.location.hostname.includes('replit') ||
                                window.location.hostname.includes('preview');
 
-export const workerBaseUrl = isLocalDevelopment ?
-    '/api' : // Използваме локалния proxy в развойна среда
-    'https://openapichatbot.radilov-k.workers.dev'; // Директно към Worker в продукция
+export const workerBaseUrl = isLocalDevelopment
+    ? '' // Използваме локалния proxy в развойна среда
+    : 'https://openapichatbot.radilov-k.workers.dev'; // Директно към Worker в продукция
 
 export const apiEndpoints = {
+    login: `${workerBaseUrl}/api/login`,
+    register: `${workerBaseUrl}/api/register`,
     dashboard: `${workerBaseUrl}/api/dashboardData`,
     log: `${workerBaseUrl}/api/log`,
     chat: `${workerBaseUrl}/api/chat`,

--- a/js/register.js
+++ b/js/register.js
@@ -1,5 +1,5 @@
 import { showMessage, hideMessage } from "./messageUtils.js";
-import { workerBaseUrl } from "./config.js";
+import { apiEndpoints } from "./config.js";
 
 export function setupRegistration(formSelector, messageElSelector) {
   const form = document.querySelector(formSelector);
@@ -43,7 +43,7 @@ export function setupRegistration(formSelector, messageElSelector) {
       submitBtn.textContent = 'Обработка...';
     }
     try {
-      const res = await fetch(`${workerBaseUrl}/api/register`, {
+      const res = await fetch(apiEndpoints.register, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password, confirm_password: confirmPassword })


### PR DESCRIPTION
## Summary
- tweak `workerBaseUrl` logic
- centralize login and register endpoints in `config.js`
- use those endpoints in `index.html` and registration logic
- adjust registration test to new API
- add unit test for login endpoint URL

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a9ac3342083268d25e36935cde37e