### PR TITLE
Improve particles background

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -20,6 +20,15 @@ body {
   box-shadow: 0 0 15px rgba(0,0,0,0.6);
 }
 
+/* Прозрачни контейнери в страницата с въпросника */
+#questPage .container {
+  max-width: 100%;
+  margin: 20px auto;
+  padding: 0;
+  background-color: transparent;
+  box-shadow: none;
+}
+
 .question-text {
   font-size: 18px;
   color: #80cbc4;
@@ -70,6 +79,8 @@ p {
 .page {
   display: none;
   animation: fadeIn 0.4s ease-in-out;
+  position: relative;
+  z-index: 2;
 }
 
 .page.active {

--- a/quest.html
+++ b/quest.html
@@ -193,7 +193,7 @@
   </style>
   <!-- === КРАЙ: НОВИ СТИЛОВЕ === -->
 </head>
-<body>
+<body id="questPage">
 
 <svg style="position:absolute;width:0;height:0" aria-hidden="true">
   <symbol id="icon-brain" viewBox="0 0 40 40" fill="currentColor">
@@ -208,6 +208,7 @@
     <path d="M20 10v10l6 6" />
   </symbol>
 </svg>
+<div id="particles-js"></div>
 
 <!-- Прогрес бар -->
 <div class="step-indicator-container">
@@ -300,7 +301,6 @@
     pageDiv.id = 'page0';
 
     pageDiv.innerHTML = `
-      <div id="particles-js"></div>
       <div class="hero-content">
         <img class="hero-image" id="heroImage" src="https://radilovk.github.io/bodybest/img/myquest.png" alt="Hero">
         


### PR DESCRIPTION
## Summary
- keep `particles-js` div at body level in quest page
- remove duplicate `particles-js` element from hero
- make all question containers transparent
- ensure page content sits above particle layer

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=8192 npm test -- --runInBand` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688369f74e708326a2e1ca2e02ad7e87