### PR TITLE
Add bottom stats bar and questionnaire instructions

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -386,6 +386,21 @@ input[type="checkbox"] {
     user-select: none;
 }
 
+.bottom-stats {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background-color: rgba(18, 18, 18, 0.85);
+    backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    padding: 10px 0;
+    z-index: 1000;
+}
+
 .stat-item {
     text-align: center;
 }
@@ -401,6 +416,14 @@ input[type="checkbox"] {
     height: 80px;
     display: block;
     margin: 0 auto 5px;
+}
+
+.quest-instructions {
+    text-align: center;
+    margin: 20px auto;
+    max-width: 600px;
+    color: #cccccc;
+    font-size: 0.95rem;
 }
 
 @keyframes fadeInContent {
@@ -425,6 +448,10 @@ input[type="checkbox"] {
   }
   .stats-bar {
     gap: 30px;
+  }
+  .bottom-stats .stat-icon {
+    width: 50px;
+    height: 50px;
   }
   #page0.hero-start-page #startBtn {
     width: 100%;

--- a/quest.html
+++ b/quest.html
@@ -224,6 +224,24 @@
 <div class="container" id="dynamicContainer">
   <!-- Динамично генерираните "страници" ще се вмъкнат тук -->
 </div>
+<p id="questInstructions" class="quest-instructions" style="display:none">
+  За да получите адаптирана и работеща стратегия за вас,
+  въведете коректна и изчерпателна информация
+</p>
+<div id="bottomStats" class="stats-bar bottom-stats">
+  <div class="stat-item">
+    <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/aibrain.png" alt="AI Algorithm">
+    <div class="stat-label">AI Med Алгоритъм</div>
+  </div>
+  <div class="stat-item">
+    <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/medic.png" alt="Medical Experts">
+    <div class="stat-label">Реални специалисти</div>
+  </div>
+  <div class="stat-item">
+    <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/clock.png" alt="24/7 Assistant">
+    <div class="stat-label">24/7 Личен асистент</div>
+  </div>
+</div>
 
 <!-- Тайна зона за мобилни устройства за Admin достъп -->
 <div id="secretTapArea" style="position: fixed; top: 0; left: 0; width: 30px; height: 30px; opacity: 0; z-index: 9999;"></div>
@@ -330,20 +348,7 @@
           </button>
         </div>
         
-        <div class="stats-bar">
-          <div class="stat-item">
-            <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/aibrain.png" alt="AI Algorithm">
-            <div class="stat-label">AI Med Алгоритъм</div>
-          </div>
-          <div class="stat-item">
-            <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/medic.png" alt="Medical Experts">
-            <div class="stat-label">Реални специалисти</div>
-          </div>
-          <div class="stat-item">
-            <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/clock.png" alt="24/7 Assistant">
-            <div class="stat-label">24/7 Личен асистент</div>
-          </div>
-        </div>
+        
       </div>
     `;
     container.appendChild(pageDiv);
@@ -629,6 +634,10 @@
          }
     } else { console.error(`Грешка: Активна страница с индекс ${currentPageIndex} не е намерена.`); }
     updateProgress();
+    const instructions = document.getElementById('questInstructions');
+    if (instructions) {
+      instructions.style.display = currentPageIndex > 0 && currentPageIndex < pages.length - 1 ? 'block' : 'none';
+    }
     console.log("Показване на страница:", currentPageIndex, `(ID: page${currentPageIndex})`);
   }
 


### PR DESCRIPTION
## Summary
- show instructions and persistent stats bar on questionnaire page
- ensure bottom stats bar stays fixed and adapts to mobile view
- adjust `showPage` logic to toggle instructions visibility

## Testing
- `npm run lint`
- `npm test` *(fails: planGenerationLogs, pendingPlanModIntegration, populateUI)*

------
https://chatgpt.com/codex/tasks/task_e_68840cb6c46c8326a694fd1823149d19