### PR TITLE
Improve quest container background

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -30,6 +30,16 @@ body {
   box-shadow: none;
 }
 
+/* Специален контейнер за въпросника */
+#dynamicContainer {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 10px;
+  background-color: rgba(30, 80, 140, 0.2);
+  backdrop-filter: blur(4px);
+  border-radius: 10px;
+}
+
 .question-text {
   font-size: 20px;
   font-weight: 600;
@@ -219,6 +229,10 @@ input[type="checkbox"] {
   .container {
     margin: 60px 15px 20px;
     padding: 15px;
+  }
+  #dynamicContainer {
+    margin: 0 10px;
+    padding: 8px;
   }
   .nav-buttons button {
     width: auto;

--- a/quest.html
+++ b/quest.html
@@ -246,11 +246,10 @@
 
 <div class="container" id="dynamicContainer">
   <!-- Динамично генерираните "страници" ще се вмъкнат тук -->
-</div>
-
-<div id="questInstructions" class="quest-instructions">
-  За да получите индивидуален и максимално ефективен план за вас,
-  въведете коректна и изчерпателна информация
+  <div id="questInstructions" class="quest-instructions">
+    За да получите индивидуален и максимално ефективен план за вас,
+    въведете коректна и изчерпателна информация
+  </div>
 </div>
 
 <div id="persistentStats" class="stats-bar">


### PR DESCRIPTION
## Summary
- move instructions inside `#dynamicContainer`
- add new semi-transparent blue style for `#dynamicContainer`
- tweak responsive padding/margins for mobile screens

## Testing
- `npm run lint`
- `npm test` *(fails: TypeError and OOM in several suites)*

------
https://chatgpt.com/codex/tasks/task_e_6884398a3b788326889b473ade6c40ba