### PR TITLE
Fix meal color bar layout

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -244,6 +244,8 @@ body.dark-theme .detailed-metric-item .value-current {
   border-radius: 2px;
   background-color: var(--primary-color);
   margin-right: var(--space-md);
+  height: 100%;
+  align-self: stretch;
 }
 
 .meal-card[data-meal-type='dinner'] .meal-color-bar {


### PR DESCRIPTION
## Summary
- keep meal color bar the full height of the meal card

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880185284108326abbe32056857a6e8