### PR TITLE
Add profile section navigation

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -64,6 +64,17 @@
     </details>
     <button id="regeneratePlan">Генерирай нов план</button>
     <button id="aiSummary">AI резюме</button>
+    <nav id="profileCardNav" class="profile-card-nav">
+      <a href="#profileSummary" data-target="profileSummary">Резюме</a>
+      <a href="#caloriesMacros" data-target="caloriesMacros">Калории</a>
+      <a href="#allowedForbiddenFoods" data-target="allowedForbiddenFoods">Храни</a>
+      <a href="#week1Menu" data-target="week1Menu">Седмица 1</a>
+      <a href="#principlesWeek2_4" data-target="principlesWeek2_4">Принципи</a>
+      <a href="#hydrationCookingSupplements" data-target="hydrationCookingSupplements">Хидратация</a>
+      <a href="#psychologicalGuidance" data-target="psychologicalGuidance">Психология</a>
+      <a href="#generationMetadata" data-target="generationMetadata">Метаданни</a>
+      <a href="#detailedTargets" data-target="detailedTargets">Цели</a>
+    </nav>
     <div id="adminProfileContainer"></div>
     <a id="openFullProfile" class="button button-small" href="#" target="_blank" title="Отвори пълния профил в нов таб">
       <i class="fas fa-external-link-alt me-1"></i>Пълен профил

