### PR TITLE
Fix mobile profile nav toggle position

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -324,7 +324,16 @@ details[open] summary::after {
     display: flex;
   }
   .profile-nav-container {
-    position: static;
-    padding-block: 0;
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    padding: var(--space-sm);
+    display: flex;
+    justify-content: flex-end;
+    pointer-events: none;
+  }
+  .profile-nav-container #profileCardNavToggle {
+    pointer-events: auto;
   }
 }


### PR DESCRIPTION
## Summary
- keep profile navigation toggle fixed at bottom on mobile screens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687db4443c908326b17a7f9a7f67d3c2