### PR TITLE
Preload test email template

### DIFF
--- a/js/__tests__/loadTestEmailTemplate.test.js
+++ b/js/__tests__/loadTestEmailTemplate.test.js
@@ -1,0 +1,24 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+
+let loadTemplate
+
+beforeEach(async () => {
+  jest.resetModules()
+  document.body.innerHTML = `
+    <textarea id="testEmailBody"></textarea>
+    <button id="showStats"></button>
+    <button id="sendQuery"></button>`
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, text: async () => '<h1>Hi</h1>' })
+  ;({ loadTestEmailTemplate: loadTemplate } = await import('../admin.js'))
+})
+
+afterEach(() => {
+  global.fetch && global.fetch.mockRestore()
+})
+
+test('loads welcome template into textarea', async () => {
+  await loadTemplate()
+  expect(global.fetch).toHaveBeenCalledWith('data/welcomeEmailTemplate.html')
+  expect(document.getElementById('testEmailBody').value).toBe('<h1>Hi</h1>')
+})

--- a/js/admin.js
+++ b/js/admin.js
@@ -99,6 +99,7 @@ const testEmailForm = document.getElementById('testEmailForm');
 const testEmailToInput = document.getElementById('testEmailTo');
 const testEmailSubjectInput = document.getElementById('testEmailSubject');
 const testEmailBodyInput = document.getElementById('testEmailBody');
+const testEmailSection = document.getElementById('testEmailSection');
 const testImageForm = document.getElementById('testImageForm');
 const testImageFileInput = document.getElementById('testImageFile');
 const testImagePromptInput = document.getElementById('testImagePrompt');
@@ -1310,11 +1311,24 @@ async function saveEmailSettings() {
     }
 }
 
+let testEmailTemplateLoaded = false
+
+async function loadTestEmailTemplate() {
+    if (testEmailTemplateLoaded || !testEmailBodyInput) return
+    try {
+        const resp = await fetch('data/welcomeEmailTemplate.html')
+        testEmailBodyInput.value = await resp.text()
+        testEmailTemplateLoaded = true
+    } catch (err) {
+        console.error('Error loading test email template:', err)
+    }
+}
+
 async function sendTestEmail() {
     if (!testEmailForm) return;
     const recipient = testEmailToInput ? testEmailToInput.value.trim() : '';
     const subject = testEmailSubjectInput ? testEmailSubjectInput.value.trim() : '';
-    const body = testEmailBodyInput ? testEmailBodyInput.value.trim() : '';
+    const body = testEmailBodyInput ? testEmailBodyInput.value : '';
     if (!recipient || !subject || !body) {
         alert('Моля попълнете всички полета.');
         return;
@@ -1630,6 +1644,7 @@ document.addEventListener('DOMContentLoaded', () => {
         await loadAiConfig();
         await loadAiPresets();
         if (emailSettingsForm) await loadEmailSettings();
+        if (testEmailSection?.open) await loadTestEmailTemplate();
         setInterval(checkForNotifications, 60000);
         setInterval(loadNotifications, 60000);
     })();
@@ -1657,6 +1672,12 @@ if (emailSettingsForm) {
     emailSettingsForm.addEventListener('submit', async (e) => {
         e.preventDefault();
         await saveEmailSettings();
+    });
+}
+
+if (testEmailSection) {
+    testEmailSection.addEventListener('toggle', () => {
+        if (testEmailSection.open) loadTestEmailTemplate();
     });
 }
 
@@ -1693,6 +1714,7 @@ export {
     unreadClients,
     sendTestEmail,
     confirmAndSendTestEmail,
+    loadTestEmailTemplate,
     sendTestImage,
     sendTestQuestionnaire,
     sendAdminQuery


### PR DESCRIPTION
## Summary
- preload the default email HTML when the test email section is opened
- avoid trimming the body so HTML is preserved
- export `loadTestEmailTemplate` and test its behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e17edd96c832686c96627ae72a0da