### PR TITLE
Fix worker mail module

### DIFF
--- a/preworker.js
+++ b/preworker.js
@@ -13,7 +13,27 @@
 // - Запазени всички предходни функционалности.
 
 import crypto from 'node:crypto';
-import { sendEmailUniversal } from './utils/emailSender.js';
+// Вградена функция за изпращане на имейли, за да работи скриптът
+// като самостоятелен файл в Cloudflare.
+async function sendEmailUniversal(to, subject, body, env = {}) {
+  const endpoint = env.MAILER_ENDPOINT_URL ||
+    (typeof process !== 'undefined' ? process.env.MAILER_ENDPOINT_URL : undefined);
+  if (endpoint) {
+    const resp = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ to, subject, message: body })
+    });
+    if (!resp.ok) {
+      throw new Error(`Mailer responded with ${resp.status}`);
+    }
+    return;
+  }
+
+  const { sendEmail } = await import('./sendEmailWorker.js');
+  const phpEnv = { MAIL_PHP_URL: env.MAIL_PHP_URL || (typeof process !== 'undefined' ? process.env.MAIL_PHP_URL : undefined) };
+  await sendEmail(to, subject, body, phpEnv);
+}
 import { parseJsonSafe } from './utils/parseJsonSafe.js';
 
 const WELCOME_SUBJECT = 'Добре дошъл в MyBody!';

--- a/worker.js
+++ b/worker.js
@@ -13,7 +13,27 @@
 // - Запазени всички предходни функционалности.
 
 import crypto from 'node:crypto';
-import { sendEmailUniversal } from './utils/emailSender.js';
+// Вградена функция за изпращане на имейли, за да работи скриптът
+// като самостоятелен файл в Cloudflare.
+async function sendEmailUniversal(to, subject, body, env = {}) {
+  const endpoint = env.MAILER_ENDPOINT_URL ||
+    (typeof process !== 'undefined' ? process.env.MAILER_ENDPOINT_URL : undefined);
+  if (endpoint) {
+    const resp = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ to, subject, message: body })
+    });
+    if (!resp.ok) {
+      throw new Error(`Mailer responded with ${resp.status}`);
+    }
+    return;
+  }
+
+  const { sendEmail } = await import('./sendEmailWorker.js');
+  const phpEnv = { MAIL_PHP_URL: env.MAIL_PHP_URL || (typeof process !== 'undefined' ? process.env.MAIL_PHP_URL : undefined) };
+  await sendEmail(to, subject, body, phpEnv);
+}
 import { parseJsonSafe } from './utils/parseJsonSafe.js';
 
 const WELCOME_SUBJECT = 'Добре дошъл в MyBody!';


### PR DESCRIPTION
## Summary
- embed `sendEmailUniversal` directly in worker files so Cloudflare dashboard can run standalone
- keep `worker.js` and `preworker.js` in sync

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ea9f6d5bc8326877c008b1f4b500e