### PR TITLE
Enhance index page UX

### DIFF
--- a/css/index_styles.css
+++ b/css/index_styles.css
@@ -37,7 +37,17 @@
         h1, h2 { font-family: var(--font-secondary); font-weight: 700; color: var(--primary-color); margin-top: 0; }
         h1 { font-size: clamp(1.7rem, 5vw, 2.1rem); margin-bottom: calc(var(--space-lg)*0.8); text-align: center; }
         h2 { font-size: clamp(1.3rem, 4vw, 1.7rem); margin-bottom: var(--space-lg); }
-        p { margin-bottom: var(--space-lg); color: var(--text-color-secondary); font-size: var(--fs-base);} 
+        p { margin-bottom: var(--space-lg); color: var(--text-color-secondary); font-size: var(--fs-base);}
+
+        .hero { text-align: center; }
+        .hero-animation { width: 200px; height: 200px; margin: 0 auto var(--space-lg); }
+        .rotate { transform-origin: 50% 50%; animation: rotate 15s linear infinite; }
+        .icon path, .icon line, .icon circle { stroke: currentColor; stroke-width: 2; fill: currentColor; }
+        .brain { color: var(--primary-color); }
+        .dna { color: var(--secondary-color); }
+        .person { color: var(--accent-color); }
+        .food { color: var(--color-success); }
+        @keyframes rotate { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
 
         .marketing-banner {
             background-color: var(--primary-color);
@@ -61,13 +71,23 @@
         }
         .form-section { margin-bottom: var(--space-lg); }
         .form-section.hidden { display: none; }
-        .form-group { margin-bottom: calc(var(--space-lg)*0.8); text-align: left; }
+        .form-wrapper { display: flex; flex-direction: column; gap: var(--space-lg); }
+        .form-group { margin-bottom: calc(var(--space-lg)*0.8); text-align: left; position: relative; }
         label { display: block; margin-bottom: 0.4rem; font-weight: 500; color: var(--text-color-primary); font-size: var(--fs-sm); }
         input[type="email"], input[type="password"] {
-            width: 100%; padding: 0.7rem; border: 1px solid var(--border-color);
+            width: 100%; padding: 0.8rem; border: 1px solid var(--border-color);
             border-radius: 0.5rem; background-color: #fff; color: var(--text-color-primary); font-size: var(--fs-base);
             transition: border-color 0.2s, box-shadow 0.2s;
         }
+        .with-icon i, .toggle-pass { position: absolute; top: 50%; transform: translateY(-50%); right: 0.8rem; color: var(--accent-color); }
+        .toggle-pass { background: none; border: none; cursor: pointer; }
+        .floating label { position: absolute; left: 0.8rem; top: 0.8rem; pointer-events: none; transition: transform 0.2s, color 0.2s; background: transparent; }
+        .floating input:focus + label,
+        .floating input:not(:placeholder-shown) + label { transform: translateY(-0.6rem) scale(0.85); color: var(--primary-color); }
+        .password-strength { font-size: 0.75rem; margin-top: 0.3rem; }
+        .strength-weak { color: var(--color-danger); }
+        .strength-medium { color: var(--color-warning); }
+        .strength-strong { color: var(--color-success); }
         input:focus {
              border-color: var(--primary-color); outline: none;
              box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.2);
@@ -114,6 +134,9 @@
             margin-bottom: calc(var(--space-lg)*0.5); /* Отстояние преди другия линк */
         }
 
+        @keyframes fadeSlideIn { from { opacity: 0; transform: translateY(-20px); } to { opacity: 1; transform: translateY(0); } }
+        .fade-in { animation: fadeSlideIn 0.3s ease; }
+
         /* Съобщения */
         .message {
             padding: 0.8rem; border-radius: 0.5rem; margin-top: var(--space-lg);
@@ -122,6 +145,10 @@
         }
         .message.error { color: var(--color-danger); background-color: rgba(231, 76, 60, 0.1); border-color: var(--color-danger); }
         .message.success { color: var(--color-success); background-color: rgba(46, 204, 113, 0.1); border-color: var(--color-success); }
+
+        .benefits { list-style: none; padding: 0; margin: var(--space-lg) 0; display: grid; gap: var(--space-sm); }
+        .benefits li { display: flex; align-items: center; gap: 0.5rem; font-size: 0.9rem; color: var(--text-color-primary); }
+        .benefits li i { color: var(--secondary-color); }
 
         /* Секция за въпросник */
         .questionnaire-link {
@@ -145,4 +172,6 @@
             .card { padding: calc(var(--space-lg) * 2); }
             .button { width: auto; padding: 0.8rem 2rem; }
             .questionnaire-link { text-align: center; }
+            .form-wrapper { flex-direction: row; }
+            .benefits { grid-template-columns: repeat(3, 1fr); }
         }

