### PR TITLE
Handle missing analysis data in analyze.html

### DIFF
--- a/reganalize/analyze.html
+++ b/reganalize/analyze.html
@@ -176,11 +176,6 @@
         const analysisData = {/*---JSON_DATA_PLACEHOLDER---*/};
 
         document.addEventListener('DOMContentLoaded', function() {
-            if (!analysisData || !analysisData.client) {
-                document.body.innerHTML = '<h1>Грешка при зареждане на данните за анализ.</h1>';
-                document.body.classList.add('loaded');
-                return;
-            }
 
             // --- Хелпър функции за генериране на HTML ---
             const generateMotivationStars = (rating) => {
@@ -265,8 +260,35 @@
                 document.body.classList.add('loaded');
             };
 
-            // Извикване на рендиращата функция
-            renderAnalysis(analysisData);
+            const hasRequiredData = analysisData && analysisData.client && Array.isArray(analysisData.healthDashboard) && Array.isArray(analysisData.deepDive);
+
+            if (hasRequiredData) {
+                renderAnalysis(analysisData);
+            } else {
+                const params = new URLSearchParams(location.search);
+                const userId = params.get('userId');
+                if (!userId) {
+                    document.body.innerHTML = '<h1>Грешка при зареждане на данните за анализ.</h1>';
+                    document.body.classList.add('loaded');
+                    return;
+                }
+                fetch(`/api/getInitialAnalysis?userId=${encodeURIComponent(userId)}`)
+                    .then(res => {
+                        if (!res.ok) throw new Error('HTTP ' + res.status);
+                        return res.json();
+                    })
+                    .then(resp => {
+                        if (resp && resp.success && resp.analysis) {
+                            renderAnalysis(resp.analysis);
+                        } else {
+                            throw new Error('Invalid response');
+                        }
+                    })
+                    .catch(() => {
+                        document.body.innerHTML = '<h1>Грешка при зареждане на данните за анализ.</h1>';
+                        document.body.classList.add('loaded');
+                    });
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- detect when the page loads without injected analysis data
- fetch `/api/getInitialAnalysis` using the userId from the query string
- render the analysis after a successful fetch or show an error message on failure

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b0865a0588326a45c836b6edb98fa