### PR TITLE
Fix sticky CTA on mobile

### DIFF
--- a/reganalize/analyze.html
+++ b/reganalize/analyze.html
@@ -215,10 +215,10 @@
                 bottom: 12px;
                 left: 50%;
                 transform: translateX(-50%);
-                width: 80%;
-                max-width: 340px;
+                width: 70%;
+                max-width: 300px;
                 font-size: 1.1em;
-                padding: 12px 30px;
+                padding: 12px 24px;
                 z-index: 1000;
                 animation-name: pulse-glow-mobile;
             }
@@ -409,7 +409,7 @@
     document.addEventListener('DOMContentLoaded', () => {
         const cta = document.getElementById('cta-button');
         const toggleCtaVisibility = () => {
-            const threshold = document.body.scrollHeight / 3;
+            const threshold = document.documentElement.scrollHeight / 3;
             if (window.scrollY > threshold) {
                 cta.classList.remove('cta-button--hidden');
             } else {
@@ -418,6 +418,7 @@
         };
         toggleCtaVisibility();
         window.addEventListener('scroll', toggleCtaVisibility);
+        window.addEventListener('resize', toggleCtaVisibility);
     });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- adjust mobile CTA width and padding
- compute scroll threshold reliably and update on resize

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd34d8250832694dd21900b427ad8