### PR TITLE
Refine progress bar gradient

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -209,8 +209,9 @@ details[open] summary::after {
   overflow: hidden;
 }
 #analyticsSummary .progress-fill {
-  background: var(--progress-gradient);
+  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
   box-shadow: 0 0 6px var(--progress-bar-glow-color);
+  filter: drop-shadow(0 0 2px var(--progress-end-color));
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -59,7 +59,8 @@
 
   --progress-bar-bg-empty: #e9ecef;
   --progress-gradient: linear-gradient(to right, var(--color-danger), var(--color-warning), var(--color-success));
-  --progress-bar-glow-color: var(--color-success);
+  --progress-end-color: var(--color-success);
+  --progress-bar-glow-color: var(--progress-end-color);
   --progress-bar-height: 1rem;
   --progress-bar-radius: var(--radius-sm);
 

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -34,8 +34,9 @@
   overflow: hidden;
 }
 .progress-fill {
-  background: var(--progress-gradient);
+  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
   box-shadow: 0 0 6px var(--progress-bar-glow-color);
+  filter: drop-shadow(0 0 2px var(--progress-end-color));
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
@@ -111,8 +112,9 @@
   margin-bottom: var(--space-sm);
 }
 .analytics-card .mini-progress-fill {
-  background: var(--progress-gradient);
+  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
   box-shadow: 0 0 6px var(--progress-bar-glow-color);
+  filter: drop-shadow(0 0 2px var(--progress-end-color));
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;

--- a/js/__tests__/getProgressColor.test.js
+++ b/js/__tests__/getProgressColor.test.js
@@ -1,0 +1,13 @@
+import { getProgressColor } from '../utils.js';
+
+describe('getProgressColor', () => {
+  test.each([
+    [0, 'rgb(231, 76, 60)'],
+    [50, 'rgb(243, 156, 18)'],
+    [75, 'rgb(255, 203, 0)'],
+    [100, 'rgb(46, 204, 113)'],
+    [25, 'rgb(237, 116, 39)']
+  ])('returns color for %i%%', (pct, expected) => {
+    expect(getProgressColor(pct)).toBe(expected);
+  });
+});

--- a/js/__tests__/sendTestImage.test.js
+++ b/js/__tests__/sendTestImage.test.js
@@ -19,7 +19,8 @@ beforeEach(async () => {
   }));
   jest.unstable_mockModule('../utils.js', () => ({
     fileToDataURL: jest.fn(async () => 'data:image/png;base64,imgdata'),
-    fileToText: jest.fn()
+    fileToText: jest.fn(),
+    getProgressColor: jest.fn(() => 'rgb(0,0,0)')
   }));
 
   const mod = await import('../admin.js');

--- a/js/__tests__/sendTestQuestionnaire.test.js
+++ b/js/__tests__/sendTestQuestionnaire.test.js
@@ -23,7 +23,8 @@ beforeEach(async () => {
   }));
   jest.unstable_mockModule('../utils.js', () => ({
     fileToText: jest.fn(async () => '{"a":1}'),
-    fileToDataURL: jest.fn()
+    fileToDataURL: jest.fn(),
+    getProgressColor: jest.fn(() => 'rgb(0,0,0)')
   }));
 
   const mod = await import('../admin.js');

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,7 +1,7 @@
 import { apiEndpoints } from './config.js';
 import { loadConfig, saveConfig } from './adminConfig.js';
 import { labelMap, statusMap } from './labelMap.js';
-import { fileToDataURL, fileToText } from './utils.js';
+import { fileToDataURL, fileToText, getProgressColor } from './utils.js';
 import { loadTemplateInto } from './templateLoader.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 
@@ -427,6 +427,7 @@ function renderAnalyticsCurrent(cur) {
             pb.className = 'progress-bar';
             const fill = document.createElement('div');
             fill.className = 'progress-fill';
+            fill.style.setProperty('--progress-end-color', getProgressColor(pct));
             fill.style.width = `${Math.max(0, Math.min(100, pct))}%`;
             pb.appendChild(fill);
             pbContainer.appendChild(pb);

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,6 +1,6 @@
 // populateUI.js - Попълване на UI с данни
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
-import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml } from './utils.js';
+import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, getProgressColor } from './utils.js';
 import { generateId } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, planHasRecContent } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
