### PR TITLE
Enhance quest page with persistent stats

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -407,6 +407,32 @@ input[type="checkbox"] {
     margin: 0 auto 5px;
 }
 
+.persistent-stats {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    padding: 10px 15px;
+    background-color: rgba(18, 18, 18, 0.85);
+    backdrop-filter: blur(6px);
+    z-index: 1100;
+    margin-top: 0;
+    flex-direction: row;
+    justify-content: center;
+}
+
+.instructions-text {
+    max-width: 600px;
+    margin: 20px auto 10px;
+    text-align: center;
+    color: #b0b0b0;
+    line-height: 1.4;
+}
+
+body#questPage {
+    padding-bottom: 110px;
+}
+
 @keyframes fadeInContent {
   to { opacity: 1; transform: translateY(0); }
 }
@@ -430,6 +456,16 @@ input[type="checkbox"] {
   .stats-bar {
     gap: 30px;
   }
+  .persistent-stats {
+    padding: 8px 10px;
+  }
+  .persistent-stats .stat-icon {
+    width: 60px;
+    height: 60px;
+  }
+  .persistent-stats .stat-label {
+    font-size: 0.8rem;
+  }
   #page0.hero-start-page #startBtn {
     width: 100%;
     padding: 16px 20px;
@@ -441,5 +477,8 @@ input[type="checkbox"] {
   .stats-bar {
     flex-direction: row;
     justify-content: center;
+  }
+  .persistent-stats {
+    padding: 10px 20px;
   }
 }

--- a/quest.html
+++ b/quest.html
@@ -226,6 +226,26 @@
   <!-- Динамично генерираните "страници" ще се вмъкнат тук -->
 </div>
 
+<div id="questInstruction" class="instructions-text">
+  За да получите индивидуален и максимално ефективен план за вас,
+  въведете коректна и изчерпателна информация
+</div>
+
+<div id="persistentStats" class="stats-bar persistent-stats">
+  <div class="stat-item">
+    <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/aibrain.png" alt="AI Algorithm">
+    <div class="stat-label">AI Med Алгоритъм</div>
+  </div>
+  <div class="stat-item">
+    <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/medic.png" alt="Medical Experts">
+    <div class="stat-label">Реални специалисти</div>
+  </div>
+  <div class="stat-item">
+    <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/clock.png" alt="24/7 Assistant">
+    <div class="stat-label">24/7 Личен асистент</div>
+  </div>
+</div>
+
 <!-- Тайна зона за мобилни устройства за Admin достъп -->
 <div id="secretTapArea" style="position: fixed; top: 0; left: 0; width: 30px; height: 30px; opacity: 0; z-index: 9999;"></div>
 
@@ -331,20 +351,6 @@
           </button>
         </div>
         
-        <div class="stats-bar">
-          <div class="stat-item">
-            <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/aibrain.png" alt="AI Algorithm">
-            <div class="stat-label">AI Med Алгоритъм</div>
-          </div>
-          <div class="stat-item">
-            <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/medic.png" alt="Medical Experts">
-            <div class="stat-label">Реални специалисти</div>
-          </div>
-          <div class="stat-item">
-            <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/clock.png" alt="24/7 Assistant">
-            <div class="stat-label">24/7 Личен асистент</div>
-          </div>
-        </div>
       </div>
     `;
     container.appendChild(pageDiv);


### PR DESCRIPTION
## Summary
- keep question stats visible throughout the questionnaire
- insert instructional message for correct questionnaire filling
- style persistent stats bar for desktop and mobile

## Testing
- `npm run lint`
- `npm test` *(fails: TypeError in aiConfigUsage.test, expected substring not found in planGenerationLogs.test, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68841a67630c8326b1c4fe21b9f58bdd