### PR TITLE
Fix progress bar color fill

### DIFF
--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -226,15 +226,18 @@ describe('progress bar width handling', () => {
   };
 
   test.each([
-    [50, '50%', false],
-    [120, '100%', false],
-    [-10, '', true],
-    [0, '', true]
-  ])('value %i sets width %s', async (val, expectedWidth, hidden) => {
+    [50, '50%', false, 'var(--color-warning)'],
+    [120, '100%', false, 'var(--color-success)'],
+    [-10, '', true, ''],
+    [0, '', true, '']
+  ])('value %i sets width %s', async (val, expectedWidth, hidden, color) => {
     await setup(val);
     expect(document.getElementById('goalProgressFill').style.width).toBe(expectedWidth);
     expect(document.getElementById('engagementProgressFill').style.width).toBe(expectedWidth);
     expect(document.getElementById('healthProgressFill').style.width).toBe(expectedWidth);
+    expect(document.getElementById('goalProgressFill').style.background).toBe(color);
+    expect(document.getElementById('engagementProgressFill').style.background).toBe(color);
+    expect(document.getElementById('healthProgressFill').style.background).toBe(color);
     expect(document.getElementById('goalCard').classList.contains('hidden')).toBe(hidden);
     expect(document.getElementById('engagementCard').classList.contains('hidden')).toBe(hidden);
     expect(document.getElementById('healthCard').classList.contains('hidden')).toBe(hidden);

--- a/js/__tests__/sendTestImage.test.js
+++ b/js/__tests__/sendTestImage.test.js
@@ -19,7 +19,8 @@ beforeEach(async () => {
   }));
   jest.unstable_mockModule('../utils.js', () => ({
     fileToDataURL: jest.fn(async () => 'data:image/png;base64,imgdata'),
-    fileToText: jest.fn()
+    fileToText: jest.fn(),
+    getProgressColor: jest.fn()
   }));
 
   const mod = await import('../admin.js');

--- a/js/__tests__/sendTestQuestionnaire.test.js
+++ b/js/__tests__/sendTestQuestionnaire.test.js
@@ -23,7 +23,8 @@ beforeEach(async () => {
   }));
   jest.unstable_mockModule('../utils.js', () => ({
     fileToText: jest.fn(async () => '{"a":1}'),
-    fileToDataURL: jest.fn()
+    fileToDataURL: jest.fn(),
+    getProgressColor: jest.fn()
   }));
 
   const mod = await import('../admin.js');

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,7 +1,7 @@
 import { apiEndpoints } from './config.js';
 import { loadConfig, saveConfig } from './adminConfig.js';
 import { labelMap, statusMap } from './labelMap.js';
-import { fileToDataURL, fileToText } from './utils.js';
+import { fileToDataURL, fileToText, getProgressColor } from './utils.js';
 import { loadTemplateInto } from './templateLoader.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 
@@ -427,7 +427,9 @@ function renderAnalyticsCurrent(cur) {
             pb.className = 'progress-bar';
             const fill = document.createElement('div');
             fill.className = 'progress-fill';
-            fill.style.width = `${Math.max(0, Math.min(100, pct))}%`;
+            const bounded = Math.max(0, Math.min(100, pct));
+            fill.style.width = `${bounded}%`;
+            fill.style.background = getProgressColor(bounded);
             pb.appendChild(fill);
             pbContainer.appendChild(pb);
             dd.appendChild(pbContainer);

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,6 +1,6 @@
 // populateUI.js - Попълване на UI с данни
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
-import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml } from './utils.js';
+import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, getProgressColor } from './utils.js';
 import { generateId } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, planHasRecContent } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
