### PR TITLE
Add animated landing page

### DIFF
--- a/css/landing_styles.css
+++ b/css/landing_styles.css
@@ -1,0 +1,50 @@
+body {
+    margin: 0;
+    font-family: var(--font-primary);
+    background: var(--bg-color) var(--bg-gradient);
+    color: var(--text-color-primary);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: var(--space-lg);
+}
+.hero-title {
+    font-family: var(--font-secondary);
+    color: var(--primary-color);
+    font-size: clamp(2rem, 5vw, 3rem);
+    margin: 0 0 var(--space-lg);
+}
+.hero-tagline {
+    color: var(--text-color-secondary);
+    font-size: clamp(1rem, 3vw, 1.4rem);
+    margin-bottom: var(--space-lg);
+}
+.start-btn {
+    margin-top: var(--space-lg);
+}
+.hero-animation {
+    width: 200px;
+    height: 200px;
+    margin: 0 auto var(--space-lg);
+}
+.rotate {
+    transform-origin: 50% 50%;
+    animation: rotate 15s linear infinite;
+}
+.icon path,
+.icon line,
+.icon circle {
+    stroke: currentColor;
+    stroke-width: 2;
+    fill: currentColor;
+}
+.brain { color: var(--primary-color); }
+.dna { color: var(--secondary-color); }
+.person { color: var(--accent-color); }
+.food { color: var(--color-success); }
+@keyframes rotate {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}

--- a/landing.html
+++ b/landing.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MyBody.Best - Начало</title>
+    <!-- Шрифтовете и базови променливи -->
+    <link href="css/base_styles.css" rel="stylesheet">
+    <link href="css/components_styles.css" rel="stylesheet">
+    <link href="css/landing_styles.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+</head>
+<body>
+    <div class="hero">
+        <h1 class="hero-title">MyBody.Best</h1>
+        <p class="hero-tagline">Вашият персонален път към по-добро здраве</p>
+        <svg class="hero-animation" viewBox="0 0 200 200" aria-hidden="true">
+            <g class="rotate">
+                <g transform="rotate(0) translate(0,-70) rotate(0)" class="icon brain">
+                    <path d="M10 20c-2-4 0-8 4-9 3-4 9-4 12-1 3-3 9-3 12 0s3 7 1 9c3 1 5 4 3 7s-5 3-7 2c0 2-2 5-5 5s-5-2-6-4c-3 1-6 0-7-3-1-2 0-4 1-6z"></path>
+                </g>
+                <g transform="rotate(90) translate(0,-70) rotate(-90)" class="icon dna">
+                    <path d="M0 15 Q10 0 20 15T40 15" fill="none"></path>
+                    <path d="M0 25 Q10 40 20 25T40 25" fill="none"></path>
+                    <line x1="0" y1="15" x2="0" y2="25"></line>
+                    <line x1="40" y1="15" x2="40" y2="25"></line>
+                </g>
+                <g transform="rotate(180) translate(0,-70) rotate(-180)" class="icon person">
+                    <circle cx="20" cy="10" r="5"></circle>
+                    <path d="M20 15v15"></path>
+                    <path d="M10 30c2-5 18-5 20 0" fill="none"></path>
+                </g>
+                <g transform="rotate(270) translate(0,-70) rotate(-270)" class="icon food">
+                    <path d="M20 10c-3-6-9-6-12 0s-1 10 3 15 9 6 9 6 6-2 9-6 6-9 3-15z"></path>
+                    <path d="M18 2c-1-2-3-2-4 0" fill="none"></path>
+                </g>
+            </g>
+        </svg>
+        <a href="quest.html" class="button button-primary start-btn">Започни въпросника</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add initial landing page with minimal hero section
- include rotating SVG icons and start button

## Testing
- `npm run lint`
- `npm test -- --runInBand` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6882dee04dec83269ed5a990be341e67