### PR TITLE
Корекция на стила за изпълнени хранения

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -367,11 +367,11 @@ body.dark-theme .detailed-metric-item .value-current {
 
 .meal-list li.completed {
     background-color: var(--color-success-bg);
-    border-left: 4px solid color-mix(in srgb, var(--meal-color) 30%, white);
+    border-left: 2px solid color-mix(in srgb, var(--meal-color) 60%, white);
 }
 
 .meal-list li.completed .meal-color-bar {
-    background-color: var(--color-success);
+    background-color: var(--meal-color);
 }
 
 .meal-list li.completed .meal-name {

--- a/js/__tests__/dashboardPanelStyles.test.js
+++ b/js/__tests__/dashboardPanelStyles.test.js
@@ -1,0 +1,19 @@
+import fs from 'fs';
+
+// Проверяваме дали правилото за .meal-list li.completed съдържа коректен цвят
+// за бордера
+
+describe('dashboard_panel_styles.css', () => {
+  test('completed meal border-left color', () => {
+    const css = fs.readFileSync('css/dashboard_panel_styles.css', 'utf8');
+    const ruleMatch = css.match(/\.meal-list li\.completed\s*{([^}]*)}/);
+    expect(ruleMatch).not.toBeNull();
+    const rule = ruleMatch[1];
+    const borderMatch = rule.match(/border-left:\s*([^;]+);/);
+    expect(borderMatch).not.toBeNull();
+    const border = borderMatch[1].trim();
+    expect(border).toBe(
+      '2px solid color-mix(in srgb, var(--meal-color) 60%, white)'
+    );
+  });
+});


### PR DESCRIPTION
## Обобщение
- променен е `border-left` в `css/dashboard_panel_styles.css` според изискванията
- цветната лента при изпълнено хранене вече използва собствения цвят на храната
- добавен е тест `dashboardPanelStyles.test.js` за проверка на стойността на `border-left`

## Тестване
- `npm run lint`
- `npm test` *(неуспех поради недостиг на памет)*

------
https://chatgpt.com/codex/tasks/task_e_688045a99ae4832680be5c7e00bafabe