### PR TITLE
Add config-based AI settings

### DIFF
--- a/js/__tests__/aiConfigUsage.test.js
+++ b/js/__tests__/aiConfigUsage.test.js
@@ -1,0 +1,77 @@
+import { jest } from '@jest/globals';
+import * as worker from '../../worker.js';
+
+const userId = 'u1';
+
+describe('AI config usage', () => {
+  test('processSingleUserPlan uses plan config', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(key => {
+          if (key === `${userId}_initial_answers`) return Promise.resolve('{"name":"A","email":"a@a.bg"}');
+          if (key === `${userId}_final_plan`) return Promise.resolve(null);
+          if (key.endsWith('_current_status')) return Promise.resolve('{}');
+          return Promise.resolve(null);
+        }),
+        put: jest.fn(),
+        delete: jest.fn()
+      },
+      RESOURCES_KV: {
+        get: jest.fn(key => {
+          if (key === 'question_definitions') return '[]';
+          if (['base_diet_model','allowed_meal_combinations','eating_psychology'].includes(key)) return '';
+          if (key === 'recipe_data') return '{}';
+          if (key === 'model_plan_generation') return 'model';
+          if (key.startsWith('prompt_generate_')) return 'tpl';
+          if (key === 'plan_token_limit') return '123';
+          if (key === 'plan_temperature') return '0.25';
+          return null;
+        })
+      },
+      GEMINI_API_KEY: 'k'
+    };
+
+    const spy = jest.spyOn(worker, 'callModel').mockResolvedValue('{}');
+
+    await worker.processSingleUserPlan(userId, env);
+
+    expect(spy).toHaveBeenCalled();
+    spy.mock.calls.forEach(c => {
+      expect(c[3]).toEqual({ temperature: 0.25, maxTokens: 123 });
+    });
+    spy.mockRestore();
+  });
+
+  test('handleChatRequest uses chat config', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(key => {
+          if (key.endsWith('_initial_answers')) return Promise.resolve('{"name":"U","goal":"gain"}');
+          if (key.endsWith('_final_plan')) return Promise.resolve('{"profileSummary":"s","caloriesMacros":{},"allowedForbiddenFoods":{},"hydrationCookingSupplements":{},"week1Menu":{}}');
+          if (key.startsWith('plan_status_')) return Promise.resolve('ready');
+          if (key.endsWith('_chat_history')) return Promise.resolve('[]');
+          if (key.endsWith('_current_status')) return Promise.resolve('{}');
+          return Promise.resolve(null);
+        }),
+        put: jest.fn()
+      },
+      RESOURCES_KV: {
+        get: jest.fn(key => {
+          if (key === 'recipe_data') return '{}';
+          if (key === 'prompt_chat') return 'Say %%USER_MESSAGE%%';
+          if (key === 'model_chat') return 'base-model';
+          if (key === 'chat_token_limit') return '55';
+          if (key === 'chat_temperature') return '0.8';
+          return null;
+        })
+      },
+      GEMINI_API_KEY: 'key'
+    };
+
+    const spy = jest.spyOn(worker, 'callModel').mockResolvedValue('ok');
+    const request = { json: async () => ({ userId, message: 'm' }) };
+    await worker.handleChatRequest(request, env);
+    expect(spy).toHaveBeenCalledWith('base-model', expect.any(String), env, { temperature: 0.8, maxTokens: 55 });
+    spy.mockRestore();
+  });
+});

