### PR TITLE
Add admin color settings

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -256,6 +256,23 @@
     </form>
   </details>
 
+  <details id="colorSettings" class="card">
+    <summary>Настройки на цветове</summary>
+    <label>Основен цвят
+      <input type="color" id="primaryColorInput">
+    </label>
+    <label>Вторичен цвят
+      <input type="color" id="secondaryColorInput">
+    </label>
+    <label>Акцентен цвят
+      <input type="color" id="accentColorInput">
+    </label>
+    <label>Терциерен цвят
+      <input type="color" id="tertiaryColorInput">
+    </label>
+    <button id="saveColorConfig">Запази</button>
+  </details>
+
   <details id="testEmailSection" class="card">
     <summary>Тестов имейл</summary>
     <form id="testEmailForm">
@@ -294,5 +311,6 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="js/admin.js"></script>
+  <script type="module" src="js/adminColors.js"></script>
 </body>
 </html>

--- a/js/__tests__/adminColors.test.js
+++ b/js/__tests__/adminColors.test.js
@@ -1,0 +1,49 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let initColorSettings;
+let mockLoad;
+let mockSave;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <input id="primaryColorInput" type="color">
+    <input id="secondaryColorInput" type="color">
+    <input id="accentColorInput" type="color">
+    <input id="tertiaryColorInput" type="color">
+    <button id="saveColorConfig"></button>`;
+
+  mockLoad = jest.fn().mockResolvedValue({ colors: { primary: '#111111', secondary: '#222222' } });
+  mockSave = jest.fn().mockResolvedValue({});
+  jest.unstable_mockModule('../adminConfig.js', () => ({
+    loadConfig: mockLoad,
+    saveConfig: mockSave
+  }));
+  ({ initColorSettings } = await import('../adminColors.js'));
+});
+
+afterEach(() => {
+  mockLoad.mockReset();
+  mockSave.mockReset();
+});
+
+test('initColorSettings loads config and sets CSS vars', async () => {
+  await initColorSettings();
+  expect(mockLoad).toHaveBeenCalledWith(['colors']);
+  expect(document.getElementById('primaryColorInput').value).toBe('#111111');
+  expect(document.documentElement.style.getPropertyValue('--primary-color')).toBe('#111111');
+});
+
+test('save button gathers colors and calls saveConfig', async () => {
+  await initColorSettings();
+  document.getElementById('primaryColorInput').value = '#333333';
+  document.getElementById('secondaryColorInput').value = '#444444';
+  document.getElementById('saveColorConfig').click();
+  expect(mockSave).toHaveBeenCalledWith({ colors: {
+    primary: '#333333',
+    secondary: '#444444',
+    accent: document.getElementById('accentColorInput').value,
+    tertiary: document.getElementById('tertiaryColorInput').value
+  } });
+});

--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -1,0 +1,51 @@
+import { loadConfig, saveConfig } from './adminConfig.js';
+
+const inputSelectors = {
+  primary: '#primaryColorInput',
+  secondary: '#secondaryColorInput',
+  accent: '#accentColorInput',
+  tertiary: '#tertiaryColorInput'
+};
+
+const inputs = {};
+
+function setCssVar(key, val) {
+  document.documentElement.style.setProperty(`--${key}-color`, val);
+}
+
+export async function initColorSettings() {
+  for (const [key, sel] of Object.entries(inputSelectors)) {
+    inputs[key] = document.querySelector(sel);
+  }
+  const saveBtn = document.getElementById('saveColorConfig');
+  if (!saveBtn) return;
+  try {
+    const { colors = {} } = await loadConfig(['colors']);
+    Object.entries(inputs).forEach(([k, el]) => {
+      if (!el) return;
+      if (colors[k]) {
+        el.value = colors[k];
+        setCssVar(k, colors[k]);
+      }
+      el.addEventListener('input', () => setCssVar(k, el.value));
+    });
+  } catch (err) {
+    console.warn('Неуспешно зареждане на цветовете', err);
+  }
+
+  saveBtn.addEventListener('click', async () => {
+    const colors = {};
+    Object.entries(inputs).forEach(([k, el]) => {
+      if (el) colors[k] = el.value;
+    });
+    try {
+      await saveConfig({ colors });
+      alert('Цветовете са записани.');
+    } catch (err) {
+      console.error('Грешка при запис на цветовете', err);
+      alert('Грешка при запис на цветовете.');
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initColorSettings);

--- a/preworker.js
+++ b/preworker.js
@@ -274,7 +274,8 @@ const AI_CONFIG_KEYS = [
     'questionnaire_email_body',
     'analysis_email_subject',
     'analysis_email_body',
-    'send_questionnaire_email'
+    'send_questionnaire_email',
+    'colors'
 ];
 // ------------- END BLOCK: GlobalConstantsAndBindings -------------
 

--- a/worker.js
+++ b/worker.js
@@ -274,7 +274,8 @@ const AI_CONFIG_KEYS = [
     'questionnaire_email_body',
     'analysis_email_subject',
     'analysis_email_body',
-    'send_questionnaire_email'
+    'send_questionnaire_email',
+    'colors'
 ];
 // ------------- END BLOCK: GlobalConstantsAndBindings -------------
 


### PR DESCRIPTION
## Summary
- let admins configure project colors
- persist color data via Worker KV
- include new module on admin page
- test color settings logic

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6883bfd014e08326b0dcd6634795e7e0