### PR TITLE
Implement step-wise plan generation

### DIFF
--- a/worker_modules/planGenerationSteps.js
+++ b/worker_modules/planGenerationSteps.js
@@ -1,0 +1,36 @@
+export async function generateProfile(replacements, env, modelName) {
+  const template = await env.RESOURCES_KV.get('prompt_generate_profile');
+  if (!template) throw new Error('Missing prompt_generate_profile');
+  const populated = populatePrompt(template, replacements);
+  const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
+  const cleaned = cleanGeminiJson(raw);
+  return safeParseJson(cleaned, {});
+}
+
+export async function generateMenu(replacements, env, modelName) {
+  const template = await env.RESOURCES_KV.get('prompt_generate_menu');
+  if (!template) throw new Error('Missing prompt_generate_menu');
+  const populated = populatePrompt(template, replacements);
+  const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
+  const cleaned = cleanGeminiJson(raw);
+  return safeParseJson(cleaned, {});
+}
+
+export async function generatePrinciples(replacements, env, modelName) {
+  const template = await env.RESOURCES_KV.get('prompt_generate_principles');
+  if (!template) throw new Error('Missing prompt_generate_principles');
+  const populated = populatePrompt(template, replacements);
+  const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
+  const cleaned = cleanGeminiJson(raw);
+  return safeParseJson(cleaned, {});
+}
+
+export async function generateGuidance(replacements, env, modelName) {
+  const template = await env.RESOURCES_KV.get('prompt_generate_guidance');
+  if (!template) throw new Error('Missing prompt_generate_guidance');
+  const populated = populatePrompt(template, replacements);
+  const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
+  const cleaned = cleanGeminiJson(raw);
+  return safeParseJson(cleaned, {});
+}
+


### PR DESCRIPTION
## Summary
- add `worker_modules/planGenerationSteps.js` with individual generation helpers
- split plan generation into separate steps in `processSingleUserPlan`
- load new prompts from KV and record errors per step
- update `AI_CONFIG_KEYS`

## Testing
- `npm run lint`
- `npm test` *(fails: Ineffective mark-compacts near heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_6883d6568ab4832686b8cbe729456483