### PR TITLE
Refine dashboard progress bars

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -59,7 +59,8 @@
 
   --progress-bar-bg-empty: #e9ecef;
   --progress-gradient: linear-gradient(to right, var(--color-danger), var(--color-warning), var(--color-success));
-  --progress-bar-height: 1rem; 
+  --progress-bar-glow-color: var(--color-success);
+  --progress-bar-height: 1rem;
   --progress-bar-radius: var(--radius-sm);
 
   --toast-bg: rgba(44, 62, 80, 0.95); --toast-text: #fff; --toast-radius: var(--radius-md);

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -26,14 +26,23 @@
   margin: var(--space-sm) auto;
 }
 .progress-bar {
-  background: var(--progress-gradient); border-radius: var(--progress-bar-radius);
-  position: relative; height: var(--progress-bar-height); overflow: hidden;
+  background: var(--progress-gradient);
+  border-radius: 6px;
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  box-shadow: 0 0 6px var(--progress-bar-glow-color);
 }
 .progress-mask {
-  position: absolute; top: 0; right: 0; bottom: 0; left: auto;
-  background: var(--progress-bar-bg-empty);
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: auto;
+  background: var(--surface-background);
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
-  width: 100%; border-radius: 0;
+  width: 100%;
+  border-radius: 6px;
 }
 .index-card .index-value {
   font-size: 1.2rem; font-weight: 700; color: var(--primary-color);


### PR DESCRIPTION
## Summary
- add `--progress-bar-glow-color` variable
- style dashboard progress bars with smaller height, rounded corners, surface track and subtle glow

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68801eddb90c8326b49c2ee6fdfcb98d