### PR TITLE
Add dynamic system theme listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ API requests to paths starting with `/api` are automatically proxied to
 
 The application will be available at `http://localhost:5173` by default.
 
+### Динамична тема
+
+Интерфейсът следва системната светла/тъмна настройка. Ако в LocalStorage е избрана опцията "system", промяната на темата в операционната система се отразява моментално.
+
 ### Build
 
 Create an optimized production build in the `dist` folder:

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -188,12 +188,6 @@ export function setupStaticEventListeners() {
 
     if (selectors.feedbackForm) selectors.feedbackForm.addEventListener('submit', handleFeedbackFormSubmit);
 
-    const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-    prefersDarkScheme.addEventListener('change', e => {
-        const pref = localStorage.getItem('theme') || 'system';
-        if (pref === 'system') applyTheme(e.matches ? 'dark' : 'light'); // applyTheme from uiHandlers
-        updateThemeButtonText(); // updateThemeButtonText from uiHandlers
-    });
     document.body.addEventListener('closeExtraMealModalEvent', () => {
         closeModal('extraMealEntryModal');
     });

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -46,9 +46,23 @@ export function handleMenuKeydown(event) {
     if (event.key === 'Escape' && selectors.mainMenu?.classList.contains('menu-open')) closeMenu();
 }
 
+let systemThemeMediaQuery;
+
+function handleSystemThemeChange(e) {
+    const pref = localStorage.getItem('theme') || 'system';
+    if (pref === 'system') {
+        applyTheme(e.matches ? 'dark' : 'light');
+        updateThemeButtonText();
+    }
+}
+
 export function initializeTheme() {
     const savedTheme = localStorage.getItem('theme') || 'system';
-    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    systemThemeMediaQuery = systemThemeMediaQuery || window.matchMedia('(prefers-color-scheme: dark)');
+    const systemTheme = systemThemeMediaQuery.matches ? 'dark' : 'light';
+    if (!systemThemeMediaQuery.onchange) {
+        systemThemeMediaQuery.addEventListener('change', handleSystemThemeChange);
+    }
     applyTheme(savedTheme === 'system' ? systemTheme : savedTheme);
     updateThemeButtonText();
 }


### PR DESCRIPTION
## Summary
- sync theme with OS preference changes
- remove old listener wiring
- document new automatic theme sync

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d887a7b6083269310a9373b13d384