### PR TITLE
Improve progress bar glow

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -209,13 +209,22 @@ details[open] summary::after {
   overflow: visible;
 }
 #analyticsSummary .progress-fill {
+  position: relative;
   background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
-  box-shadow: 0 0 6px var(--progress-bar-glow-color), 0 0 4px var(--progress-end-color);
-  filter: drop-shadow(0 0 2px var(--progress-end-color));
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
   border-radius: inherit;
+}
+#analyticsSummary .progress-fill::after {
+  content: '';
+  position: absolute;
+  inset: -2px 0;
+  background: inherit;
+  border-radius: inherit;
+  filter: blur(4px);
+  opacity: 0.6;
+  z-index: -1;
 }
 #analyticsSummary .progress-fill.animate-progress {
   animation: progress-grow 0.8s forwards;

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -60,7 +60,7 @@
   --progress-bar-bg-empty: #e9ecef;
   --progress-gradient: linear-gradient(to right, var(--color-danger), var(--color-warning), var(--color-success));
   --progress-end-color: var(--color-success);
-  --progress-bar-glow-color: var(--progress-end-color);
+  --progress-bar-glow-color: color-mix(in srgb, var(--progress-end-color) 60%, transparent);
   --progress-bar-height: 1rem;
   --progress-bar-radius: var(--radius-sm);
 

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -33,13 +33,22 @@
   max-width: 300px;
 }
 .step-progress-bar {
+  position: relative;
   height: 100%;
   background-color: var(--secondary-color);
-  box-shadow: 0 0 6px var(--progress-bar-glow-color), 0 0 4px var(--progress-end-color);
-  filter: drop-shadow(0 0 2px var(--progress-end-color));
   width: 0%;
   transition: width 0.4s ease-in-out;
   border-radius: var(--radius-sm);
+}
+.step-progress-bar::after {
+  content: '';
+  position: absolute;
+  inset: -2px 0;
+  background: inherit;
+  border-radius: inherit;
+  filter: blur(3px);
+  opacity: 0.6;
+  z-index: -1;
 }
 .step-progress-bar.animate-progress {
   animation: progress-grow 0.4s forwards;

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -34,13 +34,22 @@
   overflow: visible;
 }
 .progress-fill {
+  position: relative;
   background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
-  box-shadow: 0 0 6px var(--progress-bar-glow-color), 0 0 4px var(--progress-end-color);
-  filter: drop-shadow(0 0 2px var(--progress-end-color));
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
   border-radius: inherit;
+}
+.progress-fill::after {
+  content: '';
+  position: absolute;
+  inset: -2px 0;
+  background: inherit;
+  border-radius: inherit;
+  filter: blur(4px);
+  opacity: 0.6;
+  z-index: -1;
 }
 
 .progress-fill.animate-progress {
@@ -121,13 +130,22 @@
   margin-bottom: var(--space-sm);
 }
 .analytics-card .mini-progress-fill {
+  position: relative;
   background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
-  box-shadow: 0 0 6px var(--progress-bar-glow-color), 0 0 4px var(--progress-end-color);
-  filter: drop-shadow(0 0 2px var(--progress-end-color));
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
   border-radius: inherit;
+}
+.analytics-card .mini-progress-fill::after {
+  content: '';
+  position: absolute;
+  inset: -2px 0;
+  background: inherit;
+  border-radius: inherit;
+  filter: blur(3px);
+  opacity: 0.6;
+  z-index: -1;
 }
 .analytics-card .mini-progress-fill.animate-progress {
   animation: progress-grow 0.8s forwards;


### PR DESCRIPTION
## Summary
- tone down progress bar glow
- keep glow gradient in sync with fill color

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68803b764880832681f94254022ac827