### PR TITLE
Fix hero background transparency

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -20,6 +20,16 @@ body {
   box-shadow: 0 0 15px rgba(0,0,0,0.6);
 }
 
+/* Прозрачни контейнери в страницата с въпросника */
+#questPage .container {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+  box-shadow: none;
+}
+
 .question-text {
   font-size: 18px;
   color: #80cbc4;
@@ -70,6 +80,8 @@ p {
 .page {
   display: none;
   animation: fadeIn 0.4s ease-in-out;
+  position: relative;
+  z-index: 2;
 }
 
 .page.active {
@@ -239,7 +251,11 @@ input[type="checkbox"] {
   box-sizing: border-box;
   color: #fff;
   /* Динамичен градиентен фон */
-  background: linear-gradient(35deg, #1f2c35, #2c3e50, #466368);
+  background: linear-gradient(35deg,
+    rgba(31, 44, 53, 0.85),
+    rgba(44, 62, 80, 0.85),
+    rgba(70, 99, 104, 0.85)
+  );
   background-size: 200% 200%;
   animation: gradientAnimation 15s ease infinite;
 }

--- a/quest.html
+++ b/quest.html
@@ -37,7 +37,11 @@
       box-sizing: border-box;
       color: #fff;
       /* Динамичен градиентен фон */
-      background: linear-gradient(35deg, #1f2c35, #2c3e50, #466368);
+      background: linear-gradient(35deg,
+        rgba(31, 44, 53, 0.85),
+        rgba(44, 62, 80, 0.85),
+        rgba(70, 99, 104, 0.85)
+      );
       background-size: 200% 200%;
       animation: gradientAnimation 15s ease infinite;
     }
@@ -193,7 +197,7 @@
   </style>
   <!-- === КРАЙ: НОВИ СТИЛОВЕ === -->
 </head>
-<body>
+<body id="questPage">
 
 <svg style="position:absolute;width:0;height:0" aria-hidden="true">
   <symbol id="icon-brain" viewBox="0 0 40 40" fill="currentColor">
@@ -208,6 +212,7 @@
     <path d="M20 10v10l6 6" />
   </symbol>
 </svg>
+<div id="particles-js"></div>
 
 <!-- Прогрес бар -->
 <div class="step-indicator-container">
@@ -300,7 +305,6 @@
     pageDiv.id = 'page0';
 
     pageDiv.innerHTML = `
-      <div id="particles-js"></div>
       <div class="hero-content">
         <img class="hero-image" id="heroImage" src="https://radilovk.github.io/bodybest/img/myquest.png" alt="Hero">
         


### PR DESCRIPTION
## Summary
- tweak hero gradient to be semi-transparent so particles show through

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=8192 npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688369f74e708326a2e1ca2e02ad7e87