### PR TITLE
Add admin tools in edit client view

### DIFF
--- a/editclient.html
+++ b/editclient.html
@@ -69,6 +69,13 @@
                         <li><a class="dropdown-item" href="#"><i class="bi bi-file-earmark-pdf"></i> Експорт като PDF</a></li>
                         <li><a class="dropdown-item" href="#"><i class="bi bi-copy"></i> Клонирай план</a></li>
                         <li><a class="dropdown-item" href="#"><i class="bi bi-clock-history"></i> История на промените</a></li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><button class="dropdown-item" id="regeneratePlan" type="button"><i class="bi bi-arrow-repeat"></i> Генерирай нов план</button></li>
+                        <li><button class="dropdown-item" id="aiSummary" type="button"><i class="bi bi-robot"></i> AI резюме</button></li>
+                        <li><button class="dropdown-item" id="exportData" type="button"><i class="bi bi-download"></i> Експортирай всички данни</button></li>
+                        <li><button class="dropdown-item" id="exportPlan" type="button"><i class="bi bi-file-earmark-code"></i> Експортирай плана JSON</button></li>
+                        <li><button class="dropdown-item" id="exportCsv" type="button"><i class="bi bi-file-earmark-spreadsheet"></i> Експортирай дневниците CSV</button></li>
+                        <li><button class="dropdown-item" id="generatePraise" type="button"><i class="bi bi-emoji-smile"></i> Генерирай похвала</button></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- integrate AI and export tools in editclient page
- implement matching handlers in `editClient.js` for AI summary, regenerate plan, data exports, and praise

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d7cf7c798832680ab84b83473bb93