@@ -46,7 +46,10 @@ function populateDashboardMainIndexes(currentAnalytics) {
         hide(selectors.goalCard);
     } else {
         show(selectors.goalCard);
-        if (selectors.goalProgressFill) selectors.goalProgressFill.style.width = `${Math.max(0, Math.min(100, goalProgressPercent))}%`;
+        if (selectors.goalProgressFill) {
+            selectors.goalProgressFill.style.setProperty('--progress-end-color', getProgressColor(goalProgressPercent));
+            selectors.goalProgressFill.style.width = `${Math.max(0, Math.min(100, goalProgressPercent))}%`;
+        }
         if (selectors.goalProgressBar) selectors.goalProgressBar.setAttribute('aria-valuenow', `${Math.round(goalProgressPercent)}`);
         if (selectors.goalProgressText) {
             const goal = safeGet(fullDashboardData.initialAnswers, 'goal', '').toLowerCase();
@@ -68,7 +71,10 @@ function populateDashboardMainIndexes(currentAnalytics) {
         hide(selectors.engagementCard);
     } else {
         show(selectors.engagementCard);
-        if (selectors.engagementProgressFill) selectors.engagementProgressFill.style.width = `${Math.max(0, Math.min(100, engagementScore))}%`;
+        if (selectors.engagementProgressFill) {
+            selectors.engagementProgressFill.style.setProperty('--progress-end-color', getProgressColor(engagementScore));
+            selectors.engagementProgressFill.style.width = `${Math.max(0, Math.min(100, engagementScore))}%`;
+        }
         if (selectors.engagementProgressBar) selectors.engagementProgressBar.setAttribute('aria-valuenow', `${Math.round(engagementScore)}`);
         if (selectors.engagementProgressText) selectors.engagementProgressText.textContent = `${Math.round(engagementScore)}%`;
     }
@@ -78,7 +84,10 @@ function populateDashboardMainIndexes(currentAnalytics) {
         hide(selectors.healthCard);
     } else {
         show(selectors.healthCard);
-        if (selectors.healthProgressFill) selectors.healthProgressFill.style.width = `${Math.max(0, Math.min(100, healthScore))}%`;
+        if (selectors.healthProgressFill) {
+            selectors.healthProgressFill.style.setProperty('--progress-end-color', getProgressColor(healthScore));
+            selectors.healthProgressFill.style.width = `${Math.max(0, Math.min(100, healthScore))}%`;
+        }
         if (selectors.healthProgressBar) selectors.healthProgressBar.setAttribute('aria-valuenow', `${Math.round(healthScore)}`);
         if (selectors.healthProgressText) selectors.healthProgressText.textContent = `${Math.round(healthScore)}%`;
     }
@@ -178,6 +187,7 @@ function populateDashboardDetailedAnalytics(analyticsData) {
             if (!isNaN(metric.currentValueNumeric)) {
                 const value = Number(metric.currentValueNumeric);
                 const percent = value <= 5 ? ((value - 1) / 4) * 100 : Math.max(0, Math.min(100, value));
+                fill.style.setProperty('--progress-end-color', getProgressColor(percent));
                 fill.style.width = `${Math.max(0, Math.min(100, percent))}%`;
             }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -92,3 +92,32 @@ export function fileToText(file) {
         reader.readAsText(file);
     });
 }
+
+/**
+ * Изчислява крайния цвят на прогрес бар спрямо процента.
+ * @param {number} percent Стойността в диапазона 0-100.
+ * @returns {string} CSS rgb() низ за крайния цвят.
+ */
+export function getProgressColor(percent) {
+    const stops = [
+        { pct: 0, color: [231, 76, 60] },       // червено
+        { pct: 50, color: [243, 156, 18] },     // оранжево
+        { pct: 75, color: [255, 203, 0] },      // жълто
+        { pct: 100, color: [46, 204, 113] }     // зелено
+    ];
+    const p = Math.max(0, Math.min(100, percent));
+    for (let i = 1; i < stops.length; i++) {
+        if (p <= stops[i].pct) {
+            const lower = stops[i - 1];
+            const upper = stops[i];
+            const range = upper.pct - lower.pct;
+            const t = range === 0 ? 0 : (p - lower.pct) / range;
+            const r = Math.round(lower.color[0] + (upper.color[0] - lower.color[0]) * t);
+            const g = Math.round(lower.color[1] + (upper.color[1] - lower.color[1]) * t);
+            const b = Math.round(lower.color[2] + (upper.color[2] - lower.color[2]) * t);
+            return `rgb(${r}, ${g}, ${b})`;
+        }
+    }
+    const c = stops[stops.length - 1].color;
+    return `rgb(${c[0]}, ${c[1]}, ${c[2]})`;
+}


### PR DESCRIPTION
## Summary
- tailor progress bar gradient to end at the current percent
- set glow color dynamically using the end color
- expose `getProgressColor` helper and tests
- adapt progress fill updates in dashboard and admin

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880336376f48326abda54cad557c277