--- a/index.html
+++ b/index.html
@@ -16,6 +16,31 @@
         <div class="card">
             <h1>MyBody.Best</h1>
 
+            <div class="hero">
+                <svg class="hero-animation" viewBox="0 0 200 200" aria-hidden="true">
+                    <g class="rotate">
+                        <g transform="rotate(0) translate(0,-70) rotate(0)" class="icon brain">
+                            <path d="M10 20c-2-4 0-8 4-9 3-4 9-4 12-1 3-3 9-3 12 0s3 7 1 9c3 1 5 4 3 7s-5 3-7 2c0 2-2 5-5 5s-5-2-6-4c-3 1-6 0-7-3-1-2 0-4 1-6z"></path>
+                        </g>
+                        <g transform="rotate(90) translate(0,-70) rotate(-90)" class="icon dna">
+                            <path d="M0 15 Q10 0 20 15T40 15" fill="none"></path>
+                            <path d="M0 25 Q10 40 20 25T40 25" fill="none"></path>
+                            <line x1="0" y1="15" x2="0" y2="25"></line>
+                            <line x1="40" y1="15" x2="40" y2="25"></line>
+                        </g>
+                        <g transform="rotate(180) translate(0,-70) rotate(-180)" class="icon person">
+                            <circle cx="20" cy="10" r="5"></circle>
+                            <path d="M20 15v15"></path>
+                            <path d="M10 30c2-5 18-5 20 0" fill="none"></path>
+                        </g>
+                        <g transform="rotate(270) translate(0,-70) rotate(-270)" class="icon food">
+                            <path d="M20 10c-3-6-9-6-12 0s-1 10 3 15 9 6 9 6 6-2 9-6 6-9 3-15z"></path>
+                            <path d="M18 2c-1-2-3-2-4 0" fill="none"></path>
+                        </g>
+                    </g>
+                </svg>
+            </div>
+
             <section class="marketing-banner">
                 <div class="intro-text">
                     <h2>Защо MyBody.Best?</h2>
@@ -26,17 +51,20 @@
                 </div>
             </section>
 
+            <div class="form-wrapper">
             <!-- Секция за Вход -->
             <div id="login-section" class="form-section">
                 <h2>Вход</h2>
                 <form id="login-form" novalidate>
-                    <div class="form-group">
-                        <label for="login-email">Имейл:</label>
-                        <input type="email" id="login-email" name="email" required autocomplete="email" class="input-focus-animate">
+                    <div class="form-group floating with-icon">
+                        <input placeholder=" " type="email" id="login-email" name="email" required autocomplete="email" class="input-focus-animate">
+                        <label for="login-email">Имейл</label>
+                        <i class="bi bi-envelope"></i>
                     </div>
-                    <div class="form-group">
-                        <label for="login-password">Парола:</label>
-                        <input type="password" id="login-password" name="password" required autocomplete="current-password" class="input-focus-animate">
+                    <div class="form-group floating with-icon password-group">
+                        <input placeholder=" " type="password" id="login-password" name="password" required autocomplete="current-password" class="input-focus-animate">
+                        <label for="login-password">Парола</label>
+                        <button type="button" class="toggle-pass" aria-label="Покажи паролата"><i class="bi bi-eye"></i></button>
                     </div>
                     <div id="login-message" class="message error" role="alert"></div>
                     <button type="submit" class="button">Вход</button>
@@ -54,23 +82,34 @@
                     <div class="progress-bar-steps"><div id="registerProgressBar" class="step-progress-bar"></div></div>
                 </div>
                 <form id="register-form" novalidate>
-                    <div class="form-group">
-                        <label for="register-email">Имейл:</label>
-                        <input type="email" id="register-email" name="register_email" required autocomplete="email" class="input-focus-animate">
+                    <div class="form-group floating with-icon">
+                        <input placeholder=" " type="email" id="register-email" name="register_email" required autocomplete="email" class="input-focus-animate">
+                        <label for="register-email">Имейл</label>
+                        <i class="bi bi-envelope"></i>
                     </div>
-                    <div class="form-group">
-                        <label for="register-password">Парола (мин. 8 знака):</label>
-                        <input type="password" id="register-password" name="register_password" required minlength="8" autocomplete="new-password" class="input-focus-animate">
+                    <div class="form-group floating with-icon password-group">
+                        <input placeholder=" " type="password" id="register-password" name="register_password" required minlength="8" autocomplete="new-password" class="input-focus-animate">
+                        <label for="register-password">Парола (мин. 8 знака)</label>
+                        <button type="button" class="toggle-pass" aria-label="Покажи паролата"><i class="bi bi-eye"></i></button>
+                        <div id="register-strength" class="password-strength"></div>
                     </div>
