### PR TITLE
Refine progress bar gradient

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -211,7 +211,7 @@ details[open] summary::after {
 }
 #analyticsSummary .progress-fill {
   position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
+  background: var(--progress-gradient);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -64,11 +64,18 @@
 
   --color-success: #2ecc71; --color-success-bg: rgba(46, 204, 113, 0.1);
   --color-warning: #f39c12; --color-warning-bg: rgba(243, 156, 18, 0.1);
+  --color-yellow: #ffcb00;
   --color-danger: #e74c3c; --color-danger-bg: rgba(231, 76, 60, 0.1);
   --color-info: #3498db; --color-info-bg: rgba(52, 152, 219, 0.1);
 
   --progress-bar-bg-empty: #e9ecef;
-  --progress-gradient: linear-gradient(to right, var(--color-danger), var(--color-warning), var(--color-success));
+  --progress-gradient: linear-gradient(
+    to right,
+    var(--color-danger) 0%,
+    var(--color-warning) 50%,
+    var(--color-yellow) 75%,
+    var(--color-success) 100%
+  );
   --progress-end-color: var(--color-success);
   --progress-bar-glow-color: color-mix(in srgb, var(--progress-end-color) 60%, transparent);
   --progress-bar-height: 1rem;

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -36,7 +36,7 @@
 }
 .progress-fill {
   position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
+  background: var(--progress-gradient);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
@@ -136,7 +136,7 @@
 }
 .analytics-card .mini-progress-fill {
   position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
+  background: var(--progress-gradient);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;


### PR DESCRIPTION
## Summary
- add `--color-yellow` and multi-color gradient vars
- use `--progress-gradient` for progress bar fills

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6880e5abd1148326b8567aecba8c3632