### PR TITLE
Adjust progress bar glow

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -207,6 +207,7 @@ details[open] summary::after {
   position: relative;
   height: var(--progress-bar-height);
   overflow: visible;
+  z-index: 0;
 }
 #analyticsSummary .progress-fill {
   position: relative;
@@ -215,16 +216,18 @@ details[open] summary::after {
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
   border-radius: inherit;
+  z-index: 1;
 }
 #analyticsSummary .progress-fill::after {
   content: '';
   position: absolute;
   inset: -2px;
-  background: inherit;
+  background: var(--progress-bar-glow-color);
   border-radius: inherit;
-  filter: blur(3px);
-  opacity: 0.45;
-  z-index: -1;
+  filter: blur(4px);
+  opacity: 0.25;
+  z-index: 0;
+  pointer-events: none;
 }
 #analyticsSummary .progress-fill.animate-progress {
   animation: progress-grow 0.8s forwards;

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -32,6 +32,7 @@
   position: relative;
   height: 12px;
   overflow: visible;
+  z-index: 0;
 }
 .progress-fill {
   position: relative;
@@ -40,16 +41,18 @@
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
   border-radius: inherit;
+  z-index: 1;
 }
 .progress-fill::after {
   content: '';
   position: absolute;
   inset: -2px;
-  background: inherit;
+  background: var(--progress-bar-glow-color);
   border-radius: inherit;
-  filter: blur(3px);
-  opacity: 0.45;
-  z-index: -1;
+  filter: blur(4px);
+  opacity: 0.25;
+  z-index: 0;
+  pointer-events: none;
 }
 
 .progress-fill.animate-progress {
@@ -128,6 +131,7 @@
   height: 0.5rem;
   overflow: visible;
   margin-bottom: var(--space-sm);
+  z-index: 0;
 }
 .analytics-card .mini-progress-fill {
   position: relative;
@@ -136,16 +140,18 @@
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
   border-radius: inherit;
+  z-index: 1;
 }
 .analytics-card .mini-progress-fill::after {
   content: '';
   position: absolute;
   inset: -2px;
-  background: inherit;
+  background: var(--progress-bar-glow-color);
   border-radius: inherit;
-  filter: blur(2px);
-  opacity: 0.45;
-  z-index: -1;
+  filter: blur(3px);
+  opacity: 0.25;
+  z-index: 0;
+  pointer-events: none;
 }
 .analytics-card .mini-progress-fill.animate-progress {
   animation: progress-grow 0.8s forwards;


### PR DESCRIPTION
## Summary
- make progress bar glow subtler
- ensure glow extends past bar edge

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68803f5fa5388326b7772a292cf1b706