### PR TITLE
Разширяване на откриването на типа хранене

### DIFF
--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -127,3 +127,38 @@ test('populates daily plan with color bars and meal types', async () => {
   expect(cards[0].dataset.mealType).toBe('lunch');
   expect(cards[1].dataset.mealType).toBe('dinner');
 });
+
+test('detects meal type variants correctly', async () => {
+  jest.resetModules();
+  const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+  const currentDayKey = dayNames[new Date().getDay()];
+  const fullData = {
+    userName: 'Иван',
+    analytics: { current: {}, streak: {} },
+    planData: {
+      week1Menu: {
+        [currentDayKey]: [
+          { meal_name: 'Бърз обед', items: [] },
+          { meal_name: 'Късен обяд', items: [] },
+          { meal_name: 'Вечерно хранене', items: [] }
+        ]
+      }
+    },
+    dailyLogs: [],
+    currentStatus: {},
+    initialData: {},
+    initialAnswers: {}
+  };
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: fullData,
+    todaysMealCompletionStatus: {},
+    planHasRecContent: false
+  }));
+  ({ populateUI } = await import('../populateUI.js'));
+  populateUI();
+  const cards = document.querySelectorAll('#dailyMealList .meal-card');
+  expect(cards.length).toBe(3);
+  expect(cards[0].dataset.mealType).toBe('lunch');
+  expect(cards[1].dataset.mealType).toBe('lunch');
+  expect(cards[2].dataset.mealType).toBe('dinner');
+});

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -252,8 +252,10 @@ function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {
         const mealStatusKey = `${currentDayKey}_${index}`;
 
         const lowerName = (mealItem.meal_name || '').toLowerCase();
-        if (lowerName.includes('обяд')) li.dataset.mealType = 'lunch';
-        else if (lowerName.includes('вечеря')) li.dataset.mealType = 'dinner';
+        const lunchVariants = ['обяд', 'обед'];
+        const dinnerVariants = ['вечеря', 'вечерно хранене'];
+        if (lunchVariants.some(v => lowerName.includes(v))) li.dataset.mealType = 'lunch';
+        else if (dinnerVariants.some(v => lowerName.includes(v))) li.dataset.mealType = 'dinner';
 
         let itemsHtml = (mealItem.items || []).map(i => {
             const name = i.name || 'Неизвестен продукт';


### PR DESCRIPTION
## Обобщение
- допълнени са проверки в `populateUI.js` за разпознаване на варианти като "обед" и "вечерно хранене"
- добавен е нов unit тест в `populateUI.test.js` за валидиране на тези наименования

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68801f9518688326994cecc23219b81d