### PR TITLE
Update activityType ids

### DIFF
--- a/kv/DIET_RESOURCES/question_definitions.json
+++ b/kv/DIET_RESOURCES/question_definitions.json
@@ -546,7 +546,7 @@
         "children": {
             "Всеки ден": [
                 {
-                    "id": "activityType",
+                    "id": "activityTypeDaily",
                     "text": "Какъв спорт?",
                     "type": "checkbox",
                     "options": [
@@ -568,7 +568,7 @@
                                 "type": "text",
                                 "options": [],
                                 "dependsOn": {
-                                    "question": "activityType",
+                                    "question": "activityTypeDaily",
                                     "value": "Друго"
                                 },
                                 "children": []
@@ -590,7 +590,7 @@
             ],
             "2-3 пъти\/седм": [
                 {
-                    "id": "activityType",
+                    "id": "activityTypeWeekly",
                     "text": "Какъв спорт?",
                     "type": "select",
                     "options": [
@@ -618,7 +618,7 @@
             ],
             "Рядко": [
                 {
-                    "id": "activityType",
+                    "id": "activityTypeRare",
                     "text": "Какъв спорт?",
                     "type": "select",
                     "options": [

--- a/questions.json
+++ b/questions.json
@@ -203,7 +203,7 @@
         "children": {
             "Всеки ден": [
                 {
-                    "id": "activityType",
+                    "id": "activityTypeDaily",
                     "text": "Какъв спорт?",
                     "type": "checkbox",
                     "options": [
@@ -225,7 +225,7 @@
                                 "type": "text",
                                 "options": [],
                                 "dependsOn": {
-                                    "question": "activityType",
+                                    "question": "activityTypeDaily",
                                     "value": "Друго"
                                 },
                                 "children": []
@@ -247,7 +247,7 @@
             ],
             "2-3 пъти/седм": [
                 {
-                    "id": "activityType",
+                    "id": "activityTypeWeekly",
                     "text": "Какъв спорт?",
                     "type": "select",
                     "options": [
@@ -275,7 +275,7 @@
             ],
             "Рядко": [
                 {
-                    "id": "activityType",
+                    "id": "activityTypeRare",
                     "text": "Какъв спорт?",
                     "type": "select",
                     "options": [


### PR DESCRIPTION
## Summary
- rename duplicate `activityType` IDs to `activityTypeDaily`, `activityTypeWeekly`, and `activityTypeRare`
- update internal references accordingly

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68817ab5de0c83269ab246b6ac9e175c