### PR TITLE
Add animated meal completion tick

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -376,8 +376,23 @@ body.dark-theme .detailed-metric-item .value-current {
 }
 
 .meal-list li.completed .meal-name {
-    text-decoration: line-through;
-    opacity: 0.7;
+    opacity: 0.9;
+}
+
+.meal-list li .check-icon {
+    display: none;
+    margin-left: var(--space-sm);
+    color: var(--color-success, var(--primary-color));
+}
+
+.meal-list li.completed .check-icon {
+    display: inline-block;
+    animation: checkmark-pop 0.3s ease-out;
+}
+
+@keyframes checkmark-pop {
+    from { transform: scale(0); opacity: 0; }
+    to { transform: scale(1); opacity: 1; }
 }
 
 /* Секцията с бутони - КЛЮЧОВИ ПРОМЕНИ ЗА ВИСОЧИНАТА ТУК */

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -289,7 +289,9 @@ function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {
         li.innerHTML = `
             <div class="meal-color-bar"></div>
             <div class="meal-content-wrapper">
-                <h2 class="meal-name">${mealItem.meal_name || 'Хранене'}</h2>
+                <h2 class="meal-name">${mealItem.meal_name || 'Хранене'}
+                    <span class="check-icon" aria-hidden="true"><svg class="icon"><use href="#icon-check"/></svg></span>
+                </h2>
                 <div class="meal-items">${itemsHtml}</div>
             </div>
             <div class="actions">


### PR DESCRIPTION
## Summary
- show a completion check mark next to meal name instead of strike-through
- keep the check mark hidden until the meal is marked as completed

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max_old_space_size=4096 npm test -- -w=1` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6880489bcef0832699138609afd59f12