### PR TITLE
Add client selector for questionnaire tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ The Cloudflare account ID is filled automatically from `config.js`.
 Use the small image button next to the send icon to upload a picture. The file is sent to `/api/analyzeImage` and the analysis appears as a bot reply.
 The admin panel (`admin.html`) also provides a **Test Image Analysis** form that sends a selected picture to `/api/analyzeImage` and shows the JSON response.
 Има и секция **Тест на анализ на въпросник**, която изпраща JSON отговори към `/api/submitQuestionnaire` и извежда статуса на обработката заедно с получения анализ. Заредете файл с резултати или поставете съдържанието в текстовото поле и натиснете **Изпрати**.
+Падащо меню **Клиент** автоматично се попълва със списък на всички профили. Може и да въведете `userId` ръчно. Достатъчно е да посочите имейл или `userId` (или и двете). При успешно изпращане и върнат идентификатор се появява бутон **Отвори анализа**, който отваря `analysis.html?userId=<ID>` в нов таб.
 
 ```bash
 curl -X POST https://<your-domain>/api/submitQuestionnaire \

--- a/admin.html
+++ b/admin.html
@@ -237,11 +237,14 @@
     <summary>Тест на анализ на въпросник</summary>
     <form id="testQuestionnaireForm">
       <label>Имейл:<br><input id="testQEmail" type="email"></label>
+      <label>Клиент:<br><select id="testQClient"></select></label>
+      <label>User ID:<br><input id="testQUserId" type="text"></label>
       <label>Файл с отговори:<br><input id="testQFile" type="file" accept="application/json"></label>
       <label>JSON отговори:<br><textarea id="testQText" rows="5"></textarea></label>
       <button type="submit">Изпрати</button>
     </form>
     <pre id="testQResult" class="json"></pre>
+    <a id="openTestQAnalysis" class="button button-small hidden" target="_blank">Отвори анализа</a>
   </details>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/js/__tests__/sendTestQuestionnaire.test.js
+++ b/js/__tests__/sendTestQuestionnaire.test.js
@@ -8,10 +8,13 @@ beforeEach(async () => {
   document.body.innerHTML = `
     <form id="testQuestionnaireForm">
       <input id="testQEmail">
+      <select id="testQClient"><option value="u1">User 1</option></select>
+      <input id="testQUserId">
       <input id="testQFile" type="file">
       <textarea id="testQText"></textarea>
       <pre id="testQResult"></pre>
     </form>
