### PR TITLE
Fix CTA text colors in analysis

### DIFF
--- a/reganalize/analyze.html
+++ b/reganalize/analyze.html
@@ -431,14 +431,24 @@
         .benefit-icon:hover i {
             transform: scale(1.2);
         }
-        .benefit-item h3 { font-size: 1.2em; font-weight: 700; margin-bottom: 10px; color: white; }
-        .benefit-item p { font-size: 0.95em; color: rgba(255, 255, 255, 0.7); line-height: 1.6; margin: 0; }
+        .benefit-item h3 {
+            font-size: 1.2em;
+            font-weight: 700;
+            margin-bottom: 10px;
+            color: var(--heading-color);
+        }
+        .benefit-item p {
+            font-size: 0.95em;
+            color: var(--text-color);
+            line-height: 1.6;
+            margin: 0;
+        }
         
         .cta-final-pitch {
             max-width: 600px;
             margin: 0 auto;
             font-size: 1.1em;
-            color: rgba(255, 255, 255, 0.9);
+            color: var(--heading-color);
             position: relative;
             z-index: 2;
         }


### PR DESCRIPTION
## Summary
- fix text color in CTA section so it is readable on light background

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688191d2d9ec8326a11f7deeb1a53048