### PR TITLE
Add questionnaire analysis test tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,7 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
 - `POST /api/analyzeImage` – анализира качено изображение и връща резултат. Изпращайте поле `image` с пълен `data:` URL. Ендпойнтът не изисква `WORKER_ADMIN_TOKEN`, освен ако изрично не сте го добавили като защита.
 - `POST /api/runImageModel` – изпраща байтовете на изображение към избран Cloudflare AI модел. Заявката приема `{ "model": "@cf/llava-hf/llava-1.5-7b-hf", "prompt": "Описание", "image": [..] }` и връща JSON от `env.AI.run`. При заявки с друг метод се връща статус 405.
 - `POST /api/sendTestEmail` – изпраща тестов имейл. Изисква администраторски токен.
+- `POST /api/testQuestionnaireAnalysis` – генерира анализ на въпросник за съществуващ клиент. Изисква администраторски токен.
 - `POST /api/sendEmail` – изпраща имейл чрез PHP бекенда. Изисква HTTP заглавка `Authorization: Bearer <WORKER_ADMIN_TOKEN>` и приема JSON `{ "to": "user@example.com", "subject": "Тема", "text": "Съобщение" }`. Заявките са ограничени до няколко на минута.
 
   ```bash

--- a/admin.html
+++ b/admin.html
@@ -223,6 +223,19 @@
     </form>
   </details>
 
+  <details id="testQuestSection" class="card">
+    <summary>Тест на анализ на въпросник</summary>
+    <form id="testQuestForm">
+      <label>User ID: <input id="testQuestUserId" type="text" required></label>
+      <label>Отговори (JSON, по избор):<br>
+        <textarea id="testQuestData" rows="5"></textarea>
+      </label>
+      <button type="submit">Стартирай анализ</button>
+    </form>
+    <pre id="testQuestResult" class="json"></pre>
+    <a id="openQuestAnalysis" href="#" target="_blank" style="display:none">Отвори analyze.html</a>
+  </details>
+
   <details id="testImageSection" class="card">
     <summary>Тест на анализ на изображение</summary>
     <form id="testImageForm">

--- a/js/__tests__/sendTestQuestionnaire.test.js
+++ b/js/__tests__/sendTestQuestionnaire.test.js
@@ -1,0 +1,39 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let send;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <form id="testQuestForm">
+      <input id="testQuestUserId">
+      <textarea id="testQuestData"></textarea>
+      <pre id="testQuestResult"></pre>
+    </form>
+    <button id="showStats"></button>
+    <button id="sendQuery"></button>`;
+
+  jest.unstable_mockModule('../config.js', () => ({
+    apiEndpoints: { testQuestionnaireAnalysis: '/api/testQuestionnaireAnalysis' }
+  }));
+
+  const mod = await import('../admin.js');
+  send = mod.sendTestQuest;
+});
+
+afterEach(() => {
+  global.fetch && global.fetch.mockRestore();
+});
+
+test('sendTestQuest posts provided data', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  document.getElementById('testQuestUserId').value = 'u1';
+  document.getElementById('testQuestData').value = '{"a":1}';
+  await send();
+  expect(global.fetch).toHaveBeenCalledWith('/api/testQuestionnaireAnalysis', expect.objectContaining({
+    method: 'POST',
+    headers: expect.any(Object),
+    body: JSON.stringify({ userId: 'u1', answers: { a: 1 } })
+  }));
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -100,6 +100,11 @@ const testImageForm = document.getElementById('testImageForm');
 const testImageFileInput = document.getElementById('testImageFile');
 const testImagePromptInput = document.getElementById('testImagePrompt');
 const testImageResultPre = document.getElementById('testImageResult');
+const testQuestForm = document.getElementById('testQuestForm');
+const testQuestUserId = document.getElementById('testQuestUserId');
+const testQuestData = document.getElementById('testQuestData');
+const testQuestResultPre = document.getElementById('testQuestResult');
+const openQuestAnalysisLink = document.getElementById('openQuestAnalysis');
 const clientNameHeading = document.getElementById('clientName');
 const closeProfileBtn = document.getElementById('closeProfile');
 const notificationsList = document.getElementById('notificationsList');
@@ -1293,6 +1298,39 @@ async function sendTestImage() {
     }
 }
 
+async function sendTestQuest() {
+    if (!testQuestForm) return;
+    const userId = testQuestUserId ? testQuestUserId.value.trim() : '';
+    if (!userId) return;
+    if (openQuestAnalysisLink) openQuestAnalysisLink.style.display = 'none';
+    const payload = { userId };
+    const raw = testQuestData ? testQuestData.value.trim() : '';
+    if (raw) {
+        try { payload.answers = JSON.parse(raw); }
+        catch { alert('Невалиден JSON'); return; }
+    }
+    try {
+        const adminToken = sessionStorage.getItem('adminToken') || localStorage.getItem('adminToken') || '';
+        const headers = { 'Content-Type': 'application/json' };
+        if (adminToken) headers.Authorization = `Bearer ${adminToken}`;
+        const resp = await fetch(apiEndpoints.testQuestionnaireAnalysis, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(payload)
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (testQuestResultPre) testQuestResultPre.textContent = JSON.stringify(data, null, 2);
+        if (openQuestAnalysisLink) {
+            openQuestAnalysisLink.href = `analyze.html?userId=${encodeURIComponent(userId)}`;
+            openQuestAnalysisLink.style.display = 'inline';
+        }
+        if (!resp.ok || !data.success) alert(data.message || 'Грешка');
+    } catch (err) {
+        console.error('Error testing questionnaire analysis:', err);
+        alert('Грешка при заявката.');
+    }
+}
+
 async function loadAiPresets() {
     if (!presetSelect) return;
     try {
@@ -1489,6 +1527,13 @@ if (testImageForm) {
     });
 }
 
+if (testQuestForm) {
+    testQuestForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        await sendTestQuest();
+    });
+}
+
 export {
     allClients,
     loadClients,
@@ -1502,5 +1547,6 @@ export {
     sendTestEmail,
     confirmAndSendTestEmail,
     sendTestImage,
+    sendTestQuest,
     sendAdminQuery
 };

--- a/js/config.js
+++ b/js/config.js
@@ -47,7 +47,8 @@ export const apiEndpoints = {
     saveAiPreset: `${workerBaseUrl}/api/saveAiPreset`,
     testAiModel: `${workerBaseUrl}/api/testAiModel`,
     analyzeImage: `${workerBaseUrl}/api/analyzeImage`,
-    sendTestEmail: `${workerBaseUrl}/api/sendTestEmail`
+    sendTestEmail: `${workerBaseUrl}/api/sendTestEmail`,
+    testQuestionnaireAnalysis: `${workerBaseUrl}/api/testQuestionnaireAnalysis`
 };
 
 // Cloudflare Account ID за използване в чат асистента


### PR DESCRIPTION
## Summary
- extend AI endpoints with `/api/testQuestionnaireAnalysis`
- allow `handleAnalyzeInitialAnswers` to accept custom answers/dry-run
- implement backend handler and route
- add admin panel form for questionnaire analysis
- wire up JS logic for the new form
- expose link to open generated analysis
- document new endpoint in README
- add tests for `sendTestQuest` helper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687acf524ae88326b6d4e89e045ec210