### PR TITLE
Add note about Cloudflare editor warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ so you can use it directly:
 const encoded = Buffer.from('hello').toString('base64');
 ```
 
+> **Note**: Уеб редакторът на Cloudflare няма типове за Node. Възможно е да виждате предупреждения в редактора, макар че worker-ът работи нормално след деплой.
+
 След успешната инсталация стартирайте `npm run dev` отново.
 
 If the error persists, be sure to run TypeScript with this configuration:


### PR DESCRIPTION
## Summary
- warn about missing Node typings in Cloudflare's web editor near Node compatibility instructions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ecd8899a0832689689a4dd49c0f23