### PR TITLE
Update mail JSON payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,7 @@ wrangler secret list
 grep MAIL_PHP_URL .env
 ```
 Примерен PHP скрипт за изпращане на писма е наличен в [docs/mail_smtp.php](docs/mail_smtp.php). Настройте `MAIL_PHP_URL` да сочи към същия или сходен адрес.
+Скриптът приема JSON поле `body` или `message` и използва стойността като HTML съдържание на имейла.
 
 ### PHP script requirements
 

--- a/js/__tests__/emailSender.test.js
+++ b/js/__tests__/emailSender.test.js
@@ -16,7 +16,7 @@ test('uses MAILER_ENDPOINT_URL when provided', async () => {
   expect(fetch).toHaveBeenCalledWith('https://api.mail/send', expect.objectContaining({
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ to: 'a@b.bg', subject: 'S', message: 'B' })
+    body: JSON.stringify({ to: 'a@b.bg', subject: 'S', message: 'B', body: 'B' })
   }));
   fetch.mockRestore();
 });

--- a/js/__tests__/mailer.test.js
+++ b/js/__tests__/mailer.test.js
@@ -24,7 +24,8 @@ test('sends welcome email with correct options', async () => {
         body: JSON.stringify({
             to: 'client@example.com',
             subject: 'Добре дошъл в MyBody!',
-            message: expected
+            message: expected,
+            body: expected
         })
     }))
 })

--- a/js/__tests__/sendEmailWorker.test.js
+++ b/js/__tests__/sendEmailWorker.test.js
@@ -50,7 +50,7 @@ test('calls PHP endpoint on valid input', async () => {
   expect(fetch).toHaveBeenCalledWith(
     'https://mybody.best/mailer/mail.php',
     expect.objectContaining({
-      body: JSON.stringify({ to: 'a@b.bg', subject: 'S', message: 'B' }),
+      body: JSON.stringify({ to: 'a@b.bg', subject: 'S', message: 'B', body: 'B' }),
       headers: { 'Content-Type': 'application/json' }
     })
   );
@@ -70,7 +70,7 @@ test('sendEmail forwards data to PHP endpoint', async () => {
   expect(fetch).toHaveBeenCalledWith(
     'https://mybody.best/mailer/mail.php',
     expect.objectContaining({
-      body: JSON.stringify({ to: 't@e.com', subject: 'Hi', message: 'Body' }),
+      body: JSON.stringify({ to: 't@e.com', subject: 'Hi', message: 'Body', body: 'Body' }),
       headers: { 'Content-Type': 'application/json' }
     })
   );

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -57,7 +57,7 @@ async function sendViaPhp(to, subject, message, env = {}) {
   const resp = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ to, subject, message })
+    body: JSON.stringify({ to, subject, message, body: message })
   });
   if (!resp.ok) {
     throw new Error(`PHP mailer error ${resp.status}`);

--- a/utils/emailSender.js
+++ b/utils/emailSender.js
@@ -15,7 +15,7 @@ export async function sendEmailUniversal(to, subject, body, env = {}) {
     const resp = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ to, subject, message: body })
+      body: JSON.stringify({ to, subject, message: body, body })
     });
     if (!resp.ok) {
       throw new Error(`Mailer responded with ${resp.status}`);


### PR DESCRIPTION
## Summary
- send `body` field along with `message` in `sendEmailWorker.js` and `emailSender.js`
- expect new field in relevant tests
- document PHP mail API accepting `body` or `message`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ee68546e883269a9529f7cefcf1d6