### PR TITLE
Add 127.0.0.1 as local host

### DIFF
--- a/js/__tests__/login.test.js
+++ b/js/__tests__/login.test.js
@@ -6,8 +6,8 @@ const importConfig = async (hostname) => {
   return import('../config.js');
 };
 
-test('login endpoint in local development', async () => {
-  const { apiEndpoints } = await importConfig('localhost');
+test.each(['localhost', '127.0.0.1'])('login endpoint in local development (%s)', async (host) => {
+  const { apiEndpoints } = await importConfig(host);
   expect(apiEndpoints.login).toBe('/api/login');
 });
 

--- a/js/config.js
+++ b/js/config.js
@@ -2,6 +2,7 @@
 
 // Определяваме базовия URL според средата
 export const isLocalDevelopment = window.location.hostname === 'localhost' ||
+                               window.location.hostname === '127.0.0.1' ||
                                window.location.hostname.includes('replit') ||
                                window.location.hostname.includes('preview');
 


### PR DESCRIPTION
## Summary
- treat 127.0.0.1 as local development host
- check localhost and 127.0.0.1 in login test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687aa0244f408326b003bc052fb3816c