### PR TITLE
Improve progress bar color handling

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -209,8 +209,8 @@ details[open] summary::after {
   overflow: hidden;
 }
 #analyticsSummary .progress-fill {
-  background: var(--progress-gradient);
-  box-shadow: 0 0 6px var(--progress-bar-glow-color);
+  background-color: var(--color-danger);
+  box-shadow: 0 0 6px var(--color-danger);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -34,8 +34,8 @@
   overflow: hidden;
 }
 .progress-fill {
-  background: var(--progress-gradient);
-  box-shadow: 0 0 6px var(--progress-bar-glow-color);
+  background-color: var(--color-danger);
+  box-shadow: 0 0 6px var(--color-danger);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
@@ -111,8 +111,8 @@
   margin-bottom: var(--space-sm);
 }
 .analytics-card .mini-progress-fill {
-  background: var(--progress-gradient);
-  box-shadow: 0 0 6px var(--progress-bar-glow-color);
+  background-color: var(--color-danger);
+  box-shadow: 0 0 6px var(--color-danger);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;

--- a/js/__tests__/sendTestImage.test.js
+++ b/js/__tests__/sendTestImage.test.js
@@ -19,7 +19,8 @@ beforeEach(async () => {
   }));
   jest.unstable_mockModule('../utils.js', () => ({
     fileToDataURL: jest.fn(async () => 'data:image/png;base64,imgdata'),
-    fileToText: jest.fn()
+    fileToText: jest.fn(),
+    applyProgressStyles: jest.fn()
   }));
 
   const mod = await import('../admin.js');

--- a/js/__tests__/sendTestQuestionnaire.test.js
+++ b/js/__tests__/sendTestQuestionnaire.test.js
@@ -23,7 +23,8 @@ beforeEach(async () => {
   }));
   jest.unstable_mockModule('../utils.js', () => ({
     fileToText: jest.fn(async () => '{"a":1}'),
-    fileToDataURL: jest.fn()
+    fileToDataURL: jest.fn(),
+    applyProgressStyles: jest.fn()
   }));
 
   const mod = await import('../admin.js');

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,7 +1,7 @@
 import { apiEndpoints } from './config.js';
 import { loadConfig, saveConfig } from './adminConfig.js';
 import { labelMap, statusMap } from './labelMap.js';
-import { fileToDataURL, fileToText } from './utils.js';
+import { fileToDataURL, fileToText, applyProgressStyles } from './utils.js';
 import { loadTemplateInto } from './templateLoader.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 
@@ -427,7 +427,7 @@ function renderAnalyticsCurrent(cur) {
             pb.className = 'progress-bar';
             const fill = document.createElement('div');
             fill.className = 'progress-fill';
-            fill.style.width = `${Math.max(0, Math.min(100, pct))}%`;
+            applyProgressStyles(fill, pct);
             pb.appendChild(fill);
             pbContainer.appendChild(pb);
             dd.appendChild(pbContainer);

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,6 +1,6 @@
 // populateUI.js - Попълване на UI с данни
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
-import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml } from './utils.js';
+import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressStyles } from './utils.js';
 import { generateId } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, planHasRecContent } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
@@ -46,7 +46,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
         hide(selectors.goalCard);
     } else {
         show(selectors.goalCard);
-        if (selectors.goalProgressFill) selectors.goalProgressFill.style.width = `${Math.max(0, Math.min(100, goalProgressPercent))}%`;
+        if (selectors.goalProgressFill) applyProgressStyles(selectors.goalProgressFill, goalProgressPercent);
         if (selectors.goalProgressBar) selectors.goalProgressBar.setAttribute('aria-valuenow', `${Math.round(goalProgressPercent)}`);
         if (selectors.goalProgressText) {
             const goal = safeGet(fullDashboardData.initialAnswers, 'goal', '').toLowerCase();
@@ -68,7 +68,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
         hide(selectors.engagementCard);
     } else {
         show(selectors.engagementCard);
-        if (selectors.engagementProgressFill) selectors.engagementProgressFill.style.width = `${Math.max(0, Math.min(100, engagementScore))}%`;
+        if (selectors.engagementProgressFill) applyProgressStyles(selectors.engagementProgressFill, engagementScore);
         if (selectors.engagementProgressBar) selectors.engagementProgressBar.setAttribute('aria-valuenow', `${Math.round(engagementScore)}`);
         if (selectors.engagementProgressText) selectors.engagementProgressText.textContent = `${Math.round(engagementScore)}%`;
     }
@@ -78,7 +78,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
         hide(selectors.healthCard);
     } else {
         show(selectors.healthCard);
-        if (selectors.healthProgressFill) selectors.healthProgressFill.style.width = `${Math.max(0, Math.min(100, healthScore))}%`;
+        if (selectors.healthProgressFill) applyProgressStyles(selectors.healthProgressFill, healthScore);
         if (selectors.healthProgressBar) selectors.healthProgressBar.setAttribute('aria-valuenow', `${Math.round(healthScore)}`);
         if (selectors.healthProgressText) selectors.healthProgressText.textContent = `${Math.round(healthScore)}%`;
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -92,3 +92,52 @@ export function fileToText(file) {
         reader.readAsText(file);
     });
 }
+
+/**
+ * Пресмята цвят на прогрес бар спрямо процент завършеност.
+ * 0% -> червено, 50% -> оранжево, 100% -> зелено.
+ * @param {number} percent Процентът на запълване.
+ * @returns {string} RGB(A) низ за използване като цвят.
+ */
+export function getProgressColor(percent) {
+    const clamp = Math.max(0, Math.min(100, Number(percent)));
+    const hexToRgb = (hex) => {
+        const clean = hex.replace('#', '');
+        const num = parseInt(clean.length === 3 ? clean.split('').map(c => c + c).join('') : clean, 16);
+        return {
+            r: (num >> 16) & 255,
+            g: (num >> 8) & 255,
+            b: num & 255
+        };
+    };
+    const mix = (c1, c2, f) => ({
+        r: Math.round(c1.r + (c2.r - c1.r) * f),
+        g: Math.round(c1.g + (c2.g - c1.g) * f),
+        b: Math.round(c1.b + (c2.b - c1.b) * f)
+    });
+    const danger = hexToRgb('#e74c3c');
+    const warning = hexToRgb('#f39c12');
+    const success = hexToRgb('#2ecc71');
+    let rgb;
+    if (clamp <= 50) {
+        rgb = mix(danger, warning, clamp / 50);
+    } else {
+        rgb = mix(warning, success, (clamp - 50) / 50);
+    }
+    return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.85)`;
+}
+
+/**
+ * Прилага стил на прогрес елемент според зададения процент.
+ * Задава ширина, фон и лек глоу ефект.
+ * @param {HTMLElement} el Елементът на прогрес бара.
+ * @param {number} percent Процентът на запълване.
+ */
+export function applyProgressStyles(el, percent) {
+    if (!el) return;
+    const pct = Math.max(0, Math.min(100, Number(percent)));
+    const color = getProgressColor(pct);
+    el.style.width = `${pct}%`;
+    el.style.backgroundColor = color;
+    el.style.boxShadow = `0 0 6px ${color}`;
+}


### PR DESCRIPTION
## Summary
- compute progress color based on percentage
- apply dynamic color with glow effect in progress bars
- adjust CSS defaults for progress bars
- update tests for new util

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688032d8d9c4832682705766ee8afc3e