### PR TITLE
Add admin test questionnaire form

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -233,6 +233,17 @@
     <pre id="testImageResult" class="json"></pre>
   </details>
 
+  <details id="testQuestionnaireSection" class="card">
+    <summary>Тест на анализ на въпросник</summary>
+    <form id="testQuestionnaireForm">
+      <label>Имейл:<br><input id="testQEmail" type="email"></label>
+      <label>Файл с отговори:<br><input id="testQFile" type="file" accept="application/json"></label>
+      <label>JSON отговори:<br><textarea id="testQText" rows="5"></textarea></label>
+      <button type="submit">Изпрати</button>
+    </form>
+    <pre id="testQResult" class="json"></pre>
+  </details>
+
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="js/admin.js"></script>
 </body>

--- a/js/__tests__/sendTestQuestionnaire.test.js
+++ b/js/__tests__/sendTestQuestionnaire.test.js
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let send;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <form id="testQuestionnaireForm">
+      <input id="testQEmail">
+      <input id="testQFile" type="file">
+      <textarea id="testQText"></textarea>
+      <pre id="testQResult"></pre>
+    </form>
+    <button id="showStats"></button>
+    <button id="sendQuery"></button>`;
+
+  jest.unstable_mockModule('../config.js', () => ({
+    apiEndpoints: { submitQuestionnaire: '/api/submitQuestionnaire' }
+  }));
+
+  const mod = await import('../admin.js');
+  send = mod.sendTestQuestionnaire;
+});
+
+afterEach(() => {
+  global.fetch && global.fetch.mockRestore();
+});
+
+test('sendTestQuestionnaire posts parsed JSON', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  const file = new File(['{"a":1}'], 'data.json', { type: 'application/json' });
+  Object.defineProperty(document.getElementById('testQFile'), 'files', { value: [file] });
+  document.getElementById('testQEmail').value = 'a@b.bg';
+  await send();
+  expect(global.fetch).toHaveBeenCalledWith('/api/submitQuestionnaire', expect.objectContaining({
+    method: 'POST',
+    headers: expect.any(Object),
+    body: JSON.stringify({ a: 1, email: 'a@b.bg' })
+  }));
+});

--- a/js/config.js
+++ b/js/config.js
@@ -47,7 +47,8 @@ export const apiEndpoints = {
     saveAiPreset: `${workerBaseUrl}/api/saveAiPreset`,
     testAiModel: `${workerBaseUrl}/api/testAiModel`,
     analyzeImage: `${workerBaseUrl}/api/analyzeImage`,
-    sendTestEmail: `${workerBaseUrl}/api/sendTestEmail`
+    sendTestEmail: `${workerBaseUrl}/api/sendTestEmail`,
+    submitQuestionnaire: `${workerBaseUrl}/api/submitQuestionnaire`
 };
 
 // Cloudflare Account ID за използване в чат асистента


### PR DESCRIPTION
## Summary
- extend admin panel with a test questionnaire section
- handle JSON answers upload in admin.js
- support new API endpoint in config
- test posting questionnaire answers

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687adf7c01dc8326b6498f4830a9293c