### PR TITLE
Update tertiary color and meal completion styling

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -11,7 +11,7 @@
   --primary-color: #3A506B;
   --secondary-color: #5BC0BE;
   --accent-color: #778DA9;
-  --tertiary-color: #B5A3C3;
+  --tertiary-color: #CBBADD;
 
   --text-color-primary: #2c3e50;
   --text-color-secondary: #555;
@@ -109,7 +109,7 @@ body.dark-theme {
   --primary-color: #84A98C;
   --secondary-color: #E4725C;
   --accent-color: #B5A3C3;
-  --tertiary-color: #B5A3C3;
+  --tertiary-color: #8E6CC3;
 
   --text-color-primary: #F0F2F5;
   --text-color-secondary: #A0A5B9;

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -291,7 +291,10 @@ body.dark-theme .detailed-metric-item .value-current {
 
 .meal-list li.completed {
     background-color: var(--color-success-bg);
-    border-left: 4px solid var(--color-success);
+}
+
+.meal-list li.completed .meal-color-bar {
+    background-color: var(--color-success);
 }
 
 .meal-list li.completed .meal-name {

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -127,3 +127,41 @@ test('populates daily plan with color bars and meal types', async () => {
   expect(cards[0].dataset.mealType).toBe('lunch');
   expect(cards[1].dataset.mealType).toBe('dinner');
 });
+
+test('applies success color to completed meal bar', async () => {
+  jest.resetModules();
+  const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+  const currentDayKey = dayNames[new Date().getDay()];
+  const mealStatusKey = `${currentDayKey}_0`;
+  const fullData = {
+    userName: 'Иван',
+    analytics: { current: {}, streak: {} },
+    planData: {
+      week1Menu: {
+        [currentDayKey]: [
+          { meal_name: 'Вкусен обяд', items: [] }
+        ]
+      }
+    },
+    dailyLogs: [{ date: new Date().toISOString().split('T')[0], data: { completedMealsStatus: { [mealStatusKey]: true } } }],
+    currentStatus: {},
+    initialData: {},
+    initialAnswers: {}
+  };
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: fullData,
+    todaysMealCompletionStatus: {},
+    planHasRecContent: false
+  }));
+  ({ populateUI } = await import('../populateUI.js'));
+
+  const style = document.createElement('style');
+  style.textContent = `#dailyMealList li.completed .meal-color-bar { background-color: rgb(46, 204, 113); }`;
+  document.head.appendChild(style);
+
+  populateUI();
+  const li = document.querySelector('#dailyMealList li.completed');
+  expect(li).not.toBeNull();
+  const color = getComputedStyle(li.querySelector('.meal-color-bar')).backgroundColor;
+  expect(color).toBe('rgb(46, 204, 113)');
+});


### PR DESCRIPTION
## Summary
- tweak `--tertiary-color` for light and dark themes
- adjust meal completion appearance
- test meal color bar styling when completed

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68801f9126248326a54eb43d923f67d1