### PR TITLE
Enable dynamic email templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ node scripts/view-usage-logs.js sendTestEmail 5
 | `questionnaire_email_subject` | Тема на имейла след попълнен въпросник |
 | `questionnaire_email_body` | HTML съдържание за потвърждението на въпросника |
 | `send_questionnaire_email` | "1" или "0" за включване или изключване на потвърждението |
+| `analysis_email_subject` | Тема на имейла след обработка на въпросника |
+| `analysis_email_body` | HTML съдържание за писмото с линка към анализа |
 | `question_definitions` | JSON с дефиниции на всички въпроси |
 | `recipe_data` | Данни за примерни рецепти |
 
@@ -857,6 +859,8 @@ ANALYSIS_PAGE_URL=https://example.com/analyze.html
 
 При ненастроени стойности се използват вградените теми и HTML шаблон.
 Секцията **Настройки за имейли** в `admin.html` показва визуално превю под всяко поле за HTML съдържание, за да виждате крайния резултат преди изпращане.
+Алтернативно може да запишете динамично стойностите в KV хранилището чрез ключовете
+`analysis_email_subject` и `analysis_email_body`.
 
 **Очакван резултат**
 

--- a/js/__tests__/initialAnalysis.test.js
+++ b/js/__tests__/initialAnalysis.test.js
@@ -124,6 +124,38 @@ describe('initial analysis handlers', () => {
     expect(callBody.message).toContain('https://app.example.com/analyze.html?utm=1&userId=u1')
   })
 
+  test('uses templates from RESOURCES_KV when env vars missing', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { response: '{"ok":true}' } })
+    })
+    const env = {
+      MAILER_ENDPOINT_URL: 'https://mail.example.com',
+      ANALYSIS_PAGE_URL: 'https://app.example.com/analyze.html',
+      USER_METADATA_KV: {
+        get: jest.fn(key => key === 'u1_initial_answers' ? Promise.resolve('{"name":"А","email":"a@ex.bg"}') : Promise.resolve(null)),
+        put: jest.fn()
+      },
+      RESOURCES_KV: {
+        get: jest.fn(key => {
+          if (key === 'prompt_questionnaire_analysis') return 'Analyze %%ANSWERS_JSON%%'
+          if (key === 'model_questionnaire_analysis') return '@cf/test-model'
+          if (key === 'analysis_email_subject') return 'Subj'
+          if (key === 'analysis_email_body') return '<p>{{name}} <a href="{{link}}">линк</a></p>'
+          return null
+        })
+      },
+      CF_ACCOUNT_ID: 'acc',
+      CF_AI_TOKEN: 't'
+    }
+    await worker.handleAnalyzeInitialAnswers('u1', env)
+    const emailCall = global.fetch.mock.calls.find(c => c[0] === 'https://mail.example.com')
+    const callBody = JSON.parse(emailCall[1].body)
+    expect(callBody.subject).toBe('Subj')
+    expect(callBody.message).toContain('https://app.example.com/analyze.html?userId=u1')
+    expect(callBody.message).toContain('А')
+  })
+
   test('handleGetInitialAnalysisRequest returns parsed analysis', async () => {
     const env = { USER_METADATA_KV: { get: jest.fn().mockResolvedValue('{"a":1}') } }
     const req = { url: 'https://x/api/getInitialAnalysis?userId=u1' }

--- a/js/__tests__/submitQuestionnaireEmail.test.js
+++ b/js/__tests__/submitQuestionnaireEmail.test.js
@@ -56,3 +56,26 @@ test('skips confirmation email when disabled', async () => {
   expect(res.success).toBe(true)
   expect(fetch).not.toHaveBeenCalled()
 })
+
+test('uses templates from RESOURCES_KV when env vars missing', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true })
+  const env = {
+    MAILER_ENDPOINT_URL: 'https://mail.example.com',
+    USER_METADATA_KV: {
+      get: jest.fn(async key => key === 'email_to_uuid_test@ex.bg' ? 'u1' : null),
+      put: jest.fn()
+    },
+    RESOURCES_KV: {
+      get: jest.fn(key => {
+        if (key === 'questionnaire_email_subject') return 'Тема'
+        if (key === 'questionnaire_email_body') return '<p>{{name}}</p>'
+        return null
+      })
+    }
+  }
+  const req = { json: async () => ({ email: 'test@ex.bg', name: 'Иван' }) }
+  await handleSubmitQuestionnaire(req, env)
+  const callBody = JSON.parse(global.fetch.mock.calls[0][1].body)
+  expect(callBody.subject).toBe('Тема')
+  expect(callBody.message).toBe('<p>Иван</p>')
+})

