### PR TITLE
Fix analysis link with existing query params

### DIFF
--- a/js/__tests__/initialAnalysis.test.js
+++ b/js/__tests__/initialAnalysis.test.js
@@ -64,6 +64,34 @@ describe('initial analysis handlers', () => {
     warnSpy.mockRestore()
   })
 
+  test('adds userId to ANALYSIS_PAGE_URL with existing query', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { response: '{"ok":true}' } })
+    })
+    const env = {
+      MAILER_ENDPOINT_URL: 'https://mail.example.com',
+      ANALYSIS_PAGE_URL: 'https://app.example.com/analyze.html?utm=1',
+      USER_METADATA_KV: {
+        get: jest.fn(key => key === 'u1_initial_answers' ? Promise.resolve('{"name":"A","email":"a@ex.bg"}') : Promise.resolve(null)),
+        put: jest.fn()
+      },
+      RESOURCES_KV: {
+        get: jest.fn(key => {
+          if (key === 'prompt_questionnaire_analysis') return 'Analyze %%ANSWERS_JSON%%'
+          if (key === 'model_questionnaire_analysis') return '@cf/test-model'
+          return null
+        })
+      },
+      CF_ACCOUNT_ID: 'acc',
+      CF_AI_TOKEN: 't'
+    }
+    await worker.handleAnalyzeInitialAnswers('u1', env)
+    const emailCall = global.fetch.mock.calls.find(c => c[0] === 'https://mail.example.com')
+    const callBody = JSON.parse(emailCall[1].body)
+    expect(callBody.message).toContain('https://app.example.com/analyze.html?utm=1&userId=u1')
+  })
+
   test('handleGetInitialAnalysisRequest returns parsed analysis', async () => {
     const env = { USER_METADATA_KV: { get: jest.fn().mockResolvedValue('{"a":1}') } }
     const req = { url: 'https://x/api/getInitialAnalysis?userId=u1' }

--- a/preworker.js
+++ b/preworker.js
@@ -1501,7 +1501,9 @@ async function handleAnalyzeInitialAnswers(userId, env) {
         await env.USER_METADATA_KV.put(`${userId}_analysis`, cleaned);
         console.log(`INITIAL_ANALYSIS (${userId}): Analysis stored.`);
         const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] || 'https://mybody.best/analyze.html';
-        const link = `${baseUrl}?userId=${encodeURIComponent(userId)}`;
+        const url = new URL(baseUrl);
+        url.searchParams.set('userId', userId);
+        const link = url.toString();
         if (answers.email) {
             const name = answers.name || 'Клиент';
             await sendAnalysisLinkEmail(answers.email, name, link, env);

--- a/worker.js
+++ b/worker.js
@@ -1501,7 +1501,9 @@ async function handleAnalyzeInitialAnswers(userId, env) {
         await env.USER_METADATA_KV.put(`${userId}_analysis`, cleaned);
         console.log(`INITIAL_ANALYSIS (${userId}): Analysis stored.`);
         const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] || 'https://mybody.best/analyze.html';
-        const link = `${baseUrl}?userId=${encodeURIComponent(userId)}`;
+        const url = new URL(baseUrl);
+        url.searchParams.set('userId', userId);
+        const link = url.toString();
         if (answers.email) {
             const name = answers.name || 'Клиент';
             await sendAnalysisLinkEmail(answers.email, name, link, env);


### PR DESCRIPTION
## Summary
- ensure analysis link preserves existing query params
- test handleAnalyzeInitialAnswers when ANALYSIS_PAGE_URL already has a query string

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ad1624fe08326a4fe61ccdaf91c9e