### PR TITLE
Add radar chart template

### DIFF
--- a/radar-chart-template.html
+++ b/radar-chart-template.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Радарна диаграма - шаблон</title>
+  <link rel="stylesheet" href="css/base_styles.css">
+  <link rel="stylesheet" href="css/components_styles.css">
+  <link rel="stylesheet" href="css/dashboard_panel_styles.css">
+  <link rel="stylesheet" href="css/responsive_styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+</head>
+<body>
+  <div class="card" style="max-width:480px;margin:2rem auto;">
+    <h3><i class="bi bi-graph-up"></i> Радарна диаграма</h3>
+    <div class="chart-container">
+      <canvas id="radarChart" width="320" height="240"></canvas>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script>
+    const ctx = document.getElementById('radarChart').getContext('2d');
+    new Chart(ctx, {
+      type: 'radar',
+      data: {
+        labels: ['Сила', 'Издръжливост', 'Гъвкавост', 'Бързина', 'Баланс'],
+        datasets: [{
+          label: 'Примерни стойности',
+          data: [80, 60, 70, 50, 90],
+          backgroundColor: 'rgba(91, 192, 222, 0.2)',
+          borderColor: 'rgba(91, 192, 222, 1)',
+          pointBackgroundColor: 'rgba(91, 192, 222, 1)'
+        }]
+      },
+      options: {
+        responsive: true,
+        scales: {
+          r: { beginAtZero: true, suggestedMax: 100 }
+        }
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML example with Chart.js radar diagram for future analytics module work

## Testing
- `npm run lint`
- `npm test` *(fails: a Jest worker was killed)*

------
https://chatgpt.com/codex/tasks/task_e_688115f7097c8326acd48d5ee5ea8e58