### PR TITLE
Refactor env access for nodejs_compat

### DIFF
--- a/preworker.js
+++ b/preworker.js
@@ -15,7 +15,7 @@
 // като самостоятелен файл в Cloudflare.
 async function sendEmailUniversal(to, subject, body, env = {}) {
   const endpoint = env.MAILER_ENDPOINT_URL ||
-    (typeof process !== 'undefined' ? process.env.MAILER_ENDPOINT_URL : undefined);
+    globalThis['process']?.env?.MAILER_ENDPOINT_URL;
   if (endpoint) {
     const resp = await fetch(endpoint, {
       method: 'POST',
@@ -29,7 +29,7 @@ async function sendEmailUniversal(to, subject, body, env = {}) {
   }
 
   const { sendEmail } = await import('./sendEmailWorker.js');
-  const phpEnv = { MAIL_PHP_URL: env.MAIL_PHP_URL || (typeof process !== 'undefined' ? process.env.MAIL_PHP_URL : undefined) };
+  const phpEnv = { MAIL_PHP_URL: env.MAIL_PHP_URL || globalThis['process']?.env?.MAIL_PHP_URL };
   await sendEmail(to, subject, body, phpEnv);
 }
 import { parseJsonSafe } from './utils/parseJsonSafe.js';

--- a/utils/emailSender.js
+++ b/utils/emailSender.js
@@ -10,7 +10,7 @@
  */
 export async function sendEmailUniversal(to, subject, body, env = {}) {
   const endpoint = env.MAILER_ENDPOINT_URL ||
-    (typeof process !== 'undefined' ? process.env.MAILER_ENDPOINT_URL : undefined);
+    globalThis['process']?.env?.MAILER_ENDPOINT_URL;
   if (endpoint) {
     const resp = await fetch(endpoint, {
       method: 'POST',
@@ -24,7 +24,7 @@ export async function sendEmailUniversal(to, subject, body, env = {}) {
   }
 
   const { sendEmail } = await import('../sendEmailWorker.js');
-  const phpEnv = { MAIL_PHP_URL: env.MAIL_PHP_URL || (typeof process !== 'undefined' ? process.env.MAIL_PHP_URL : undefined) };
+  const phpEnv = { MAIL_PHP_URL: env.MAIL_PHP_URL || globalThis['process']?.env?.MAIL_PHP_URL };
   await sendEmail(to, subject, body, phpEnv);
 }
 

--- a/worker.js
+++ b/worker.js
@@ -15,7 +15,7 @@
 // като самостоятелен файл в Cloudflare.
 async function sendEmailUniversal(to, subject, body, env = {}) {
   const endpoint = env.MAILER_ENDPOINT_URL ||
-    (typeof process !== 'undefined' ? process.env.MAILER_ENDPOINT_URL : undefined);
+    globalThis['process']?.env?.MAILER_ENDPOINT_URL;
   if (endpoint) {
     const resp = await fetch(endpoint, {
       method: 'POST',
@@ -29,7 +29,7 @@ async function sendEmailUniversal(to, subject, body, env = {}) {
   }
 
   const { sendEmail } = await import('./sendEmailWorker.js');
-  const phpEnv = { MAIL_PHP_URL: env.MAIL_PHP_URL || (typeof process !== 'undefined' ? process.env.MAIL_PHP_URL : undefined) };
+  const phpEnv = { MAIL_PHP_URL: env.MAIL_PHP_URL || globalThis['process']?.env?.MAIL_PHP_URL };
   await sendEmail(to, subject, body, phpEnv);
 }
 import { parseJsonSafe } from './utils/parseJsonSafe.js';


### PR DESCRIPTION
## Summary
- read environment variables via `globalThis['process']?.env`
- keep worker and preworker in sync

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ec76de45c8326b8169ce17befe30a