### PR TITLE
Add admin fields for questionnaire email

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ node scripts/view-usage-logs.js sendTestEmail 5
 | `image_temperature` | Температура за анализ на изображение |
 | `welcome_email_subject` | Тема на приветствения имейл |
 | `welcome_email_body` | HTML съдържание за приветствения имейл |
+| `questionnaire_email_subject` | Тема на имейла след попълнен въпросник |
+| `questionnaire_email_body` | HTML съдържание за потвърждението на въпросника |
 | `question_definitions` | JSON с дефиниции на всички въпроси |
 | `recipe_data` | Данни за примерни рецепти |
 

--- a/admin.html
+++ b/admin.html
@@ -232,6 +232,8 @@
     <form id="emailSettingsForm">
       <label>Тема:<br><input id="welcomeEmailSubject" type="text"></label>
       <label>Съдържание:<br><textarea id="welcomeEmailBody" rows="5"></textarea></label>
+      <label>Тема на имейла след въпросник:<br><input id="questionnaireEmailSubject" type="text"></label>
+      <label>Съдържание:<br><textarea id="questionnaireEmailBody" rows="5"></textarea></label>
       <label>Тема на имейла за анализ:<br><input id="analysisEmailSubject" type="text"></label>
       <label>Съдържание:<br><textarea id="analysisEmailBody" rows="5"></textarea></label>
       <button type="submit">Запази</button>

--- a/js/admin.js
+++ b/js/admin.js
@@ -93,6 +93,8 @@ const testAnalysisBtn = document.getElementById('testAnalysisModel');
 const emailSettingsForm = document.getElementById('emailSettingsForm');
 const welcomeEmailSubjectInput = document.getElementById('welcomeEmailSubject');
 const welcomeEmailBodyInput = document.getElementById('welcomeEmailBody');
+const questionnaireEmailSubjectInput = document.getElementById('questionnaireEmailSubject');
+const questionnaireEmailBodyInput = document.getElementById('questionnaireEmailBody');
 const analysisEmailSubjectInput = document.getElementById('analysisEmailSubject');
 const analysisEmailBodyInput = document.getElementById('analysisEmailBody');
 const testEmailForm = document.getElementById('testEmailForm');
@@ -1276,6 +1278,8 @@ async function loadEmailSettings() {
         const cfg = data.config || {}
         if (welcomeEmailSubjectInput) welcomeEmailSubjectInput.value = cfg.welcome_email_subject || ''
         if (welcomeEmailBodyInput) welcomeEmailBodyInput.value = cfg.welcome_email_body || ''
+        if (questionnaireEmailSubjectInput) questionnaireEmailSubjectInput.value = cfg.questionnaire_email_subject || ''
+        if (questionnaireEmailBodyInput) questionnaireEmailBodyInput.value = cfg.questionnaire_email_body || ''
         if (analysisEmailSubjectInput) analysisEmailSubjectInput.value = cfg.analysis_email_subject || ''
         if (analysisEmailBodyInput) analysisEmailBodyInput.value = cfg.analysis_email_body || ''
     } catch (err) {
@@ -1289,6 +1293,8 @@ async function saveEmailSettings() {
         updates: {
             welcome_email_subject: welcomeEmailSubjectInput ? welcomeEmailSubjectInput.value.trim() : '',
             welcome_email_body: welcomeEmailBodyInput ? welcomeEmailBodyInput.value.trim() : '',
+            questionnaire_email_subject: questionnaireEmailSubjectInput ? questionnaireEmailSubjectInput.value.trim() : '',
+            questionnaire_email_body: questionnaireEmailBodyInput ? questionnaireEmailBodyInput.value.trim() : '',
             analysis_email_subject: analysisEmailSubjectInput ? analysisEmailSubjectInput.value.trim() : '',
             analysis_email_body: analysisEmailBodyInput ? analysisEmailBodyInput.value.trim() : ''
         }

--- a/preworker.js
+++ b/preworker.js
@@ -264,6 +264,8 @@ const AI_CONFIG_KEYS = [
     'image_temperature',
     'welcome_email_subject',
     'welcome_email_body',
+    'questionnaire_email_subject',
+    'questionnaire_email_body',
     'analysis_email_subject',
     'analysis_email_body'
 ];

--- a/worker.js
+++ b/worker.js
@@ -264,6 +264,8 @@ const AI_CONFIG_KEYS = [
     'image_temperature',
     'welcome_email_subject',
     'welcome_email_body',
+    'questionnaire_email_subject',
+    'questionnaire_email_body',
     'analysis_email_subject',
     'analysis_email_body'
 ];


### PR DESCRIPTION
## Summary
- allow editing the questionnaire confirmation email via the admin panel
- store the values in AI config
- document new config keys

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e2136dd388326a5a8a7e29de433f3