### PR TITLE
Update meal completion flow

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -264,6 +264,7 @@ body.dark-theme .detailed-metric-item .value-current {
   margin-right: var(--space-md);
   height: 100%;
   align-self: stretch;
+  cursor: pointer;
 }
 
 .meal-card[data-meal-type='dinner'] .meal-color-bar {
@@ -326,6 +327,7 @@ body.dark-theme .detailed-metric-item .value-current {
 
 .meal-list li.completed {
     background-color: var(--color-success-bg);
+    border-left: 4px solid color-mix(in srgb, var(--meal-color) 80%, white);
 }
 
 .meal-list li.completed .meal-color-bar {
@@ -358,7 +360,6 @@ body.dark-theme .detailed-metric-item .value-current {
     height: 1.6em;
 }
 
-.actions button.complete:hover { color: var(--color-success); }
 .actions button.info:hover { color: var(--secondary-color); }
 
 

--- a/css/responsive_styles.css
+++ b/css/responsive_styles.css
@@ -157,6 +157,12 @@
   }
   header h1 { font-size: 1.2rem; }
   .card { padding: var(--space-md); }
+  .meal-list li {
+    padding: var(--space-sm);
+  }
+  .meal-list li .actions {
+    margin-top: var(--space-sm);
+  }
   /* .actions button svg.icon { width: 1.4em; height: 1.4em; } */ /* This seems too generic for meal list actions, already handled there */
   .modal-content { padding: var(--space-md); }
   #toast { width: calc(100% - 2 * var(--space-md)); }

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -122,6 +122,9 @@ test('populates daily plan with color bars and meal types', async () => {
   expect(cards.length).toBe(3);
   cards.forEach(card => {
     expect(card.querySelector('.meal-color-bar')).not.toBeNull();
+    expect(card.dataset.day).toBeDefined();
+    expect(card.dataset.index).toBeDefined();
+    expect(card.querySelector('button.complete')).toBeNull();
   });
   expect(cards[0].dataset.mealType).toBe('breakfast');
   expect(cards[1].dataset.mealType).toBe('lunch');

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -288,11 +288,11 @@ function handleDelegatedClicks(event) {
         if (type && key) openInfoModalWithDetails(key, type);
         return;
     }
-    const completeButton = target.closest('button.complete');
-    if (completeButton) {
+    const colorBar = target.closest('.meal-color-bar');
+    if (colorBar) {
         event.stopPropagation();
-        const day = completeButton.dataset.day; const index = completeButton.dataset.index;
-        const mealItemLi = completeButton.closest('li');
+        const mealItemLi = colorBar.closest('li');
+        const day = mealItemLi?.dataset.day; const index = mealItemLi?.dataset.index;
         if (mealItemLi && day && index !== undefined) {
             const isCompleted = mealItemLi.classList.toggle('completed');
             todaysMealCompletionStatus[`${day}_${index}`] = isCompleted; // Modifies global state from app.js

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -258,6 +258,8 @@ function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {
     dailyPlanData.forEach((mealItem, index) => {
         const li = document.createElement('li');
         li.classList.add('card', 'meal-card', 'soft-shadow');
+        li.dataset.day = currentDayKey;
+        li.dataset.index = index;
         const mealStatusKey = `${currentDayKey}_${index}`;
 
         const lowerName = (mealItem.meal_name || '').toLowerCase();
@@ -292,7 +294,6 @@ function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {
             </div>
             <div class="actions">
                 ${recipeButtonHtml}
-                <button class="button-icon-only complete" data-day="${currentDayKey}" data-index="${index}" title="Отбележи като изпълнено" aria-label="Отбележи ${mealItem.meal_name || 'храненето'} като изпълнено"><svg class="icon"><use href="#icon-check"/></svg></button>
             </div>`;
 
         if (todaysMealCompletionStatus[mealStatusKey] === true) {


### PR DESCRIPTION
## Summary
- mark meal cards as completed via `.meal-color-bar` instead of button
- add data attributes for day and index on each meal card
- show completion line and pointer styles
- adjust mobile spacing for meal cards
- update tests for new markup

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68803a0f4a2c83268a02a1b2ea72c4dd