### PR TITLE
Quest UX tweaks

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -87,7 +87,7 @@ p {
 }
 
 #questPage .page:not(.hero-start-page) {
-  background-color: rgba(44, 62, 80, 0.65);
+  background-color: rgba(44, 62, 80, 0.45);
   backdrop-filter: blur(4px);
   border-radius: 10px;
   padding: 20px;
@@ -270,9 +270,9 @@ input[type="checkbox"] {
   color: #fff;
   /* Динамичен градиентен фон */
   background: linear-gradient(35deg,
-    rgba(31, 44, 53, 0.65),
-    rgba(44, 62, 80, 0.65),
-    rgba(70, 99, 104, 0.65)
+    rgba(31, 44, 53, 0.55),
+    rgba(44, 62, 80, 0.55),
+    rgba(70, 99, 104, 0.55)
   );
   background-size: 200% 200%;
   animation: gradientAnimation 15s ease infinite;

--- a/quest.html
+++ b/quest.html
@@ -430,8 +430,8 @@
       html += `<div class="fs-xs text-muted" style="margin-top: 10px;">(Показва се ако '${question.dependency.question}' е '${question.dependency.value}')</div>`;
     }
     html += `<div class="nav-buttons">
-               <button type="button" id="nextBtn${pageIndex}">Напред ▶</button>
                ${pageIndex > 1 ? `<button type="button" id="prevBtn${pageIndex}">◀ Назад</button>` : ''}
+               <button type="button" id="nextBtn${pageIndex}">Напред ▶</button>
              </div>`;
     pageDiv.innerHTML = html;
     container.appendChild(pageDiv);
@@ -693,7 +693,18 @@
     if (!question || !question.id) return true;
     const qId = question.id; let isValid = true; let errorMessage = '';
     const element = document.getElementById(qId);
-    const requiredFields = ['name','gender','age','height','weight','goal','motivation'];
+    const requiredFields = [
+      'name',
+      'gender',
+      'age',
+      'height',
+      'weight',
+      'goal',
+      'motivation',
+      'physicalActivity',
+      'waterIntake',
+      'sleepHours'
+    ];
     const isRequired = requiredFields.includes(qId);
     let value = '';
     if (['text', 'number', 'email', 'textarea'].includes(question.type)) {


### PR DESCRIPTION
## Summary
- switch the order of 'Напред'/'Назад' buttons in the questionnaire
- make blue question background lighter
- enforce more required questionnaire fields

## Testing
- `npm run lint`
- `npm test js/__tests__/aiHelper.test.js`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6883d2063bcc8326b0860a4624d32cf8