### PR TITLE
Enhance password reset UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
 - `POST /api/recordFeedbackChat` – отбелязва, че автоматичният чат е разгледан.
 - `POST /api/submitFeedback` – изпраща обратна връзка от клиента.
 - `POST /api/requestPasswordReset` – изпраща линк за възстановяване на парола.
+- `POST /api/performPasswordReset` – задава нова парола по изпратения токен.
 - `GET /api/getAiConfig` – зарежда текущата AI конфигурация.
 - `POST /api/setAiConfig` – записва токени и модели в `RESOURCES_KV`.
 - `GET /api/listAiPresets` – връща имената на записаните AI конфигурации.
@@ -840,6 +841,9 @@ To send a test email задайте `WORKER_ADMIN_TOKEN`. Може да посо
 | `ANALYSIS_EMAIL_SUBJECT` | Subject for the email, sent when the personal analysis is ready. |
 | `ANALYSIS_EMAIL_BODY` | HTML body template for that email. Use `{{name}}` и `{{link}}` за персонализация. |
 | `ANALYSIS_PAGE_URL` | Base URL към `analyze.html` за генериране на линка в писмото. |
+| `PASSWORD_RESET_EMAIL_SUBJECT` | Subject за писмото при заявка за нова парола. |
+| `PASSWORD_RESET_EMAIL_BODY` | HTML шаблон за имейла с линка за смяна на паролата. Използвайте `{{link}}`. |
+| `PASSWORD_RESET_PAGE_URL` | Базов URL към `reset-password.html` за генериране на линка. |
 | `WORKER_URL` | Base URL of the main worker used by `mailer.js` to fetch email templates when no subject or body is provided. |
 
 ### HTML шаблон за приветствени имейли

--- a/css/index_styles.css
+++ b/css/index_styles.css
@@ -111,7 +111,8 @@
         .toggle-link {
             color: var(--primary-color); background: none; border: none; cursor: pointer;
             text-decoration: underline; padding: 0; /* Намален padding */
-            font-size: 0.85rem; display: block; margin-top: calc(var(--space-lg)*0.7); /* Леко намалено отстояние */
+            font-size: 0.85rem; display: inline-flex; align-items: center; gap: 0.3rem;
+            margin-top: calc(var(--space-lg)*0.7); /* Леко намалено отстояние */
             text-align: center; /* Центриране по подразбиране */
             transition: color 0.2s;
         }

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
                     <div id="login-message" class="message error" role="alert"></div>
                     <button type="submit" class="button">Вход</button>
                     <!-- Линк за забравена парола -->
-                    <button type="button" id="forgot-password-link" class="toggle-link">Забравена парола?</button>
+                    <button type="button" id="forgot-password-link" class="toggle-link"><i class="bi bi-question-circle"></i> Забравена парола?</button>
                 </form>
                 <button id="show-register" class="toggle-link">Нямате акаунт? Регистрирайте се</button>
             </div>

--- a/reset-password.html
+++ b/reset-password.html
@@ -18,6 +18,7 @@
                 <div class="form-group">
                     <label for="new-password">Нова парола:</label>
                     <input type="password" id="new-password" name="password" required autocomplete="new-password">
+                    <div id="reset-strength" class="password-strength"></div>
                 </div>
                 <div class="form-group">
                     <label for="confirm-password">Потвърди паролата:</label>
@@ -26,6 +27,7 @@
                 <div id="reset-message" class="message" role="alert"></div>
                 <button type="submit" class="button">Запази</button>
             </form>
+            <button id="reset-back" class="toggle-link">Назад към вход</button>
         </div>
     </div>
 
@@ -35,6 +37,39 @@
 
         const form = document.getElementById('reset-password-form');
         const messageEl = document.getElementById('reset-message');
+        const backBtn = document.getElementById('reset-back');
+        const strengthEl = document.getElementById('reset-strength');
+        const passwordInputEl = document.getElementById('new-password');
+
+        backBtn.addEventListener('click', () => {
+            window.location.href = 'index.html';
+        });
+
+        function evaluateStrength(value) {
+            let score = 0;
+            if (value.length >= 8) score++;
+            if (/[A-Z]/.test(value)) score++;
+            if (/[0-9]/.test(value)) score++;
+            if (/[^A-Za-z0-9]/.test(value)) score++;
+            return score;
+        }
+
+        function updateStrength() {
+            if (!strengthEl) return;
+            const val = passwordInputEl.value;
+            const score = evaluateStrength(val);
+            let text = '';
+            let cls = '';
+            if (val) {
+                if (score <= 1) { text = 'Слаба'; cls = 'strength-weak'; }
+                else if (score === 2 || score === 3) { text = 'Средна'; cls = 'strength-medium'; }
+                else { text = 'Силна'; cls = 'strength-strong'; }
+            }
+            strengthEl.textContent = text;
+            strengthEl.className = 'password-strength ' + cls;
+        }
+        passwordInputEl.addEventListener('input', updateStrength);
+        updateStrength();
         const token = new URLSearchParams(window.location.search).get('token');
         if (!token) {
             showMessage(messageEl, 'Липсва токен за възстановяване.', true);
@@ -84,6 +119,7 @@
                     }
                     showMessage(messageEl, data.message || 'Паролата е сменена.', false);
                     form.reset();
+                    setTimeout(() => { window.location.href = 'index.html'; }, 2000);
                 } catch (err) {
                     console.error('Reset password error:', err);
                     showMessage(messageEl, err.message, true);


### PR DESCRIPTION
## Summary
- show an icon for the 'Forgot password' link and tweak `.toggle-link` styling
- enhance `reset-password.html` with strength indicator, login button and redirect
- document `performPasswordReset` and related environment variables

## Testing
- `npm run lint`
- `NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=6144' npm test -- --runInBand` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6883c6d982a883269bdd876d63ee990f