### PR TITLE
Update password reset endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,7 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
 - `POST /api/generatePraise` – създава мотивационно съобщение.
 - `POST /api/recordFeedbackChat` – отбелязва, че автоматичният чат е разгледан.
 - `POST /api/submitFeedback` – изпраща обратна връзка от клиента.
+- `POST /api/requestPasswordReset` – изпраща линк за възстановяване на парола.
 - `GET /api/getAiConfig` – зарежда текущата AI конфигурация.
 - `POST /api/setAiConfig` – записва токени и модели в `RESOURCES_KV`.
 - `GET /api/listAiPresets` – връща имената на записаните AI конфигурации.

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -71,7 +71,7 @@
             }
 
             try {
-                const response = await fetch(apiEndpoints.forgotPassword, {
+                const response = await fetch(apiEndpoints.requestPasswordReset, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ email })

--- a/js/config.js
+++ b/js/config.js
@@ -26,7 +26,7 @@ export const apiEndpoints = {
     acknowledgeAiUpdate: `${workerBaseUrl}/api/acknowledgeAiUpdate`,
     recordFeedbackChat: `${workerBaseUrl}/api/recordFeedbackChat`,
     submitFeedback: `${workerBaseUrl}/api/submitFeedback`,
-    forgotPassword: `${workerBaseUrl}/api/requestPasswordReset`,
+    requestPasswordReset: `${workerBaseUrl}/api/requestPasswordReset`,
     performPasswordReset: `${workerBaseUrl}/api/performPasswordReset`,
     getAchievements: `${workerBaseUrl}/api/getAchievements`,
     generatePraise: `${workerBaseUrl}/api/generatePraise`,


### PR DESCRIPTION
## Summary
- rename API endpoint key to `requestPasswordReset`
- update forgot-password logic to use the new key
- document the endpoint in README

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6883874eaff08326b5b12a58667bc89b