### PR TITLE
Show quantity custom field

### DIFF
--- a/css/extra_meal_form_styles.css
+++ b/css/extra_meal_form_styles.css
@@ -253,6 +253,12 @@
   margin-bottom: var(--space-md);
 }
 
+/* Поле за въвеждане на точно количество */
+#extraMealEntryModal #quantityCustom {
+  margin-top: var(--space-sm);
+  display: block;
+}
+
 #extraMealEntryModal .quantity-card-option {
   display: flex;
   border: 1px solid var(--input-border-color);

--- a/extra-meal-entry-form.html
+++ b/extra-meal-entry-form.html
@@ -72,7 +72,7 @@
                 </label>
             </div>
         </fieldset>
-        <input type="text" id="quantityCustom" name="quantityCustom" class="hidden input-focus-animate" style="margin-top: var(--space-sm);" placeholder="Напр. 100гр, 2 с.л., специфично количество" aria-label="Уточнение за количество">
+        <input type="text" id="quantityCustom" name="quantityCustom" class="input-focus-animate" style="margin-top: var(--space-sm);" placeholder="Напр. 100гр, 2 с.л., специфично количество" aria-label="Уточнение за количество">
 
         <div class="form-group" style="margin-top: var(--space-md);">
             <label for="mealTimeSelect">Кога го консумирахте?</label>

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -132,7 +132,6 @@ export function initializeExtraMealFormLogic(formContainerElement) {
 
     const foodDescriptionInput = form.querySelector('#foodDescription');
     const suggestionsDropdown = form.querySelector('#foodSuggestionsDropdown');
-    const quantityCustomInput = form.querySelector('#quantityCustom');
     const quantityVisualRadios = form.querySelectorAll('input[name="quantityEstimateVisual"]');
     const mealTimeSelect = form.querySelector('#mealTimeSelect');
     const mealTimeSpecificInput = form.querySelector('#mealTimeSpecific');
@@ -169,24 +168,6 @@ export function initializeExtraMealFormLogic(formContainerElement) {
         });
     }
 
-    if (quantityVisualRadios.length > 0 && quantityCustomInput) {
-        quantityVisualRadios.forEach(radio => {
-            radio.addEventListener('change', function() {
-                if (this.value === 'other_quantity_describe' && this.checked) {
-                    quantityCustomInput.classList.remove('hidden');
-                    quantityCustomInput.focus();
-                } else {
-                    quantityCustomInput.classList.add('hidden');
-                }
-            });
-        });
-        const initiallyCheckedRadio = form.querySelector('input[name="quantityEstimateVisual"]:checked');
-        if (initiallyCheckedRadio && initiallyCheckedRadio.value === 'other_quantity_describe') {
-            quantityCustomInput.classList.remove('hidden');
-        } else if (quantityCustomInput) {
-            quantityCustomInput.classList.add('hidden');
-        }
-    }
 
     if (foodDescriptionInput && quantityVisualRadios.length > 0) {
         foodDescriptionInput.addEventListener('input', function() {


### PR DESCRIPTION
## Summary
- show the custom quantity input by default in the extra meal form
- adjust form styles so the input aligns with quantity options
- simplify JS by removing logic for toggling the custom field

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: populateUI.test.js ran out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688138024a2c832680660d9937891728