### PR TITLE
Update test email template

### DIFF
--- a/data/testEmailTemplate.html
+++ b/data/testEmailTemplate.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+  <meta charset="UTF-8">
+  <title>Тестов HTML имейл</title>
+</head>
+<body style="font-family: Arial, sans-serif; background:#f5f5f5; margin:0; padding:20px;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:600px;margin:auto;background:#ffffff;border-radius:8px;">
+    <tr>
+      <td style="padding:20px;text-align:center;">
+        <h2 style="color:#2c3e50;margin-top:0;">Здравей, {{name}}</h2>
+        <p style="color:#333;line-height:1.5;">Това е примерен HTML имейл. Целта е да демонстрира, че съдържанието може да бъде форматирано.</p>
+        <p style="color:#333;line-height:1.5;">Ако виждаш този текст с правилните стилове, значи всичко работи.</p>
+        <a href="https://mybody.best" style="display:inline-block;margin-top:20px;padding:10px 25px;background:#4A90E2;color:#ffffff;text-decoration:none;border-radius:50px;">Посети MyBody</a>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/js/__tests__/loadTestEmailTemplate.test.js
+++ b/js/__tests__/loadTestEmailTemplate.test.js
@@ -17,8 +17,8 @@ afterEach(() => {
   global.fetch && global.fetch.mockRestore()
 })
 
-test('loads welcome template into textarea', async () => {
+test('loads test email template into textarea', async () => {
   await loadTemplate()
-  expect(global.fetch).toHaveBeenCalledWith('data/welcomeEmailTemplate.html')
+  expect(global.fetch).toHaveBeenCalledWith('data/testEmailTemplate.html')
   expect(document.getElementById('testEmailBody').value).toBe('<h1>Hi</h1>')
 })

--- a/js/admin.js
+++ b/js/admin.js
@@ -1362,7 +1362,7 @@ let testEmailTemplateLoaded = false
 async function loadTestEmailTemplate() {
     if (testEmailTemplateLoaded || !testEmailBodyInput) return
     try {
-        const resp = await fetch('data/welcomeEmailTemplate.html')
+        const resp = await fetch('data/testEmailTemplate.html')
         testEmailBodyInput.value = await resp.text()
         if (testEmailPreview) testEmailPreview.innerHTML = sanitizeHTML(testEmailBodyInput.value)
         testEmailTemplateLoaded = true


### PR DESCRIPTION
## Summary
- add new HTML file for test emails with inline styles
- update admin page to load the new test email template
- adjust related unit test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687ef2882d1083269dc2ef510a0842f0