--- a/preworker.js
+++ b/preworker.js
@@ -158,6 +158,8 @@ const ANALYSIS_READY_BODY_TEMPLATE = '<p>Здравей, {{name}}.</p>' +
     '<p>Вашият персонален анализ е готов. Можете да го видите <a href="{{link}}">тук</a>.</p>' +
     '<p>– Екипът на MyBody</p>';
 const ANALYSIS_PAGE_URL_VAR_NAME = 'ANALYSIS_PAGE_URL';
+const ANALYSIS_EMAIL_SUBJECT_VAR_NAME = 'ANALYSIS_EMAIL_SUBJECT';
+const ANALYSIS_EMAIL_BODY_VAR_NAME = 'ANALYSIS_EMAIL_BODY';
 
 async function sendWelcomeEmail(to, name, env) {
     const html = WELCOME_BODY_TEMPLATE.replace(/{{\s*name\s*}}/g, name);
@@ -185,8 +187,18 @@ async function isQuestionnaireEmailEnabled(env) {
 
 async function sendQuestionnaireConfirmationEmail(to, name, env) {
     if (!(await isQuestionnaireEmailEnabled(env))) return;
-    const subject = env?.[QUESTIONNAIRE_EMAIL_SUBJECT_VAR_NAME] || QUESTIONNAIRE_SUBJECT;
-    const tpl = env?.[QUESTIONNAIRE_EMAIL_BODY_VAR_NAME] || QUESTIONNAIRE_BODY_TEMPLATE;
+    let subject = env?.[QUESTIONNAIRE_EMAIL_SUBJECT_VAR_NAME];
+    let tpl = env?.[QUESTIONNAIRE_EMAIL_BODY_VAR_NAME];
+    if (!subject && env?.RESOURCES_KV) {
+        subject = await env.RESOURCES_KV.get('questionnaire_email_subject') || QUESTIONNAIRE_SUBJECT;
+    } else if (!subject) {
+        subject = QUESTIONNAIRE_SUBJECT;
+    }
+    if (!tpl && env?.RESOURCES_KV) {
+        tpl = await env.RESOURCES_KV.get('questionnaire_email_body') || QUESTIONNAIRE_BODY_TEMPLATE;
+    } else if (!tpl) {
+        tpl = QUESTIONNAIRE_BODY_TEMPLATE;
+    }
     const html = tpl.replace(/{{\s*name\s*}}/g, name);
     try {
         await sendEmailUniversal(to, subject, html, env);
@@ -196,8 +208,18 @@ async function sendQuestionnaireConfirmationEmail(to, name, env) {
 }
 
 async function sendAnalysisLinkEmail(to, name, link, env) {
-    const subject = env?.ANALYSIS_EMAIL_SUBJECT || ANALYSIS_READY_SUBJECT;
-    const tpl = env?.ANALYSIS_EMAIL_BODY || ANALYSIS_READY_BODY_TEMPLATE;
+    let subject = env?.[ANALYSIS_EMAIL_SUBJECT_VAR_NAME];
+    let tpl = env?.[ANALYSIS_EMAIL_BODY_VAR_NAME];
+    if (!subject && env?.RESOURCES_KV) {
+        subject = await env.RESOURCES_KV.get('analysis_email_subject') || ANALYSIS_READY_SUBJECT;
+    } else if (!subject) {
+        subject = ANALYSIS_READY_SUBJECT;
+    }
+    if (!tpl && env?.RESOURCES_KV) {
+        tpl = await env.RESOURCES_KV.get('analysis_email_body') || ANALYSIS_READY_BODY_TEMPLATE;
+    } else if (!tpl) {
+        tpl = ANALYSIS_READY_BODY_TEMPLATE;
+    }
     if (!tpl.includes('{{name}}')) {
         console.warn('ANALYSIS_EMAIL_BODY missing {{name}} placeholder');
     }

--- a/worker.js
+++ b/worker.js
@@ -158,6 +158,8 @@ const ANALYSIS_READY_BODY_TEMPLATE = '<p>Здравей, {{name}}.</p>' +
     '<p>Вашият персонален анализ е готов. Можете да го видите <a href="{{link}}">тук</a>.</p>' +
     '<p>– Екипът на MyBody</p>';
 const ANALYSIS_PAGE_URL_VAR_NAME = 'ANALYSIS_PAGE_URL';
+const ANALYSIS_EMAIL_SUBJECT_VAR_NAME = 'ANALYSIS_EMAIL_SUBJECT';
+const ANALYSIS_EMAIL_BODY_VAR_NAME = 'ANALYSIS_EMAIL_BODY';
 
 async function sendWelcomeEmail(to, name, env) {
     const html = WELCOME_BODY_TEMPLATE.replace(/{{\s*name\s*}}/g, name);
@@ -185,8 +187,18 @@ async function isQuestionnaireEmailEnabled(env) {
 
 async function sendQuestionnaireConfirmationEmail(to, name, env) {
     if (!(await isQuestionnaireEmailEnabled(env))) return;
-    const subject = env?.[QUESTIONNAIRE_EMAIL_SUBJECT_VAR_NAME] || QUESTIONNAIRE_SUBJECT;
-    const tpl = env?.[QUESTIONNAIRE_EMAIL_BODY_VAR_NAME] || QUESTIONNAIRE_BODY_TEMPLATE;
+    let subject = env?.[QUESTIONNAIRE_EMAIL_SUBJECT_VAR_NAME];
+    let tpl = env?.[QUESTIONNAIRE_EMAIL_BODY_VAR_NAME];
+    if (!subject && env?.RESOURCES_KV) {
+        subject = await env.RESOURCES_KV.get('questionnaire_email_subject') || QUESTIONNAIRE_SUBJECT;
+    } else if (!subject) {
+        subject = QUESTIONNAIRE_SUBJECT;
+    }
+    if (!tpl && env?.RESOURCES_KV) {
+        tpl = await env.RESOURCES_KV.get('questionnaire_email_body') || QUESTIONNAIRE_BODY_TEMPLATE;
+    } else if (!tpl) {
+        tpl = QUESTIONNAIRE_BODY_TEMPLATE;
+    }
     const html = tpl.replace(/{{\s*name\s*}}/g, name);
     try {
         await sendEmailUniversal(to, subject, html, env);
@@ -196,8 +208,18 @@ async function sendQuestionnaireConfirmationEmail(to, name, env) {
 }
 
 async function sendAnalysisLinkEmail(to, name, link, env) {
-    const subject = env?.ANALYSIS_EMAIL_SUBJECT || ANALYSIS_READY_SUBJECT;
-    const tpl = env?.ANALYSIS_EMAIL_BODY || ANALYSIS_READY_BODY_TEMPLATE;
+    let subject = env?.[ANALYSIS_EMAIL_SUBJECT_VAR_NAME];
+    let tpl = env?.[ANALYSIS_EMAIL_BODY_VAR_NAME];
+    if (!subject && env?.RESOURCES_KV) {
+        subject = await env.RESOURCES_KV.get('analysis_email_subject') || ANALYSIS_READY_SUBJECT;
+    } else if (!subject) {
+        subject = ANALYSIS_READY_SUBJECT;
+    }
+    if (!tpl && env?.RESOURCES_KV) {
+        tpl = await env.RESOURCES_KV.get('analysis_email_body') || ANALYSIS_READY_BODY_TEMPLATE;
+    } else if (!tpl) {
+        tpl = ANALYSIS_READY_BODY_TEMPLATE;
+    }
     if (!tpl.includes('{{name}}')) {
         console.warn('ANALYSIS_EMAIL_BODY missing {{name}} placeholder');
     }


### PR DESCRIPTION
## Summary
- make worker read questionnaire/analysis email settings from `RESOURCES_KV`
- keep worker and preworker in sync
- document the new config keys
- test kv template usage for questionnaire and analysis emails

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ee94169448326b5d9c64b631d04a4