### PR TITLE
Add analysis email settings

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -232,6 +232,8 @@
     <form id="emailSettingsForm">
       <label>Тема:<br><input id="welcomeEmailSubject" type="text"></label>
       <label>Съдържание:<br><textarea id="welcomeEmailBody" rows="5"></textarea></label>
+      <label>Тема на имейла за анализ:<br><input id="analysisEmailSubject" type="text"></label>
+      <label>Съдържание:<br><textarea id="analysisEmailBody" rows="5"></textarea></label>
       <button type="submit">Запази</button>
     </form>
   </details>

--- a/js/admin.js
+++ b/js/admin.js
@@ -93,6 +93,8 @@ const testAnalysisBtn = document.getElementById('testAnalysisModel');
 const emailSettingsForm = document.getElementById('emailSettingsForm');
 const welcomeEmailSubjectInput = document.getElementById('welcomeEmailSubject');
 const welcomeEmailBodyInput = document.getElementById('welcomeEmailBody');
+const analysisEmailSubjectInput = document.getElementById('analysisEmailSubject');
+const analysisEmailBodyInput = document.getElementById('analysisEmailBody');
 const testEmailForm = document.getElementById('testEmailForm');
 const testEmailToInput = document.getElementById('testEmailTo');
 const testEmailSubjectInput = document.getElementById('testEmailSubject');
@@ -1273,6 +1275,8 @@ async function loadEmailSettings() {
         const cfg = data.config || {}
         if (welcomeEmailSubjectInput) welcomeEmailSubjectInput.value = cfg.welcome_email_subject || ''
         if (welcomeEmailBodyInput) welcomeEmailBodyInput.value = cfg.welcome_email_body || ''
+        if (analysisEmailSubjectInput) analysisEmailSubjectInput.value = cfg.analysis_email_subject || ''
+        if (analysisEmailBodyInput) analysisEmailBodyInput.value = cfg.analysis_email_body || ''
     } catch (err) {
         console.error('Error loading email settings:', err)
     }
@@ -1283,7 +1287,9 @@ async function saveEmailSettings() {
     const payload = {
         updates: {
             welcome_email_subject: welcomeEmailSubjectInput ? welcomeEmailSubjectInput.value.trim() : '',
-            welcome_email_body: welcomeEmailBodyInput ? welcomeEmailBodyInput.value.trim() : ''
+            welcome_email_body: welcomeEmailBodyInput ? welcomeEmailBodyInput.value.trim() : '',
+            analysis_email_subject: analysisEmailSubjectInput ? analysisEmailSubjectInput.value.trim() : '',
+            analysis_email_body: analysisEmailBodyInput ? analysisEmailBodyInput.value.trim() : ''
         }
     }
     try {

--- a/preworker.js
+++ b/preworker.js
@@ -172,8 +172,6 @@ const ANALYSIS_READY_SUBJECT = 'Вашият персонален анализ �
 const ANALYSIS_READY_BODY_TEMPLATE = '<p>Здравей, {{name}}.</p>' +
     '<p>Вашият персонален анализ е готов. Можете да го видите <a href="{{link}}">тук</a>.</p>' +
     '<p>– Екипът на MyBody</p>';
-const ANALYSIS_EMAIL_SUBJECT_VAR_NAME = 'ANALYSIS_EMAIL_SUBJECT';
-const ANALYSIS_EMAIL_BODY_VAR_NAME = 'ANALYSIS_EMAIL_BODY';
 const ANALYSIS_PAGE_URL_VAR_NAME = 'ANALYSIS_PAGE_URL';
 
 async function sendWelcomeEmail(to, name, env) {
@@ -203,8 +201,8 @@ async function sendQuestionnaireConfirmationEmail(to, name, env) {
 async function sendAnalysisLinkEmail(to, name, link, env) {
     const sendEmail = await getSendEmail(env);
     if (sendEmail === defaultSendEmail) return;
-    const subject = env?.[ANALYSIS_EMAIL_SUBJECT_VAR_NAME] || ANALYSIS_READY_SUBJECT;
-    const tpl = env?.[ANALYSIS_EMAIL_BODY_VAR_NAME] || ANALYSIS_READY_BODY_TEMPLATE;
+    const subject = env?.ANALYSIS_EMAIL_SUBJECT || ANALYSIS_READY_SUBJECT;
+    const tpl = env?.ANALYSIS_EMAIL_BODY || ANALYSIS_READY_BODY_TEMPLATE;
     if (!tpl.includes('{{name}}')) {
         console.warn('ANALYSIS_EMAIL_BODY missing {{name}} placeholder');
     }
@@ -265,7 +263,9 @@ const AI_CONFIG_KEYS = [
     'image_token_limit',
     'image_temperature',
     'welcome_email_subject',
-    'welcome_email_body'
+    'welcome_email_body',
+    'analysis_email_subject',
+    'analysis_email_body'
 ];
 // ------------- END BLOCK: GlobalConstantsAndBindings -------------
 

--- a/worker.js
+++ b/worker.js
@@ -172,8 +172,6 @@ const ANALYSIS_READY_SUBJECT = 'Вашият персонален анализ �
 const ANALYSIS_READY_BODY_TEMPLATE = '<p>Здравей, {{name}}.</p>' +
     '<p>Вашият персонален анализ е готов. Можете да го видите <a href="{{link}}">тук</a>.</p>' +
     '<p>– Екипът на MyBody</p>';
-const ANALYSIS_EMAIL_SUBJECT_VAR_NAME = 'ANALYSIS_EMAIL_SUBJECT';
-const ANALYSIS_EMAIL_BODY_VAR_NAME = 'ANALYSIS_EMAIL_BODY';
 const ANALYSIS_PAGE_URL_VAR_NAME = 'ANALYSIS_PAGE_URL';
 
 async function sendWelcomeEmail(to, name, env) {
@@ -203,8 +201,8 @@ async function sendQuestionnaireConfirmationEmail(to, name, env) {
 async function sendAnalysisLinkEmail(to, name, link, env) {
     const sendEmail = await getSendEmail(env);
     if (sendEmail === defaultSendEmail) return;
-    const subject = env?.[ANALYSIS_EMAIL_SUBJECT_VAR_NAME] || ANALYSIS_READY_SUBJECT;
-    const tpl = env?.[ANALYSIS_EMAIL_BODY_VAR_NAME] || ANALYSIS_READY_BODY_TEMPLATE;
+    const subject = env?.ANALYSIS_EMAIL_SUBJECT || ANALYSIS_READY_SUBJECT;
+    const tpl = env?.ANALYSIS_EMAIL_BODY || ANALYSIS_READY_BODY_TEMPLATE;
     if (!tpl.includes('{{name}}')) {
         console.warn('ANALYSIS_EMAIL_BODY missing {{name}} placeholder');
     }
@@ -265,7 +263,9 @@ const AI_CONFIG_KEYS = [
     'image_token_limit',
     'image_temperature',
     'welcome_email_subject',
-    'welcome_email_body'
+    'welcome_email_body',
+    'analysis_email_subject',
+    'analysis_email_body'
 ];
 // ------------- END BLOCK: GlobalConstantsAndBindings -------------
 


### PR DESCRIPTION
## Summary
- extend admin UI with subject/body fields for analysis emails
- support new fields in admin.js
- handle analysis email options in workers
- load templates from ANALYSIS_EMAIL_BODY env var

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dc7e405188326869dd0dbac52920d