### PR TITLE
Fix mobile profile nav

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -288,43 +288,6 @@ details[open] summary::after {
 }
 @media (max-width: 600px) {
   #profileCardNavToggle {
-    display: flex;
-    position: fixed;
-    bottom: var(--space-lg);
-    right: var(--space-lg);
-    width: 50px;
-    height: 50px;
-    border-radius: var(--radius-round);
-    background: var(--primary-color);
-    color: var(--text-color-on-primary);
-    border: none;
-    box-shadow: var(--shadow-md);
-    align-items: center;
-    justify-content: center;
-    font-size: 1.2rem;
-    z-index: 1100;
-  }
-  #profileCardNav {
-    position: fixed;
-    bottom: calc(var(--space-lg) + 60px);
-    right: var(--space-lg);
-    background: rgba(255, 255, 255, 0.95);
-    border: 1px solid var(--border-color-soft, #ccc);
-    padding: var(--space-sm);
-    border-radius: var(--radius-md, 4px);
-    max-height: 60vh;
-    overflow-y: auto;
     display: none;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: var(--space-sm);
-    box-shadow: var(--shadow-md);
-  }
-  #profileCardNav.open {
-    display: flex;
-  }
-  .profile-nav-container {
-    position: static;
-    padding-block: 0;
   }
 }


### PR DESCRIPTION
## Summary
- remove floating nav behaviour for mobile screens
- keep `#profileCardNav` sticky and hide toggle

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687db85f6eb88326908c826faeb914eb