### PR TITLE
Improve profile card navigation

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -288,38 +288,43 @@ details[open] summary::after {
 }
 @media (max-width: 600px) {
   #profileCardNavToggle {
-    display: block;
+    display: flex;
     position: fixed;
-    top: 10px;
-    right: 10px;
-    background: rgba(0, 0, 0, 0.5);
-    color: #fff;
+    bottom: var(--space-lg);
+    right: var(--space-lg);
+    width: 50px;
+    height: 50px;
+    border-radius: var(--radius-round);
+    background: var(--primary-color);
+    color: var(--text-color-on-primary);
     border: none;
-    padding: 6px 8px;
-    border-radius: 4px;
+    box-shadow: var(--shadow-md);
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
     z-index: 1100;
   }
   #profileCardNav {
     position: fixed;
-    top: 50px;
-    right: 10px;
+    bottom: calc(var(--space-lg) + 60px);
+    right: var(--space-lg);
     background: rgba(255, 255, 255, 0.95);
     border: 1px solid var(--border-color-soft, #ccc);
-    padding: 8px;
+    padding: var(--space-sm);
     border-radius: var(--radius-md, 4px);
     max-height: 60vh;
     overflow-y: auto;
     display: none;
     flex-direction: column;
     align-items: flex-start;
-    gap: 8px;
+    gap: var(--space-sm);
+    box-shadow: var(--shadow-md);
   }
   #profileCardNav.open {
     display: flex;
   }
   .profile-nav-container {
-    position: sticky;
-    top: 0;
-    padding-block: 4px;
+    position: static;
+    padding-block: 0;
   }
 }

--- a/js/admin.js
+++ b/js/admin.js
@@ -678,6 +678,7 @@ function setupProfileCardNav() {
     };
     const closeMenu = () => {
         nav.classList.remove('open');
+        if (toggleBtn) toggleBtn.setAttribute('aria-expanded', 'false');
     };
     links.forEach(l => {
         l.addEventListener('click', (e) => {
@@ -692,8 +693,15 @@ function setupProfileCardNav() {
         });
     });
     if (toggleBtn) {
-        toggleBtn.addEventListener('click', () => {
-            nav.classList.toggle('open');
+        toggleBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const isOpen = nav.classList.toggle('open');
+            toggleBtn.setAttribute('aria-expanded', String(isOpen));
+        });
+        document.addEventListener('click', (e) => {
+            if (nav.classList.contains('open') && !nav.contains(e.target) && e.target !== toggleBtn) {
+                closeMenu();
+            }
         });
     }
     if (profileNavObserver) {


### PR DESCRIPTION
## Summary
- refine mobile layout for profile card navigation
- keep profile navigation button sticky on phones
- enhance JS toggle logic and accessibility

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687daef3ee648326bbca190574c428c7