### PR TITLE
Add password reset token tests

### DIFF
--- a/js/__tests__/passwordReset.test.js
+++ b/js/__tests__/passwordReset.test.js
@@ -36,3 +36,26 @@ test('handlePerformPasswordReset updates password and deletes token', async () =
   expect(kv._store['pwreset_tok123']).toBeUndefined();
   expect(JSON.parse(kv._store['credential_u1']).passwordHash).not.toBe('old');
 });
+
+test('handleRequestPasswordReset sets token expiration', async () => {
+  const kv = createStore({ 'email_to_uuid_a@b.bg': 'u1' });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  const env = { USER_METADATA_KV: kv, MAILER_ENDPOINT_URL: 'https://mail.test' };
+  const req = { json: async () => ({ email: 'a@b.bg' }) };
+  await handleRequestPasswordReset(req, env);
+  const putArgs = kv.put.mock.calls[0];
+  expect(putArgs[2]).toEqual({ expirationTtl: 3600 });
+  global.fetch.mockRestore();
+});
+
+test('handlePerformPasswordReset fails for invalid token', async () => {
+  const kv = createStore({
+    'credential_u1': JSON.stringify({ userId: 'u1', passwordHash: 'old' })
+  });
+  const env = { USER_METADATA_KV: kv };
+  const req = { json: async () => ({ token: 'missing', password: 'Newpass123', confirm_password: 'Newpass123' }) };
+  const res = await handlePerformPasswordReset(req, env);
+  expect(res.success).toBe(false);
+  expect(res.message).toBe('Невалиден или изтекъл токен.');
+  expect(JSON.parse(kv._store['credential_u1']).passwordHash).toBe('old');
+});


### PR DESCRIPTION
## Summary
- extend password reset tests
  - check token expiration TTL when generating reset token
  - verify password change fails when token is invalid
- mock KV and email sending within new tests

## Testing
- `npm run lint`
- `NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=4096' npx jest --runInBand` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6883958e702483269b638582c748dda1