### PR TITLE
Improve stats icons on mobile

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -356,15 +356,14 @@ input[type="checkbox"] {
 }
 
 .stat-label {
-    font-size: 1.2rem;
-    text-transform: uppercase;
-    letter-spacing: 1px;
+    font-size: 1rem;
+    letter-spacing: 0.5px;
 }
 
 /* Малки икони за статистиките */
 .stat-icon {
-    width: 40px;
-    height: 40px;
+    width: 80px;
+    height: 80px;
     display: block;
     margin: 0 auto 5px;
 }
@@ -395,6 +394,13 @@ input[type="checkbox"] {
   #page0.hero-start-page #startBtn {
     width: 100%;
     padding: 16px 20px;
+    justify-content: center;
+  }
+}
+
+@media (min-width: 769px) {
+  .stats-bar {
+    flex-direction: row;
     justify-content: center;
   }
 }

--- a/quest.html
+++ b/quest.html
@@ -145,16 +145,22 @@
         text-align: center;
     }
     .stat-label {
-        font-size: 1.2rem;
-        text-transform: uppercase;
-        letter-spacing: 1px;
+        font-size: 1rem;
+        letter-spacing: 0.5px;
     }
 
     .stat-icon {
-        width: 40px;
-        height: 40px;
+        width: 80px;
+        height: 80px;
         display: block;
         margin: 0 auto 5px;
+    }
+
+    @media (min-width: 769px) {
+      .stats-bar {
+        flex-direction: row;
+        justify-content: center;
+      }
     }
     
     @keyframes fadeInContent {


### PR DESCRIPTION
## Summary
- enlarge statistic icons to 80px
- adjust label typography for consistency
- add responsive rules so stats are row-aligned on larger screens

## Testing
- `npm run lint`
- `npm test` *(fails: populateUI.test.js out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68834f0dc0248326ad98a478c75e7537