### PR TITLE
Redesign start page icons

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -283,16 +283,10 @@ input[type="checkbox"] {
   transform: translateY(20px);
 }
 
-.trust-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 50px;
-  font-size: 0.9rem;
-  margin-bottom: 25px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+
+.hero-image {
+  max-width: 250px;
+  margin: 0 auto 20px auto;
 }
 
 .hero-title {
@@ -302,13 +296,8 @@ input[type="checkbox"] {
   text-shadow: 2px 2px 8px rgba(0,0,0,0.3);
   margin-bottom: 15px;
   line-height: 1.2;
-  min-height: 100px; /* Осигурява място за typewriter-а да не прескача */
 }
 
-.hero-title .typewriter-cursor {
-    color: #4fc3a1; /* Цвят на курсора */
-    font-weight: bold;
-}
 
 .hero-subtitle {
   font-size: 1.1rem;
@@ -367,10 +356,10 @@ input[type="checkbox"] {
     text-align: center;
 }
 
-.stat-value {
-    font-size: 1.8rem;
-    font-weight: bold;
-    color: #fff;
+.stat-icon {
+    width: 40px;
+    height: 40px;
+    margin: 0 auto 8px auto;
 }
 
 .stat-label {

--- a/quest.html
+++ b/quest.html
@@ -80,16 +80,10 @@
       opacity: 0;
     }
     
-    .trust-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 8px 16px;
-      background: rgba(255, 255, 255, 0.1);
-      border-radius: 50px;
-      font-size: 0.9rem;
-      margin-bottom: 25px;
-      border: 1px solid rgba(255, 255, 255, 0.2);
+
+    .hero-image {
+      max-width: 250px;
+      margin: 0 auto 20px auto;
     }
     
     .hero-title {
@@ -99,12 +93,8 @@
       text-shadow: 2px 2px 8px rgba(0,0,0,0.3);
       margin-bottom: 15px;
       line-height: 1.2;
-      min-height: 100px; /* Осигурява място за typewriter-а да не прескача */
     }
 
-    .hero-title .typewriter-cursor {
-        color: #4fc3a1; /* Цвят на курсора */
-    }
     
     .hero-subtitle {
       font-size: 1.1rem;
@@ -199,6 +189,20 @@
 </head>
 <body>
 
+<svg style="position:absolute;width:0;height:0" aria-hidden="true">
+  <symbol id="icon-brain" viewBox="0 0 40 40" fill="currentColor">
+    <path d="M10 20c-2-4 0-8 4-9 3-4 9-4 12-1 3-3 9-3 12 0s3 7 1 9c3 1 5 4 3 7s-5 3-7 2c0 2-2 5-5 5s-5-2-6-4c-3 1-6 0-7-3-1-2 0-4 1-6z" />
+  </symbol>
+  <symbol id="icon-doctor" viewBox="0 0 40 40" fill="none" stroke="currentColor" stroke-width="2">
+    <circle cx="20" cy="12" r="6" />
+    <path d="M10 32v-5a10 10 0 0 1 20 0v5" />
+  </symbol>
+  <symbol id="icon-clock" viewBox="0 0 40 40" fill="none" stroke="currentColor" stroke-width="2">
+    <circle cx="20" cy="20" r="18" />
+    <path d="M20 10v10l6 6" />
+  </symbol>
+</svg>
+
 <!-- Прогрес бар -->
 <div class="step-indicator-container">
   <span class="step-indicator-label">Стъпка <span id="questCurrentStep">0</span> от <span id="questTotalSteps">0</span></span>
@@ -219,7 +223,6 @@
 
 <!-- Библиотеки за ефекти -->
 <script src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js"></script>
-<script src="https://unpkg.com/typewriter-effect@latest/dist/core.js"></script>
 
 
 <script type="module">
@@ -293,14 +296,7 @@
     pageDiv.innerHTML = `
       <div id="particles-js"></div>
       <div class="hero-content">
-        <div class="trust-badge">
-          <i class="bi bi-shield-check"></i>
-          <span>Доверен от 1000+ доволни клиенти</span>
-        </div>
-        
-        <h1 class="hero-title">
-            <span id="typewriter-text"></span>
-        </h1>
+        <img class="hero-image" id="heroImage" src="img/assisticon.png" alt="Hero">
         
         <p class="hero-subtitle">
           Вашият персонализиран път към по-добро здраве започва с едно натискане.
@@ -314,44 +310,23 @@
         
         <div class="stats-bar">
           <div class="stat-item">
-            <div class="stat-value">97%</div>
-            <div class="stat-label">Успеваемост</div>
+            <div class="stat-icon"><svg class="icon"><use href="#icon-brain"/></svg></div>
+            <div class="stat-label">AI Med Алгоритъм</div>
           </div>
           <div class="stat-item">
-            <div class="stat-value">24/7</div>
-            <div class="stat-label">Поддръжка</div>
+            <div class="stat-icon"><svg class="icon"><use href="#icon-doctor"/></svg></div>
+            <div class="stat-label">Реални специалисти</div>
           </div>
-           <div class="stat-item">
-            <div class="stat-value">100%</div>
-            <div class="stat-label">Научно обосновано</div>
+          <div class="stat-item">
+            <div class="stat-icon"><svg class="icon"><use href="#icon-clock"/></svg></div>
+            <div class="stat-label">24/7 Личен асистент</div>
           </div>
         </div>
       </div>
     `;
     container.appendChild(pageDiv);
 
-    // --- Активиране на ефектите САМО за тази страница ---
-    // 1. Ефект на пишеща машина
-    const typewriterEl = pageDiv.querySelector('#typewriter-text');
-    if (typewriterEl) {
-        const typewriter = new Typewriter(typewriterEl, {
-            loop: true,
-            delay: 75,
-            cursorClassName: 'typewriter-cursor'
-        });
-        typewriter
-            .typeString('Вашето здраве започва тук.')
-            .pauseFor(2000)
-            .deleteAll()
-            .typeString('Персонализирани решения.')
-            .pauseFor(2000)
-            .deleteAll()
-            .typeString('Научно обосновани резултати.')
-            .pauseFor(2500)
-            .start();
-    }
-
-    // 2. Ефект с частици
+    // --- Активиране на ефекта с частици САМО за тази страница ---
     if (window.particlesJS) {
         particlesJS('particles-js', {
             "particles": { "number": { "value": 60, "density": { "enable": true, "value_area": 800 } }, "color": { "value": "#4fc3a1" }, "shape": { "type": "circle" }, "opacity": { "value": 0.5, "random": true }, "size": { "value": 3, "random": true }, "line_linked": { "enable": true, "distance": 150, "color": "#ffffff", "opacity": 0.1, "width": 1 }, "move": { "enable": true, "speed": 1, "direction": "none", "out_mode": "out" } },


### PR DESCRIPTION
## Summary
- remove trust badge and typewriter effect
- add hero image placeholder and custom SVG icons
- update stats to use new icons
- clean styles for hero page

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6882e8966f6c832693aba71dabaac48f