### PR TITLE
Fix meal card spacing in dashboard

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -235,7 +235,6 @@ body.dark-theme .detailed-metric-item .value-current {
 }
 
 .meal-card {
-  margin-bottom: calc(var(--space-unit) * 2);
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- remove the redundant `margin-bottom` from `.meal-card`
- keep margin only on `.meal-list li`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880185b5bbc83268ccc45b4e6d2ad7c