### PR TITLE
Add glow and animation to progress bars

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -206,16 +206,19 @@ details[open] summary::after {
   border-radius: var(--progress-bar-radius);
   position: relative;
   height: var(--progress-bar-height);
-  overflow: hidden;
+  overflow: visible;
 }
 #analyticsSummary .progress-fill {
   background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
-  box-shadow: 0 0 6px var(--progress-bar-glow-color);
+  box-shadow: 0 0 6px var(--progress-bar-glow-color), 0 0 4px var(--progress-end-color);
   filter: drop-shadow(0 0 2px var(--progress-end-color));
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
   border-radius: inherit;
+}
+#analyticsSummary .progress-fill.animate-progress {
+  animation: progress-grow 0.8s forwards;
 }
 
 .button-small {

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -346,3 +346,6 @@ body.dark-theme .button-icon-only:hover { background-color: rgba(255,255,255,0.0
 .soft-shadow {
   box-shadow: var(--shadow-soft);
 }
+
+@keyframes progress-grow { from { width: 0; } to { width: var(--target-width); } }
+

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -28,16 +28,21 @@
   height: 8px;
   background-color: var(--surface-background);
   border-radius: var(--radius-sm);
-  overflow: hidden;
+  overflow: visible;
   margin: 0 auto;
   max-width: 300px;
 }
 .step-progress-bar {
   height: 100%;
   background-color: var(--secondary-color);
+  box-shadow: 0 0 6px var(--progress-bar-glow-color), 0 0 4px var(--progress-end-color);
+  filter: drop-shadow(0 0 2px var(--progress-end-color));
   width: 0%;
   transition: width 0.4s ease-in-out;
   border-radius: var(--radius-sm);
+}
+.step-progress-bar.animate-progress {
+  animation: progress-grow 0.4s forwards;
 }
 
 .accordion-container {

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -31,16 +31,25 @@
   border-radius: 6px;
   position: relative;
   height: 12px;
-  overflow: hidden;
+  overflow: visible;
 }
 .progress-fill {
   background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
-  box-shadow: 0 0 6px var(--progress-bar-glow-color);
+  box-shadow: 0 0 6px var(--progress-bar-glow-color), 0 0 4px var(--progress-end-color);
   filter: drop-shadow(0 0 2px var(--progress-end-color));
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
   border-radius: inherit;
+}
+
+.progress-fill.animate-progress {
+  animation: progress-grow 0.8s forwards;
+}
+
+@keyframes progress-grow {
+  from { width: 0; }
+  to { width: var(--target-width); }
 }
 .index-card .index-value {
   font-size: 1.2rem; font-weight: 700; color: var(--primary-color);
@@ -108,17 +117,20 @@
   border-radius: var(--progress-bar-radius);
   position: relative;
   height: 0.5rem;
-  overflow: hidden;
+  overflow: visible;
   margin-bottom: var(--space-sm);
 }
 .analytics-card .mini-progress-fill {
   background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
-  box-shadow: 0 0 6px var(--progress-bar-glow-color);
+  box-shadow: 0 0 6px var(--progress-bar-glow-color), 0 0 4px var(--progress-end-color);
   filter: drop-shadow(0 0 2px var(--progress-end-color));
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
   border-radius: inherit;
+}
+.analytics-card .mini-progress-fill.animate-progress {
+  animation: progress-grow 0.8s forwards;
 }
 .analytics-card { cursor: pointer; }
 .metric-current-text {

--- a/js/__tests__/assistantChatImagePreview.test.js
+++ b/js/__tests__/assistantChatImagePreview.test.js
@@ -19,7 +19,8 @@ beforeEach(async () => {
     cloudflareAccountId: 'c'
   }));
   jest.unstable_mockModule('../utils.js', () => ({
-    fileToDataURL: jest.fn(async () => 'data:image/png;base64,imgdata')
+    fileToDataURL: jest.fn(async () => 'data:image/png;base64,imgdata'),
+    animateProgressFill: jest.fn()
   }));
 
   global.fetch = jest.fn().mockResolvedValue({

--- a/js/__tests__/assistantChatModelAgreement.test.js
+++ b/js/__tests__/assistantChatModelAgreement.test.js
@@ -19,7 +19,8 @@ beforeEach(async () => {
     cloudflareAccountId: 'c'
   }));
   jest.unstable_mockModule('../utils.js', () => ({
-    fileToDataURL: jest.fn(async () => 'data:image/png;base64,imgdata')
+    fileToDataURL: jest.fn(async () => 'data:image/png;base64,imgdata'),
+    animateProgressFill: jest.fn()
   }));
 
   global.fetch = jest.fn().mockResolvedValue({

--- a/js/__tests__/sendTestImage.test.js
+++ b/js/__tests__/sendTestImage.test.js
@@ -20,7 +20,8 @@ beforeEach(async () => {
   jest.unstable_mockModule('../utils.js', () => ({
     fileToDataURL: jest.fn(async () => 'data:image/png;base64,imgdata'),
     fileToText: jest.fn(),
-    getProgressColor: jest.fn(() => 'rgb(0,0,0)')
+    getProgressColor: jest.fn(() => 'rgb(0,0,0)'),
+    animateProgressFill: jest.fn()
   }));
 
   const mod = await import('../admin.js');

--- a/js/__tests__/sendTestQuestionnaire.test.js
+++ b/js/__tests__/sendTestQuestionnaire.test.js
@@ -24,7 +24,8 @@ beforeEach(async () => {
   jest.unstable_mockModule('../utils.js', () => ({
     fileToText: jest.fn(async () => '{"a":1}'),
     fileToDataURL: jest.fn(),
-    getProgressColor: jest.fn(() => 'rgb(0,0,0)')
+    getProgressColor: jest.fn(() => 'rgb(0,0,0)'),
+    animateProgressFill: jest.fn()
   }));
 
   const mod = await import('../admin.js');

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,7 +1,7 @@
 import { apiEndpoints } from './config.js';
 import { loadConfig, saveConfig } from './adminConfig.js';
 import { labelMap, statusMap } from './labelMap.js';
-import { fileToDataURL, fileToText, getProgressColor } from './utils.js';
+import { fileToDataURL, fileToText, getProgressColor, animateProgressFill } from './utils.js';
 import { loadTemplateInto } from './templateLoader.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 
@@ -428,7 +428,7 @@ function renderAnalyticsCurrent(cur) {
             const fill = document.createElement('div');
             fill.className = 'progress-fill';
             fill.style.setProperty('--progress-end-color', getProgressColor(pct));
-            fill.style.width = `${Math.max(0, Math.min(100, pct))}%`;
+            animateProgressFill(fill, pct);
             pb.appendChild(fill);
             pbContainer.appendChild(pb);
             dd.appendChild(pbContainer);

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,6 +1,6 @@
 // populateUI.js - Попълване на UI с данни
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
-import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, getProgressColor } from './utils.js';
+import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, getProgressColor, animateProgressFill } from './utils.js';
 import { generateId } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, planHasRecContent } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
@@ -48,7 +48,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
         show(selectors.goalCard);
         if (selectors.goalProgressFill) {
             selectors.goalProgressFill.style.setProperty('--progress-end-color', getProgressColor(goalProgressPercent));
-            selectors.goalProgressFill.style.width = `${Math.max(0, Math.min(100, goalProgressPercent))}%`;
+            animateProgressFill(selectors.goalProgressFill, goalProgressPercent);
         }
         if (selectors.goalProgressBar) selectors.goalProgressBar.setAttribute('aria-valuenow', `${Math.round(goalProgressPercent)}`);
         if (selectors.goalProgressText) {
@@ -73,7 +73,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
         show(selectors.engagementCard);
         if (selectors.engagementProgressFill) {
             selectors.engagementProgressFill.style.setProperty('--progress-end-color', getProgressColor(engagementScore));
-            selectors.engagementProgressFill.style.width = `${Math.max(0, Math.min(100, engagementScore))}%`;
+            animateProgressFill(selectors.engagementProgressFill, engagementScore);
         }
         if (selectors.engagementProgressBar) selectors.engagementProgressBar.setAttribute('aria-valuenow', `${Math.round(engagementScore)}`);
         if (selectors.engagementProgressText) selectors.engagementProgressText.textContent = `${Math.round(engagementScore)}%`;
@@ -86,7 +86,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
         show(selectors.healthCard);
         if (selectors.healthProgressFill) {
             selectors.healthProgressFill.style.setProperty('--progress-end-color', getProgressColor(healthScore));
-            selectors.healthProgressFill.style.width = `${Math.max(0, Math.min(100, healthScore))}%`;
+            animateProgressFill(selectors.healthProgressFill, healthScore);
         }
         if (selectors.healthProgressBar) selectors.healthProgressBar.setAttribute('aria-valuenow', `${Math.round(healthScore)}`);
         if (selectors.healthProgressText) selectors.healthProgressText.textContent = `${Math.round(healthScore)}%`;
@@ -188,7 +188,7 @@ function populateDashboardDetailedAnalytics(analyticsData) {
                 const value = Number(metric.currentValueNumeric);
                 const percent = value <= 5 ? ((value - 1) / 4) * 100 : Math.max(0, Math.min(100, value));
                 fill.style.setProperty('--progress-end-color', getProgressColor(percent));
-                fill.style.width = `${Math.max(0, Math.min(100, percent))}%`;
+                animateProgressFill(fill, percent);
             }
 
             cardsContainer.appendChild(card);

--- a/js/stepProgress.js
+++ b/js/stepProgress.js
@@ -1,7 +1,9 @@
+import { animateProgressFill } from './utils.js';
+
 export function updateStepProgress(barEl, currentStep, totalSteps, currentLabelEl, totalLabelEl) {
   if (barEl && totalSteps > 0) {
     const percent = Math.round((Math.max(0, currentStep) / totalSteps) * 100);
-    barEl.style.width = `${Math.max(0, Math.min(100, percent))}%`;
+    animateProgressFill(barEl, percent);
   }
   if (currentLabelEl) currentLabelEl.textContent = currentStep;
   if (totalLabelEl) totalLabelEl.textContent = totalSteps;

--- a/js/utils.js
+++ b/js/utils.js
@@ -121,3 +121,20 @@ export function getProgressColor(percent) {
     const c = stops[stops.length - 1].color;
     return `rgb(${c[0]}, ${c[1]}, ${c[2]})`;
 }
+
+/**
+ * Анимира плавно запълването на елемент от 0 до подадения процент.
+ * @param {HTMLElement} el Елементът, представляващ запълването.
+ * @param {number} percent Процент за крайна широчина.
+ */
+export function animateProgressFill(el, percent) {
+    if (!el) return;
+    const target = Math.max(0, Math.min(100, percent));
+    el.style.setProperty("--target-width", `${target}%`);
+    el.style.width = `${target}%`;
+    el.classList.add("animate-progress");
+    el.addEventListener("animationend", () => {
+        el.classList.remove("animate-progress");
+    }, { once: true });
+}
+


### PR DESCRIPTION
## Summary
- improve progress bar glow by using drop shadows on all sides
- animate progress bar fill with new `animateProgressFill` helper
- adjust styles for admin, dashboard and component progress bars
- update tests to mock new helper

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68803756325c83269c2eb6b428acf134