@@ -46,7 +46,11 @@ function populateDashboardMainIndexes(currentAnalytics) {
         hide(selectors.goalCard);
     } else {
         show(selectors.goalCard);
-        if (selectors.goalProgressFill) selectors.goalProgressFill.style.width = `${Math.max(0, Math.min(100, goalProgressPercent))}%`;
+        if (selectors.goalProgressFill) {
+            const bounded = Math.max(0, Math.min(100, goalProgressPercent));
+            selectors.goalProgressFill.style.width = `${bounded}%`;
+            selectors.goalProgressFill.style.background = getProgressColor(bounded);
+        }
         if (selectors.goalProgressBar) selectors.goalProgressBar.setAttribute('aria-valuenow', `${Math.round(goalProgressPercent)}`);
         if (selectors.goalProgressText) {
             const goal = safeGet(fullDashboardData.initialAnswers, 'goal', '').toLowerCase();
@@ -68,7 +72,11 @@ function populateDashboardMainIndexes(currentAnalytics) {
         hide(selectors.engagementCard);
     } else {
         show(selectors.engagementCard);
-        if (selectors.engagementProgressFill) selectors.engagementProgressFill.style.width = `${Math.max(0, Math.min(100, engagementScore))}%`;
+        if (selectors.engagementProgressFill) {
+            const bounded = Math.max(0, Math.min(100, engagementScore));
+            selectors.engagementProgressFill.style.width = `${bounded}%`;
+            selectors.engagementProgressFill.style.background = getProgressColor(bounded);
+        }
         if (selectors.engagementProgressBar) selectors.engagementProgressBar.setAttribute('aria-valuenow', `${Math.round(engagementScore)}`);
         if (selectors.engagementProgressText) selectors.engagementProgressText.textContent = `${Math.round(engagementScore)}%`;
     }
@@ -78,7 +86,11 @@ function populateDashboardMainIndexes(currentAnalytics) {
         hide(selectors.healthCard);
     } else {
         show(selectors.healthCard);
-        if (selectors.healthProgressFill) selectors.healthProgressFill.style.width = `${Math.max(0, Math.min(100, healthScore))}%`;
+        if (selectors.healthProgressFill) {
+            const bounded = Math.max(0, Math.min(100, healthScore));
+            selectors.healthProgressFill.style.width = `${bounded}%`;
+            selectors.healthProgressFill.style.background = getProgressColor(bounded);
+        }
         if (selectors.healthProgressBar) selectors.healthProgressBar.setAttribute('aria-valuenow', `${Math.round(healthScore)}`);
         if (selectors.healthProgressText) selectors.healthProgressText.textContent = `${Math.round(healthScore)}%`;
     }
@@ -178,7 +190,9 @@ function populateDashboardDetailedAnalytics(analyticsData) {
             if (!isNaN(metric.currentValueNumeric)) {
                 const value = Number(metric.currentValueNumeric);
                 const percent = value <= 5 ? ((value - 1) / 4) * 100 : Math.max(0, Math.min(100, value));
-                fill.style.width = `${Math.max(0, Math.min(100, percent))}%`;
+                const bounded = Math.max(0, Math.min(100, percent));
+                fill.style.width = `${bounded}%`;
+                fill.style.background = getProgressColor(bounded);
             }
 
             cardsContainer.appendChild(card);

--- a/js/utils.js
+++ b/js/utils.js
@@ -92,3 +92,16 @@ export function fileToText(file) {
         reader.readAsText(file);
     });
 }
+
+/**
+ * Определя цвят за прогрес бар според процента.
+ * @param {number} percent - Стойност между 0 и 100.
+ * @returns {string} CSS цвят.
+ */
+export function getProgressColor(percent) {
+    const p = Number(percent);
+    if (isNaN(p)) return 'var(--color-danger)';
+    if (p >= 80) return 'var(--color-success)';
+    if (p >= 50) return 'var(--color-warning)';
+    return 'var(--color-danger)';
+}


### PR DESCRIPTION
## Summary
- add `getProgressColor` helper
- color bars in admin panel and dashboard cards with the helper
- adjust unit tests and mocks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68802c14838883268fa720a76525541f