### PR TITLE
Add sticky profile nav

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -262,6 +262,11 @@ details[open] summary::after {
   margin-top: 10px;
   margin-bottom: 10px;
   flex-wrap: wrap;
+  position: sticky;
+  top: calc(var(--header-height) + var(--tabs-height));
+  z-index: 980;
+  background-color: var(--surface-background, #f8f9fa);
+  padding: 4px 0;
 }
 #profileCardNav a {
   padding: 4px 8px;

--- a/js/__tests__/adminProfileNav.test.js
+++ b/js/__tests__/adminProfileNav.test.js
@@ -1,0 +1,27 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let setupProfileCardNav;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <button id="showStats"></button>
+    <nav id="profileCardNav">
+      <a data-target="s1">S1</a>
+      <a data-target="s2">S2</a>
+    </nav>
+    <section id="s1"></section>
+    <section id="s2"></section>`;
+  const mod = await import('../admin.js');
+  setupProfileCardNav = mod.setupProfileCardNav;
+});
+
+test('activates link on click', () => {
+  const [link1, link2] = document.querySelectorAll('#profileCardNav a');
+  HTMLElement.prototype.scrollIntoView = jest.fn();
+  setupProfileCardNav();
+  expect(link1.classList.contains('active')).toBe(true);
+  link2.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  expect(link2.classList.contains('active')).toBe(true);
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -666,22 +666,35 @@ function setupTabs() {
 function setupProfileCardNav() {
     const nav = document.getElementById('profileCardNav');
     if (!nav) return;
-    const links = nav.querySelectorAll('a[data-target]');
+    const links = Array.from(nav.querySelectorAll('a[data-target]'));
     if (links.length === 0) return;
+    const sections = links.map(l => document.getElementById(l.dataset.target)).filter(Boolean);
     const activate = (link) => {
         links.forEach(l => l.classList.toggle('active', l === link));
     };
-    links.forEach(l => {
-        l.addEventListener('click', (e) => {
+    links.forEach(link => {
+        link.addEventListener('click', (e) => {
             e.preventDefault();
-            const targetId = l.getAttribute('data-target');
-            const section = document.getElementById(targetId);
+            const section = document.getElementById(link.dataset.target);
             if (section) {
-                section.scrollIntoView({ behavior: 'smooth' });
-                activate(l);
+                section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                activate(link);
             }
         });
     });
+    const onScroll = () => {
+        const offset = nav.offsetHeight + 20;
+        let activeLink = links[0];
+        sections.forEach((section, idx) => {
+            const rect = section.getBoundingClientRect();
+            if (rect.top - offset <= 0) {
+                activeLink = links[idx];
+            }
+        });
+        activate(activeLink);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    activate(links[0]);
 }
 
 function resetTabs() {
@@ -1651,6 +1664,7 @@ export {
     checkForNotifications,
     showClient,
     setCurrentUserId,
+    setupProfileCardNav,
     unreadClients,
     sendTestEmail,
     confirmAndSendTestEmail,


### PR DESCRIPTION
## Summary
- make profile section nav sticky so it's always visible
- track scroll position and highlight active nav link
- export `setupProfileCardNav` for reuse
- cover profile nav behaviour with a new test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d866667f08326817def37b8637b59