### PR TITLE
Remove index animation and reuse quest hero

### DIFF
--- a/css/index_styles.css
+++ b/css/index_styles.css
@@ -39,15 +39,9 @@
         h2 { font-size: clamp(1.3rem, 4vw, 1.7rem); margin-bottom: var(--space-lg); }
         p { margin-bottom: var(--space-lg); color: var(--text-color-secondary); font-size: var(--fs-base);}
 
-        .hero { text-align: center; }
-        .hero-animation { width: 200px; height: 200px; margin: 0 auto var(--space-lg); }
-        .rotate { transform-origin: 50% 50%; animation: rotate 15s linear infinite; }
-        .icon path, .icon line, .icon circle { stroke: currentColor; stroke-width: 2; fill: currentColor; }
-        .brain { color: var(--primary-color); }
-        .dna { color: var(--secondary-color); }
-        .person { color: var(--accent-color); }
-        .food { color: var(--color-success); }
-        @keyframes rotate { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+        .hero-content { text-align: center; margin-bottom: var(--space-lg); }
+        .hero-image { max-width: 250px; margin: 0 auto var(--space-lg); }
+        .hero-subtitle { font-size: 1.1rem; color: var(--text-color-secondary); margin-bottom: var(--space-lg); }
 
         .marketing-banner {
             background-color: var(--primary-color);

--- a/index.html
+++ b/index.html
@@ -16,29 +16,9 @@
         <div class="card">
             <h1>MyBody.Best</h1>
 
-            <div class="hero">
-                <svg class="hero-animation" viewBox="0 0 200 200" aria-hidden="true">
-                    <g class="rotate">
-                        <g transform="rotate(0) translate(0,-70) rotate(0)" class="icon brain">
-                            <path d="M10 20c-2-4 0-8 4-9 3-4 9-4 12-1 3-3 9-3 12 0s3 7 1 9c3 1 5 4 3 7s-5 3-7 2c0 2-2 5-5 5s-5-2-6-4c-3 1-6 0-7-3-1-2 0-4 1-6z"></path>
-                        </g>
-                        <g transform="rotate(90) translate(0,-70) rotate(-90)" class="icon dna">
-                            <path d="M0 15 Q10 0 20 15T40 15" fill="none"></path>
-                            <path d="M0 25 Q10 40 20 25T40 25" fill="none"></path>
-                            <line x1="0" y1="15" x2="0" y2="25"></line>
-                            <line x1="40" y1="15" x2="40" y2="25"></line>
-                        </g>
-                        <g transform="rotate(180) translate(0,-70) rotate(-180)" class="icon person">
-                            <circle cx="20" cy="10" r="5"></circle>
-                            <path d="M20 15v15"></path>
-                            <path d="M10 30c2-5 18-5 20 0" fill="none"></path>
-                        </g>
-                        <g transform="rotate(270) translate(0,-70) rotate(-270)" class="icon food">
-                            <path d="M20 10c-3-6-9-6-12 0s-1 10 3 15 9 6 9 6 6-2 9-6 6-9 3-15z"></path>
-                            <path d="M18 2c-1-2-3-2-4 0" fill="none"></path>
-                        </g>
-                    </g>
-                </svg>
+            <div class="hero-content">
+                <img class="hero-image" src="https://radilovk.github.io/bodybest/img/myquest.png" alt="Hero">
+                <p class="hero-subtitle">Разкажи ни повече за теб и твоите цели и стартирай промяната</p>
             </div>
 
             <section class="marketing-banner">


### PR DESCRIPTION
## Summary
- remove old rotating SVG animation from `index.html`
- copy hero block from `quest.html` for a cleaner landing
- drop unused animation CSS and add basic hero styles

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test -- --runInBand` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68837c86361c8326b6495a57b6e49c61