### PR TITLE
Добавяне на прогрес бар към формите

### DIFF
--- a/adaptive_quiz_template.html
+++ b/adaptive_quiz_template.html
@@ -540,6 +540,31 @@
             line-height: 1.5;
         }
 
+        .step-indicator-container {
+            text-align: center;
+            margin-top: 15px;
+        }
+        .step-indicator-label {
+            display: block;
+            font-size: 0.85rem;
+            color: #94a3b8;
+            margin-bottom: 6px;
+        }
+        .progress-bar-steps {
+            width: 100%;
+            height: 8px;
+            background: #475569;
+            border-radius: 6px;
+            overflow: hidden;
+        }
+        .step-progress-bar {
+            height: 100%;
+            background: #6ee7b7;
+            width: 0%;
+            border-radius: 6px;
+            transition: width 0.4s ease;
+        }
+
         .aq-progress-section-card {
             background: rgba(255, 255, 255, 0.05); /* Subtle background */
             border-radius: 8px;
@@ -941,6 +966,10 @@
             <div class="aq-header-modern">
                 <h1 id="adaptiveQuizGeneralTitle">Вашият Чек-ин</h1>
                 <p id="adaptiveQuizGeneralDescription">Няколко бързи въпроса, за да сме сигурни, че сте на прав път.</p>
+                <div class="step-indicator-container">
+                    <span class="step-indicator-label">Въпрос <span id="quizCurrentStep">0</span> от <span id="quizTotalSteps">0</span></span>
+                    <div class="progress-bar-steps"><div id="quizProgressBar" class="step-progress-bar"></div></div>
+                </div>
             </div>
 
             <!-- Question Container -->

--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -42,22 +42,7 @@
       line-height: 1.5;
       margin-bottom: 20px;
     }
-    /* Прогрес бар */
-    #progressContainer {
-      width: 100%;
-      background-color: #333;
-      height: 10px;
-      position: fixed;
-      top: 0;
-      left: 0;
-      z-index: 1000;
-    }
-    #progressBar {
-      height: 100%;
-      width: 0%;
-      background-color: #4fc3a1;
-      transition: width 0.4s ease;
-    }
+    /* Прогрес бар - използва се общият компонент */
     /* Всяка страница се състои от "екран" */
     .page {
       display: none;

--- a/js/adaptiveQuiz.js
+++ b/js/adaptiveQuiz.js
@@ -67,7 +67,16 @@ export async function openAdaptiveQuizModal() {
             selectors.adaptiveQuizGeneralDescription.textContent = currentQuizData.quizDescription || "Няколко бързи въпроса, за да сме сигурни, че сте на прав път.";
         }
 
-        if (selectors.quizProgressBar) selectors.quizProgressBar.style.width = '0%';
+        if (selectors.quizProgressBar) {
+            selectors.quizProgressBar.style.width = '0%';
+            updateStepProgress(
+                selectors.quizProgressBar,
+                0,
+                currentQuizData.questions.length,
+                document.getElementById('quizCurrentStep'),
+                document.getElementById('quizTotalSteps')
+            );
+        }
 
         selectors.quizLoadingIndicator.classList.add('hidden');
         if(selectors.adaptiveQuizGeneralTitle.parentElement) selectors.adaptiveQuizGeneralTitle.parentElement.classList.remove('hidden');
@@ -332,13 +341,15 @@ export function renderCurrentQuizQuestion(isTransitioningNext = true) {
         selectors.quizQuestionContainer.appendChild(questionCardElement);
 
         const progressBar = selectors.quizProgressBar;
+        const currentLabel = document.getElementById('quizCurrentStep');
+        const totalLabel = document.getElementById('quizTotalSteps');
         if (progressBar && localCurrentQuizData && localCurrentQuizData.questions.length > 0) {
             updateStepProgress(
                 progressBar,
                 localCurrentQuestionIndex + 1,
                 localCurrentQuizData.questions.length,
-                null,
-                null
+                currentLabel,
+                totalLabel
             );
             const progressPercentage = ((localCurrentQuestionIndex + 1) / localCurrentQuizData.questions.length) * 100;
             progressBar.setAttribute('aria-valuenow', progressPercentage);

--- a/quest.html
+++ b/quest.html
@@ -11,8 +11,9 @@
 <body>
 
 <!-- Прогрес бар -->
-<div id="progressContainer">
-  <div id="progressBar"></div>
+<div class="step-indicator-container">
+  <span class="step-indicator-label">Стъпка <span id="questCurrentStep">0</span> от <span id="questTotalSteps">0</span></span>
+  <div class="progress-bar-steps"><div id="questProgressBar" class="step-progress-bar"></div></div>
 </div>
 
 <div class="container" id="dynamicContainer">
@@ -100,6 +101,14 @@
 
     totalPages = 1 + flatPages.length + 2; // Стартова + Въпроси + Регистрация + Финална
     console.log("Общо страници (включително старт и финал):", totalPages);
+
+    updateStepProgress(
+      document.getElementById('questProgressBar'),
+      0,
+      totalPages > 1 ? totalPages - 1 : 1,
+      document.getElementById('questCurrentStep'),
+      document.getElementById('questTotalSteps')
+    );
 
     showPage(0); // Показваме стартовата страница
   }
@@ -516,13 +525,14 @@
 
   /***** Функция за обновяване на прогрес бара *****/
   function updateProgress() {
-    const progressBar = document.getElementById('progressBar');
-    const progressContainer = document.getElementById('progressContainer');
-    if (!progressBar || !progressContainer || totalPages <= 1) return;
+    const progressBar = document.getElementById('questProgressBar');
+    const currentLabel = document.getElementById('questCurrentStep');
+    const totalLabel = document.getElementById('questTotalSteps');
+    if (!progressBar || totalPages <= 1) return;
 
     const currentStep = currentPageIndex;
     const totalSteps = totalPages > 1 ? totalPages - 1 : 1;
-    updateStepProgress(progressBar, currentStep, totalSteps, null, null);
+    updateStepProgress(progressBar, currentStep, totalSteps, currentLabel, totalLabel);
   }
 
   /***** Съхраняване и зареждане на прогреса чрез localStorage *****/


### PR DESCRIPTION
## Summary
- introduce unified progress bar in `quest.html`
- style questionnaire to rely on common progress bar component
- update adaptive quiz template with progress display
- sync adaptive quiz logic to update progress labels

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d7e860f9083268e040520daddac42