### PR TITLE
Remove index hero animation

### DIFF
--- a/css/index_styles.css
+++ b/css/index_styles.css
@@ -38,17 +38,6 @@
         h1 { font-size: clamp(1.7rem, 5vw, 2.1rem); margin-bottom: calc(var(--space-lg)*0.8); text-align: center; }
         h2 { font-size: clamp(1.3rem, 4vw, 1.7rem); margin-bottom: var(--space-lg); }
         p { margin-bottom: var(--space-lg); color: var(--text-color-secondary); font-size: var(--fs-base);}
-
-        .hero { text-align: center; }
-        .hero-animation { width: 200px; height: 200px; margin: 0 auto var(--space-lg); }
-        .rotate { transform-origin: 50% 50%; animation: rotate 15s linear infinite; }
-        .icon path, .icon line, .icon circle { stroke: currentColor; stroke-width: 2; fill: currentColor; }
-        .brain { color: var(--primary-color); }
-        .dna { color: var(--secondary-color); }
-        .person { color: var(--accent-color); }
-        .food { color: var(--color-success); }
-        @keyframes rotate { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
-
         .marketing-banner {
             background-color: var(--primary-color);
             color: #fff;

--- a/index.html
+++ b/index.html
@@ -15,32 +15,6 @@
     <div class="landing-container">
         <div class="card">
             <h1>MyBody.Best</h1>
-
-            <div class="hero">
-                <svg class="hero-animation" viewBox="0 0 200 200" aria-hidden="true">
-                    <g class="rotate">
-                        <g transform="rotate(0) translate(0,-70) rotate(0)" class="icon brain">
-                            <path d="M10 20c-2-4 0-8 4-9 3-4 9-4 12-1 3-3 9-3 12 0s3 7 1 9c3 1 5 4 3 7s-5 3-7 2c0 2-2 5-5 5s-5-2-6-4c-3 1-6 0-7-3-1-2 0-4 1-6z"></path>
-                        </g>
-                        <g transform="rotate(90) translate(0,-70) rotate(-90)" class="icon dna">
-                            <path d="M0 15 Q10 0 20 15T40 15" fill="none"></path>
-                            <path d="M0 25 Q10 40 20 25T40 25" fill="none"></path>
-                            <line x1="0" y1="15" x2="0" y2="25"></line>
-                            <line x1="40" y1="15" x2="40" y2="25"></line>
-                        </g>
-                        <g transform="rotate(180) translate(0,-70) rotate(-180)" class="icon person">
-                            <circle cx="20" cy="10" r="5"></circle>
-                            <path d="M20 15v15"></path>
-                            <path d="M10 30c2-5 18-5 20 0" fill="none"></path>
-                        </g>
-                        <g transform="rotate(270) translate(0,-70) rotate(-270)" class="icon food">
-                            <path d="M20 10c-3-6-9-6-12 0s-1 10 3 15 9 6 9 6 6-2 9-6 6-9 3-15z"></path>
-                            <path d="M18 2c-1-2-3-2-4 0" fill="none"></path>
-                        </g>
-                    </g>
-                </svg>
-            </div>
-
             <section class="marketing-banner">
                 <div class="intro-text">
                     <h2>Защо MyBody.Best?</h2>


### PR DESCRIPTION
## Summary
- remove hero animation markup from `index.html`
- drop unused animation styles from `css/index_styles.css`

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max_old_space_size=4096 npm test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_68837ef770a88326929d906bd337c18c