### PR TITLE
Replace star emoji rating and add icons

### DIFF
--- a/code.html
+++ b/code.html
@@ -1206,11 +1206,11 @@
                 autocomplete="off"
               >
                 <option value="">Без оценка</option>
-                <option value="5">⭐⭐⭐⭐⭐ (Отлично)</option>
-                <option value="4">⭐⭐⭐⭐ (Много добре)</option>
-                <option value="3">⭐⭐⭐ (Добре)</option>
-                <option value="2">⭐⭐ (Задоволително)</option>
-                <option value="1">⭐ (Лошо)</option>
+                <option value="5">5 – Отлично</option>
+                <option value="4">4 – Много добре</option>
+                <option value="3">3 – Добре</option>
+                <option value="2">2 – Задоволително</option>
+                <option value="1">1 – Лошо</option>
               </select>
             </div>
             <button

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -91,6 +91,7 @@
   align-items: center;
   justify-content: center;
   font-size: 1rem;
+  line-height: 1;
   cursor: pointer;
   transition: transform 0.3s ease;
 }

--- a/css/extra_meal_form_styles.css
+++ b/css/extra_meal_form_styles.css
@@ -154,6 +154,7 @@
     font-size: 1.1em;
     display: inline-flex;
     align-items: center;
+    vertical-align: middle;
     justify-content: center;
 }
 

--- a/extra-meal-entry-form.html
+++ b/extra-meal-entry-form.html
@@ -1,4 +1,5 @@
 <!-- extra-meal-entry-form.html -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 <form id="extraMealEntryFormActual" aria-labelledby="extraMealModalFormTitle" novalidate>
     <div class="form-wizard-header" style="margin-bottom: var(--space-lg);">
         <h3 id="extraMealModalFormTitle" style="text-align:center; margin-bottom: var(--space-md);">Добавяне на Извънредно Хранене</h3>


### PR DESCRIPTION
## Summary
- include Bootstrap icons in the extra meal entry form snippet
- simplify rating options to numeric text
- tune achievement medal alignment
- ensure emoji icons align inside extra meal form

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880406f70608326912463b305cb13ba