### PR TITLE
Embed client profile in admin panel

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -61,7 +61,7 @@
     </details>
     <button id="regeneratePlan">Генерирай нов план</button>
     <button id="aiSummary">AI резюме</button>
-    <iframe id="fullProfileFrame" class="profile-frame hidden" title="Пълен профил"></iframe>
+    <div id="adminProfileContainer"></div>
     <a id="openFullProfile" href="#" target="_blank">Отвори в нов таб</a>
     <a id="openUserData" href="#" target="_blank">JSON изглед</a>
     </section>

--- a/css/admin.css
+++ b/css/admin.css
@@ -191,6 +191,10 @@ details[open] summary::after {
   margin-top: 10px;
 }
 
+#adminProfileContainer {
+  margin-top: 10px;
+}
+
 .profile-frame {
   width: 100%;
   height: 80vh;


### PR DESCRIPTION
## Summary
- load the shared profile template directly in the admin interface
- call `initClientProfile` after loading
- cleanup on close and keep URL consistent
- adjust tests and minor styles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b98293e18832699ee16deecb27ce5