### PR TITLE
Обновление на прогрес баровете

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -211,11 +211,17 @@ details[open] summary::after {
 }
 #analyticsSummary .progress-fill {
   position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
-  height: 100%;
-  transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
-  width: 0;
-  border-radius: inherit;
+  height: 6px;
+  border-radius: 3px;
+  background-image: linear-gradient(
+      to right,
+      rgba(255, 46, 46, 0.25),
+      var(--progress-end-color)
+  );
+  background-size: 0% 100%;
+  background-repeat: no-repeat;
+  transition: background-size 0.6s ease-out;
+  width: 100%;
   z-index: 1;
 }
 #analyticsSummary .progress-fill::after {
@@ -228,9 +234,6 @@ details[open] summary::after {
   opacity: 0.25;
   z-index: 0;
   pointer-events: none;
-}
-#analyticsSummary .progress-fill.animate-progress {
-  animation: progress-grow 0.8s forwards;
 }
 
 .button-small {

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -36,11 +36,17 @@
 }
 .progress-fill {
   position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
-  height: 100%;
-  transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
-  width: 0;
-  border-radius: inherit;
+  height: 6px;
+  border-radius: 3px;
+  background-image: linear-gradient(
+      to right,
+      rgba(255, 46, 46, 0.25),
+      var(--progress-end-color)
+  );
+  background-size: 0% 100%;
+  background-repeat: no-repeat;
+  transition: background-size 0.6s ease-out;
+  width: 100%;
   z-index: 1;
 }
 .progress-fill::after {
@@ -55,14 +61,6 @@
   pointer-events: none;
 }
 
