### PR TITLE
Add step progress module and form animations

### DIFF
--- a/css/index_styles.css
+++ b/css/index_styles.css
@@ -60,7 +60,8 @@
             margin-top: 0.5rem; /* Отстояние над бутона */
         }
         .button:hover { background-color: var(--secondary-color); transform: translateY(-2px); box-shadow: var(--shadow-md); }
-        .button:active { transform: translateY(0px) scale(0.98); } /* По-малко движение при клик */
+        @keyframes buttonBounce { from { transform: scale(1); } 50% { transform: scale(0.96); } to { transform: scale(1); } }
+        .button:active { transform: translateY(0px) scale(0.98); animation: buttonBounce 0.2s ease; } /* По-малко движение при клик */
         .button.button-secondary { background-color: var(--secondary-color); }
         .button.button-secondary:hover { background-color: var(--primary-color); }
 
@@ -88,6 +89,16 @@
         }
         .message.error { color: var(--color-danger); background-color: rgba(231, 76, 60, 0.1); border-color: var(--color-danger); }
         .message.success { color: var(--color-success); background-color: rgba(46, 204, 113, 0.1); border-color: var(--color-success); }
+
+        /* Прогрес бар за регистрация и други форми */
+        .step-indicator-container { margin-bottom: var(--space-lg); text-align: center; }
+        .step-indicator-label { display: block; font-size: 0.85em; color: var(--text-color-secondary); margin-bottom: var(--space-xs); }
+        .progress-bar-steps { width: 100%; height: 8px; background-color: var(--progress-bar-bg-empty); border-radius: var(--radius-sm); overflow: hidden; margin: 0 auto; max-width: 300px; }
+        .progress-bar-steps .progress-bar-fill { height: 100%; background-color: var(--secondary-color); width: 0%; transition: width 0.4s ease-in-out; border-radius: var(--radius-sm); }
+
+        /* Анимация при фокус на поле */
+        .input-focus-animate { transition: transform 0.15s ease, box-shadow 0.2s; }
+        .input-focus-animate:focus { transform: scale(1.02); }
 
         /* Секция за въпросник */
         .questionnaire-link {

--- a/extra-meal-entry-form.html
+++ b/extra-meal-entry-form.html
@@ -18,7 +18,7 @@
         <div class="form-group"> <!-- Използваме общ клас за група от форма -->
             <label for="foodDescription">Какво консумирахте?</label>
             <div class="autocomplete-container" style="position: relative;">
-                <textarea id="foodDescription" name="foodDescription" rows="3" placeholder="Въведете текст..." required aria-required="true" aria-describedby="foodDescriptionHelp"></textarea> <!-- Няма нужда от form-control, ако е глобално стилизиран textarea -->
+                <textarea id="foodDescription" name="foodDescription" rows="3" placeholder="Въведете текст..." required aria-required="true" aria-describedby="foodDescriptionHelp" class="input-focus-animate"></textarea> <!-- Няма нужда от form-control, ако е глобално стилизиран textarea -->
                 <div id="foodSuggestionsDropdown" class="autocomplete-suggestions hidden" role="listbox" style="position: absolute; background-color: var(--surface-background); border: 1px solid var(--input-border-color); border-top: none; z-index: 1050; width: 100%; max-height: 150px; overflow-y: auto; box-shadow: var(--shadow-sm); border-bottom-left-radius: var(--radius-md); border-bottom-right-radius: var(--radius-md);">
                     <!-- Предложенията ще се добавят от JS -->
                 </div>
@@ -71,7 +71,7 @@
                 </label>
             </div>
         </fieldset>
-        <input type="text" id="quantityCustom" name="quantityCustom" class="hidden" style="margin-top: var(--space-sm);" placeholder="Напр. 100гр, 2 с.л., специфично количество" aria-label="Уточнение за количество">
+        <input type="text" id="quantityCustom" name="quantityCustom" class="hidden input-focus-animate" style="margin-top: var(--space-sm);" placeholder="Напр. 100гр, 2 с.л., специфично количество" aria-label="Уточнение за количество">
 
         <div class="form-group" style="margin-top: var(--space-md);">
             <label for="mealTimeSelect">Кога го консумирахте?</label>
@@ -83,7 +83,7 @@
                 <option value="specific_time">По-рано днес (посочете точно)</option>
                 <option value="yesterday_specific_time">Вчера (посочете точно)</option>
             </select>
-            <input type="datetime-local" id="mealTimeSpecific" name="mealTimeSpecific" class="hidden" style="margin-top: var(--space-sm);" aria-label="Конкретно време на консумация">
+            <input type="datetime-local" id="mealTimeSpecific" name="mealTimeSpecific" class="hidden input-focus-animate" style="margin-top: var(--space-sm);" aria-label="Конкретно време на консумация">
         </div>
     </div>
 
@@ -105,7 +105,7 @@
                 <label><input type="radio" name="reasonPrimary" value="нямах_планирана"> <span class="emoji-icon" style="margin-right: var(--space-xs); font-size: 1.1em;">🤷</span> Нямах планирана храна</label>
                 <label><input type="radio" name="reasonPrimary" value="other_reason"> <span class="emoji-icon" style="margin-right: var(--space-xs); font-size: 1.1em;">❓</span> Друга причина</label>
             </div>
-            <input type="text" id="reasonOtherText" name="reasonOtherText" class="hidden" style="margin-top: var(--space-sm);" placeholder="Моля, уточнете причината" aria-label="Уточнение за причина">
+            <input type="text" id="reasonOtherText" name="reasonOtherText" class="hidden input-focus-animate" style="margin-top: var(--space-sm);" placeholder="Моля, уточнете причината" aria-label="Уточнение за причина">
         </fieldset>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -21,11 +21,11 @@
                 <form id="login-form" novalidate>
                     <div class="form-group">
                         <label for="login-email">Имейл:</label>
-                        <input type="email" id="login-email" name="email" required autocomplete="email">
+                        <input type="email" id="login-email" name="email" required autocomplete="email" class="input-focus-animate">
                     </div>
                     <div class="form-group">
                         <label for="login-password">Парола:</label>
-                        <input type="password" id="login-password" name="password" required autocomplete="current-password">
+                        <input type="password" id="login-password" name="password" required autocomplete="current-password" class="input-focus-animate">
                     </div>
                     <div id="login-message" class="message error" role="alert"></div>
                     <button type="submit" class="button">Вход</button>
@@ -38,18 +38,22 @@
             <!-- Секция за Регистрация -->
             <div id="register-section" class="form-section hidden">
                 <h2>Регистрация</h2>
+                <div class="step-indicator-container">
+                    <span class="step-indicator-label">Стъпка <span id="regCurrentStep">1</span> от <span id="regTotalSteps">3</span></span>
+                    <div class="progress-bar-steps"><div id="registerProgressBar" class="progress-bar-fill"></div></div>
+                </div>
                 <form id="register-form" novalidate>
                     <div class="form-group">
                         <label for="register-email">Имейл:</label>
-                        <input type="email" id="register-email" name="register_email" required autocomplete="email">
+                        <input type="email" id="register-email" name="register_email" required autocomplete="email" class="input-focus-animate">
                     </div>
                     <div class="form-group">
                         <label for="register-password">Парола (мин. 8 знака):</label>
-                        <input type="password" id="register-password" name="register_password" required minlength="8" autocomplete="new-password">
+                        <input type="password" id="register-password" name="register_password" required minlength="8" autocomplete="new-password" class="input-focus-animate">
                     </div>
                     <div class="form-group">
                         <label for="confirm-password">Потвърди Парола:</label>
-                        <input type="password" id="confirm-password" name="confirm_password" required minlength="8" autocomplete="new-password">
+                        <input type="password" id="confirm-password" name="confirm_password" required minlength="8" autocomplete="new-password" class="input-focus-animate">
                     </div>
                     <div id="register-message" class="message" role="alert"></div>
                     <button type="submit" class="button button-secondary">Регистрация</button>
@@ -70,6 +74,7 @@
     <script type="module">
         import { showMessage, hideMessage } from './js/messageUtils.js';
         import { setupRegistration } from './js/register.js';
+        import { createStepProgress } from './js/stepProgress.js';
         import { apiEndpoints } from './js/config.js';
         // Селектори
         const loginSection = document.getElementById('login-section');
@@ -81,6 +86,22 @@
         const forgotPasswordLink = document.getElementById('forgot-password-link'); // Нов селектор
         const loginMessage = document.getElementById('login-message');
         const registerMessage = document.getElementById('register-message');
+        const regEmail = document.getElementById('register-email');
+        const regPass = document.getElementById('register-password');
+        const regConfirm = document.getElementById('confirm-password');
+        const registerProgress = createStepProgress({
+            barSelector: '#registerProgressBar',
+            currentSelector: '#regCurrentStep',
+            totalSelector: '#regTotalSteps',
+            totalSteps: 3
+        });
+        const updateRegProgress = () => {
+            const filled = [regEmail.value.trim(), regPass.value.trim(), regConfirm.value.trim()]
+                .filter(v => v).length;
+            registerProgress.update(filled);
+        };
+        [regEmail, regPass, regConfirm].forEach(el => el.addEventListener('input', updateRegProgress));
+        updateRegProgress();
 
         // Базов URL на Worker-а е дефиниран в config.js
 
@@ -99,7 +120,8 @@
             registerSection.classList.remove('hidden');
             hideMessage(loginMessage);
             hideMessage(registerMessage); // Скриваме и двете при превключване
-            registerForm.reset(); // Изчистваме формата за регистрация
+            registerForm.reset();
+            updateRegProgress();
         });
 
         showLoginLink.addEventListener('click', () => {
@@ -107,7 +129,8 @@
             loginSection.classList.remove('hidden');
             hideMessage(loginMessage);
             hideMessage(registerMessage);
-            loginForm.reset(); // Изчистваме формата за вход
+            loginForm.reset();
+            updateRegProgress();
         });
 
         // Обработка на клик върху "Забравена парола"
