### PR TITLE
Add progress bar module and form animations

### DIFF
--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -10,6 +10,36 @@
 }
 .card:hover { transform: translateY(-4px); box-shadow: var(--shadow-lg); }
 
+/* -------------------------------------------------------------------------- */
+/* STEP PROGRESS BAR COMPONENT                                                */
+/* -------------------------------------------------------------------------- */
+.step-indicator-container {
+  text-align: center;
+  margin-bottom: var(--space-md);
+}
+.step-indicator-label {
+  display: block;
+  font-size: 0.85em;
+  color: var(--text-color-muted);
+  margin-bottom: var(--space-xs);
+}
+.progress-bar-steps {
+  width: 100%;
+  height: 8px;
+  background-color: var(--progress-bar-bg-empty);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  margin: 0 auto;
+  max-width: 300px;
+}
+.step-progress-bar {
+  height: 100%;
+  background-color: var(--secondary-color);
+  width: 0%;
+  transition: width 0.4s ease-in-out;
+  border-radius: var(--radius-sm);
+}
+
 .accordion-container {
   border: 1px solid var(--border-color-soft); border-radius: var(--radius-lg);
   overflow: hidden; margin-bottom: var(--space-md);

--- a/css/index_styles.css
+++ b/css/index_styles.css
@@ -51,6 +51,14 @@
              border-color: var(--primary-color); outline: none;
              box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.2);
         }
+
+        .input-focus-animate {
+            transition: transform 0.2s ease, border-color 0.2s, box-shadow 0.2s;
+        }
+
+        .input-focus-animate:focus {
+            transform: scale(1.02);
+        }
         /* Стил за бутоните */
         .button {
             display: inline-block; background-color: var(--primary-color); color: #fff; border: none;
@@ -60,7 +68,12 @@
             margin-top: 0.5rem; /* Отстояние над бутона */
         }
         .button:hover { background-color: var(--secondary-color); transform: translateY(-2px); box-shadow: var(--shadow-md); }
-        .button:active { transform: translateY(0px) scale(0.98); } /* По-малко движение при клик */
+        .button:active { animation: button-bounce 0.25s ease; }
+        @keyframes button-bounce {
+            0% { transform: translateY(0) scale(1); }
+            50% { transform: translateY(-2px) scale(0.97); }
+            100% { transform: translateY(0) scale(1); }
+        }
         .button.button-secondary { background-color: var(--secondary-color); }
         .button.button-secondary:hover { background-color: var(--primary-color); }
 

--- a/extra-meal-entry-form.html
+++ b/extra-meal-entry-form.html
@@ -18,7 +18,7 @@
         <div class="form-group"> <!-- Използваме общ клас за група от форма -->
             <label for="foodDescription">Какво консумирахте?</label>
             <div class="autocomplete-container" style="position: relative;">
-                <textarea id="foodDescription" name="foodDescription" rows="3" placeholder="Въведете текст..." required aria-required="true" aria-describedby="foodDescriptionHelp"></textarea> <!-- Няма нужда от form-control, ако е глобално стилизиран textarea -->
+            <textarea id="foodDescription" name="foodDescription" rows="3" placeholder="Въведете текст..." required aria-required="true" aria-describedby="foodDescriptionHelp" class="input-focus-animate"></textarea> <!-- Няма нужда от form-control, ако е глобално стилизиран textarea -->
                 <div id="foodSuggestionsDropdown" class="autocomplete-suggestions hidden" role="listbox" style="position: absolute; background-color: var(--surface-background); border: 1px solid var(--input-border-color); border-top: none; z-index: 1050; width: 100%; max-height: 150px; overflow-y: auto; box-shadow: var(--shadow-sm); border-bottom-left-radius: var(--radius-md); border-bottom-right-radius: var(--radius-md);">
                     <!-- Предложенията ще се добавят от JS -->
                 </div>
@@ -71,7 +71,7 @@
                 </label>
             </div>
         </fieldset>
-        <input type="text" id="quantityCustom" name="quantityCustom" class="hidden" style="margin-top: var(--space-sm);" placeholder="Напр. 100гр, 2 с.л., специфично количество" aria-label="Уточнение за количество">
+        <input type="text" id="quantityCustom" name="quantityCustom" class="hidden input-focus-animate" style="margin-top: var(--space-sm);" placeholder="Напр. 100гр, 2 с.л., специфично количество" aria-label="Уточнение за количество">
 
         <div class="form-group" style="margin-top: var(--space-md);">
             <label for="mealTimeSelect">Кога го консумирахте?</label>
@@ -83,7 +83,7 @@
                 <option value="specific_time">По-рано днес (посочете точно)</option>
                 <option value="yesterday_specific_time">Вчера (посочете точно)</option>
             </select>
