### PR TITLE
Add assistant wiggle animation

### DIFF
--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -332,6 +332,19 @@ body.dark-theme .chat-messages .message.bot { color: #e0e0e0; }
   height: 32px;
   animation: assistantPulse 2s infinite;
 }
+@keyframes assistantWiggle {
+  0%   { transform: rotate(0deg); }
+  15%  { transform: rotate(-10deg); }
+  30%  { transform: rotate(12deg); }
+  45%  { transform: rotate(-8deg); }
+  60%  { transform: rotate(6deg); }
+  75%  { transform: rotate(-4deg); }
+  100% { transform: rotate(0deg); }
+}
+.assistant-icon.wiggle {
+  animation: assistantWiggle 0.6s ease-out, assistantPulse 2s infinite;
+}
 @media (prefers-reduced-motion: reduce) {
   #chat-fab .assistant-icon { animation: none; }
+  .assistant-icon.wiggle { animation: none; }
 }

--- a/js/__tests__/assistantIconWiggle.test.js
+++ b/js/__tests__/assistantIconWiggle.test.js
@@ -1,0 +1,56 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let triggerAssistantWiggle;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `<button id="chat-fab"><img class="assistant-icon"></button>`;
+  const selectors = { chatFab: document.getElementById('chat-fab') };
+  jest.unstable_mockModule('../uiElements.js', () => ({
+    selectors,
+    initializeSelectors: jest.fn(),
+    loadInfoTexts: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({ isLocalDevelopment: false, apiEndpoints: {} }));
+  jest.unstable_mockModule('../utils.js', () => ({ safeParseFloat: jest.fn(), escapeHtml: jest.fn(), fileToDataURL: jest.fn() }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    initializeTheme: jest.fn(),
+    activateTab: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: jest.fn(),
+    showLoading: jest.fn(),
+    showToast: jest.fn(),
+    updateTabsOverflowIndicator: jest.fn()
+  }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ populateUI: jest.fn() }));
+  jest.unstable_mockModule('../eventListeners.js', () => ({
+    setupStaticEventListeners: jest.fn(),
+    setupDynamicEventListeners: jest.fn(),
+    initializeCollapsibleCards: jest.fn()
+  }));
+  jest.unstable_mockModule('../chat.js', () => ({
+    displayMessage: jest.fn(),
+    displayTypingIndicator: jest.fn(),
+    scrollToChatBottom: jest.fn(),
+    setAutomatedChatPending: jest.fn()
+  }));
+  jest.unstable_mockModule('../achievements.js', () => ({ initializeAchievements: jest.fn() }));
+  jest.unstable_mockModule('../adaptiveQuiz.js', () => ({
+    openAdaptiveQuizModal: jest.fn(),
+    renderCurrentQuizQuestion: jest.fn(),
+    showQuizValidationMessage: jest.fn(),
+    hideQuizValidationMessage: jest.fn()
+  }));
+  jest.unstable_mockModule('../planModChat.js', () => ({ openPlanModificationChat: jest.fn() }));
+  const mod = await import('../app.js');
+  triggerAssistantWiggle = mod.triggerAssistantWiggle;
+});
+
+test('wiggle class toggles on animation end', () => {
+  const icon = document.querySelector('.assistant-icon');
+  triggerAssistantWiggle();
+  expect(icon.classList.contains('wiggle')).toBe(true);
+  icon.dispatchEvent(new Event('animationend'));
+  expect(icon.classList.contains('wiggle')).toBe(false);
+});

--- a/js/app.js
+++ b/js/app.js
@@ -78,6 +78,7 @@ async function checkAdminQueries(userId) {
             });
             if (!selectors.chatWidget?.classList.contains('visible')) {
                 if (selectors.chatFab) selectors.chatFab.classList.add('notification');
+                triggerAssistantWiggle();
                 setAutomatedChatPending(true);
             }
         }
@@ -136,6 +137,16 @@ export function setCurrentQuizData(data) { currentQuizData = data; }
 export function setUserQuizAnswers(answers) { userQuizAnswers = answers; }
 export function setCurrentQuestionIndex(index) { currentQuestionIndex = index; }
 export function setActiveTooltip(tooltip) { activeTooltip = tooltip; }
+
+export function triggerAssistantWiggle() {
+    const icon = selectors.chatFab?.querySelector('.assistant-icon');
+    if (!icon) return;
+    icon.classList.add('wiggle');
+    function handleEnd() {
+        icon.classList.remove('wiggle');
+    }
+    icon.addEventListener('animationend', handleEnd, { once: true });
+}
 
 // Функция за нулиране на глобалното състояние при изход
 export function resetAppState() {
@@ -267,6 +278,7 @@ async function initializeApp() {
     try {
         if (isLocalDevelopment) console.log("initializeApp starting from app.js...");
         initializeSelectors();
+        triggerAssistantWiggle();
         await loadInfoTexts();
         if (!document.getElementById('planModInProgressIcon') && selectors.planModificationBtn) {
             const icon = document.createElement('svg');
@@ -426,6 +438,7 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
         if (data.triggerAutomatedFeedbackChat) {
             setAutomatedChatPending(true);
             if (selectors.chatFab) selectors.chatFab.classList.add('notification');
+            triggerAssistantWiggle();
         }
 
         populateUI();


### PR DESCRIPTION
## Summary
- introduce `assistantWiggle` keyframes and `.assistant-icon.wiggle` class
- export `triggerAssistantWiggle` in `app.js` and call it when needed
- animate chat icon on init and on new admin/feedback messages
- test wiggle class behaviour

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*


------
https://chatgpt.com/codex/tasks/task_e_6881a3aa059c83269dd487ecdaf9d983