-                    <div class="form-group">
-                        <label for="confirm-password">Потвърди Парола:</label>
-                        <input type="password" id="confirm-password" name="confirm_password" required minlength="8" autocomplete="new-password" class="input-focus-animate">
+                    <div class="form-group floating with-icon password-group">
+                        <input placeholder=" " type="password" id="confirm-password" name="confirm_password" required minlength="8" autocomplete="new-password" class="input-focus-animate">
+                        <label for="confirm-password">Потвърди Парола</label>
+                        <button type="button" class="toggle-pass" aria-label="Покажи паролата"><i class="bi bi-eye"></i></button>
                     </div>
                     <div id="register-message" class="message" role="alert"></div>
                     <button type="submit" class="button button-secondary">Регистрация</button>
                 </form>
                 <button id="show-login" class="toggle-link">Имате акаунт? Влезте</button>
             </div>
+            </div>
+
+            <ul class="benefits">
+                <li><i class="bi bi-bar-chart"></i> Следете прогреса си лесно</li>
+                <li><i class="bi bi-people"></i> Съвети от експерти</li>
+                <li><i class="bi bi-heart-pulse"></i> Персонализирани планове</li>
+            </ul>
 
              <!-- Връзка към въпросника -->
              <div class="questionnaire-link">
@@ -103,9 +142,50 @@
         const regCurrent = document.getElementById('regCurrentStep');
         const regTotal = document.getElementById('regTotalSteps');
         const themeToggleBtn = document.getElementById('theme-toggle');
+        const toggleButtons = document.querySelectorAll('.toggle-pass');
+        const strengthEl = document.getElementById('register-strength');
+        const registerPasswordInput = document.getElementById('register-password');
 
         initializeTheme();
         themeToggleBtn.addEventListener('click', toggleTheme);
+
+        toggleButtons.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const group = btn.closest('.password-group');
+                const input = group.querySelector('input');
+                const isPass = input.type === 'password';
+                input.type = isPass ? 'text' : 'password';
+                btn.innerHTML = isPass ? '<i class="bi bi-eye-slash"></i>' : '<i class="bi bi-eye"></i>';
+            });
+        });
+
+        function evaluateStrength(value) {
+            let score = 0;
+            if (value.length >= 8) score++;
+            if (/[A-Z]/.test(value)) score++;
+            if (/[0-9]/.test(value)) score++;
+            if (/[^A-Za-z0-9]/.test(value)) score++;
+            return score;
+        }
+
+        function updateStrength() {
+            if (!strengthEl) return;
+            const val = registerPasswordInput.value;
+            const score = evaluateStrength(val);
+            let text = '';
+            let cls = '';
+            if (val) {
+                if (score <= 1) { text = 'Слаба'; cls = 'strength-weak'; }
+                else if (score === 2 || score === 3) { text = 'Средна'; cls = 'strength-medium'; }
+                else { text = 'Силна'; cls = 'strength-strong'; }
+            }
+            strengthEl.textContent = text;
+            strengthEl.className = 'password-strength ' + cls;
+        }
+        if (registerPasswordInput) {
+            registerPasswordInput.addEventListener('input', updateStrength);
+            updateStrength();
+        }
 
         const regInputs = Array.from(registerForm.querySelectorAll('input'));
         const totalRegSteps = regInputs.length;
@@ -133,6 +213,8 @@
         showRegisterLink.addEventListener('click', () => {
             loginSection.classList.add('hidden');
             registerSection.classList.remove('hidden');
+            registerSection.classList.add('fade-in');
+            loginSection.classList.remove('fade-in');
             hideMessage(loginMessage);
             hideMessage(registerMessage); // Скриваме и двете при превключване
             registerForm.reset(); // Изчистваме формата за регистрация
@@ -142,6 +224,8 @@
         showLoginLink.addEventListener('click', () => {
             registerSection.classList.add('hidden');
             loginSection.classList.remove('hidden');
+            loginSection.classList.add('fade-in');
+            registerSection.classList.remove('fade-in');
             hideMessage(loginMessage);
             hideMessage(registerMessage);
             loginForm.reset(); // Изчистваме формата за вход


### PR DESCRIPTION
## Summary
- add animated hero from landing page
- arrange login and registration side-by-side on large screens
- apply floating labels with icons
- implement password visibility toggle and strength meter
- insert small benefits section
- animate form switching

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68836e88936c83268acf500b0be3fe94