-            <input type="datetime-local" id="mealTimeSpecific" name="mealTimeSpecific" class="hidden" style="margin-top: var(--space-sm);" aria-label="Конкретно време на консумация">
+            <input type="datetime-local" id="mealTimeSpecific" name="mealTimeSpecific" class="hidden input-focus-animate" style="margin-top: var(--space-sm);" aria-label="Конкретно време на консумация">
         </div>
     </div>
 
@@ -105,7 +105,7 @@
                 <label><input type="radio" name="reasonPrimary" value="нямах_планирана"> <span class="emoji-icon" style="margin-right: var(--space-xs); font-size: 1.1em;">🤷</span> Нямах планирана храна</label>
                 <label><input type="radio" name="reasonPrimary" value="other_reason"> <span class="emoji-icon" style="margin-right: var(--space-xs); font-size: 1.1em;">❓</span> Друга причина</label>
             </div>
-            <input type="text" id="reasonOtherText" name="reasonOtherText" class="hidden" style="margin-top: var(--space-sm);" placeholder="Моля, уточнете причината" aria-label="Уточнение за причина">
+            <input type="text" id="reasonOtherText" name="reasonOtherText" class="hidden input-focus-animate" style="margin-top: var(--space-sm);" placeholder="Моля, уточнете причината" aria-label="Уточнение за причина">
         </fieldset>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
     <link href="css/base_styles.css" rel="stylesheet">
     <link href="css/index_styles.css" rel="stylesheet">
+    <link href="css/components_styles.css" rel="stylesheet">
     <link href="css/responsive_styles.css" rel="stylesheet">
 </head>
 <body>
@@ -21,11 +22,11 @@
                 <form id="login-form" novalidate>
                     <div class="form-group">
                         <label for="login-email">Имейл:</label>
-                        <input type="email" id="login-email" name="email" required autocomplete="email">
+                        <input type="email" id="login-email" name="email" required autocomplete="email" class="input-focus-animate">
                     </div>
                     <div class="form-group">
                         <label for="login-password">Парола:</label>
-                        <input type="password" id="login-password" name="password" required autocomplete="current-password">
+                        <input type="password" id="login-password" name="password" required autocomplete="current-password" class="input-focus-animate">
                     </div>
                     <div id="login-message" class="message error" role="alert"></div>
                     <button type="submit" class="button">Вход</button>
@@ -38,18 +39,22 @@
             <!-- Секция за Регистрация -->
             <div id="register-section" class="form-section hidden">
                 <h2>Регистрация</h2>
+                <div class="step-indicator-container">
+                    <span class="step-indicator-label">Стъпка <span id="regCurrentStep">0</span> от <span id="regTotalSteps">3</span></span>
+                    <div class="progress-bar-steps"><div id="registerProgressBar" class="step-progress-bar"></div></div>
+                </div>
                 <form id="register-form" novalidate>
                     <div class="form-group">
                         <label for="register-email">Имейл:</label>
-                        <input type="email" id="register-email" name="register_email" required autocomplete="email">
+                        <input type="email" id="register-email" name="register_email" required autocomplete="email" class="input-focus-animate">
                     </div>
                     <div class="form-group">
                         <label for="register-password">Парола (мин. 8 знака):</label>
-                        <input type="password" id="register-password" name="register_password" required minlength="8" autocomplete="new-password">
+                        <input type="password" id="register-password" name="register_password" required minlength="8" autocomplete="new-password" class="input-focus-animate">
                     </div>
                     <div class="form-group">
                         <label for="confirm-password">Потвърди Парола:</label>
-                        <input type="password" id="confirm-password" name="confirm_password" required minlength="8" autocomplete="new-password">
+                        <input type="password" id="confirm-password" name="confirm_password" required minlength="8" autocomplete="new-password" class="input-focus-animate">
                     </div>
                     <div id="register-message" class="message" role="alert"></div>
                     <button type="submit" class="button button-secondary">Регистрация</button>
@@ -71,6 +76,7 @@
     <script type="module">
         import { showMessage, hideMessage } from './js/messageUtils.js';
         import { setupRegistration } from './js/register.js';
+        import { updateStepProgress } from './js/stepProgress.js';
         import { toggleTheme, initializeTheme } from './js/uiHandlers.js';
         import { apiEndpoints } from './js/config.js';
         // Селектори
@@ -83,10 +89,24 @@
         const forgotPasswordLink = document.getElementById('forgot-password-link'); // Нов селектор
         const loginMessage = document.getElementById('login-message');
         const registerMessage = document.getElementById('register-message');
+        const regBar = document.getElementById('registerProgressBar');
+        const regCurrent = document.getElementById('regCurrentStep');
+        const regTotal = document.getElementById('regTotalSteps');
         const themeToggleBtn = document.getElementById('theme-toggle');
 
         initializeTheme();
         themeToggleBtn.addEventListener('click', toggleTheme);
