### PR TITLE
Improve profile nav responsiveness

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -259,7 +259,7 @@ details[open] summary::after {
 #profileCardNav {
   display: flex;
   gap: 8px;
-  margin-top: 10px;
+  margin-top: 0;
   margin-bottom: 10px;
   flex-wrap: wrap;
 }
@@ -267,7 +267,11 @@ details[open] summary::after {
   display: none;
 }
 .profile-nav-container {
-  position: relative;
+  position: sticky;
+  top: 0;
+  z-index: 900;
+  background: var(--surface-background);
+  padding-block: 4px;
 }
 #profileCardNav a {
   padding: 4px 8px;
@@ -303,6 +307,8 @@ details[open] summary::after {
     border: 1px solid var(--border-color-soft, #ccc);
     padding: 8px;
     border-radius: var(--radius-md, 4px);
+    max-height: 60vh;
+    overflow-y: auto;
     display: none;
     flex-direction: column;
     align-items: flex-start;
@@ -310,5 +316,10 @@ details[open] summary::after {
   }
   #profileCardNav.open {
     display: flex;
+  }
+  .profile-nav-container {
+    position: sticky;
+    top: 0;
+    padding-block: 4px;
   }
 }

--- a/js/admin.js
+++ b/js/admin.js
@@ -126,6 +126,7 @@ let currentUserId = null;
 function setCurrentUserId(val) {
     currentUserId = val;
 }
+let profileNavObserver = null;
 let currentPlanData = null;
 let currentDashboardData = null;
 let allClients = [];
@@ -667,8 +668,11 @@ function setupProfileCardNav() {
     const nav = document.getElementById('profileCardNav');
     const toggleBtn = document.getElementById('profileCardNavToggle');
     if (!nav) return;
-    const links = nav.querySelectorAll('a[data-target]');
+    const links = Array.from(nav.querySelectorAll('a[data-target]'));
     if (links.length === 0) return;
+    const sections = links
+        .map(l => document.getElementById(l.getAttribute('data-target')))
+        .filter(Boolean);
     const activate = (link) => {
         links.forEach(l => l.classList.toggle('active', l === link));
     };
@@ -692,6 +696,17 @@ function setupProfileCardNav() {
             nav.classList.toggle('open');
         });
     }
+    if (profileNavObserver) {
+        profileNavObserver.disconnect();
+    }
+    profileNavObserver = new IntersectionObserver((entries) => {
+        const visible = entries.find(e => e.isIntersecting);
+        if (visible) {
+            const link = links.find(l => l.getAttribute('data-target') === visible.target.id);
+            if (link) activate(link);
+        }
+    }, { rootMargin: '-45% 0px -50% 0px' });
+    sections.forEach(sec => profileNavObserver.observe(sec));
 }
 
 function resetTabs() {


### PR DESCRIPTION
## Summary
- make profile nav sticky on mobile as well
- limit popup height so long lists scroll

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687daa7526508326ab0bf756d5f411fd