### PR TITLE
Refactor admin config API helpers

### DIFF
--- a/js/__tests__/adminConfig.test.js
+++ b/js/__tests__/adminConfig.test.js
@@ -1,0 +1,42 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let loadConfig, saveConfig;
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.unstable_mockModule('../config.js', () => ({
+    apiEndpoints: { getAiConfig: '/get', setAiConfig: '/set' }
+  }));
+  ({ loadConfig, saveConfig } = await import('../adminConfig.js'));
+});
+
+afterEach(() => {
+  global.fetch && global.fetch.mockRestore();
+  sessionStorage.clear();
+  localStorage.clear();
+});
+
+test('loadConfig returns full config', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, config: { a: 1 } }) });
+  const cfg = await loadConfig();
+  expect(global.fetch).toHaveBeenCalledWith('/get');
+  expect(cfg).toEqual({ a: 1 });
+});
+
+test('loadConfig can filter keys', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, config: { a: 1, b: 2 } }) });
+  const res = await loadConfig(['b']);
+  expect(res).toEqual({ b: 2 });
+});
+
+test('saveConfig posts updates with token', async () => {
+  sessionStorage.setItem('adminToken', 't');
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  await saveConfig({ a: 2 });
+  expect(global.fetch).toHaveBeenCalledWith('/set', expect.objectContaining({
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+    body: JSON.stringify({ updates: { a: 2 } })
+  }));
+});

--- a/js/adminConfig.js
+++ b/js/adminConfig.js
@@ -1,0 +1,38 @@
+import { apiEndpoints } from './config.js';
+
+/**
+ * Зарежда конфигурационни стойности от сървъра.
+ * @param {string[]} [keys] - Списък от ключове за филтриране.
+ * @returns {Promise<object>} Получената конфигурация.
+ */
+export async function loadConfig(keys) {
+    const resp = await fetch(apiEndpoints.getAiConfig);
+    const data = await resp.json();
+    if (!resp.ok || !data.success) throw new Error(data.message || 'Error');
+    const cfg = data.config || {};
+    if (Array.isArray(keys) && keys.length) {
+        const subset = {};
+        for (const k of keys) subset[k] = cfg[k];
+        return subset;
+    }
+    return cfg;
+}
+
+/**
+ * Записва конфигурация в сървъра.
+ * @param {object} updates - Ключове и стойности за обновяване.
+ * @returns {Promise<object>} Отговорът от API.
+ */
+export async function saveConfig(updates) {
+    const adminToken = sessionStorage.getItem('adminToken') || localStorage.getItem('adminToken') || '';
+    const headers = { 'Content-Type': 'application/json' };
+    if (adminToken) headers.Authorization = `Bearer ${adminToken}`;
+    const resp = await fetch(apiEndpoints.setAiConfig, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ updates })
+    });
+    const data = await resp.json();
+    if (!resp.ok || !data.success) throw new Error(data.message || 'Error');
+    return data;
+}


### PR DESCRIPTION
## Summary
- add reusable `adminConfig` module for loading and saving config
- refactor `admin.js` to use these helpers
- cover new helper functions with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687eab60abc083269afffe4499504f08