### PR TITLE
Update analysis link

### DIFF
--- a/js/__tests__/sendTestQuestionnaire.test.js
+++ b/js/__tests__/sendTestQuestionnaire.test.js
@@ -58,7 +58,7 @@ test('response renders in #testQResult and link is shown', async () => {
   expect(text.startsWith(JSON.stringify(responseData, null, 2))).toBe(true);
   const link = document.getElementById('openTestQAnalysis');
   expect(link.classList.contains('hidden')).toBe(false);
-  expect(link.getAttribute('href')).toBe('analyze.html?userId=u5');
+  expect(link.getAttribute('href')).toBe('reganalize/analyze.html?userId=u5');
 });
 
 test('calls reAnalyzeQuestionnaire when no JSON is provided', async () => {
@@ -69,5 +69,5 @@ test('calls reAnalyzeQuestionnaire when no JSON is provided', async () => {
   expect(global.fetch).toHaveBeenCalledWith('/api/reAnalyzeQuestionnaire', expect.any(Object));
   const link = document.getElementById('openTestQAnalysis');
   expect(link.classList.contains('hidden')).toBe(false);
-  expect(link.getAttribute('href')).toBe('analyze.html?userId=u1');
+  expect(link.getAttribute('href')).toBe('reganalize/analyze.html?userId=u1');
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -1348,7 +1348,7 @@ async function sendTestQuestionnaire() {
             if (resp.ok && data.success && data.userId) {
                 if (openTestQAnalysisLink) {
                     openTestQAnalysisLink.classList.remove('hidden');
-                    openTestQAnalysisLink.href = `analyze.html?userId=${encodeURIComponent(data.userId)}`;
+                    openTestQAnalysisLink.href = `reganalize/analyze.html?userId=${encodeURIComponent(data.userId)}`;
                 }
             } else if (!resp.ok || !data.success) {
                 alert(data.message || 'Грешка при стартиране на анализа.');
@@ -1382,7 +1382,7 @@ async function sendTestQuestionnaire() {
         if (resp.ok && data.success && data.userId) {
             if (openTestQAnalysisLink) {
                 openTestQAnalysisLink.classList.remove('hidden');
-                openTestQAnalysisLink.href = `analyze.html?userId=${encodeURIComponent(data.userId)}`;
+                openTestQAnalysisLink.href = `reganalize/analyze.html?userId=${encodeURIComponent(data.userId)}`;
             }
             try {
                 const stResp = await fetch(`${apiEndpoints.analysisStatus}?userId=${encodeURIComponent(data.userId)}`);


### PR DESCRIPTION
## Summary
- adjust admin.js analysis links to point to `reganalize/analyze.html`
- update questionnaire tests for new link

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b08683b3483268784ba5374210619