### PR TITLE
Добавяне на икона за асистент

### DIFF
--- a/assistant.html
+++ b/assistant.html
@@ -20,10 +20,16 @@
     <symbol id="icon-trash" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3 6h18M8 6V4h8v2m-6 4v8m-4-8v8m8-8v8M6 6v12a2 2 0 002 2h8a2 2 0 002-2V6" />
     </symbol>
+    <symbol id="icon-assistant" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2a7 7 0 0 1 7 7c0 5-7 11-7 11S5 14 5 9a7 7 0 0 1 7-7z"/>
+      <circle cx="10" cy="9" r="1"/>
+      <circle cx="14" cy="9" r="1"/>
+      <path d="M9 12c1 1 5 1 6 0"/>
+    </symbol>
 </svg>
 <div id="chat-widget" class="chat-widget visible" role="log" aria-live="polite">
     <div class="chat-header">
-        <h4>💬 Cloudflare Асистент</h4>
+        <h4><svg class="icon assistant-icon" aria-hidden="true"><use href="#icon-assistant"></use></svg> Cloudflare Асистент</h4>
         <button id="chat-clear" class="chat-clear-btn" aria-label="Изчисти чата">
             <svg class="icon"><use href="#icon-trash"></use></svg>
         </button>

--- a/code.html
+++ b/code.html
@@ -211,6 +211,12 @@
       <symbol id="icon-droplet" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5">
         <path d="M12 2.25c-2.35 2.8-7.5 8.11-7.5 11.25a7.5 7.5 0 0 0 15 0c0-3.14-5.15-8.45-7.5-11.25z" />
       </symbol>
+      <symbol id="icon-assistant" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M12 2a7 7 0 0 1 7 7c0 5-7 11-7 11S5 14 5 9a7 7 0 0 1 7-7z" />
+        <circle cx="10" cy="9" r="1" />
+        <circle cx="14" cy="9" r="1" />
+        <path d="M9 12c1 1 5 1 6 0" />
+      </symbol>
     </svg>
     <!-- ======================= END SVG ICONS DEFINITION ====================== -->
 
@@ -1232,7 +1238,7 @@
       >
         <div class="modal-content plan-mod-chat-content">
           <div class="plan-mod-chat-header">
-            <h4 id="planModChatTitle">💬 Промяна на план</h4>
+            <h4 id="planModChatTitle"><svg class="icon assistant-icon" aria-hidden="true"><use href="#icon-assistant"></use></svg> Промяна на план</h4>
             <div class="chat-actions">
               <button
                 id="planModChatClear"
@@ -1281,7 +1287,7 @@
         aria-expanded="false"
         aria-controls="chat-widget"
       >
-        💬
+        <svg class="icon assistant-icon" aria-hidden="true"><use href="#icon-assistant"></use></svg>
       </button>
       <!-- ======================= END FLOATING ACTION BUTTONS =================== -->
 
@@ -1290,7 +1296,7 @@
       <!-- ======================================================================= -->
       <div id="chat-widget" class="chat-widget" role="log" aria-live="polite">
         <div class="chat-header">
-          <h4>💬 Чат с Асистент</h4>
+          <h4><svg class="icon assistant-icon" aria-hidden="true"><use href="#icon-assistant"></use></svg> Чат с Асистент</h4>
           <div class="chat-actions">
             <button
               id="chat-clear"

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -242,7 +242,8 @@
   display: flex; justify-content: space-between; align-items: center;
 }
 .chat-header h4 { margin: 0; font-size: 1.1rem; color: var(--chat-header-text); display: flex; align-items: center; }
-.chat-header h4 .emoji { margin-right: var(--space-sm); font-size: 1em; } 
+.chat-header h4 .emoji { margin-right: var(--space-sm); font-size: 1em; }
+.chat-header h4 .icon { margin-right: var(--space-sm); }
 .chat-header .chat-actions { display: flex; gap: var(--space-xs); align-items: center; }
 .chat-close-btn,
 .chat-clear-btn {
@@ -321,3 +322,16 @@ body.dark-theme .chat-messages .message.bot { color: #e0e0e0; }
 }
 #chat-upload svg { width: 20px; height: 20px; }
 #chat-upload:hover { background-color: var(--secondary-color); }
+
+@keyframes assistantPulse {
+  0%,100% { transform: scale(1); }
+  50%     { transform: scale(1.05); }
+}
+#chat-fab svg.assistant-icon {
+  width: 32px;
+  height: 32px;
+  animation: assistantPulse 2s infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  #chat-fab svg.assistant-icon { animation: none; }
+}


### PR DESCRIPTION
## Резюме
- добавен SVG символ `icon-assistant` в assistant.html и code.html
- обновени бутоните и заглавията на чата да използват новата икона
- анимирана икона в #chat-fab
- малък CSS стил за разстояние на иконите в заглавията

## Тестване
- `npm run lint`
- `npm test` *(неуспешен поради ограничения в средата)*

------
https://chatgpt.com/codex/tasks/task_e_6880e1bd56d08326b01af310482108f6