### PR TITLE
Allow CSS elements in templates

### DIFF
--- a/js/__tests__/templateLoader.test.js
+++ b/js/__tests__/templateLoader.test.js
@@ -36,3 +36,13 @@ test('blocks cross-origin urls', async () => {
   expect(errSpy).toHaveBeenCalledWith('Template load error:', expect.any(Error));
   errSpy.mockRestore();
 });
+
+test('preserves style and link tags', async () => {
+  const raw = '<link rel="stylesheet" href="x.css"><style>.a{}</style><div>Hi</div>';
+  sanitizeHTMLMock.mockReturnValueOnce(raw);
+  global.fetch.mockResolvedValueOnce({ ok: true, text: async () => raw });
+  await loadTemplateInto('/style.html', 'cont');
+  const container = document.getElementById('cont');
+  expect(container.querySelector('link[rel="stylesheet"]')).not.toBeNull();
+  expect(container.querySelector('style')).not.toBeNull();
+});

--- a/js/htmlSanitizer.js
+++ b/js/htmlSanitizer.js
@@ -1,4 +1,8 @@
-export function sanitizeHTML(html, allowedTags = ['a','b','i','u','p','div','span','ul','ol','li','br','hr','h1','h2','h3','h4','h5','h6','table','thead','tbody','tr','td','th','button','input','label','form','select','option','textarea','img','svg','use','path']) {
+export function sanitizeHTML(html, allowedTags = [
+  'a','b','i','u','p','div','span','ul','ol','li','br','hr','h1','h2','h3','h4','h5','h6',
+  'table','thead','tbody','tr','td','th','button','input','label','form','select','option','textarea',
+  'img','svg','use','path','style','link'
+]) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
   const walker = document.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT, null);


### PR DESCRIPTION
## Summary
- permit `<style>` and `<link>` in the HTML sanitizer
- test that template loader keeps CSS tags

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b9f51935c8326ba3372f05d345c47