### PR TITLE
Improve meal card hover colors

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -249,15 +249,18 @@ body.dark-theme .detailed-metric-item .value-current {
 
 /* Цветни фонове спрямо типа хранене */
 .meal-card[data-meal-type='lunch'] {
-  background: color-mix(in srgb, var(--surface-background) 90%, var(--primary-color));
+  --meal-color: var(--primary-color);
+  background: color-mix(in srgb, var(--surface-background) 90%, var(--meal-color));
 }
 
 .meal-card[data-meal-type='dinner'] {
-  background: color-mix(in srgb, var(--surface-background) 90%, var(--tertiary-color));
+  --meal-color: var(--tertiary-color);
+  background: color-mix(in srgb, var(--surface-background) 90%, var(--meal-color));
 }
 
 .meal-card[data-meal-type='breakfast'] {
-  background: color-mix(in srgb, var(--surface-background) 90%, var(--secondary-color));
+  --meal-color: var(--secondary-color);
+  background: color-mix(in srgb, var(--surface-background) 90%, var(--meal-color));
 }
 
 .meal-color-bar {
@@ -282,8 +285,20 @@ body.dark-theme .detailed-metric-item .value-current {
   background-color: var(--secondary-color);
 }
 
+.meal-card[data-meal-type='lunch']:hover {
+  background-color: color-mix(in srgb, var(--surface-background) 95%, var(--primary-color));
+}
+
+.meal-card[data-meal-type='dinner']:hover {
+  background-color: color-mix(in srgb, var(--surface-background) 95%, var(--tertiary-color));
+}
+
+.meal-card[data-meal-type='breakfast']:hover {
+  background-color: color-mix(in srgb, var(--surface-background) 95%, var(--secondary-color));
+}
+
 .meal-list li:hover {
-    background-color: color-mix(in srgb, var(--surface-background) 95%, var(--primary-color));
+    background-color: color-mix(in srgb, var(--surface-background) 95%, var(--meal-color, var(--primary-color)));
 }
 
 .meal-list li .meal-content-wrapper {


### PR DESCRIPTION
## Summary
- add `--meal-color` variable for each meal type
- adjust `.meal-list li:hover` to reference `--meal-color`
- add hover rules for specific meal types

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68802165c07c83269d0d47fab70f1c14