### PR TITLE
Improve quest page layout

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -31,7 +31,8 @@ body {
 }
 
 .question-text {
-  font-size: 18px;
+  font-size: 20px;
+  font-weight: 600;
   color: #80cbc4;
   margin-bottom: 20px;
   line-height: 1.4;
@@ -40,9 +41,10 @@ body {
 .answer-label {
   font-size: 16px;
   line-height: 1.4;
-  margin-bottom: 8px;
+  margin: 8px auto;
   display: block;
   padding: 10px;
+  width: 80%;
   border-radius: 5px;
   border: 1px solid #333;
   cursor: pointer;
@@ -84,6 +86,15 @@ p {
   z-index: 2;
 }
 
+#questPage .page:not(.hero-start-page) {
+  background-color: rgba(44, 62, 80, 0.65);
+  backdrop-filter: blur(4px);
+  border-radius: 10px;
+  padding: 20px;
+  max-width: 600px;
+  margin: 60px auto 20px;
+}
+
 .page.active {
   display: block;
 }
@@ -91,9 +102,14 @@ p {
 /* Навигационни бутони */
 .nav-buttons {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: center;
   gap: 10px;
   margin-top: 20px;
+}
+.nav-buttons button {
+  min-width: 120px;
+  flex: 1;
 }
 
 button {
@@ -120,9 +136,9 @@ input[type="email"],
 input[type="password"],
 textarea,
 select {
-  width: 93%;
+  width: 80%;
   padding: 12px;
-  margin: 10px 0 20px;
+  margin: 10px auto 20px;
   border: 1px solid #333;
   border-radius: 5px;
   background-color: #2a2a2a;
@@ -205,7 +221,9 @@ input[type="checkbox"] {
     padding: 15px;
   }
   .nav-buttons button {
-    width: 100%;
+    width: auto;
+    min-width: 120px;
+    flex: 1;
   }
   .question-text {
     font-size: 16px;


### PR DESCRIPTION
## Summary
- refine question text style
- center answer inputs and labels
- align nav buttons horizontally
- add semi-transparent container background

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6883cf3446a88326a6370a10dfcd798e