### PR TITLE
Fix quest hero page freeze

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -260,6 +260,7 @@ input[type="checkbox"] {
   top: 0;
   left: 0;
   z-index: 1;
+  pointer-events: none; /* не блокира докосванията върху съдържанието */
 }
 
 /* Премахваме стиловете на .container за първата страница */

--- a/quest.html
+++ b/quest.html
@@ -329,7 +329,8 @@
     container.appendChild(pageDiv);
 
     // --- Активиране на ефекта с частици САМО за тази страница ---
-    if (window.particlesJS) {
+    const isMobile = window.matchMedia('(max-width: 768px)').matches;
+    if (window.particlesJS && !isMobile) {
         particlesJS('particles-js', {
             "particles": { "number": { "value": 60, "density": { "enable": true, "value_area": 800 } }, "color": { "value": "#4fc3a1" }, "shape": { "type": "circle" }, "opacity": { "value": 0.5, "random": true }, "size": { "value": 3, "random": true }, "line_linked": { "enable": true, "distance": 150, "color": "#ffffff", "opacity": 0.1, "width": 1 }, "move": { "enable": true, "speed": 1, "direction": "none", "out_mode": "out" } },
             "interactivity": { "detect_on": "canvas", "events": { "onhover": { "enable": true, "mode": "grab" }, "onclick": { "enable": true, "mode": "push" } }, "modes": { "grab": { "distance": 140, "line_linked": { "opacity": 0.3 } }, "push": { "particles_nb": 4 } } },


### PR DESCRIPTION
## Summary
- allow tapping through particle overlay on hero page
- disable particle animation on small screens

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6882f7b0159c832697f8a8f4832f6142