-.progress-fill.animate-progress {
-  animation: progress-grow 0.8s forwards;
-}
-
-@keyframes progress-grow {
-  from { width: 0; }
-  to { width: var(--target-width); }
-}
 .index-card .index-value {
   font-size: 1.2rem; font-weight: 700; color: var(--primary-color);
   text-align: center;
@@ -136,11 +134,17 @@
 }
 .analytics-card .mini-progress-fill {
   position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
-  height: 100%;
-  transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
-  width: 0;
-  border-radius: inherit;
+  height: 6px;
+  border-radius: 3px;
+  background-image: linear-gradient(
+      to right,
+      rgba(255, 46, 46, 0.25),
+      var(--progress-end-color)
+  );
+  background-size: 0% 100%;
+  background-repeat: no-repeat;
+  transition: background-size 0.6s ease-out;
+  width: 100%;
   z-index: 1;
 }
 .analytics-card .mini-progress-fill::after {
@@ -153,9 +157,6 @@
   opacity: 0.25;
   z-index: 0;
   pointer-events: none;
-}
-.analytics-card .mini-progress-fill.animate-progress {
-  animation: progress-grow 0.8s forwards;
 }
 .analytics-card { cursor: pointer; }
 .metric-current-text {

--- a/js/__tests__/getProgressColor.test.js
+++ b/js/__tests__/getProgressColor.test.js
@@ -2,11 +2,11 @@ import { getProgressColor } from '../utils.js';
 
 describe('getProgressColor', () => {
   test.each([
-    [0, 'rgb(231, 76, 60)'],
-    [50, 'rgb(243, 156, 18)'],
-    [75, 'rgb(255, 203, 0)'],
-    [100, 'rgb(46, 204, 113)'],
-    [25, 'rgb(237, 116, 39)']
+    [0, 'rgba(255, 46, 46, 0.25)'],
+    [50, 'rgba(247, 227, 0, 0.45)'],
+    [75, 'rgba(197, 230, 17, 0.55)'],
+    [100, 'rgba(46, 204, 113, 0.65)'],
+    [25, 'rgba(255, 165, 0, 0.35)']
   ])('returns color for %i%%', (pct, expected) => {
     expect(getProgressColor(pct)).toBe(expected);
   });

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -293,15 +293,15 @@ describe('progress bar width handling', () => {
   };
 
   test.each([
-    [50, '50%', false],
-    [120, '100%', false],
+    [50, '50% 100%', false],
+    [120, '100% 100%', false],
     [-10, '', true],
     [0, '', true]
   ])('value %i sets width %s', async (val, expectedWidth, hidden) => {
     await setup(val);
-    expect(document.getElementById('goalProgressFill').style.width).toBe(expectedWidth);
-    expect(document.getElementById('engagementProgressFill').style.width).toBe(expectedWidth);
-    expect(document.getElementById('healthProgressFill').style.width).toBe(expectedWidth);
+    expect(document.getElementById('goalProgressFill').style.backgroundSize).toBe(expectedWidth);
+    expect(document.getElementById('engagementProgressFill').style.backgroundSize).toBe(expectedWidth);
+    expect(document.getElementById('healthProgressFill').style.backgroundSize).toBe(expectedWidth);
     expect(document.getElementById('goalCard').classList.contains('hidden')).toBe(hidden);
     expect(document.getElementById('engagementCard').classList.contains('hidden')).toBe(hidden);
     expect(document.getElementById('healthCard').classList.contains('hidden')).toBe(hidden);

--- a/js/utils.js
+++ b/js/utils.js
@@ -100,10 +100,11 @@ export function fileToText(file) {
  */
 export function getProgressColor(percent) {
     const stops = [
-        { pct: 0, color: [231, 76, 60] },       // червено
-        { pct: 50, color: [243, 156, 18] },     // оранжево
-        { pct: 75, color: [255, 203, 0] },      // жълто
-        { pct: 100, color: [46, 204, 113] }     // зелено
+        { pct: 0, color: [255, 46, 46, 0.25] },
+        { pct: 25, color: [255, 165, 0, 0.35] },
+        { pct: 50, color: [247, 227, 0, 0.45] },
+        { pct: 75, color: [197, 230, 17, 0.55] },
+        { pct: 100, color: [46, 204, 113, 0.65] }
     ];
     const p = Math.max(0, Math.min(100, percent));
     for (let i = 1; i < stops.length; i++) {
@@ -115,11 +116,12 @@ export function getProgressColor(percent) {
             const r = Math.round(lower.color[0] + (upper.color[0] - lower.color[0]) * t);
             const g = Math.round(lower.color[1] + (upper.color[1] - lower.color[1]) * t);
             const b = Math.round(lower.color[2] + (upper.color[2] - lower.color[2]) * t);
-            return `rgb(${r}, ${g}, ${b})`;
+            const a = +(lower.color[3] + (upper.color[3] - lower.color[3]) * t).toFixed(2);
+            return `rgba(${r}, ${g}, ${b}, ${a})`;
         }
     }
     const c = stops[stops.length - 1].color;
-    return `rgb(${c[0]}, ${c[1]}, ${c[2]})`;
+    return `rgba(${c[0]}, ${c[1]}, ${c[2]}, ${c[3]})`;
 }
 
 /**
@@ -130,11 +132,15 @@ export function getProgressColor(percent) {
 export function animateProgressFill(el, percent) {
     if (!el) return;
     const target = Math.max(0, Math.min(100, percent));
-    el.style.setProperty("--target-width", `${target}%`);
-    el.style.width = `${target}%`;
-    el.classList.add("animate-progress");
-    el.addEventListener("animationend", () => {
-        el.classList.remove("animate-progress");
-    }, { once: true });
+    if (el.classList.contains('step-progress-bar')) {
+        el.style.setProperty('--target-width', `${target}%`);
+        el.style.width = `${target}%`;
+        el.classList.add('animate-progress');
+        el.addEventListener('animationend', () => {
+            el.classList.remove('animate-progress');
+        }, { once: true });
+    } else {
+        el.style.backgroundSize = `${target}% 100%`;
+    }
 }
 


### PR DESCRIPTION
## Summary
- добавен е градиент и плавно запълване за `.progress-fill`
- обновена е логиката за изчисляване на цвета в `getProgressColor`
- промени в `animateProgressFill` за работа с новия градиент
- адаптирани са тестовете към новите стилове

## Testing
- `npm run lint`
- `npm test` *(fail: js/__tests__/populateUI.test.js OOM)*

------
https://chatgpt.com/codex/tasks/task_e_6881225823248326aa1f31d1c523cf22