### PR TITLE
Implement cached plan sections

### DIFF
--- a/worker_modules/planGenerationSteps.js
+++ b/worker_modules/planGenerationSteps.js
@@ -1,36 +1,56 @@
-export async function generateProfile(replacements, env, modelName) {
+export async function generateProfile(replacements, env, modelName, userId) {
   const template = await env.RESOURCES_KV.get('prompt_generate_profile');
   if (!template) throw new Error('Missing prompt_generate_profile');
   const populated = populatePrompt(template, replacements);
   const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
   const cleaned = cleanGeminiJson(raw);
-  return safeParseJson(cleaned, {});
+  const parsed = safeParseJson(cleaned, {});
+  await env.USER_METADATA_KV.put(
+    `plan_section_profile_${userId}`,
+    JSON.stringify({ ts: Date.now(), data: parsed })
+  );
+  return parsed;
 }
 
-export async function generateMenu(replacements, env, modelName) {
+export async function generateMenu(replacements, env, modelName, userId) {
   const template = await env.RESOURCES_KV.get('prompt_generate_menu');
   if (!template) throw new Error('Missing prompt_generate_menu');
   const populated = populatePrompt(template, replacements);
   const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
   const cleaned = cleanGeminiJson(raw);
-  return safeParseJson(cleaned, {});
+  const parsed = safeParseJson(cleaned, {});
+  await env.USER_METADATA_KV.put(
+    `plan_section_menu_${userId}`,
+    JSON.stringify({ ts: Date.now(), data: parsed })
+  );
+  return parsed;
 }
 
-export async function generatePrinciples(replacements, env, modelName) {
+export async function generatePrinciples(replacements, env, modelName, userId) {
   const template = await env.RESOURCES_KV.get('prompt_generate_principles');
   if (!template) throw new Error('Missing prompt_generate_principles');
   const populated = populatePrompt(template, replacements);
   const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
   const cleaned = cleanGeminiJson(raw);
-  return safeParseJson(cleaned, {});
+  const parsed = safeParseJson(cleaned, {});
+  await env.USER_METADATA_KV.put(
+    `plan_section_principles_${userId}`,
+    JSON.stringify({ ts: Date.now(), data: parsed })
+  );
+  return parsed;
 }
 
-export async function generateGuidance(replacements, env, modelName) {
+export async function generateGuidance(replacements, env, modelName, userId) {
   const template = await env.RESOURCES_KV.get('prompt_generate_guidance');
   if (!template) throw new Error('Missing prompt_generate_guidance');
   const populated = populatePrompt(template, replacements);
   const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
   const cleaned = cleanGeminiJson(raw);
-  return safeParseJson(cleaned, {});
+  const parsed = safeParseJson(cleaned, {});
+  await env.USER_METADATA_KV.put(
+    `plan_section_guidance_${userId}`,
+    JSON.stringify({ ts: Date.now(), data: parsed })
+  );
+  return parsed;
 }
 


### PR DESCRIPTION
## Summary
- cache individual plan sections in USER_METADATA_KV
- reassemble a complete plan only regenerating outdated sections

## Testing
- `npm run lint`
- `npm test -- --runInBand` *(fails: planGenerationLogs.test.js, pendingPlanModIntegration.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6883dfb5b43c83269005b6df4c643b8e