### PR TITLE
Refine progress bar gradient

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -211,7 +211,7 @@ details[open] summary::after {
 }
 #analyticsSummary .progress-fill {
   position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
+  background: var(--progress-gradient);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -68,7 +68,13 @@
   --color-info: #3498db; --color-info-bg: rgba(52, 152, 219, 0.1);
 
   --progress-bar-bg-empty: #e9ecef;
-  --progress-gradient: linear-gradient(to right, var(--color-danger), var(--color-warning), var(--color-success));
+  --progress-gradient: linear-gradient(
+    to right,
+    var(--color-danger) 0%,
+    var(--color-warning) 50%,
+    #ffcb00 75%,
+    var(--color-success) 100%
+  );
   --progress-end-color: var(--color-success);
   --progress-bar-glow-color: color-mix(in srgb, var(--progress-end-color) 60%, transparent);
   --progress-bar-height: 1rem;

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -36,7 +36,7 @@
 }
 .progress-fill {
   position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
+  background: var(--progress-gradient);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
@@ -136,7 +136,7 @@
 }
 .analytics-card .mini-progress-fill {
   position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
+  background: var(--progress-gradient);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;


### PR DESCRIPTION
## Summary
- add defined multi-stop gradient variables
- apply the gradient to dashboard and admin progress bars

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6880d7014c788326917caa49c92e5a6f