### PR TITLE
Enable stand-alone extra meal form

### DIFF
--- a/extra-meal-entry-form.html
+++ b/extra-meal-entry-form.html
@@ -171,3 +171,7 @@
         <button type="submit" id="emSubmitBtn" class="button button-primary" style="flex-grow: 1;">Запази</button> <!-- Добавен клас button -->
     </div>
 </form>
+    <script type="module">
+        import { initializeExtraMealFormLogic } from './js/extraMealForm.js';
+        initializeExtraMealFormLogic(document);
+    </script>

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -19,7 +19,7 @@ fetch(new URL("../data/commonFoods.json", import.meta.url))
         }
     });
 
-function initializeExtraMealFormLogic(formContainerElement) {
+export function initializeExtraMealFormLogic(formContainerElement) {
     const form = formContainerElement.querySelector('#extraMealEntryFormActual');
     if (!form) {
         console.error("EMF Logic Error: Form #extraMealEntryFormActual not found within container!");


### PR DESCRIPTION
## Summary
- export `initializeExtraMealFormLogic`
- load form logic in `extra-meal-entry-form.html`

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test -- --runInBand` *(fails: FATAL ERROR OOM)*

------
https://chatgpt.com/codex/tasks/task_e_68812f97b33c8326b753f285d19391f7