### PR TITLE
Add plan section status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ curl -X POST https://<your-domain>/api/runImageModel \
 
 След попълване на въпросника Cloudflare worker-ът съхранява резултата като `<userId>_analysis` и го връща чрез `/api/getInitialAnalysis?userId=<ID>`.
 Статусът на изчисляването се пази отделно в ключ `<userId>_analysis_status` и може да се провери с `/api/analysisStatus?userId=<ID>`.
+За състоянието на отделните секции от плана се използват ключове `plan_section_*_<userId>`. Проверката става чрез `/api/plan-section-status?userId=<ID>`.
 Шаблонът `reganalize/analyze.html` визуализира тези данни.
 Когато анализът е генериран, потребителят получава имейл с линк към страницата,
 на който параметърът `userId` зарежда индивидуалния JSON.
@@ -707,6 +708,7 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
 - `POST /api/submitQuestionnaire` – изпраща отговорите от началния въпросник.
 - `GET /api/analysisStatus` – връща текущия статус на персоналния анализ.
 - `GET /api/getInitialAnalysis` – връща първоначалния анализ.
+- `GET /api/plan-section-status` – проверява кои части от плана са записани в KV.
 - `POST /api/analyzeImage` – анализира качено изображение и връща резултат. Изпращайте поле `image` с пълен `data:` URL. Ендпойнтът не изисква `WORKER_ADMIN_TOKEN`, освен ако изрично не сте го добавили като защита.
 - `POST /api/runImageModel` – изпраща байтовете на изображение към избран Cloudflare AI модел. Заявката приема `{ "model": "@cf/llava-hf/llava-1.5-7b-hf", "prompt": "Описание", "image": [..] }` и връща JSON от `env.AI.run`. При заявки с друг метод се връща статус 405.
 - `POST /api/sendTestEmail` – изпраща тестов имейл. Изисква администраторски токен.

--- a/js/__tests__/planSectionStatus.test.js
+++ b/js/__tests__/planSectionStatus.test.js
@@ -1,0 +1,19 @@
+import { jest } from '@jest/globals';
+import * as worker from '../../worker.js';
+
+describe('plan section status handler', () => {
+  test('returns status for each section', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(key => {
+          if (key.includes('profile') || key.includes('guidance')) return Promise.resolve('{}');
+          return Promise.resolve(null);
+        })
+      }
+    };
+    const req = { url: 'https://x/api/plan-section-status?userId=u1' };
+    const res = await worker.handlePlanSectionStatusRequest(req, env);
+    expect(res.success).toBe(true);
+    expect(res.sections).toEqual({ profile: 'ready', menu: 'missing', principles: 'missing', guidance: 'ready' });
+  });
+});

--- a/preworker.js
+++ b/preworker.js
@@ -429,6 +429,8 @@ export default {
                 responseBody = await handleReAnalyzeQuestionnaireRequest(request, env, ctx);
             } else if (method === 'GET' && path === '/api/planStatus') {
                 responseBody = await handlePlanStatusRequest(request, env);
+            } else if (method === 'GET' && path === '/api/plan-section-status') {
+                responseBody = await handlePlanSectionStatusRequest(request, env);
             } else if (method === 'GET' && path === '/api/analysisStatus') {
                 responseBody = await handleAnalysisStatusRequest(request, env);
             } else if (method === 'GET' && path === '/api/dashboardData') {
@@ -854,6 +856,28 @@ async function handlePlanStatusRequest(request, env) {
     }
 }
 // ------------- END FUNCTION: handlePlanStatusRequest -------------
+
+// ------------- START FUNCTION: handlePlanSectionStatusRequest -------------
+async function handlePlanSectionStatusRequest(request, env) {
+    const url = new URL(request.url);
+    const userId = url.searchParams.get('userId');
+    if (!userId) return { success: false, message: 'Липсва ID на потребител.', statusHint: 400 };
+    try {
+        const sectionKeys = ['profile', 'menu', 'principles', 'guidance'];
+        const results = await Promise.all(
+            sectionKeys.map(name => env.USER_METADATA_KV.get(`plan_section_${name}_${userId}`))
+        );
+        const sections = {};
+        sectionKeys.forEach((name, idx) => {
+            sections[name] = results[idx] ? 'ready' : 'missing';
+        });
+        return { success: true, userId, sections };
+    } catch (error) {
+        console.error(`Error fetching plan section statuses for ${userId}:`, error.message, error.stack);
+        return { success: false, message: 'Грешка при проверка на секциите.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handlePlanSectionStatusRequest -------------
 
 // ------------- START FUNCTION: handleAnalysisStatusRequest -------------
 async function handleAnalysisStatusRequest(request, env) {
@@ -4317,4 +4341,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, handleSubmitQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, handlePlanSectionStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, handleSubmitQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };

--- a/worker.js
+++ b/worker.js
@@ -429,6 +429,8 @@ export default {
                 responseBody = await handleReAnalyzeQuestionnaireRequest(request, env, ctx);
             } else if (method === 'GET' && path === '/api/planStatus') {
                 responseBody = await handlePlanStatusRequest(request, env);
+            } else if (method === 'GET' && path === '/api/plan-section-status') {
+                responseBody = await handlePlanSectionStatusRequest(request, env);
             } else if (method === 'GET' && path === '/api/analysisStatus') {
                 responseBody = await handleAnalysisStatusRequest(request, env);
             } else if (method === 'GET' && path === '/api/dashboardData') {
@@ -854,6 +856,28 @@ async function handlePlanStatusRequest(request, env) {
     }
 }
 // ------------- END FUNCTION: handlePlanStatusRequest -------------
+
+// ------------- START FUNCTION: handlePlanSectionStatusRequest -------------
+async function handlePlanSectionStatusRequest(request, env) {
+    const url = new URL(request.url);
+    const userId = url.searchParams.get('userId');
+    if (!userId) return { success: false, message: 'Липсва ID на потребител.', statusHint: 400 };
+    try {
+        const sectionKeys = ['profile', 'menu', 'principles', 'guidance'];
+        const results = await Promise.all(
+            sectionKeys.map(name => env.USER_METADATA_KV.get(`plan_section_${name}_${userId}`))
+        );
+        const sections = {};
+        sectionKeys.forEach((name, idx) => {
+            sections[name] = results[idx] ? 'ready' : 'missing';
+        });
+        return { success: true, userId, sections };
+    } catch (error) {
+        console.error(`Error fetching plan section statuses for ${userId}:`, error.message, error.stack);
+        return { success: false, message: 'Грешка при проверка на секциите.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handlePlanSectionStatusRequest -------------
 
 // ------------- START FUNCTION: handleAnalysisStatusRequest -------------
 async function handleAnalysisStatusRequest(request, env) {
@@ -4317,4 +4341,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, handleSubmitQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, handlePlanSectionStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, handleSubmitQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };


### PR DESCRIPTION
## Summary
- implement handlePlanSectionStatusRequest in worker/preworker
- add `/api/plan-section-status` routing
- document new endpoint in README
- cover handler with unit test

## Testing
- `npm run lint`
- `npm test` *(fails: planGenerationLogs.test.js, pendingPlanModIntegration.test.js, populateUI.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68840d49e9108326ad6e9d52edde852b