--- a/preworker.js
+++ b/preworker.js
@@ -36,11 +36,12 @@ async function sendEmailUniversal(to, subject, body, env = {}) {
 import { parseJsonSafe } from './utils/parseJsonSafe.js';
 
 // ----- START GENERATED PLAN STEP FUNCTIONS -----
-async function generateProfile(replacements, env, modelName, userId) {
+async function generateProfile(replacements, env, modelName, userId, opts = {}) {
   const template = await env.RESOURCES_KV.get('prompt_generate_profile');
   if (!template) throw new Error('Missing prompt_generate_profile');
   const populated = populatePrompt(template, replacements);
-  const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
+  const { temperature = 0.1, maxTokens = 4000 } = opts;
+  const raw = await callModel(modelName, populated, env, { temperature, maxTokens });
   const cleaned = cleanGeminiJson(raw);
   const parsed = safeParseJson(cleaned, {});
   await env.USER_METADATA_KV.put(
@@ -50,11 +51,12 @@ async function generateProfile(replacements, env, modelName, userId) {
   return parsed;
 }
 
-async function generateMenu(replacements, env, modelName, userId) {
+async function generateMenu(replacements, env, modelName, userId, opts = {}) {
   const template = await env.RESOURCES_KV.get('prompt_generate_menu');
   if (!template) throw new Error('Missing prompt_generate_menu');
   const populated = populatePrompt(template, replacements);
-  const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
+  const { temperature = 0.1, maxTokens = 4000 } = opts;
+  const raw = await callModel(modelName, populated, env, { temperature, maxTokens });
   const cleaned = cleanGeminiJson(raw);
   const parsed = safeParseJson(cleaned, {});
   await env.USER_METADATA_KV.put(
@@ -64,11 +66,12 @@ async function generateMenu(replacements, env, modelName, userId) {
   return parsed;
 }
 
-async function generatePrinciples(replacements, env, modelName, userId) {
+async function generatePrinciples(replacements, env, modelName, userId, opts = {}) {
   const template = await env.RESOURCES_KV.get('prompt_generate_principles');
   if (!template) throw new Error('Missing prompt_generate_principles');
   const populated = populatePrompt(template, replacements);
-  const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
+  const { temperature = 0.1, maxTokens = 4000 } = opts;
+  const raw = await callModel(modelName, populated, env, { temperature, maxTokens });
   const cleaned = cleanGeminiJson(raw);
   const parsed = safeParseJson(cleaned, {});
   await env.USER_METADATA_KV.put(
@@ -78,11 +81,12 @@ async function generatePrinciples(replacements, env, modelName, userId) {
   return parsed;
 }
 
-async function generateGuidance(replacements, env, modelName, userId) {
+async function generateGuidance(replacements, env, modelName, userId, opts = {}) {
   const template = await env.RESOURCES_KV.get('prompt_generate_guidance');
   if (!template) throw new Error('Missing prompt_generate_guidance');
   const populated = populatePrompt(template, replacements);
-  const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
+  const { temperature = 0.1, maxTokens = 4000 } = opts;
+  const raw = await callModel(modelName, populated, env, { temperature, maxTokens });
   const cleaned = cleanGeminiJson(raw);
   const parsed = safeParseJson(cleaned, {});
   await env.USER_METADATA_KV.put(
@@ -1174,6 +1178,13 @@ async function handleChatRequest(request, env) {
         const chatPromptTpl = promptOverride || await env.RESOURCES_KV.get('prompt_chat');
         const chatModel = await env.RESOURCES_KV.get('model_chat');
         const modelToUse = model || chatModel;
+        const [chatTokenLimitStr, chatTemperatureStr] = await Promise.all([
+            env.RESOURCES_KV.get('chat_token_limit'),
+            env.RESOURCES_KV.get('chat_temperature')
+        ]);
+        const chatTokenLimit = parseInt(chatTokenLimitStr, 10) || 800;
+        const chatTemperatureVal = parseFloat(chatTemperatureStr);
+        const chatTemperature = isNaN(chatTemperatureVal) ? 0.7 : chatTemperatureVal;
         const geminiKey = env[GEMINI_API_KEY_SECRET_NAME];
         const openaiKey = env[OPENAI_API_KEY_SECRET_NAME];
 
@@ -1212,7 +1223,7 @@ async function handleChatRequest(request, env) {
             '%%RECENT_LOGS_SUMMARY%%':recentLogsSummary
         };
         const populatedPrompt = populatePrompt(chatPromptTpl,r);
-        const aiRespRaw = await callModel(modelToUse, populatedPrompt, env, { temperature: 0.7, maxTokens: 800 });
+        const aiRespRaw = await callModel(modelToUse, populatedPrompt, env, { temperature: chatTemperature, maxTokens: chatTokenLimit });
 
         let respToUser = aiRespRaw.trim(); let planModReq=null; const sig='[PLAN_MODIFICATION_REQUEST]'; const sigIdx=respToUser.lastIndexOf(sig);
         if(sigIdx!==-1){
@@ -1714,6 +1725,13 @@ async function handleGeneratePraiseRequest(request, env) {
         const geminiKey = env[GEMINI_API_KEY_SECRET_NAME];
         const openaiKey = env[OPENAI_API_KEY_SECRET_NAME];
         const model = await env.RESOURCES_KV.get('model_chat') || await env.RESOURCES_KV.get('model_plan_generation');
+        const [chatTokenLimitStr, chatTemperatureStr] = await Promise.all([
+            env.RESOURCES_KV.get('chat_token_limit'),
+            env.RESOURCES_KV.get('chat_temperature')
+        ]);
+        const chatTokenLimit = parseInt(chatTokenLimitStr, 10) || 400;
+        const chatTemperatureVal = parseFloat(chatTemperatureStr);
+        const chatTemperature = isNaN(chatTemperatureVal) ? 0.6 : chatTemperatureVal;
 
         let title = 'Браво!';
         let message = 'Продължавай в същия дух!';
@@ -1723,7 +1741,7 @@ async function handleGeneratePraiseRequest(request, env) {
             const replacements = createPraiseReplacements(initialAnswers, logs, avgMetric, mealAdh);
             const populated = populatePrompt(promptTpl, replacements);
             try {
-                const raw = await callModel(model, populated, env, { temperature: 0.6, maxTokens: 400 });
+                const raw = await callModel(model, populated, env, { temperature: chatTemperature, maxTokens: chatTokenLimit });
                 const cleaned = cleanGeminiJson(raw);
                 const parsed = safeParseJson(cleaned, null);
                 if (parsed && parsed.title && parsed.message) {
@@ -2441,12 +2459,14 @@ async function processSingleUserPlan(userId, env) {
         }
         console.log(`PROCESS_USER_PLAN (${userId}): Processing for email: ${initialAnswers.email || 'N/A'}`);
         const planBuilder = { profileSummary: null, caloriesMacros: null, week1Menu: null, principlesWeek2_4: [], additionalGuidelines: [], hydrationCookingSupplements: null, allowedForbiddenFoods: {}, psychologicalGuidance: null, detailedTargets: null, generationMetadata: { timestamp: '', modelUsed: null, errors: [] } };
-        const [ questionsJsonString, baseDietModelContent, allowedMealCombinationsContent, eatingPsychologyContent, recipeDataStr, geminiApiKey, openaiApiKey, planModelName, pendingPlanModStr ] = await Promise.all([
+        const [ questionsJsonString, baseDietModelContent, allowedMealCombinationsContent, eatingPsychologyContent, recipeDataStr, geminiApiKey, openaiApiKey, planModelName, pendingPlanModStr, planTokenLimitStr, planTemperatureStr ] = await Promise.all([
             env.RESOURCES_KV.get('question_definitions'), env.RESOURCES_KV.get('base_diet_model'),
             env.RESOURCES_KV.get('allowed_meal_combinations'), env.RESOURCES_KV.get('eating_psychology'),
             env.RESOURCES_KV.get('recipe_data'), env[GEMINI_API_KEY_SECRET_NAME], env[OPENAI_API_KEY_SECRET_NAME],
             env.RESOURCES_KV.get('model_plan_generation'),
-            env.USER_METADATA_KV.get(`pending_plan_mod_${userId}`)
+            env.USER_METADATA_KV.get(`pending_plan_mod_${userId}`),
+            env.RESOURCES_KV.get('plan_token_limit'),
+            env.RESOURCES_KV.get('plan_temperature')
         ]);
         const pendingPlanModData = safeParseJson(pendingPlanModStr, pendingPlanModStr);
         let pendingPlanModText = '';
@@ -2468,6 +2488,9 @@ async function processSingleUserPlan(userId, env) {
             throw new Error("CRITICAL: Plan generation model name ('model_plan_generation') not found in RESOURCES_KV.");
         }
         planBuilder.generationMetadata.modelUsed = planModelName;
+        const planTokenLimit = parseInt(planTokenLimitStr, 10) || 4000;
+        const planTemperature = parseFloat(planTemperatureStr);
+        const planTemperatureSafe = isNaN(planTemperature) ? 0.1 : planTemperature;
         let questionTextMap = new Map();
         if (questionsJsonString) { try { const defs = JSON.parse(questionsJsonString); if (Array.isArray(defs)) defs.forEach(q => { if (q.id && q.text) questionTextMap.set(q.id, q.text); }); } catch (e) { console.warn(`PROCESS_USER_PLAN_WARN (${userId}): Failed to parse question_definitions: ${e.message}`); } } else { console.warn(`PROCESS_USER_PLAN_WARN (${userId}): Resource 'question_definitions' not found.`); }
         const recipeData = safeParseJson(recipeDataStr, {});
@@ -2550,25 +2573,25 @@ async function processSingleUserPlan(userId, env) {
         const needGuidance = !guidanceSec || guidanceSec.ts < lastUpdateTs;
 
         try {
-            const profileRes = needProfile ? await generateProfile(replacements, env, planModelName, userId) : profileSec.data;
+            const profileRes = needProfile ? await generateProfile(replacements, env, planModelName, userId, { temperature: planTemperatureSafe, maxTokens: planTokenLimit }) : profileSec.data;
             Object.assign(planBuilder, profileRes);
         } catch (e) {
             planBuilder.generationMetadata.errors.push(`Profile gen error: ${e.message}`);
         }
         try {
-            const menuRes = needMenu ? await generateMenu(replacements, env, planModelName, userId) : menuSec.data;
+            const menuRes = needMenu ? await generateMenu(replacements, env, planModelName, userId, { temperature: planTemperatureSafe, maxTokens: planTokenLimit }) : menuSec.data;
             Object.assign(planBuilder, menuRes);
         } catch (e) {
             planBuilder.generationMetadata.errors.push(`Menu gen error: ${e.message}`);
         }
         try {
-            const principlesRes = needPrinciples ? await generatePrinciples(replacements, env, planModelName, userId) : principlesSec.data;
+            const principlesRes = needPrinciples ? await generatePrinciples(replacements, env, planModelName, userId, { temperature: planTemperatureSafe, maxTokens: planTokenLimit }) : principlesSec.data;
             Object.assign(planBuilder, principlesRes);
         } catch (e) {
             planBuilder.generationMetadata.errors.push(`Principles gen error: ${e.message}`);
         }
         try {
-            const guidanceRes = needGuidance ? await generateGuidance(replacements, env, planModelName, userId) : guidanceSec.data;
+            const guidanceRes = needGuidance ? await generateGuidance(replacements, env, planModelName, userId, { temperature: planTemperatureSafe, maxTokens: planTokenLimit }) : guidanceSec.data;
             Object.assign(planBuilder, guidanceRes);
         } catch (e) {
             planBuilder.generationMetadata.errors.push(`Guidance gen error: ${e.message}`);

--- a/worker.js
+++ b/worker.js
@@ -36,11 +36,12 @@ async function sendEmailUniversal(to, subject, body, env = {}) {
 import { parseJsonSafe } from './utils/parseJsonSafe.js';
 
 // ----- START GENERATED PLAN STEP FUNCTIONS -----
-async function generateProfile(replacements, env, modelName, userId) {
+async function generateProfile(replacements, env, modelName, userId, opts = {}) {
   const template = await env.RESOURCES_KV.get('prompt_generate_profile');
   if (!template) throw new Error('Missing prompt_generate_profile');
   const populated = populatePrompt(template, replacements);
-  const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
+  const { temperature = 0.1, maxTokens = 4000 } = opts;
+  const raw = await callModel(modelName, populated, env, { temperature, maxTokens });
   const cleaned = cleanGeminiJson(raw);
   const parsed = safeParseJson(cleaned, {});
   await env.USER_METADATA_KV.put(
@@ -50,11 +51,12 @@ async function generateProfile(replacements, env, modelName, userId) {
   return parsed;
 }
 
-async function generateMenu(replacements, env, modelName, userId) {
+async function generateMenu(replacements, env, modelName, userId, opts = {}) {
   const template = await env.RESOURCES_KV.get('prompt_generate_menu');
   if (!template) throw new Error('Missing prompt_generate_menu');
   const populated = populatePrompt(template, replacements);
-  const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
+  const { temperature = 0.1, maxTokens = 4000 } = opts;
+  const raw = await callModel(modelName, populated, env, { temperature, maxTokens });
   const cleaned = cleanGeminiJson(raw);
   const parsed = safeParseJson(cleaned, {});
   await env.USER_METADATA_KV.put(
@@ -64,11 +66,12 @@ async function generateMenu(replacements, env, modelName, userId) {
   return parsed;
 }
 
-async function generatePrinciples(replacements, env, modelName, userId) {
+async function generatePrinciples(replacements, env, modelName, userId, opts = {}) {
   const template = await env.RESOURCES_KV.get('prompt_generate_principles');
   if (!template) throw new Error('Missing prompt_generate_principles');
   const populated = populatePrompt(template, replacements);
-  const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
+  const { temperature = 0.1, maxTokens = 4000 } = opts;
+  const raw = await callModel(modelName, populated, env, { temperature, maxTokens });
   const cleaned = cleanGeminiJson(raw);
   const parsed = safeParseJson(cleaned, {});
   await env.USER_METADATA_KV.put(
@@ -78,11 +81,12 @@ async function generatePrinciples(replacements, env, modelName, userId) {
   return parsed;
 }
 
-async function generateGuidance(replacements, env, modelName, userId) {
+async function generateGuidance(replacements, env, modelName, userId, opts = {}) {
   const template = await env.RESOURCES_KV.get('prompt_generate_guidance');
   if (!template) throw new Error('Missing prompt_generate_guidance');
   const populated = populatePrompt(template, replacements);
-  const raw = await callModel(modelName, populated, env, { temperature: 0.1, maxTokens: 4000 });
+  const { temperature = 0.1, maxTokens = 4000 } = opts;
+  const raw = await callModel(modelName, populated, env, { temperature, maxTokens });
   const cleaned = cleanGeminiJson(raw);
   const parsed = safeParseJson(cleaned, {});
   await env.USER_METADATA_KV.put(
@@ -1174,6 +1178,13 @@ async function handleChatRequest(request, env) {
         const chatPromptTpl = promptOverride || await env.RESOURCES_KV.get('prompt_chat');
         const chatModel = await env.RESOURCES_KV.get('model_chat');
         const modelToUse = model || chatModel;
+        const [chatTokenLimitStr, chatTemperatureStr] = await Promise.all([
+            env.RESOURCES_KV.get('chat_token_limit'),
+            env.RESOURCES_KV.get('chat_temperature')
+        ]);
+        const chatTokenLimit = parseInt(chatTokenLimitStr, 10) || 800;
+        const chatTemperatureVal = parseFloat(chatTemperatureStr);
+        const chatTemperature = isNaN(chatTemperatureVal) ? 0.7 : chatTemperatureVal;
         const geminiKey = env[GEMINI_API_KEY_SECRET_NAME];
         const openaiKey = env[OPENAI_API_KEY_SECRET_NAME];
 
@@ -1212,7 +1223,7 @@ async function handleChatRequest(request, env) {
             '%%RECENT_LOGS_SUMMARY%%':recentLogsSummary
         };
         const populatedPrompt = populatePrompt(chatPromptTpl,r);
-        const aiRespRaw = await callModel(modelToUse, populatedPrompt, env, { temperature: 0.7, maxTokens: 800 });
+        const aiRespRaw = await callModel(modelToUse, populatedPrompt, env, { temperature: chatTemperature, maxTokens: chatTokenLimit });
 
         let respToUser = aiRespRaw.trim(); let planModReq=null; const sig='[PLAN_MODIFICATION_REQUEST]'; const sigIdx=respToUser.lastIndexOf(sig);
         if(sigIdx!==-1){
@@ -1714,6 +1725,13 @@ async function handleGeneratePraiseRequest(request, env) {
         const geminiKey = env[GEMINI_API_KEY_SECRET_NAME];
         const openaiKey = env[OPENAI_API_KEY_SECRET_NAME];
         const model = await env.RESOURCES_KV.get('model_chat') || await env.RESOURCES_KV.get('model_plan_generation');
+        const [chatTokenLimitStr, chatTemperatureStr] = await Promise.all([
+            env.RESOURCES_KV.get('chat_token_limit'),
+            env.RESOURCES_KV.get('chat_temperature')
+        ]);
+        const chatTokenLimit = parseInt(chatTokenLimitStr, 10) || 400;
+        const chatTemperatureVal = parseFloat(chatTemperatureStr);
+        const chatTemperature = isNaN(chatTemperatureVal) ? 0.6 : chatTemperatureVal;
 
         let title = 'Браво!';
         let message = 'Продължавай в същия дух!';
@@ -1723,7 +1741,7 @@ async function handleGeneratePraiseRequest(request, env) {
             const replacements = createPraiseReplacements(initialAnswers, logs, avgMetric, mealAdh);
             const populated = populatePrompt(promptTpl, replacements);
             try {
-                const raw = await callModel(model, populated, env, { temperature: 0.6, maxTokens: 400 });
+                const raw = await callModel(model, populated, env, { temperature: chatTemperature, maxTokens: chatTokenLimit });
                 const cleaned = cleanGeminiJson(raw);
                 const parsed = safeParseJson(cleaned, null);
                 if (parsed && parsed.title && parsed.message) {
@@ -2441,12 +2459,14 @@ async function processSingleUserPlan(userId, env) {
         }
         console.log(`PROCESS_USER_PLAN (${userId}): Processing for email: ${initialAnswers.email || 'N/A'}`);
         const planBuilder = { profileSummary: null, caloriesMacros: null, week1Menu: null, principlesWeek2_4: [], additionalGuidelines: [], hydrationCookingSupplements: null, allowedForbiddenFoods: {}, psychologicalGuidance: null, detailedTargets: null, generationMetadata: { timestamp: '', modelUsed: null, errors: [] } };
-        const [ questionsJsonString, baseDietModelContent, allowedMealCombinationsContent, eatingPsychologyContent, recipeDataStr, geminiApiKey, openaiApiKey, planModelName, pendingPlanModStr ] = await Promise.all([
+        const [ questionsJsonString, baseDietModelContent, allowedMealCombinationsContent, eatingPsychologyContent, recipeDataStr, geminiApiKey, openaiApiKey, planModelName, pendingPlanModStr, planTokenLimitStr, planTemperatureStr ] = await Promise.all([
             env.RESOURCES_KV.get('question_definitions'), env.RESOURCES_KV.get('base_diet_model'),
             env.RESOURCES_KV.get('allowed_meal_combinations'), env.RESOURCES_KV.get('eating_psychology'),
             env.RESOURCES_KV.get('recipe_data'), env[GEMINI_API_KEY_SECRET_NAME], env[OPENAI_API_KEY_SECRET_NAME],
             env.RESOURCES_KV.get('model_plan_generation'),
-            env.USER_METADATA_KV.get(`pending_plan_mod_${userId}`)
+            env.USER_METADATA_KV.get(`pending_plan_mod_${userId}`),
+            env.RESOURCES_KV.get('plan_token_limit'),
+            env.RESOURCES_KV.get('plan_temperature')
         ]);
         const pendingPlanModData = safeParseJson(pendingPlanModStr, pendingPlanModStr);
         let pendingPlanModText = '';
@@ -2468,6 +2488,9 @@ async function processSingleUserPlan(userId, env) {
             throw new Error("CRITICAL: Plan generation model name ('model_plan_generation') not found in RESOURCES_KV.");
         }
         planBuilder.generationMetadata.modelUsed = planModelName;
+        const planTokenLimit = parseInt(planTokenLimitStr, 10) || 4000;
+        const planTemperature = parseFloat(planTemperatureStr);
+        const planTemperatureSafe = isNaN(planTemperature) ? 0.1 : planTemperature;
         let questionTextMap = new Map();
         if (questionsJsonString) { try { const defs = JSON.parse(questionsJsonString); if (Array.isArray(defs)) defs.forEach(q => { if (q.id && q.text) questionTextMap.set(q.id, q.text); }); } catch (e) { console.warn(`PROCESS_USER_PLAN_WARN (${userId}): Failed to parse question_definitions: ${e.message}`); } } else { console.warn(`PROCESS_USER_PLAN_WARN (${userId}): Resource 'question_definitions' not found.`); }
         const recipeData = safeParseJson(recipeDataStr, {});
@@ -2550,25 +2573,25 @@ async function processSingleUserPlan(userId, env) {
         const needGuidance = !guidanceSec || guidanceSec.ts < lastUpdateTs;
 
         try {
-            const profileRes = needProfile ? await generateProfile(replacements, env, planModelName, userId) : profileSec.data;
+            const profileRes = needProfile ? await generateProfile(replacements, env, planModelName, userId, { temperature: planTemperatureSafe, maxTokens: planTokenLimit }) : profileSec.data;
             Object.assign(planBuilder, profileRes);
         } catch (e) {
             planBuilder.generationMetadata.errors.push(`Profile gen error: ${e.message}`);
         }
         try {
-            const menuRes = needMenu ? await generateMenu(replacements, env, planModelName, userId) : menuSec.data;
+            const menuRes = needMenu ? await generateMenu(replacements, env, planModelName, userId, { temperature: planTemperatureSafe, maxTokens: planTokenLimit }) : menuSec.data;
             Object.assign(planBuilder, menuRes);
         } catch (e) {
             planBuilder.generationMetadata.errors.push(`Menu gen error: ${e.message}`);
         }
         try {
-            const principlesRes = needPrinciples ? await generatePrinciples(replacements, env, planModelName, userId) : principlesSec.data;
+            const principlesRes = needPrinciples ? await generatePrinciples(replacements, env, planModelName, userId, { temperature: planTemperatureSafe, maxTokens: planTokenLimit }) : principlesSec.data;
             Object.assign(planBuilder, principlesRes);
         } catch (e) {
             planBuilder.generationMetadata.errors.push(`Principles gen error: ${e.message}`);
         }
         try {
-            const guidanceRes = needGuidance ? await generateGuidance(replacements, env, planModelName, userId) : guidanceSec.data;
+            const guidanceRes = needGuidance ? await generateGuidance(replacements, env, planModelName, userId, { temperature: planTemperatureSafe, maxTokens: planTokenLimit }) : guidanceSec.data;
             Object.assign(planBuilder, guidanceRes);
         } catch (e) {
             planBuilder.generationMetadata.errors.push(`Guidance gen error: ${e.message}`);


### PR DESCRIPTION
## Summary
- allow plan generation and chat features to read token limit and temperature from KV
- send these values to `callModel`
- cover config usage with new tests

## Testing
- `npm run lint`
- `npm test` *(fails: processSingleUserPlan tests)*

------
https://chatgpt.com/codex/tasks/task_e_6884109cf70083268bd6ec82af988c41