### PR TITLE
Adjust checkmark style

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -383,10 +383,7 @@ body.dark-theme .detailed-metric-item .value-current {
 .meal-list li .check-icon {
     display: none;
     margin-left: 1ch; /* На един знак от името */
-    color: color-mix(in srgb,
-        var(--color-success, var(--primary-color)) 70%,
-        var(--surface-background) 30%);
-    font-weight: bold;
+    font-weight: normal;
 }
 
 .meal-list li .check-icon svg.icon {
@@ -399,6 +396,7 @@ body.dark-theme .detailed-metric-item .value-current {
 
 .meal-list li.completed .check-icon {
     display: inline-block;
+    color: color-mix(in srgb, var(--meal-color) 60%, white); /* Същият цвят като вертикалната линия */
     animation: checkmark-pop 0.3s ease-out;
 }
 


### PR DESCRIPTION
## Summary
- tweak dashboard checkmark style to match meal bar color

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test -- -i` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688050a38ab88326a51ed93a55736f7b