### PR TITLE
Handle breakfast meal type styling

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -238,6 +238,19 @@ body.dark-theme .detailed-metric-item .value-current {
   position: relative;
 }
 
+/* Цветни фонове спрямо типа хранене */
+.meal-card[data-meal-type='lunch'] {
+  background: color-mix(in srgb, var(--surface-background) 90%, var(--primary-color));
+}
+
+.meal-card[data-meal-type='dinner'] {
+  background: color-mix(in srgb, var(--surface-background) 90%, var(--tertiary-color));
+}
+
+.meal-card[data-meal-type='breakfast'] {
+  background: color-mix(in srgb, var(--surface-background) 90%, var(--secondary-color));
+}
+
 .meal-color-bar {
   width: 4px;
   border-radius: 2px;
@@ -254,6 +267,10 @@ body.dark-theme .detailed-metric-item .value-current {
 /* Определя цвят и за обяда */
 .meal-card[data-meal-type='lunch'] .meal-color-bar {
   background-color: var(--primary-color);
+}
+
+.meal-card[data-meal-type='breakfast'] .meal-color-bar {
+  background-color: var(--secondary-color);
 }
 
 .meal-list li:hover {

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -102,6 +102,7 @@ test('populates daily plan with color bars and meal types', async () => {
     planData: {
       week1Menu: {
         [currentDayKey]: [
+          { meal_name: 'Ранна закуска', items: [] },
           { meal_name: 'Вкусен обяд', items: [] },
           { meal_name: 'Лека вечеря', items: [] }
         ]
@@ -120,10 +121,11 @@ test('populates daily plan with color bars and meal types', async () => {
   ({ populateUI } = await import('../populateUI.js'));
   populateUI();
   const cards = document.querySelectorAll('#dailyMealList .meal-card');
-  expect(cards.length).toBe(2);
+  expect(cards.length).toBe(3);
   cards.forEach(card => {
     expect(card.querySelector('.meal-color-bar')).not.toBeNull();
   });
-  expect(cards[0].dataset.mealType).toBe('lunch');
-  expect(cards[1].dataset.mealType).toBe('dinner');
+  expect(cards[0].dataset.mealType).toBe('breakfast');
+  expect(cards[1].dataset.mealType).toBe('lunch');
+  expect(cards[2].dataset.mealType).toBe('dinner');
 });

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -254,6 +254,7 @@ function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {
         const lowerName = (mealItem.meal_name || '').toLowerCase();
         if (lowerName.includes('обяд')) li.dataset.mealType = 'lunch';
         else if (lowerName.includes('вечеря')) li.dataset.mealType = 'dinner';
+        else if (lowerName.includes('закуска')) li.dataset.mealType = 'breakfast';
 
         let itemsHtml = (mealItem.items || []).map(i => {
             const name = i.name || 'Неизвестен продукт';


### PR DESCRIPTION
## Summary
- add meal card background colors for breakfast, lunch, and dinner using `color-mix`
- detect breakfast meal type in `populateUI.js`
- extend test coverage for breakfast card markup

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68801f6b80648326b76e184732553e94