### PR TITLE
Update completed meal styles

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -367,11 +367,11 @@ body.dark-theme .detailed-metric-item .value-current {
 
 .meal-list li.completed {
     background-color: var(--color-success-bg);
-    border-left: 4px solid color-mix(in srgb, var(--meal-color) 30%, white);
+    border-left: 2px solid color-mix(in srgb, var(--meal-color) 60%, white);
 }
 
 .meal-list li.completed .meal-color-bar {
-    background-color: var(--color-success);
+    background-color: var(--meal-color);
 }
 
 .meal-list li.completed .meal-name {

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -203,6 +203,44 @@ test('applies success color to completed meal bar', async () => {
   expect(color).toBe('rgb(46, 204, 113)');
 });
 
+test('applies border color on completed meal', async () => {
+  jest.resetModules();
+  const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+  const currentDayKey = dayNames[new Date().getDay()];
+  const mealStatusKey = `${currentDayKey}_0`;
+  const fullData = {
+    userName: 'Иван',
+    analytics: { current: {}, streak: {} },
+    planData: {
+      week1Menu: {
+        [currentDayKey]: [
+          { meal_name: 'Вкусен обяд', items: [] }
+        ]
+      }
+    },
+    dailyLogs: [{ date: new Date().toISOString().split('T')[0], data: { completedMealsStatus: { [mealStatusKey]: true } } }],
+    currentStatus: {},
+    initialData: {},
+    initialAnswers: {}
+  };
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: fullData,
+    todaysMealCompletionStatus: {},
+    planHasRecContent: false
+  }));
+  ({ populateUI } = await import('../populateUI.js'));
+
+  const style = document.createElement('style');
+  style.textContent = `#dailyMealList li.completed { border-left-color: rgb(1, 2, 3); border-left-width: 2px; }`;
+  document.head.appendChild(style);
+
+  populateUI();
+  const li = document.querySelector('#dailyMealList li.completed');
+  expect(li).not.toBeNull();
+  const color = getComputedStyle(li).borderLeftColor;
+  expect(color).toBe('rgb(1, 2, 3)');
+});
+
 describe('progress bar width handling', () => {
   const setup = async (value) => {
     jest.resetModules();


### PR DESCRIPTION
## Summary
- adjust completed meal styles
- keep meal color bar in sync with meal types
- check border color for completed meals

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68804285efdc8326a6d954a672f6b33a