### PR TITLE
Enable editing analysis email via content settings

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -245,6 +245,16 @@
     </form>
   </details>
 
+  <details id="contentThemeSection" class="card">
+    <summary>Съдържание и тема</summary>
+    <form id="contentThemeForm">
+      <label>Тема на имейла за анализ:<br><input id="contentAnalysisSubject" type="text"></label>
+      <label>Съдържание:<br><textarea id="contentAnalysisBody" rows="5"></textarea></label>
+      <div id="contentAnalysisPreview" class="email-preview"></div>
+      <button type="submit">Запази</button>
+    </form>
+  </details>
+
   <details id="testEmailSection" class="card">
     <summary>Тестов имейл</summary>
     <form id="testEmailForm">

--- a/js/admin.js
+++ b/js/admin.js
@@ -101,6 +101,10 @@ const analysisEmailSubjectInput = document.getElementById('analysisEmailSubject'
 const analysisEmailBodyInput = document.getElementById('analysisEmailBody');
 const sendQuestionnaireEmailCheckbox = document.getElementById('sendQuestionnaireEmail');
 const sameEmailContentCheckbox = document.getElementById('sameEmailContent');
+const contentThemeForm = document.getElementById('contentThemeForm');
+const contentAnalysisSubjectInput = document.getElementById('contentAnalysisSubject');
+const contentAnalysisBodyInput = document.getElementById('contentAnalysisBody');
+const contentAnalysisPreview = document.getElementById('contentAnalysisPreview');
 const testEmailForm = document.getElementById('testEmailForm');
 const testEmailToInput = document.getElementById('testEmailTo');
 const testEmailSubjectInput = document.getElementById('testEmailSubject');
@@ -1322,6 +1326,37 @@ async function saveEmailSettings() {
     }
 }
 
+async function loadContentThemeSettings() {
+    try {
+        const cfg = await loadConfig([
+            'analysis_email_subject',
+            'analysis_email_body'
+        ]);
+        if (contentAnalysisSubjectInput) contentAnalysisSubjectInput.value = cfg.analysis_email_subject || '';
+        if (contentAnalysisBodyInput) {
+            contentAnalysisBodyInput.value = cfg.analysis_email_body || '';
+            if (contentAnalysisPreview) contentAnalysisPreview.innerHTML = sanitizeHTML(contentAnalysisBodyInput.value);
+        }
+    } catch (err) {
+        console.error('Error loading content settings:', err);
+    }
+}
+
+async function saveContentThemeSettings() {
+    if (!contentThemeForm) return;
+    const updates = {
+        analysis_email_subject: contentAnalysisSubjectInput ? contentAnalysisSubjectInput.value.trim() : '',
+        analysis_email_body: contentAnalysisBodyInput ? contentAnalysisBodyInput.value.trim() : ''
+    };
+    try {
+        await saveConfig(updates);
+        alert('Съдържанието е записано.');
+    } catch (err) {
+        console.error('Error saving content settings:', err);
+        alert('Грешка при запис на съдържанието.');
+    }
+}
+
 let testEmailTemplateLoaded = false
 
 async function loadTestEmailTemplate() {
@@ -1649,6 +1684,7 @@ document.addEventListener('DOMContentLoaded', () => {
     attachEmailPreview(questionnaireEmailBodyInput, questionnaireEmailPreview);
     attachEmailPreview(analysisEmailBodyInput, analysisEmailPreview);
     attachEmailPreview(testEmailBodyInput, testEmailPreview);
+    attachEmailPreview(contentAnalysisBodyInput, contentAnalysisPreview);
 
     if (sameEmailContentCheckbox) {
         const updateAnalysisFields = () => {
@@ -1686,6 +1722,7 @@ document.addEventListener('DOMContentLoaded', () => {
         loadAdminToken();
         await loadAiConfig();
         await loadAiPresets();
+        if (contentThemeForm) await loadContentThemeSettings();
         if (emailSettingsForm) await loadEmailSettings();
         if (testEmailSection?.open) await loadTestEmailTemplate();
         setInterval(checkForNotifications, 60000);
@@ -1715,6 +1752,13 @@ if (emailSettingsForm) {
     emailSettingsForm.addEventListener('submit', async (e) => {
         e.preventDefault();
         await saveEmailSettings();
+    });
+}
+
+if (contentThemeForm) {
+    contentThemeForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        await saveContentThemeSettings();
     });
 }
 
@@ -1761,5 +1805,7 @@ export {
     sendTestImage,
     sendTestQuestionnaire,
     sendAdminQuery,
-    attachEmailPreview
+    attachEmailPreview,
+    loadContentThemeSettings,
+    saveContentThemeSettings
 };


### PR DESCRIPTION
## Summary
- add 'Съдържание и тема' section to admin panel
- allow editing analysis email subject and body in content settings
- load/save these values via admin.js and preview HTML

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687eedff26948326b2c83ccc9022ba3f