### PR TITLE
Improve progress bar colors and accessibility

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -67,6 +67,13 @@
   --color-danger: #e74c3c; --color-danger-bg: rgba(231, 76, 60, 0.1);
   --color-info: #3498db; --color-info-bg: rgba(52, 152, 219, 0.1);
 
+  /* Цветови точки за прогрес баровете */
+  --progress-color-0: 231, 76, 60;
+  --progress-color-50: 243, 156, 18;
+  --progress-color-75: 255, 203, 0;
+  --progress-color-100: 46, 204, 113;
+  --progress-start-color: var(--color-danger);
+
   --progress-bar-bg-empty: #e9ecef;
   --progress-gradient: linear-gradient(to right, var(--color-danger), var(--color-warning), var(--color-success));
   --progress-end-color: var(--color-success);

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -36,12 +36,17 @@
 }
 .progress-fill {
   position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
+  background: linear-gradient(
+    to right,
+    color-mix(in srgb, var(--progress-start-color) 90%, transparent),
+    var(--progress-end-color)
+  );
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
   border-radius: inherit;
   z-index: 1;
+  opacity: 0.9;
 }
 .progress-fill::after {
   content: '';
@@ -136,12 +141,17 @@
 }
 .analytics-card .mini-progress-fill {
   position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
+  background: linear-gradient(
+    to right,
+    color-mix(in srgb, var(--progress-start-color) 90%, transparent),
+    var(--progress-end-color)
+  );
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
   border-radius: inherit;
   z-index: 1;
+  opacity: 0.85;
 }
 .analytics-card .mini-progress-fill::after {
   content: '';

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -125,8 +125,14 @@ function populateDashboardDetailedAnalytics(analyticsData) {
 
             const progress = document.createElement('div');
             progress.className = 'mini-progress-bar';
+            progress.setAttribute('role', 'progressbar');
+            progress.setAttribute('aria-valuemin', '0');
+            progress.setAttribute('aria-valuemax', '100');
             const fill = document.createElement('div');
             fill.className = 'mini-progress-fill';
+            if (metric.colorKey) {
+                fill.style.setProperty('--progress-start-color', `var(--color-${metric.colorKey})`);
+            }
             progress.appendChild(fill);
             card.appendChild(progress);
 
@@ -187,6 +193,7 @@ function populateDashboardDetailedAnalytics(analyticsData) {
             if (!isNaN(metric.currentValueNumeric)) {
                 const value = Number(metric.currentValueNumeric);
                 const percent = value <= 5 ? ((value - 1) / 4) * 100 : Math.max(0, Math.min(100, value));
+                progress.setAttribute('aria-valuenow', `${Math.round(percent)}`);
                 fill.style.setProperty('--progress-end-color', getProgressColor(percent));
                 animateProgressFill(fill, percent);
             }

--- a/js/utils.js
+++ b/js/utils.js
@@ -98,13 +98,21 @@ export function fileToText(file) {
  * @param {number} percent Стойността в диапазона 0-100.
  * @returns {string} CSS rgb() низ за крайния цвят.
  */
+export let progressColorStops = [
+    { pct: 0, color: [231, 76, 60] },       // червено
+    { pct: 50, color: [243, 156, 18] },     // оранжево
+    { pct: 75, color: [255, 203, 0] },      // жълто
+    { pct: 100, color: [46, 204, 113] }     // зелено
+];
+
+export function setProgressColorStops(stops) {
+    if (Array.isArray(stops) && stops.length > 0) {
+        progressColorStops = stops;
+    }
+}
+
 export function getProgressColor(percent) {
-    const stops = [
-        { pct: 0, color: [231, 76, 60] },       // червено
-        { pct: 50, color: [243, 156, 18] },     // оранжево
-        { pct: 75, color: [255, 203, 0] },      // жълто
-        { pct: 100, color: [46, 204, 113] }     // зелено
-    ];
+    const stops = progressColorStops;
     const p = Math.max(0, Math.min(100, percent));
     for (let i = 1; i < stops.length; i++) {
         if (p <= stops[i].pct) {


### PR DESCRIPTION
## Summary
- allow progress color stops to be customized
- add CSS variables for color stops and gradient start color
- use color-mix for smoother progress fill
- support per-metric color and ARIA attributes in analytics cards

## Testing
- `npm run lint`
- `CI=1 NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688127a9ce288326a93216bd361ace4f