### PR TITLE
Implement questionnaire reanalysis trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ The Cloudflare account ID is filled automatically from `config.js`.
 Use the small image button next to the send icon to upload a picture. The file is sent to `/api/analyzeImage` and the analysis appears as a bot reply.
 The admin panel (`admin.html`) also provides a **Test Image Analysis** form that sends a selected picture to `/api/analyzeImage` and shows the JSON response.
 Има и секция **Тест на анализ на въпросник**, която изпраща JSON отговори към `/api/submitQuestionnaire` и извежда статуса на обработката заедно с получения анализ. Заредете файл с резултати или поставете съдържанието в текстовото поле и натиснете **Изпрати**.
-Падащо меню **Клиент** автоматично се попълва със списък на всички профили. Може и да въведете `userId` ръчно. Достатъчно е да посочите имейл или `userId` (или и двете). При успешно изпращане и върнат идентификатор се появява бутон **Отвори анализа**, който отваря `analysis.html?userId=<ID>` в нов таб.
+Падащо меню **Клиент** автоматично се попълва със списък на всички профили. Може и да въведете `userId` ръчно. Достатъчно е да посочите имейл или `userId` (или и двете). Ако не подадете JSON данни, се зарежда автоматично съхраненият въпросник и се стартира нов анализ. При успешно изпращане и върнат идентификатор се появява бутон **Отвори анализа**, който отваря `analysis.html?userId=<ID>` в нов таб.
 
 ```bash
 curl -X POST https://<your-domain>/api/submitQuestionnaire \

--- a/js/__tests__/reAnalyzeQuestionnaire.test.js
+++ b/js/__tests__/reAnalyzeQuestionnaire.test.js
@@ -1,0 +1,39 @@
+import { jest } from '@jest/globals'
+import * as worker from '../../worker.js'
+
+const originalFetch = global.fetch
+
+afterEach(() => { global.fetch = originalFetch })
+
+test('handleReAnalyzeQuestionnaireRequest loads answers and triggers analysis', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ result: { response: '{"ok":1}' } })
+  })
+  const env = {
+    ANALYSIS_PAGE_URL: 'https://app.example.com/analyze.html',
+    USER_METADATA_KV: {
+      get: jest.fn(key => {
+        if (key === 'email_to_uuid_a@ex.bg') return Promise.resolve('u1')
+        if (key === 'u1_initial_answers') return Promise.resolve('{"name":"A","email":"a@ex.bg"}')
+        return Promise.resolve(null)
+      }),
+      put: jest.fn()
+    },
+    RESOURCES_KV: {
+      get: jest.fn(key => {
+        if (key === 'prompt_questionnaire_analysis') return 'Analyze %%ANSWERS_JSON%%'
+        if (key === 'model_questionnaire_analysis') return '@cf/test-model'
+        return null
+      })
+    },
+    CF_ACCOUNT_ID: 'acc',
+    CF_AI_TOKEN: 't'
+  }
+  const req = { json: async () => ({ email: 'a@ex.bg' }) }
+  const res = await worker.handleReAnalyzeQuestionnaireRequest(req, env)
+  expect(res.success).toBe(true)
+  expect(res.userId).toBe('u1')
+  expect(res.link).toBe('https://app.example.com/analyze.html?userId=u1')
+  expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_status', 'pending')
+})

--- a/js/__tests__/sendTestQuestionnaire.test.js
+++ b/js/__tests__/sendTestQuestionnaire.test.js
@@ -19,7 +19,7 @@ beforeEach(async () => {
     <button id="sendQuery"></button>`;
 
   jest.unstable_mockModule('../config.js', () => ({
-    apiEndpoints: { submitQuestionnaire: '/api/submitQuestionnaire' }
+    apiEndpoints: { submitQuestionnaire: '/api/submitQuestionnaire', reAnalyzeQuestionnaire: '/api/reAnalyzeQuestionnaire' }
   }));
   jest.unstable_mockModule('../utils.js', () => ({
     fileToText: jest.fn(async () => '{"a":1}'),
@@ -59,4 +59,15 @@ test('response renders in #testQResult and link is shown', async () => {
   const link = document.getElementById('openTestQAnalysis');
   expect(link.classList.contains('hidden')).toBe(false);
   expect(link.getAttribute('href')).toBe('analysis.html?userId=u5');
+});
+
+test('calls reAnalyzeQuestionnaire when no JSON is provided', async () => {
+  const data = { success: true, userId: 'u1' };
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => data });
+  document.getElementById('testQClient').value = 'u1';
+  await send();
+  expect(global.fetch).toHaveBeenCalledWith('/api/reAnalyzeQuestionnaire', expect.any(Object));
+  const link = document.getElementById('openTestQAnalysis');
+  expect(link.classList.contains('hidden')).toBe(false);
+  expect(link.getAttribute('href')).toBe('analysis.html?userId=u1');
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -1332,8 +1332,31 @@ async function sendTestQuestionnaire() {
         jsonStr = testQTextArea.value.trim();
     }
 
-    if ((!email && !userId) || !jsonStr) {
-        alert('Необходим е имейл или userId и данни.');
+    if (!jsonStr) {
+        if (!email && !userId) {
+            alert('Необходим е имейл или userId.');
+            return;
+        }
+        try {
+            const resp = await fetch(apiEndpoints.reAnalyzeQuestionnaire, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email, userId })
+            });
+            const data = await resp.json();
+            if (testQResultPre) testQResultPre.textContent = JSON.stringify(data, null, 2);
+            if (resp.ok && data.success && data.userId) {
+                if (openTestQAnalysisLink) {
+                    openTestQAnalysisLink.classList.remove('hidden');
+                    openTestQAnalysisLink.href = `analysis.html?userId=${encodeURIComponent(data.userId)}`;
+                }
+            } else if (!resp.ok || !data.success) {
+                alert(data.message || 'Грешка при стартиране на анализа.');
+            }
+        } catch (err) {
+            console.error('Error triggering analysis:', err);
+            alert('Грешка при заявката.');
+        }
         return;
     }
 

--- a/js/config.js
+++ b/js/config.js
@@ -49,6 +49,7 @@ export const apiEndpoints = {
     analyzeImage: `${workerBaseUrl}/api/analyzeImage`,
     sendTestEmail: `${workerBaseUrl}/api/sendTestEmail`,
     submitQuestionnaire: `${workerBaseUrl}/api/submitQuestionnaire`,
+    reAnalyzeQuestionnaire: `${workerBaseUrl}/api/reAnalyzeQuestionnaire`,
     analysisStatus: `${workerBaseUrl}/api/analysisStatus`,
     getInitialAnalysis: `${workerBaseUrl}/api/getInitialAnalysis`
 };


### PR DESCRIPTION
## Summary
- add `/api/reAnalyzeQuestionnaire` endpoint to re-run analysis using stored answers
- expose endpoint in config and admin panel
- automatically trigger re-analysis when no JSON is provided in *Test Questionnaire* form
- document the new workflow
- add tests for worker handler and admin behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687af7571fa083268a42d05b7d7d9457