### PR TITLE
Improve meal type recognition

### DIFF
--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -130,6 +130,40 @@ test('populates daily plan with color bars and meal types', async () => {
   expect(cards[2].dataset.mealType).toBe('dinner');
 });
 
+test('handles meal type variations', async () => {
+  jest.resetModules();
+  const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+  const currentDayKey = dayNames[new Date().getDay()];
+  const fullData = {
+    userName: 'Иван',
+    analytics: { current: {}, streak: {} },
+    planData: {
+      week1Menu: {
+        [currentDayKey]: [
+          { meal_name: 'Ранна закуска', items: [] },
+          { meal_name: 'Обедно хранене', items: [] },
+          { meal_name: 'Вечерно хранене', items: [] }
+        ]
+      }
+    },
+    dailyLogs: [],
+    currentStatus: {},
+    initialData: {},
+    initialAnswers: {}
+  };
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: fullData,
+    todaysMealCompletionStatus: {},
+    planHasRecContent: false
+  }));
+  ({ populateUI } = await import('../populateUI.js'));
+  populateUI();
+  const cards = document.querySelectorAll('#dailyMealList .meal-card');
+  expect(cards[0].dataset.mealType).toBe('breakfast');
+  expect(cards[1].dataset.mealType).toBe('lunch');
+  expect(cards[2].dataset.mealType).toBe('dinner');
+});
+
 test('applies success color to completed meal bar', async () => {
   jest.resetModules();
   const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -252,9 +252,17 @@ function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {
         const mealStatusKey = `${currentDayKey}_${index}`;
 
         const lowerName = (mealItem.meal_name || '').toLowerCase();
-        if (lowerName.includes('обяд')) li.dataset.mealType = 'lunch';
-        else if (lowerName.includes('вечеря')) li.dataset.mealType = 'dinner';
-        else if (lowerName.includes('закуска')) li.dataset.mealType = 'breakfast';
+        const mealTypeKeywords = {
+            breakfast: ['закуска'],
+            lunch: ['обяд', 'обед', 'обедно хранене'],
+            dinner: ['вечеря', 'вечерно хранене', 'късна вечеря']
+        };
+        for (const [type, words] of Object.entries(mealTypeKeywords)) {
+            if (words.some(word => lowerName.includes(word))) {
+                li.dataset.mealType = type;
+                break;
+            }
+        }
 
         let itemsHtml = (mealItem.items || []).map(i => {
             const name = i.name || 'Неизвестен продукт';


### PR DESCRIPTION
## Summary
- recognize more meal names when setting `data-meal-type`
- test new variations for meal type detection

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688021c198388326b79c89628349fefe