+    <a id="openTestQAnalysis" class="hidden"></a>
     <button id="showStats"></button>
     <button id="sendQuery"></button>`;
 
@@ -31,24 +34,29 @@ afterEach(() => {
   global.fetch && global.fetch.mockRestore();
 });
 
-test('sendTestQuestionnaire posts parsed JSON', async () => {
+test('sendTestQuestionnaire posts parsed JSON with userId only', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   const file = new File(['{"a":1}'], 'data.json', { type: 'application/json' });
   Object.defineProperty(document.getElementById('testQFile'), 'files', { value: [file] });
-  document.getElementById('testQEmail').value = 'a@b.bg';
+  document.getElementById('testQEmail').value = '';
+  document.getElementById('testQClient').value = 'u1';
   await send();
   expect(global.fetch).toHaveBeenCalledWith('/api/submitQuestionnaire', expect.objectContaining({
     method: 'POST',
     headers: expect.any(Object),
-    body: JSON.stringify({ a: 1, email: 'a@b.bg' })
+    body: JSON.stringify({ a: 1, email: '', userId: 'u1' })
   }));
 });
 
-test('response renders in #testQResult', async () => {
-  const responseData = { success: true };
+test('response renders in #testQResult and link is shown', async () => {
+  const responseData = { success: true, userId: 'u5' };
   global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => responseData });
   document.getElementById('testQEmail').value = 'a@b.bg';
   document.getElementById('testQText').value = '{"a":1}';
   await send();
-  expect(document.getElementById('testQResult').textContent).toBe(JSON.stringify(responseData, null, 2));
+  const text = document.getElementById('testQResult').textContent;
+  expect(text.startsWith(JSON.stringify(responseData, null, 2))).toBe(true);
+  const link = document.getElementById('openTestQAnalysis');
+  expect(link.classList.contains('hidden')).toBe(false);
+  expect(link.getAttribute('href')).toBe('analysis.html?userId=u5');
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -102,9 +102,12 @@ const testImagePromptInput = document.getElementById('testImagePrompt');
 const testImageResultPre = document.getElementById('testImageResult');
 const testQuestionnaireForm = document.getElementById('testQuestionnaireForm');
 const testQEmailInput = document.getElementById('testQEmail');
+const testQClientSelect = document.getElementById('testQClient');
+const testQUserIdInput = document.getElementById('testQUserId');
 const testQFileInput = document.getElementById('testQFile');
 const testQTextArea = document.getElementById('testQText');
 const testQResultPre = document.getElementById('testQResult');
+const openTestQAnalysisLink = document.getElementById('openTestQAnalysis');
 const clientNameHeading = document.getElementById('clientName');
 const closeProfileBtn = document.getElementById('closeProfile');
 const notificationsList = document.getElementById('notificationsList');
@@ -504,6 +507,7 @@ async function loadClients() {
             );
             allClients = withStatus;
             updateTagFilterOptions();
+            populateTestQClientOptions();
             renderClients();
             const stats = {
                 clients: withStatus.length,
@@ -584,6 +588,17 @@ function updateTagFilterOptions() {
         tagFilterSelect.appendChild(opt);
     });
     if (current.includes('all')) tagFilterSelect.querySelector('option[value="all"]').selected = true;
+}
+
+function populateTestQClientOptions() {
+    if (!testQClientSelect) return;
+    testQClientSelect.innerHTML = '<option value="">--</option>';
+    allClients.forEach(c => {
+        const opt = document.createElement('option');
+        opt.value = c.userId;
+        opt.textContent = `${c.name} (${c.userId})`;
+        testQClientSelect.appendChild(opt);
+    });
 }
 
 function updateStatusChart(stats) {
@@ -1301,6 +1316,10 @@ async function sendTestImage() {
 async function sendTestQuestionnaire() {
     if (!testQuestionnaireForm) return;
     const email = testQEmailInput ? testQEmailInput.value.trim() : '';
+    if (openTestQAnalysisLink) openTestQAnalysisLink.classList.add('hidden');
+    const selectedId = testQClientSelect ? testQClientSelect.value : '';
+    const manualId = testQUserIdInput ? testQUserIdInput.value.trim() : '';
+    const userId = manualId || selectedId;
     let jsonStr = '';
 
     if (testQFileInput?.files?.[0]) {
@@ -1313,8 +1332,8 @@ async function sendTestQuestionnaire() {
         jsonStr = testQTextArea.value.trim();
     }
 
-    if (!email || !jsonStr) {
-        alert('Липсва имейл или данни.');
+    if ((!email && !userId) || !jsonStr) {
+        alert('Необходим е имейл или userId и данни.');
         return;
     }
 
@@ -1326,6 +1345,7 @@ async function sendTestQuestionnaire() {
         return;
     }
     payload.email = email;
+    if (userId) payload.userId = userId;
 
     try {
         const resp = await fetch(apiEndpoints.submitQuestionnaire, {
@@ -1337,6 +1357,10 @@ async function sendTestQuestionnaire() {
         if (testQResultPre) testQResultPre.textContent = JSON.stringify(data, null, 2);
 
         if (resp.ok && data.success && data.userId) {
+            if (openTestQAnalysisLink) {
+                openTestQAnalysisLink.classList.remove('hidden');
+                openTestQAnalysisLink.href = `analysis.html?userId=${encodeURIComponent(data.userId)}`;
+            }
             try {
                 const stResp = await fetch(`${apiEndpoints.analysisStatus}?userId=${encodeURIComponent(data.userId)}`);
                 const stData = await stResp.json();


### PR DESCRIPTION
## Summary
- extend *Тест на анализ на въпросник* with a client dropdown and user id field
- show "Отвори анализа" button after successful submission
- populate the dropdown on page load and include userId in requests
- require only email or userId to trigger the test
- update tests for the new behaviour
- document the new option in the README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687af1661ec08326ae794c211b3562f8