### PR TITLE
Изчистен индикатор на стъпките

### DIFF
--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -16,17 +16,15 @@
 .step-indicator-container {
   text-align: center;
   margin-bottom: var(--space-md);
+  background-color: rgba(var(--surface-background-rgb), 0.5); /* полу-прозрачно фонче */
 }
 .step-indicator-label {
-  display: block;
-  font-size: 0.85em;
-  color: var(--text-color-muted);
-  margin-bottom: var(--space-xs);
+  display: none; /* етикетът вече не се показва */
 }
 .progress-bar-steps {
   width: 100%;
   height: 8px;
-  background-color: var(--surface-background);
+  background-color: color-mix(in srgb, var(--secondary-color) 30%, var(--surface-background)); /* по-подходящ цвят */
   border-radius: var(--radius-sm);
   overflow: visible;
   margin: 0 auto;

--- a/css/extra_meal_form_styles.css
+++ b/css/extra_meal_form_styles.css
@@ -221,17 +221,15 @@
 #extraMealEntryModal .step-indicator-container {
     margin-bottom: var(--space-lg);
     text-align: center;
+    background-color: rgba(var(--surface-background-rgb), 0.5);
 }
 #extraMealEntryModal .step-indicator-label {
-    display: block;
-    font-size: 0.85em;
-    color: var(--text-color-muted);
-    margin-bottom: var(--space-xs);
+    display: none;
 }
 #extraMealEntryModal .progress-bar-steps {
     width: 100%;
     height: 8px;
-    background-color: var(--surface-background);
+    background-color: color-mix(in srgb, var(--secondary-color) 30%, var(--surface-background));
     border-radius: var(--radius-sm);
     overflow: hidden;
     margin: 0 auto;


### PR DESCRIPTION
## Summary
- скриване на надписа към индикатора
- полупрозрачен фон на контейнера
- по-видим цвят на лентата за прогрес

## Testing
- `npm run lint`
- `npm test` *(очаквани грешки)*

------
https://chatgpt.com/codex/tasks/task_e_688407930fd083268b395043070d4b1d