### PR TITLE
Implement admin test questionnaire sending

### DIFF
--- a/js/__tests__/sendTestImage.test.js
+++ b/js/__tests__/sendTestImage.test.js
@@ -18,7 +18,8 @@ beforeEach(async () => {
     apiEndpoints: { analyzeImage: '/api/analyzeImage' }
   }));
   jest.unstable_mockModule('../utils.js', () => ({
-    fileToDataURL: jest.fn(async () => 'data:image/png;base64,imgdata')
+    fileToDataURL: jest.fn(async () => 'data:image/png;base64,imgdata'),
+    fileToText: jest.fn()
   }));
 
   const mod = await import('../admin.js');

--- a/js/__tests__/sendTestQuestionnaire.test.js
+++ b/js/__tests__/sendTestQuestionnaire.test.js
@@ -18,6 +18,10 @@ beforeEach(async () => {
   jest.unstable_mockModule('../config.js', () => ({
     apiEndpoints: { submitQuestionnaire: '/api/submitQuestionnaire' }
   }));
+  jest.unstable_mockModule('../utils.js', () => ({
+    fileToText: jest.fn(async () => '{"a":1}'),
+    fileToDataURL: jest.fn()
+  }));
 
   const mod = await import('../admin.js');
   send = mod.sendTestQuestionnaire;

--- a/js/utils.js
+++ b/js/utils.js
@@ -78,3 +78,17 @@ export function fileToDataURL(file) {
         reader.readAsDataURL(file);
     });
 }
+
+/**
+ * Чете File обект като текст.
+ * @param {File} file - Файлът за прочитане.
+ * @returns {Promise<string>} Обещание със съдържанието като текст.
+ */
+export function fileToText(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result || '');
+        reader.onerror = () => reject(reader.error);
+        reader.readAsText(file);
+    });
+}


### PR DESCRIPTION
## Summary
- add `fileToText` helper
- enhance admin test questionnaire handler to load JSON from file and show analysis
- adjust tests to mock utilities

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ae548f6348326967f865045dadfd8