### PR TITLE
Admin profile styling improvements

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="css/layout_styles.css">
   <link rel="stylesheet" href="css/components_styles.css">
   <link rel="stylesheet" href="css/admin.css">
+  <link rel="stylesheet" href="css/clientProfile.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
   <h1>Администраторски панел <span id="notificationIndicator" class="notification-dot hidden"></span></h1>
@@ -62,8 +65,12 @@
     <button id="regeneratePlan">Генерирай нов план</button>
     <button id="aiSummary">AI резюме</button>
     <div id="adminProfileContainer"></div>
-    <a id="openFullProfile" href="#" target="_blank">Отвори в нов таб</a>
-    <a id="openUserData" href="#" target="_blank">JSON изглед</a>
+    <a id="openFullProfile" class="button button-small" href="#" target="_blank" title="Отвори пълния профил в нов таб">
+      <i class="fas fa-external-link-alt me-1"></i>Пълен профил
+    </a>
+    <a id="openUserData" class="button button-small" href="#" target="_blank" title="Преглед на данните в JSON">
+      JSON изглед
+    </a>
     </section>
     <section id="notesTab" class="client-tab" role="tabpanel" aria-hidden="true">
     <details id="notesSection">
@@ -248,6 +255,7 @@
   </details>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="js/admin.js"></script>
 </body>
 </html>

--- a/js/admin.js
+++ b/js/admin.js
@@ -766,12 +766,22 @@ if (statusFilter) statusFilter.addEventListener('change', renderClients);
 if (sortOrderSelect) sortOrderSelect.addEventListener('change', renderClients);
 if (tagFilterSelect) tagFilterSelect.addEventListener('change', renderClients);
 
+function initEmbeddedProfile() {
+    if (!adminProfileContainer || !window.bootstrap) return;
+    adminProfileContainer.querySelectorAll('[data-bs-toggle="tab"]').forEach(el => {
+        bootstrap.Tab.getOrCreateInstance(el);
+    });
+    const first = adminProfileContainer.querySelector('#basic-tab');
+    if (first) bootstrap.Tab.getOrCreateInstance(first).show();
+}
+
 async function showClient(userId) {
     if (adminProfileContainer) {
         adminProfileContainer.innerHTML = '';
         history.replaceState(null, '', `?userId=${encodeURIComponent(userId)}`);
         await loadTemplateInto('profileTemplate.html', 'adminProfileContainer');
         initClientProfile();
+        initEmbeddedProfile();
     }
     try {
         const [profileResp, dashResp] = await Promise.all([


### PR DESCRIPTION
## Summary
- embed Bootstrap and Font Awesome in admin panel
- reuse client profile CSS and make "Отвори в нов таб" a styled button
- initialize Bootstrap tabs when loading a client profile

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ba2a5d69083268fa199939a26dd9c