### PR TITLE
Добавена валидация за количество при извънредно хранене

### DIFF
--- a/extra-meal-entry-form.html
+++ b/extra-meal-entry-form.html
@@ -39,7 +39,7 @@
             <div id="quantityCardGroup" class="quantity-card-selector-grid" role="radiogroup" aria-labelledby="quantityLegend" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: var(--space-sm); margin-bottom: var(--space-md);">
                 <!-- Карти за количество (структурата е запазена, но стиловете ще дойдат от extra_meal_form_styles.css) -->
                 <label class="quantity-card-option">
-                    <input type="radio" name="quantityEstimateVisual" value="не_посочено_в_стъпка_2" checked>
+                    <input type="radio" name="quantityEstimateVisual" value="не_посочено_в_стъпка_2" checked required>
                     <span class="card-content"><span class="card-icon-wrapper"><i class="bi bi-pencil-square"></i></span><span class="card-text-wrapper"><span class="card-label">Вече описано</span></span></span>
                 </label>
                 <label class="quantity-card-option">

--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -1,0 +1,32 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let handleExtraMealFormSubmit;
+let showToastMock;
+
+beforeEach(async () => {
+  jest.resetModules();
+  showToastMock = jest.fn();
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    showLoading: jest.fn(),
+    showToast: showToastMock,
+    openModal: jest.fn(),
+    closeModal: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({
+    apiEndpoints: { logExtraMeal: '/api' }
+  }));
+  jest.unstable_mockModule('../app.js', () => ({ currentUserId: 'u1' }));
+  global.fetch = jest.fn().mockResolvedValue({ json: async () => [] });
+  ({ handleExtraMealFormSubmit } = await import('../extraMealForm.js'));
+  fetch.mockClear();
+});
+
+test('показва съобщение при липса на количество', async () => {
+  document.body.innerHTML = `<form id="f"><input id="quantityCustom" name="quantityCustom"></form>`;
+  const form = document.getElementById('f');
+  const e = { preventDefault: jest.fn(), target: form };
+  await handleExtraMealFormSubmit(e);
+  expect(showToastMock).toHaveBeenCalled();
+  expect(fetch).not.toHaveBeenCalled();
+});

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -298,10 +298,18 @@ export async function openExtraMealModal() {
     }
 }
 
-async function handleExtraMealFormSubmit(event) {
+export async function handleExtraMealFormSubmit(event) {
     event.preventDefault();
     const form = event.target;
     const formData = new FormData(form);
+
+    const selectedVisual = form.querySelector('input[name="quantityEstimateVisual"]:checked');
+    const quantityCustomVal = (formData.get('quantityCustom') || '').trim();
+    if (!selectedVisual && !quantityCustomVal) {
+        showToast('Моля, изберете количество или въведете стойност.', true);
+        return;
+    }
+
     const dataToSend = { userId: currentUserId, timestamp: new Date().toISOString() };
 
     for (let [key, value] of formData.entries()) {


### PR DESCRIPTION
## Какво ново
- проверка в `handleExtraMealFormSubmit` за липса на избрано количество или въведена стойност
- маркиране на първия радиобутон за количество като `required`
- нов тест `extraMealFormSubmit` валидира отказа при празно количество

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68813adfa4e483268a7feb190f40b356