### PR TITLE
Поправка на прогрес бара в quest

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -243,7 +243,7 @@ input[type="checkbox"] {
     position: sticky;
     top: 0;
     z-index: 1000; /* Висок z-index, за да е винаги отгоре */
-    background-color: rgba(18, 18, 18, 0.85);
+    background-color: rgba(18, 18, 18, 0.5);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
     box-shadow: 0 2px 10px rgba(0,0,0,0.2);
@@ -293,6 +293,10 @@ input[type="checkbox"] {
   left: 0;
   pointer-events: none;
   z-index: 1;
+}
+
+#questPage .progress-bar-steps {
+    background-color: color-mix(in srgb, var(--secondary-color) 50%, var(--surface-background));
 }
 
 /* Премахваме стиловете на .container за първата страница */


### PR DESCRIPTION
## Какво се промени
- контейнeрът на прогрес бара вече е полу‑прозрачен
- добавен специален стил за `progress-bar-steps` в quest

## Как да се тества
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test -- -w 1` *(тестовете не успяват поради недостиг на памет)*

------
https://chatgpt.com/codex/tasks/task_e_68840e5017bc83268173b1d79c2462b4