### PR TITLE
Refactor progress bar overlay

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -202,7 +202,7 @@ details[open] summary::after {
   margin-top: 4px;
 }
 #analyticsSummary .progress-bar {
-  background: var(--surface-background);
+  background: var(--progress-gradient);
   border-radius: var(--progress-bar-radius);
   position: relative;
   height: var(--progress-bar-height);
@@ -210,11 +210,14 @@ details[open] summary::after {
   z-index: 0;
 }
 #analyticsSummary .progress-fill {
-  position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background: var(--surface-background);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
-  width: 0;
+  width: 100%;
   border-radius: inherit;
   z-index: 1;
 }
@@ -230,7 +233,12 @@ details[open] summary::after {
   pointer-events: none;
 }
 #analyticsSummary .progress-fill.animate-progress {
-  animation: progress-grow 0.8s forwards;
+  animation: progress-shrink 0.8s forwards;
+}
+
+@keyframes progress-shrink {
+  from { width: 100%; }
+  to { width: calc(100% - var(--target-width)); }
 }
 
 .button-small {

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -27,7 +27,7 @@
   margin: var(--space-sm) auto;
 }
 .progress-bar {
-  background: var(--surface-background);
+  background: var(--progress-gradient);
   border-radius: 6px;
   position: relative;
   height: 12px;
@@ -35,11 +35,14 @@
   z-index: 0;
 }
 .progress-fill {
-  position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background: var(--surface-background);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
-  width: 0;
+  width: 100%;
   border-radius: inherit;
   z-index: 1;
 }
@@ -56,12 +59,12 @@
 }
 
 .progress-fill.animate-progress {
-  animation: progress-grow 0.8s forwards;
+  animation: progress-shrink 0.8s forwards;
 }
 
-@keyframes progress-grow {
-  from { width: 0; }
-  to { width: var(--target-width); }
+@keyframes progress-shrink {
+  from { width: 100%; }
+  to { width: calc(100% - var(--target-width)); }
 }
 .index-card .index-value {
   font-size: 1.2rem; font-weight: 700; color: var(--primary-color);
@@ -126,7 +129,7 @@
   font-size: 1.05rem;
 }
 .analytics-card .mini-progress-bar {
-  background: var(--surface-background);
+  background: var(--progress-gradient);
   border-radius: var(--progress-bar-radius);
   position: relative;
   height: 0.5rem;
@@ -135,11 +138,14 @@
   z-index: 0;
 }
 .analytics-card .mini-progress-fill {
-  position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background: var(--surface-background);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
-  width: 0;
+  width: 100%;
   border-radius: inherit;
   z-index: 1;
 }
@@ -155,7 +161,7 @@
   pointer-events: none;
 }
 .analytics-card .mini-progress-fill.animate-progress {
-  animation: progress-grow 0.8s forwards;
+  animation: progress-shrink 0.8s forwards;
 }
 .analytics-card { cursor: pointer; }
 .metric-current-text {

--- a/js/utils.js
+++ b/js/utils.js
@@ -123,15 +123,15 @@ export function getProgressColor(percent) {
 }
 
 /**
- * Анимира плавно запълването на елемент от 0 до подадения процент.
- * @param {HTMLElement} el Елементът, представляващ запълването.
- * @param {number} percent Процент за крайна широчина.
+ * Анимира плавно свиването на оверлея, покриващ непопълнената част на бара.
+ * @param {HTMLElement} el Елементът-оверлей.
+ * @param {number} percent Процент на изпълнение.
  */
 export function animateProgressFill(el, percent) {
     if (!el) return;
     const target = Math.max(0, Math.min(100, percent));
     el.style.setProperty("--target-width", `${target}%`);
-    el.style.width = `${target}%`;
+    el.style.width = `calc(100% - ${target}%)`;
     el.classList.add("animate-progress");
     el.addEventListener("animationend", () => {
         el.classList.remove("animate-progress");


### PR DESCRIPTION
## Summary
- keep gradient background on progress-bar container
- turn progress-fill into a right-aligned overlay
- animate overlay shrink via new `progress-shrink` keyframe
- update JS animation helper

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6880e51d01a883269d8d419fa03b9d3b