### PR TITLE
Update analysis page URLs

### DIFF
--- a/js/__tests__/sendTestQuestionnaire.test.js
+++ b/js/__tests__/sendTestQuestionnaire.test.js
@@ -58,7 +58,7 @@ test('response renders in #testQResult and link is shown', async () => {
   expect(text.startsWith(JSON.stringify(responseData, null, 2))).toBe(true);
   const link = document.getElementById('openTestQAnalysis');
   expect(link.classList.contains('hidden')).toBe(false);
-  expect(link.getAttribute('href')).toBe('reganalize/analyze.html?userId=u5');
+  expect(link.getAttribute('href')).toBe('https://radilovk.github.io/bodybest/reganalize/analyze.html?userId=u5');
 });
 
 test('calls reAnalyzeQuestionnaire when no JSON is provided', async () => {
@@ -69,5 +69,5 @@ test('calls reAnalyzeQuestionnaire when no JSON is provided', async () => {
   expect(global.fetch).toHaveBeenCalledWith('/api/reAnalyzeQuestionnaire', expect.any(Object));
   const link = document.getElementById('openTestQAnalysis');
   expect(link.classList.contains('hidden')).toBe(false);
-  expect(link.getAttribute('href')).toBe('reganalize/analyze.html?userId=u1');
+  expect(link.getAttribute('href')).toBe('https://radilovk.github.io/bodybest/reganalize/analyze.html?userId=u1');
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -1433,7 +1433,7 @@ async function sendTestQuestionnaire() {
             if (resp.ok && data.success && data.userId) {
                 if (openTestQAnalysisLink) {
                     openTestQAnalysisLink.classList.remove('hidden');
-                    openTestQAnalysisLink.href = `reganalize/analyze.html?userId=${encodeURIComponent(data.userId)}`;
+                    openTestQAnalysisLink.href = `https://radilovk.github.io/bodybest/reganalize/analyze.html?userId=${encodeURIComponent(data.userId)}`;
                 }
             } else if (!resp.ok || !data.success) {
                 alert(data.message || 'Грешка при стартиране на анализа.');
@@ -1467,7 +1467,7 @@ async function sendTestQuestionnaire() {
         if (resp.ok && data.success && data.userId) {
             if (openTestQAnalysisLink) {
                 openTestQAnalysisLink.classList.remove('hidden');
-                openTestQAnalysisLink.href = `reganalize/analyze.html?userId=${encodeURIComponent(data.userId)}`;
+                openTestQAnalysisLink.href = `https://radilovk.github.io/bodybest/reganalize/analyze.html?userId=${encodeURIComponent(data.userId)}`;
             }
             try {
                 const stResp = await fetch(`${apiEndpoints.analysisStatus}?userId=${encodeURIComponent(data.userId)}`);

--- a/preworker.js
+++ b/preworker.js
@@ -1629,7 +1629,7 @@ async function handleAnalyzeInitialAnswers(userId, env) {
         await env.USER_METADATA_KV.put(`${userId}_analysis`, cleaned);
         await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'ready');
         console.log(`INITIAL_ANALYSIS (${userId}): Analysis stored.`);
-        const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] || 'https://mybody.best/analyze.html';
+        const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] || 'https://radilovk.github.io/bodybest/reganalize/analyze.html';
         const url = new URL(baseUrl);
         url.searchParams.set('userId', userId);
         const link = url.toString();
@@ -1687,7 +1687,7 @@ async function handleReAnalyzeQuestionnaireRequest(request, env, ctx) {
             await handleAnalyzeInitialAnswers(userId, env);
             await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'pending');
         }
-        const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] || 'https://mybody.best/analyze.html';
+        const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] || 'https://radilovk.github.io/bodybest/reganalize/analyze.html';
         const url = new URL(baseUrl);
         url.searchParams.set('userId', userId);
         return { success: true, userId, link: url.toString() };

--- a/worker.js
+++ b/worker.js
@@ -1629,7 +1629,7 @@ async function handleAnalyzeInitialAnswers(userId, env) {
         await env.USER_METADATA_KV.put(`${userId}_analysis`, cleaned);
         await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'ready');
         console.log(`INITIAL_ANALYSIS (${userId}): Analysis stored.`);
-        const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] || 'https://mybody.best/analyze.html';
+        const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] || 'https://radilovk.github.io/bodybest/reganalize/analyze.html';
         const url = new URL(baseUrl);
         url.searchParams.set('userId', userId);
         const link = url.toString();
@@ -1687,7 +1687,7 @@ async function handleReAnalyzeQuestionnaireRequest(request, env, ctx) {
             await handleAnalyzeInitialAnswers(userId, env);
             await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'pending');
         }
-        const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] || 'https://mybody.best/analyze.html';
+        const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] || 'https://radilovk.github.io/bodybest/reganalize/analyze.html';
         const url = new URL(baseUrl);
         url.searchParams.set('userId', userId);
         return { success: true, userId, link: url.toString() };


### PR DESCRIPTION
## Summary
- update analysis link defaults in worker and preworker
- use full public URL when displaying test analysis link in admin
- expect full URL in sendTestQuestionnaire tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e1a11cff483268c8bd560ab290409