--- a/css/admin.css
+++ b/css/admin.css
@@ -255,3 +255,30 @@ details[open] summary::after {
 .accordion-header.open {
   box-shadow: inset 0 -2px 0 var(--primary-color);
 }
+
+#profileCardNav {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+#profileCardNav a {
+  padding: 4px 8px;
+  border-radius: var(--radius-md, 4px);
+  background-color: var(--surface-background, #f8f9fa);
+  color: var(--primary-color);
+  text-decoration: none;
+  border: 1px solid var(--border-color-soft, #ccc);
+  font-size: 0.9rem;
+}
+#profileCardNav a.active {
+  background-color: var(--primary-color);
+  color: #fff;
+}
+@media (max-width: 600px) {
+  #profileCardNav {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/editclient.html
+++ b/editclient.html
@@ -87,6 +87,7 @@
             <!-- Main Content Column -->
             <div class="col-lg-8">
                 <!-- Profile Summary Card -->
+                <section id="profileSummary">
                 <div class="card" id="profileSummary-card">
                     <div class="card-header">
                         <h5 class="mb-0"><i class="bi bi-person-lines-fill"></i> Резюме на профила</h5>
@@ -109,9 +110,12 @@
                             <button class="btn btn-secondary btn-sm cancel-edit-btn" data-target="profileSummary-card">Отказ</button>
                         </div>
                     </div>
+
                 </div>
+                </section>
 
                 <!-- Calories & Macros Card -->
+                <section id="caloriesMacros">
                 <div class="card" id="caloriesMacros-card">
                     <div class="card-header">
                         <h5 class="mb-0"><i class="bi bi-pie-chart-fill"></i> Калории и Макроси</h5>
@@ -174,8 +178,10 @@
                         </div>
                     </div>
                 </div>
+                </section>
 
                 <!-- Allowed/Forbidden Foods Card -->
+                <section id="allowedForbiddenFoods">
                  <div class="card" id="allowedForbiddenFoods-card">
                     <div class="card-header">
                         <h5 class="mb-0"><i class="bi bi-hand-thumbs-up-fill"></i> / <i class="bi bi-hand-thumbs-down-fill"></i> Храни</h5>
@@ -241,8 +247,10 @@
                         </div>
                     </div>
                 </div>
+                </section>
 
                 <!-- Week 1 Menu Card -->
+                <section id="week1Menu">
                 <div class="card" id="week1Menu-card">
                     <div class="card-header">
                         <h5 class="mb-0"><i class="bi bi-calendar-week"></i> Меню за Седмица 1</h5>
@@ -265,8 +273,10 @@
                         </div>
                     </div>
                 </div>
+                </section>
 
                 <!-- Principles Week 2-4 Card -->
+                <section id="principlesWeek2_4">
                 <div class="card" id="principlesWeek2_4-card">
                     <div class="card-header">
                         <h5 class="mb-0"><i class="bi bi-lightbulb"></i> Принципи за Седмици 2-4</h5>
@@ -289,8 +299,10 @@
                         </div>
                     </div>
                 </div>
+                </section>
 
                 <!-- Hydration, Cooking, Supplements Card -->
+                <section id="hydrationCookingSupplements">
                 <div class="card" id="hydrationCookingSupplements-card">
                     <div class="card-header">
                         <h5 class="mb-0"><i class="bi bi-droplet-fill"></i> Хидратация, Готвене, Добавки</h5>
@@ -360,8 +372,10 @@
                         </div>
                     </div>
                 </div>
+                </section>
 
                 <!-- Psychological Guidance Card -->
+                <section id="psychologicalGuidance">
                 <div class="card" id="psychologicalGuidance-card">
                     <div class="card-header">
                         <h5 class="mb-0"><i class="bi bi-heart-fill"></i> Психологически Насоки</h5>
@@ -403,8 +417,10 @@
                         </div>
                     </div>
                 </div>
+                </section>
 
                 <!-- Generation Metadata (Read-Only) -->
+                <section id="generationMetadata">
                  <div class="card" id="generationMetadata-card">
                     <div class="card-header">
                         <h5 class="mb-0"><i class="bi bi-info-circle"></i> Метаданни на Генерацията</h5>
@@ -416,6 +432,7 @@
                         <p><strong>Грешки:</strong> <span id="metadata-errors"></span></p>
                     </div>
                 </div>
+                </section>
 
             </div>
 
@@ -433,6 +450,7 @@
                 </div>
 
                 <!-- Detailed Targets Card -->
+                <section id="detailedTargets">
                 <div class="card" id="detailedTargets-card">
                      <div class="card-header">
                         <h5 class="mb-0"><i class="bi bi-bullseye"></i> Детайлни Цели</h5>
@@ -488,6 +506,7 @@
                         </div>
                     </div>
                 </div>
+                </section>
 
                 <!-- Specialist Notes Card -->
                 <div class="card">

--- a/js/admin.js
+++ b/js/admin.js
@@ -663,6 +663,27 @@ function setupTabs() {
     activate(buttons[0]);
 }
 
+function setupProfileCardNav() {
+    const nav = document.getElementById('profileCardNav');
+    if (!nav) return;
+    const links = nav.querySelectorAll('a[data-target]');
+    if (links.length === 0) return;
+    const activate = (link) => {
+        links.forEach(l => l.classList.toggle('active', l === link));
+    };
+    links.forEach(l => {
+        l.addEventListener('click', (e) => {
+            e.preventDefault();
+            const targetId = l.getAttribute('data-target');
+            const section = document.getElementById(targetId);
+            if (section) {
+                section.scrollIntoView({ behavior: 'smooth' });
+                activate(l);
+            }
+        });
+    });
+}
+
 function resetTabs() {
     const buttons = document.querySelectorAll('#clientTabs .tab-btn');
     const panels = document.querySelectorAll('.client-tab');
@@ -773,6 +794,7 @@ async function showClient(userId) {
         await loadTemplateInto('editclient.html', 'adminProfileContainer');
         const mod = await import('./editClient.js');
         await mod.initEditClient(userId);
+        setupProfileCardNav();
     }
     try {
         const [profileResp, dashResp] = await Promise.all([


### PR DESCRIPTION
## Summary
- add profile sub-navigation in admin view
- allow smooth scrolling through profile sections
- define section wrappers for editing template
- style the sub-navigation menu for responsive layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d8791e9508326898b652e5889ef32