@@ -180,6 +203,7 @@
             setTimeout(() => {
                 document.getElementById("show-login").click();
                 hideMessage(document.getElementById("register-message"));
+                updateRegProgress();
             }, 2500);
         });
     </script>

--- a/js/adaptiveQuiz.js
+++ b/js/adaptiveQuiz.js
@@ -1,6 +1,9 @@
 // adaptiveQuiz.js - Логика за Адаптивен Въпросник
 import { selectors } from './uiElements.js';
 import { showToast, openModal as genericOpenModal } from './uiHandlers.js';
+import { createStepProgress } from './stepProgress.js';
+
+let quizProgressCtrl;
 import { safeGet, safeParseFloat } from './utils.js';
 import {
     currentUserId,
@@ -30,6 +33,11 @@ export async function openAdaptiveQuizModal() {
     }
 
     genericOpenModal('adaptiveQuizWrapper');
+    quizProgressCtrl = createStepProgress({
+        barSelector: selectors.quizProgressBar,
+        currentSelector: '#currentQuestionNumber',
+        totalSelector: '#totalQuestionsNumber'
+    });
 
     selectors.quizNavigation.classList.add('hidden');
     selectors.quizQuestionContainer.innerHTML = '';
@@ -330,17 +338,10 @@ export function renderCurrentQuizQuestion(isTransitioningNext = true) {
 
         selectors.quizQuestionContainer.appendChild(questionCardElement);
 
-        const progressBar = selectors.quizProgressBar;
-        if (progressBar && localCurrentQuizData && localCurrentQuizData.questions.length > 0) {
-            const progressPercentage = ((localCurrentQuestionIndex + 1) / localCurrentQuizData.questions.length) * 100;
-            progressBar.style.width = `${progressPercentage}%`;
-            progressBar.setAttribute('aria-valuenow', progressPercentage);
+        if (quizProgressCtrl && localCurrentQuizData && localCurrentQuizData.questions.length > 0) {
+            quizProgressCtrl.setTotal(localCurrentQuizData.questions.length);
+            quizProgressCtrl.update(localCurrentQuestionIndex + 1);
         }
-
-        const currentNumEl = document.getElementById('currentQuestionNumber');
-        const totalNumEl = document.getElementById('totalQuestionsNumber');
-        if (currentNumEl) currentNumEl.textContent = localCurrentQuestionIndex + 1;
-        if (totalNumEl) totalNumEl.textContent = localCurrentQuizData.questions.length;
 
         selectors.prevQuestionBtn.classList.toggle('hidden', localCurrentQuestionIndex === 0);
         selectors.nextQuestionBtn.classList.toggle('hidden', localCurrentQuestionIndex === localCurrentQuizData.questions.length - 1);

--- a/js/stepProgress.js
+++ b/js/stepProgress.js
@@ -1,0 +1,25 @@
+export function createStepProgress({ barSelector, currentSelector = null, totalSelector = null, totalSteps = 1 }) {
+  const bar = typeof barSelector === 'string' ? document.querySelector(barSelector) : barSelector;
+  const currentEl = currentSelector ? (typeof currentSelector === 'string' ? document.querySelector(currentSelector) : currentSelector) : null;
+  const totalEl = totalSelector ? (typeof totalSelector === 'string' ? document.querySelector(totalSelector) : totalSelector) : null;
+  let total = totalSteps;
+  let step = 0;
+  if (totalEl) totalEl.textContent = String(total);
+
+  const update = (newStep) => {
+    step = Math.max(0, Math.min(newStep, total));
+    if (bar) {
+      const percent = total > 0 ? (step / total) * 100 : 0;
+      bar.style.width = `${percent}%`;
+    }
+    if (currentEl) currentEl.textContent = String(step + 1);
+  };
+
+  const setTotal = (steps) => {
+    total = steps;
+    if (totalEl) totalEl.textContent = String(total);
+    update(step);
+  };
+
+  return { update, setTotal };
+}

--- a/quest.html
+++ b/quest.html
@@ -29,6 +29,7 @@
 <script type="module">
   import { workerBaseUrl } from './js/config.js';
   import { setupRegistration } from "./js/register.js";
+  import { createStepProgress } from "./js/stepProgress.js";
   import { showMessage, hideMessage } from "./js/messageUtils.js";
   /***** Глобални променливи *****/
   let rawQuestions = [];     // Суровият масив от questions.json (йерархичен)
@@ -37,6 +38,7 @@
   let totalPages = 0;
   let registrationPageIndex = 0;
   const responses = {};
+  const progressBarCtrl = createStepProgress({ barSelector: '#progressBar' });
   // Допустими диапазони за числовите въпроси
   const numericRanges = {
     age: { min: 10, max: 120 },
@@ -98,6 +100,7 @@
 
     totalPages = 1 + flatPages.length + 2; // Стартова + Въпроси + Регистрация + Финална
     console.log("Общо страници (включително старт и финал):", totalPages);
+    progressBarCtrl.setTotal(totalPages - 1);
 
     showPage(0); // Показваме стартовата страница
   }
@@ -514,17 +517,8 @@
 
   /***** Функция за обновяване на прогрес бара *****/
   function updateProgress() {
-    const progressBar = document.getElementById('progressBar');
-    const progressContainer = document.getElementById('progressContainer');
-    if (!progressBar || !progressContainer || totalPages <= 1) return;
-
-    // Прогресът е от 0 до (totalPages - 1), тъй като индексите са от 0
-    const currentStep = currentPageIndex;
-    // Общият брой стъпки е totalPages - 1 (тъй като не броим прогрес *след* финалната страница)
-    const totalSteps = totalPages > 1 ? totalPages - 1 : 1;
-    const percent = totalSteps > 0 ? Math.round((currentStep / totalSteps) * 100) : 0;
-
-    progressBar.style.width = Math.max(0, Math.min(100, percent)) + '%'; // Гарантираме 0-100
+    if (totalPages <= 1) return;
+    progressBarCtrl.update(currentPageIndex);
   }
 
   /***** Съхраняване и зареждане на прогреса чрез localStorage *****/


### PR DESCRIPTION
## Summary
- create shared `createStepProgress` module
- add progress bar to registration form and questionnaire
- update adaptive quiz to use progress component
- enhance focus effects and button active animation
- apply new animation class to form fields

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d75a5d8dc8326a89c0dbc74758a53