### PR TITLE
Add updateProfile/updateMenu events

### DIFF
--- a/js/__tests__/createUserEvent.test.js
+++ b/js/__tests__/createUserEvent.test.js
@@ -37,3 +37,33 @@ describe('createUserEvent planMod status', () => {
     expect(statusCalls.length).toBe(0);
   });
 });
+
+describe('createUserEvent updateProfile', () => {
+  test('sets plan status to pending', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [] }),
+        get: jest.fn(),
+        put: jest.fn()
+      }
+    };
+    const res = await createUserEvent('updateProfile', 'u1', { name: 'a' }, env);
+    expect(res.success).toBe(true);
+    const statusCall = env.USER_METADATA_KV.put.mock.calls.find(c => c[0] === 'plan_status_u1');
+    expect(statusCall).toBeTruthy();
+  });
+
+  test('returns false when event already pending', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [{ name: 'event_updateProfile_u1_old' }] }),
+        get: jest.fn().mockResolvedValue(JSON.stringify({ status: 'pending' })),
+        put: jest.fn()
+      }
+    };
+    const res = await createUserEvent('updateProfile', 'u1', { n: 1 }, env);
+    expect(res.success).toBe(false);
+    const statusCalls = env.USER_METADATA_KV.put.mock.calls.filter(c => c[0] === 'plan_status_u1');
+    expect(statusCalls.length).toBe(0);
+  });
+});

--- a/js/__tests__/userEvents.test.js
+++ b/js/__tests__/userEvents.test.js
@@ -17,4 +17,19 @@ describe('processPendingUserEvents', () => {
     expect(env.USER_METADATA_KV.put).toHaveBeenCalled();
     expect(env.USER_METADATA_KV.delete).toHaveBeenCalledWith('event_testResult_u1_1');
   });
+
+  test('processes updateProfile event', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        list: jest.fn().mockResolvedValue({ keys: [{ name: 'event_updateProfile_u1_1' }] }),
+        get: jest.fn().mockResolvedValue(JSON.stringify({ type: 'updateProfile', userId: 'u1', createdTimestamp: 1, payload: {} })),
+        delete: jest.fn(),
+        put: jest.fn()
+      }
+    };
+    const ctx = { waitUntil: jest.fn() };
+    await processPendingUserEvents(env, ctx, 5);
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
+    expect(env.USER_METADATA_KV.delete).toHaveBeenCalledWith('event_updateProfile_u1_1');
+  });
 });

