### PR TITLE
Update card layouts

### DIFF
--- a/code.html
+++ b/code.html
@@ -368,7 +368,7 @@
             <!-- Основни Индекси -->
             <div class="main-indexes">
               <div class="card index-card" id="goalCard">
-                <h4>🎯 Напредък към Цел</h4>
+                <h4>🎯 Напредък към Цел <span id="goalProgressText" class="index-value">Изчисляване...</span></h4>
                 <div class="progress-bar-container">
                   <div
                     id="goalProgressBar"
@@ -380,10 +380,9 @@
                   <div id="goalProgressFill" class="progress-fill"></div>
                   </div>
                 </div>
-                <p id="goalProgressText" class="index-value">Изчисляване...</p>
               </div>
               <div class="card index-card" id="engagementCard">
-                <h4>🔗 Ангажираност</h4>
+                <h4>🔗 Ангажираност <span id="engagementProgressText" class="index-value">Изчисляване...</span></h4>
                 <div class="progress-bar-container">
                   <div
                     id="engagementProgressBar"
@@ -398,12 +397,9 @@
                     ></div>
                   </div>
                 </div>
-                <p id="engagementProgressText" class="index-value">
-                  Изчисляване...
-                </p>
               </div>
               <div class="card index-card" id="healthCard">
-                <h4>❤️ Отношение към здравето</h4>
+                <h4>❤️ Отношение към здравето <span id="healthProgressText" class="index-value">Изчисляване...</span></h4>
                 <div class="progress-bar-container">
                   <div
                     id="healthProgressBar"
@@ -415,14 +411,10 @@
                     <div id="healthProgressFill" class="progress-fill"></div>
                   </div>
                 </div>
-                <p id="healthProgressText" class="index-value">
-                  Изчисляване...
-                </p>
               </div>
               <div class="card index-card" id="streakCard">
                 <h4>🏅 Моите успехи</h4>
                 <div id="streakGrid" class="streak-grid"></div>
-                <p id="streakCount" class="index-value">0</p>
               </div>
               <div class="card index-card" id="progressHistoryCard">
                 <h4>

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -14,13 +14,14 @@
     cursor: pointer;
 }
 .index-card h4 {
-  font-size: 1.1rem; 
-  margin-bottom: var(--space-sm); 
+  font-size: 1.1rem;
+  margin-bottom: var(--space-sm);
   text-align: center;
   color: var(--text-color-secondary); display: flex; align-items: center;
   justify-content: center; gap: var(--space-xs);
-  margin-top: var(--space-xs); 
+  margin-top: var(--space-xs);
 }
+.index-card h4 .index-value { margin: 0; }
 .index-card .progress-bar-container {
   width: 100%;
   margin: var(--space-sm) auto;
@@ -67,12 +68,9 @@
 .achievement-medal {
   width: 24px;
   height: 24px;
-  border-radius: 50%;
-  background: var(--secondary-color);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-color-on-secondary);
   font-size: 1rem;
   cursor: pointer;
   transition: transform 0.3s ease;

--- a/css/responsive_styles.css
+++ b/css/responsive_styles.css
@@ -18,6 +18,7 @@
   .index-card { min-height: 123px; padding: var(--space-md); }
   .index-card h4 { font-size: 1rem; margin-bottom: var(--space-xs); }
   .index-card .index-value { font-size: 1.1rem; }
+  .index-card h4 .index-value { margin: 0; }
 
   .table-wrapper { border: none; box-shadow: none; background: transparent; overflow: visible; }
   table { border: none; } thead { display: none; }

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -12,7 +12,7 @@ beforeEach(async () => {
     <div id="goalProgressFill"></div><div id="goalProgressBar"></div><span id="goalProgressText"></span>
     <div id="engagementProgressFill"></div><div id="engagementProgressBar"></div><span id="engagementProgressText"></span>
     <div id="healthProgressFill"></div><div id="healthProgressBar"></div><span id="healthProgressText"></span>
-    <div id="streakGrid"></div><span id="streakCount"></span>
+    <div id="streakGrid"></div>
     <h3 id="dailyPlanTitle"></h3>
     <ul id="dailyMealList"></ul>
   `;
@@ -33,7 +33,6 @@ beforeEach(async () => {
     healthProgressBar: document.getElementById('healthProgressBar'),
     healthProgressText: document.getElementById('healthProgressText'),
     streakGrid: document.getElementById('streakGrid'),
-    streakCount: document.getElementById('streakCount'),
     dailyPlanTitle: document.getElementById('dailyPlanTitle'),
     dailyMealList: document.getElementById('dailyMealList')
   };
@@ -64,7 +63,6 @@ test('populates dashboard sections', () => {
   expect(document.getElementById('goalProgressText').textContent).toBe('50%');
   expect(document.getElementById('engagementProgressText').textContent).toBe('80%');
   expect(document.getElementById('healthProgressText').textContent).toBe('70%');
-  expect(document.getElementById('streakCount').textContent).toBe('5');
   expect(document.querySelectorAll('#streakGrid .streak-day.logged').length).toBe(1);
 });
 

--- a/js/achievements.js
+++ b/js/achievements.js
@@ -94,7 +94,6 @@ function renderAchievements(newIndex = -1) {
         el.dataset.index = index;
         selectors.streakGrid.appendChild(el);
     });
-    if (selectors.streakCount) selectors.streakCount.textContent = achievements.length;
 }
 
 export function createAchievement(title, message, emoji = null) {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -213,7 +213,6 @@ function populateDashboardStreak(streakData) {
         el.title = new Date(d.date).toLocaleDateString('bg-BG');
         selectors.streakGrid.appendChild(el);
     });
-    if (selectors.streakCount) selectors.streakCount.textContent = streakData?.currentCount || 0;
 }
 
 function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -45,7 +45,6 @@ export function initializeSelectors() {
         feedbackForm: 'feedbackForm',
         progressHistoryCard: 'progressHistoryCard',
         streakGrid: 'streakGrid',
-        streakCount: 'streakCount',
         achievementShareBtn: 'achievementShareBtn',
         analyticsCardsContainer: 'analyticsCardsContainer',
         tooltipTracker: 'tooltip-tracker',
@@ -71,7 +70,7 @@ export function initializeSelectors() {
                 'feedbackForm', 'tooltipTracker', 'planModificationBtn', 'planModInProgressIcon',
                 'planModChatModal', 'planModChatMessages', 'planModChatInput',
                 'planModChatSend', 'planModChatClose', 'planModChatClear',
-                'streakGrid', 'streakCount', 'analyticsCardsContainer', 'achievementShareBtn',
+                'streakGrid', 'analyticsCardsContainer', 'achievementShareBtn',
                 'goalCard', 'engagementCard', 'healthCard', 'streakCard',
                 'recFoodAllowedCard', 'recFoodLimitCard', 'recHydrationCard',
                 'recCookingMethodsCard', 'recSupplementsCard'


### PR DESCRIPTION
## Summary
- display goal, engagement and health values inline with card headers
- remove streak count and medal backgrounds
- clean up selectors and tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68802ab123a48326a7f00d0e58aa1460