### PR TITLE
Замяна на "Дневен план" с "Меню"

### DIFF
--- a/code.html
+++ b/code.html
@@ -487,14 +487,14 @@
             </div>
             <!-- Край Акордеон детайлни показатели -->
 
-            <!-- Дневен План -->
+            <!-- Меню -->
             <div class="card">
-              <h3 id="dailyPlanTitle"><svg class="icon"><use href="#icon-utensils"></use></svg> Дневен План (Зареждане...)</h3>
+              <h3 id="dailyPlanTitle"><svg class="icon"><use href="#icon-utensils"></use></svg> Меню (Зареждане...)</h3>
               <ul id="dailyMealList" class="meal-list">
                 <li class="placeholder">Зареждане на храненията...</li>
               </ul>
             </div>
-            <!-- Край Дневен План -->
+            <!-- Край Меню -->
 
             <!-- Дневник (с интегрирано тегло) -->
             <div class="card">

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -258,7 +258,7 @@ body.dark-theme .detailed-metric-item .value-current {
 }
 #dashboardTextualAnalysis p.placeholder { font-style: italic; }
 
-/* --- Дневен План с корекции за бутоните --- */
+/* --- Меню с корекции за бутоните --- */
 .meal-list {
     margin-top: var(--space-sm);
 }

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -237,11 +237,11 @@ function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {
     const currentDayKey = dayNames[today.getDay()];
     const todayTitle = today.toLocaleDateString('bg-BG', { weekday: 'long', day: 'numeric', month: 'long' });
 
-    if(selectors.dailyPlanTitle) selectors.dailyPlanTitle.textContent = `📅 Дневен План (${capitalizeFirstLetter(todayTitle)})`;
+    if(selectors.dailyPlanTitle) selectors.dailyPlanTitle.textContent = `📅 Меню (${capitalizeFirstLetter(todayTitle)})`;
 
     const dailyPlanData = safeGet(week1Menu, currentDayKey, []);
     if (!dailyPlanData || dailyPlanData.length === 0) {
-        listElement.innerHTML = '<li class="placeholder">Няма наличен план за днес.</li>'; return;
+        listElement.innerHTML = '<li class="placeholder">Няма налично меню за днес.</li>'; return;
     }
     listElement.innerHTML = '';
 


### PR DESCRIPTION
## Извършени промени
- Заглавието и коментарите в `code.html` са обновени от **„Дневен План“** на **„Меню“**.
- Съответните текстове в `populateUI.js` са коригирани, включително съобщението при липса на меню.
- Обновен е стиловият файл `dashboard_panel_styles.css` за съответствие с новото наименование.

## Тестове и проверки
- `npm run lint` премина успешно.
- `npm test` стартира, но `populateUI.test.js` прекъсва поради недостиг на памет. Останалите тестове минават.


------
https://chatgpt.com/codex/tasks/task_e_68804b149dac8326baa4d5a7cfc29188