--- a/preworker.js
+++ b/preworker.js
@@ -3341,14 +3341,14 @@ async function evaluatePlanChange(userId, requestData, env) {
 async function createUserEvent(eventType, userId, payload, env) {
     if (!eventType || !userId) return { success: false, message: 'Невалидни параметри.' };
 
-    if (eventType === 'planMod') {
+    if (['planMod', 'updateProfile', 'updateMenu'].includes(eventType)) {
         try {
-            const existing = await env.USER_METADATA_KV.list({ prefix: `event_planMod_${userId}` });
+            const existing = await env.USER_METADATA_KV.list({ prefix: `event_${eventType}_${userId}` });
             for (const { name } of existing.keys) {
                 const val = await env.USER_METADATA_KV.get(name);
                 const parsed = safeParseJson(val, null);
                 if (parsed && parsed.status === 'pending') {
-                    return { success: false, message: 'Вече има чакаща заявка за промяна на плана.' };
+                    return { success: false, message: `Вече има чакаща заявка за ${eventType}.` };
                 }
             }
         } catch (err) {
@@ -3365,9 +3365,11 @@ async function createUserEvent(eventType, userId, payload, env) {
         payload
     };
     await env.USER_METADATA_KV.put(key, JSON.stringify(data));
-    if (eventType === 'planMod') {
+    if (['planMod', 'updateProfile', 'updateMenu'].includes(eventType)) {
         try {
-            await env.USER_METADATA_KV.put(`pending_plan_mod_${userId}`, JSON.stringify(payload || {}));
+            if (eventType === 'planMod') {
+                await env.USER_METADATA_KV.put(`pending_plan_mod_${userId}`, JSON.stringify(payload || {}));
+            }
             await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'pending', { metadata:{status:'pending'} });
         } catch (err) {
             console.error(`EVENT_SAVE_PENDING_MOD_ERROR (${userId}):`, err);
@@ -4191,6 +4193,16 @@ async function handleIrisDiagEvent(userId, payload, env) {
     await processSingleUserPlan(userId, env);
 }
 
+async function handleUpdateProfileEvent(userId, env) {
+    console.log(`[CRON-UserEvent] Processing updateProfile for ${userId}`);
+    await processSingleUserPlan(userId, env);
+}
+
+async function handleUpdateMenuEvent(userId, env) {
+    console.log(`[CRON-UserEvent] Processing updateMenu for ${userId}`);
+    await processSingleUserPlan(userId, env);
+}
+
 // ------------- START BLOCK: UserEventHandlers -------------
 const EVENT_HANDLERS = {
     planMod: async (userId, env) => {
@@ -4201,6 +4213,12 @@ const EVENT_HANDLERS = {
     },
     irisDiag: async (userId, env, payload) => {
         await handleIrisDiagEvent(userId, payload, env);
+    },
+    updateProfile: async (userId, env) => {
+        await handleUpdateProfileEvent(userId, env);
+    },
+    updateMenu: async (userId, env) => {
+        await handleUpdateMenuEvent(userId, env);
     }
 };
 

--- a/worker.js
+++ b/worker.js
@@ -3341,14 +3341,14 @@ async function evaluatePlanChange(userId, requestData, env) {
 async function createUserEvent(eventType, userId, payload, env) {
     if (!eventType || !userId) return { success: false, message: 'Невалидни параметри.' };
 
-    if (eventType === 'planMod') {
+    if (['planMod', 'updateProfile', 'updateMenu'].includes(eventType)) {
         try {
-            const existing = await env.USER_METADATA_KV.list({ prefix: `event_planMod_${userId}` });
+            const existing = await env.USER_METADATA_KV.list({ prefix: `event_${eventType}_${userId}` });
             for (const { name } of existing.keys) {
                 const val = await env.USER_METADATA_KV.get(name);
                 const parsed = safeParseJson(val, null);
                 if (parsed && parsed.status === 'pending') {
-                    return { success: false, message: 'Вече има чакаща заявка за промяна на плана.' };
+                    return { success: false, message: `Вече има чакаща заявка за ${eventType}.` };
                 }
             }
         } catch (err) {
@@ -3365,9 +3365,11 @@ async function createUserEvent(eventType, userId, payload, env) {
         payload
     };
     await env.USER_METADATA_KV.put(key, JSON.stringify(data));
-    if (eventType === 'planMod') {
+    if (['planMod', 'updateProfile', 'updateMenu'].includes(eventType)) {
         try {
-            await env.USER_METADATA_KV.put(`pending_plan_mod_${userId}`, JSON.stringify(payload || {}));
+            if (eventType === 'planMod') {
+                await env.USER_METADATA_KV.put(`pending_plan_mod_${userId}`, JSON.stringify(payload || {}));
+            }
             await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'pending', { metadata:{status:'pending'} });
         } catch (err) {
             console.error(`EVENT_SAVE_PENDING_MOD_ERROR (${userId}):`, err);
@@ -4191,6 +4193,16 @@ async function handleIrisDiagEvent(userId, payload, env) {
     await processSingleUserPlan(userId, env);
 }
 
+async function handleUpdateProfileEvent(userId, env) {
+    console.log(`[CRON-UserEvent] Processing updateProfile for ${userId}`);
+    await processSingleUserPlan(userId, env);
+}
+
+async function handleUpdateMenuEvent(userId, env) {
+    console.log(`[CRON-UserEvent] Processing updateMenu for ${userId}`);
+    await processSingleUserPlan(userId, env);
+}
+
 // ------------- START BLOCK: UserEventHandlers -------------
 const EVENT_HANDLERS = {
     planMod: async (userId, env) => {
@@ -4201,6 +4213,12 @@ const EVENT_HANDLERS = {
     },
     irisDiag: async (userId, env, payload) => {
         await handleIrisDiagEvent(userId, payload, env);
+    },
+    updateProfile: async (userId, env) => {
+        await handleUpdateProfileEvent(userId, env);
+    },
+    updateMenu: async (userId, env) => {
+        await handleUpdateMenuEvent(userId, env);
     }
 };
 


### PR DESCRIPTION
## Summary
- add new `updateProfile` and `updateMenu` user event types
- update event handler table to process the new events
- mark plan status as pending when such events are queued
- extend tests for `createUserEvent` and `processPendingUserEvents`

## Testing
- `npm run lint`
- `NODE_OPTIONS=--experimental-vm-modules npx jest js/__tests__/createUserEvent.test.js js/__tests__/userEvents.test.js`
- `NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=4096' npx jest --runInBand` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6883e8a2d0e88326b5f767fb3bb477fa