### PR TITLE
Embed client dashboard template in admin

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -139,6 +139,7 @@
       <summary>Обратна връзка <span id="feedbackDot" class="notification-dot hidden"></span></summary>
       <ul id="feedbackList"></ul>
     </details>
+    <div id="clientDashboard"></div>
   </main>
   </div>
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,6 +1,8 @@
 import { apiEndpoints } from './config.js';
 import { labelMap, statusMap } from './labelMap.js';
 import { fileToDataURL, fileToText } from './utils.js';
+import { loadTemplateInto } from './templateLoader.js';
+import { initClientProfile, setOverrideUserId } from './clientProfile.js';
 
 async function ensureLoggedIn() {
     if (localStorage.getItem('adminSession') === 'true') {
@@ -45,6 +47,7 @@ const openUserDataLink = document.getElementById('openUserData');
 const fullProfileFrame = document.getElementById('fullProfileFrame');
 const dashboardPre = document.getElementById('dashboardData');
 const copyDashboardJsonBtn = document.getElementById('copyDashboardJson');
+const clientDashboardContainer = document.getElementById('clientDashboard');
 const profileSummaryDiv = document.getElementById('profileSummary');
 const statusSummaryDiv = document.getElementById('statusSummary');
 const analyticsSummaryDiv = document.getElementById('analyticsSummary');
@@ -762,6 +765,11 @@ if (sortOrderSelect) sortOrderSelect.addEventListener('change', renderClients);
 if (tagFilterSelect) tagFilterSelect.addEventListener('change', renderClients);
 
 async function showClient(userId) {
+    if (clientDashboardContainer) {
+        await loadTemplateInto('profileTemplate.html', 'clientDashboard');
+        setOverrideUserId(userId);
+        initClientProfile();
+    }
     if (fullProfileFrame) fullProfileFrame.classList.remove('hidden');
     try {
         const [profileResp, dashResp] = await Promise.all([

--- a/js/app.js
+++ b/js/app.js
@@ -263,7 +263,7 @@ export { planHasRecContent };
  * Инициализира потребителския интерфейс и зарежда данните на таблото.
  * Извиква се при събитието DOMContentLoaded.
  */
-async function initializeApp() {
+export async function initializeApp() {
     try {
         if (isLocalDevelopment) console.log("initializeApp starting from app.js...");
         initializeSelectors();

--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -28,7 +28,13 @@ function createInfoItem(label, value) {
   return div;
 }
 
+let overrideUserId = null;
+export function setOverrideUserId(val) {
+  overrideUserId = val;
+}
+
 function getUserId() {
+  if (overrideUserId) return overrideUserId;
   const params = new URLSearchParams(window.location.search);
   return params.get('userId');
 }


### PR DESCRIPTION
## Summary
- add a new container in `admin.html` for dynamic dashboard content
- export `initializeApp` and a helper for overriding user ID
- load `profileTemplate.html` in admin panel via `showClient()`
- initialize client profile editing with the selected `userId`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b062125a48326b2b124cf8f9fd9b0