### PR TITLE
Refine progress bar glow

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -219,11 +219,11 @@ details[open] summary::after {
 #analyticsSummary .progress-fill::after {
   content: '';
   position: absolute;
-  inset: -2px 0;
+  inset: -2px;
   background: inherit;
   border-radius: inherit;
-  filter: blur(4px);
-  opacity: 0.6;
+  filter: blur(3px);
+  opacity: 0.45;
   z-index: -1;
 }
 #analyticsSummary .progress-fill.animate-progress {

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -44,11 +44,11 @@
 .progress-fill::after {
   content: '';
   position: absolute;
-  inset: -2px 0;
+  inset: -2px;
   background: inherit;
   border-radius: inherit;
-  filter: blur(4px);
-  opacity: 0.6;
+  filter: blur(3px);
+  opacity: 0.45;
   z-index: -1;
 }
 
@@ -140,11 +140,11 @@
 .analytics-card .mini-progress-fill::after {
   content: '';
   position: absolute;
-  inset: -2px 0;
+  inset: -2px;
   background: inherit;
   border-radius: inherit;
-  filter: blur(3px);
-  opacity: 0.6;
+  filter: blur(2px);
+  opacity: 0.45;
   z-index: -1;
 }
 .analytics-card .mini-progress-fill.animate-progress {


### PR DESCRIPTION
## Summary
- tweak progress bar glow to be subtler
- ensure glow extends slightly beyond bar edges

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68803d90fea48326a6b5ecfa990ad5d1