### PR TITLE
Improve email sender tests

### DIFF
--- a/js/__tests__/emailSender.test.js
+++ b/js/__tests__/emailSender.test.js
@@ -20,3 +20,21 @@ test('uses MAILER_ENDPOINT_URL when provided', async () => {
   }));
   fetch.mockRestore();
 });
+
+test('falls back to process.env variables', async () => {
+  process.env.MAILER_ENDPOINT_URL = 'https://env.mail/send';
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  await sendEmailUniversal('e@m.bg', 'S', 'B');
+  expect(fetch).toHaveBeenCalledWith('https://env.mail/send', expect.any(Object));
+  fetch.mockRestore();
+  delete process.env.MAILER_ENDPOINT_URL;
+});
+
+test('uses MAIL_PHP_URL when endpoint missing', async () => {
+  process.env.MAIL_PHP_URL = 'https://my.mail/php';
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  await sendEmailUniversal('x@y.z', 'Sub', 'Body');
+  expect(fetch).toHaveBeenCalledWith('https://my.mail/php', expect.any(Object));
+  fetch.mockRestore();
+  delete process.env.MAIL_PHP_URL;
+});

--- a/utils/emailSender.js
+++ b/utils/emailSender.js
@@ -1,5 +1,16 @@
+/**
+ * Унифицирано изпращане на имейл.
+ * При зададен MAILER_ENDPOINT_URL заявката се изпраща към него,
+ * в противен случай се използва помощния worker.
+ *
+ * @param {string} to     Получател
+ * @param {string} subject Тема
+ * @param {string} body    HTML съдържание
+ * @param {Record<string,string>} [env] допълнителни променливи
+ */
 export async function sendEmailUniversal(to, subject, body, env = {}) {
-  const endpoint = env.MAILER_ENDPOINT_URL || (typeof process !== 'undefined' ? process.env.MAILER_ENDPOINT_URL : undefined);
+  const endpoint = env.MAILER_ENDPOINT_URL ||
+    (typeof process !== 'undefined' ? process.env.MAILER_ENDPOINT_URL : undefined);
   if (endpoint) {
     const resp = await fetch(endpoint, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- document email sender behaviour with JSDoc comment
- add tests covering process.env fallbacks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ebbae3ed88326a6d9168f5c6b6055