### PR TITLE
Add reset password validation

### DIFF
--- a/reset-password.html
+++ b/reset-password.html
@@ -48,8 +48,29 @@
                 submitBtn.disabled = true;
                 submitBtn.textContent = 'Обработка...';
 
-                const password = document.getElementById('new-password').value;
-                const confirm = document.getElementById('confirm-password').value;
+                const passwordInput = document.getElementById('new-password');
+                const confirmInput = document.getElementById('confirm-password');
+                const password = passwordInput.value;
+                const confirm = confirmInput.value;
+
+                if (!password || !confirm) {
+                    showMessage(messageEl, 'Моля, попълнете всички полета.', true);
+                    submitBtn.disabled = false;
+                    submitBtn.textContent = originalText;
+                    return;
+                }
+                if (password.length < 8) {
+                    showMessage(messageEl, 'Паролата трябва да е поне 8 знака.', true);
+                    submitBtn.disabled = false;
+                    submitBtn.textContent = originalText;
+                    return;
+                }
+                if (password !== confirm) {
+                    showMessage(messageEl, 'Паролите не съвпадат.', true);
+                    submitBtn.disabled = false;
+                    submitBtn.textContent = originalText;
+                    return;
+                }
 
                 try {
                     const resp = await fetch(apiEndpoints.performPasswordReset, {


### PR DESCRIPTION
## Summary
- add input checks to `reset-password.html`

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688388e474188326924446af93cef70f