### PR TITLE
Responsive adjustments for mobile layout

### DIFF
--- a/css/responsive_styles.css
+++ b/css/responsive_styles.css
@@ -158,10 +158,11 @@
   header h1 { font-size: 1.2rem; }
   .card { padding: var(--space-md); }
   .meal-list li {
-    padding: var(--space-sm);
+    padding: var(--space-xs);
   }
   .meal-list li .actions {
-    margin-top: var(--space-sm);
+    flex-direction: row;
+    margin-top: var(--space-xs);
   }
   /* .actions button svg.icon { width: 1.4em; height: 1.4em; } */ /* This seems too generic for meal list actions, already handled there */
   .modal-content { padding: var(--space-md); }
@@ -192,13 +193,13 @@
 
   .chat-widget {
     bottom: calc(var(--tabs-height) + var(--space-sm) + 65px); /* account for bottom nav */
-    height: 70vh;
-    max-height: 450px;
+    height: 65vh;
+    max-height: 400px;
     border-radius: var(--radius-md);
   }
   .plan-mod-chat-content {
-    height: 70vh;
-    max-height: 450px;
+    height: 65vh;
+    max-height: 400px;
     border-radius: var(--radius-md);
   }
    .chat-header { padding: var(--space-xs) var(--space-sm); }
@@ -212,7 +213,7 @@
    .plan-mod-chat-close { font-size: 1.3rem; }
 
 
-   .chat-messages { padding: var(--space-sm); gap: var(--space-xs); }
+   .chat-messages { padding: var(--space-xs); gap: var(--space-xs); }
    #chat-input {
        min-height: 38px;
        border-radius: 19px; 

--- a/js/__tests__/responsiveStyles.test.js
+++ b/js/__tests__/responsiveStyles.test.js
@@ -1,0 +1,11 @@
+import fs from 'fs';
+
+// Simple unit test to verify responsive CSS rules for meal list on very small screens
+
+describe('responsive styles', () => {
+  test('meal list actions collapse on small screens', () => {
+    const css = fs.readFileSync('css/responsive_styles.css', 'utf8');
+    const pattern = /@media \(max-width: 480px\)[\s\S]*?\.meal-list li \{[\s\S]*?padding:\s*var\(--space-xs\);[\s\S]*?\}[\s\S]*?\.meal-list li .actions \{[\s\S]*?flex-direction:\s*row;[\s\S]*?margin-top:\s*var\(--space-xs\);/;
+    expect(css).toMatch(pattern);
+  });
+});


### PR DESCRIPTION
## Summary
- tweak meal list spacing for max-width 480px and keep actions in a row
- reduce chat widget height and padding in the same media block
- add test for responsive CSS rules

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688044d642408326a77c72530a6cf280