+
+        const regInputs = Array.from(registerForm.querySelectorAll('input'));
+        const totalRegSteps = regInputs.length;
+        regTotal.textContent = totalRegSteps;
+        updateStepProgress(regBar, 0, totalRegSteps, regCurrent, regTotal);
+        function refreshRegProgress() {
+            const filled = regInputs.filter(el => el.value.trim() !== '').length;
+            updateStepProgress(regBar, filled, totalRegSteps, regCurrent, regTotal);
+        }
+        regInputs.forEach(inp => inp.addEventListener('input', refreshRegProgress));
+        registerForm.addEventListener('reset', () => updateStepProgress(regBar, 0, totalRegSteps, regCurrent, regTotal));
 
         // Базов URL на Worker-а е дефиниран в config.js
 
@@ -106,6 +126,7 @@
             hideMessage(loginMessage);
             hideMessage(registerMessage); // Скриваме и двете при превключване
             registerForm.reset(); // Изчистваме формата за регистрация
+            updateStepProgress(regBar, 0, totalRegSteps, regCurrent, regTotal);
         });
 
         showLoginLink.addEventListener('click', () => {
@@ -114,6 +135,7 @@
             hideMessage(loginMessage);
             hideMessage(registerMessage);
             loginForm.reset(); // Изчистваме формата за вход
+            updateStepProgress(regBar, 0, totalRegSteps, regCurrent, regTotal);
         });
 
         // Обработка на клик върху "Забравена парола"

--- a/js/adaptiveQuiz.js
+++ b/js/adaptiveQuiz.js
@@ -1,6 +1,7 @@
 // adaptiveQuiz.js - Логика за Адаптивен Въпросник
 import { selectors } from './uiElements.js';
 import { showToast, openModal as genericOpenModal } from './uiHandlers.js';
+import { updateStepProgress } from './stepProgress.js';
 import { safeGet, safeParseFloat } from './utils.js';
 import {
     currentUserId,
@@ -332,8 +333,14 @@ export function renderCurrentQuizQuestion(isTransitioningNext = true) {
 
         const progressBar = selectors.quizProgressBar;
         if (progressBar && localCurrentQuizData && localCurrentQuizData.questions.length > 0) {
+            updateStepProgress(
+                progressBar,
+                localCurrentQuestionIndex + 1,
+                localCurrentQuizData.questions.length,
+                null,
+                null
+            );
             const progressPercentage = ((localCurrentQuestionIndex + 1) / localCurrentQuizData.questions.length) * 100;
-            progressBar.style.width = `${progressPercentage}%`;
             progressBar.setAttribute('aria-valuenow', progressPercentage);
         }
 

--- a/js/stepProgress.js
+++ b/js/stepProgress.js
@@ -1,0 +1,8 @@
+export function updateStepProgress(barEl, currentStep, totalSteps, currentLabelEl, totalLabelEl) {
+  if (barEl && totalSteps > 0) {
+    const percent = Math.round((Math.max(0, currentStep) / totalSteps) * 100);
+    barEl.style.width = `${Math.min(100, percent)}%`;
+  }
+  if (currentLabelEl) currentLabelEl.textContent = currentStep;
+  if (totalLabelEl) totalLabelEl.textContent = totalSteps;
+}

--- a/quest.html
+++ b/quest.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Въпросник за хранителни навици (Dynamic)</title>
   <link href="css/quest_styles.css" rel="stylesheet">
+  <link href="css/components_styles.css" rel="stylesheet">
 </head>
 <body>
 
@@ -30,6 +31,7 @@
   import { workerBaseUrl } from './js/config.js';
   import { setupRegistration } from "./js/register.js";
   import { showMessage, hideMessage } from "./js/messageUtils.js";
+  import { updateStepProgress } from "./js/stepProgress.js";
   /***** Глобални променливи *****/
   let rawQuestions = [];     // Суровият масив от questions.json (йерархичен)
   let flatPages = [];        // Плосък масив от всички въпроси (след рекурсивно сплескване)
@@ -518,13 +520,9 @@
     const progressContainer = document.getElementById('progressContainer');
     if (!progressBar || !progressContainer || totalPages <= 1) return;
 
-    // Прогресът е от 0 до (totalPages - 1), тъй като индексите са от 0
     const currentStep = currentPageIndex;
-    // Общият брой стъпки е totalPages - 1 (тъй като не броим прогрес *след* финалната страница)
     const totalSteps = totalPages > 1 ? totalPages - 1 : 1;
-    const percent = totalSteps > 0 ? Math.round((currentStep / totalSteps) * 100) : 0;
-
-    progressBar.style.width = Math.max(0, Math.min(100, percent)) + '%'; // Гарантираме 0-100
+    updateStepProgress(progressBar, currentStep, totalSteps, null, null);
   }
 
   /***** Съхраняване и зареждане на прогреса чрез localStorage *****/


### PR DESCRIPTION
## Summary
- create shared `updateStepProgress` helper
- add progress bar to registration steps
- animate inputs on focus and add button bounce effect
- apply input animation in extra meal form
- use new helper for questionnaire and adaptive quiz progress

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d7af44bf48326b4ebbf70c25d2ca5