### PR TITLE
Add theme manager to admin panel

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -271,6 +271,15 @@
       <input type="color" id="tertiaryColorInput">
     </label>
     <button id="saveColorConfig">Запази</button>
+    <div class="theme-controls">
+      <label>Име на тема
+        <input type="text" id="themeNameInput">
+      </label>
+      <button type="button" id="saveThemeLocal">Запиши тема</button>
+      <select id="savedThemes"></select>
+      <button type="button" id="applyThemeLocal">Зареди</button>
+      <button type="button" id="deleteThemeLocal">Изтрий</button>
+    </div>
   </details>
 
   <details id="testEmailSection" class="card">

--- a/css/admin.css
+++ b/css/admin.css
@@ -311,3 +311,11 @@ details[open] summary::after {
   padding: 8px;
   margin-top: 4px;
 }
+
+.theme-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  margin-top: var(--space-sm);
+}

--- a/js/__tests__/adminColors.test.js
+++ b/js/__tests__/adminColors.test.js
@@ -12,7 +12,12 @@ beforeEach(async () => {
     <input id="secondaryColorInput" type="color">
     <input id="accentColorInput" type="color">
     <input id="tertiaryColorInput" type="color">
-    <button id="saveColorConfig"></button>`;
+    <button id="saveColorConfig"></button>
+    <input id="themeNameInput" type="text">
+    <button id="saveThemeLocal"></button>
+    <select id="savedThemes"></select>
+    <button id="applyThemeLocal"></button>
+    <button id="deleteThemeLocal"></button>`;
 
   mockLoad = jest.fn().mockResolvedValue({ colors: { primary: '#111111', secondary: '#222222' } });
   mockSave = jest.fn().mockResolvedValue({});
@@ -35,6 +40,13 @@ test('initColorSettings loads config and sets CSS vars', async () => {
   expect(document.documentElement.style.getPropertyValue('--primary-color')).toBe('#111111');
 });
 
+test('falls back to computed colors when config missing', async () => {
+  mockLoad.mockResolvedValue({ colors: {} });
+  document.documentElement.style.setProperty('--primary-color', '#010203');
+  await initColorSettings();
+  expect(document.getElementById('primaryColorInput').value).toBe('#010203');
+});
+
 test('save button gathers colors and calls saveConfig', async () => {
   await initColorSettings();
   document.getElementById('primaryColorInput').value = '#333333';
@@ -46,4 +58,17 @@ test('save button gathers colors and calls saveConfig', async () => {
     accent: document.getElementById('accentColorInput').value,
     tertiary: document.getElementById('tertiaryColorInput').value
   } });
+});
+
+test('themes can be saved and applied', async () => {
+  mockLoad.mockResolvedValue({ colors: {} });
+  await initColorSettings();
+  document.getElementById('primaryColorInput').value = '#aaaaaa';
+  document.getElementById('themeNameInput').value = 't1';
+  document.getElementById('saveThemeLocal').click();
+  expect(JSON.parse(localStorage.getItem('colorThemes')).t1.primary).toBe('#aaaaaa');
+  document.getElementById('primaryColorInput').value = '#bbbbbb';
+  document.getElementById('savedThemes').value = 't1';
+  document.getElementById('applyThemeLocal').click();
+  expect(document.getElementById('primaryColorInput').value).toBe('#aaaaaa');
 });

--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -8,9 +8,78 @@ const inputSelectors = {
 };
 
 const inputs = {};
+const themeSelectId = 'savedThemes';
+const themeNameId = 'themeNameInput';
+const saveThemeBtnId = 'saveThemeLocal';
+const applyThemeBtnId = 'applyThemeLocal';
+const deleteThemeBtnId = 'deleteThemeLocal';
 
 function setCssVar(key, val) {
   document.documentElement.style.setProperty(`--${key}-color`, val);
+}
+
+function getSavedThemes() {
+  try {
+    return JSON.parse(localStorage.getItem('colorThemes') || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function storeThemes(themes) {
+  localStorage.setItem('colorThemes', JSON.stringify(themes));
+}
+
+function populateThemeSelect() {
+  const select = document.getElementById(themeSelectId);
+  if (!select) return;
+  select.innerHTML = '';
+  const themes = getSavedThemes();
+  Object.keys(themes).forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    select.appendChild(opt);
+  });
+}
+
+function saveTheme() {
+  const nameInput = document.getElementById(themeNameId);
+  if (!nameInput || !nameInput.value) return;
+  const themes = getSavedThemes();
+  const colors = {};
+  Object.entries(inputs).forEach(([k, el]) => {
+    if (el) colors[k] = el.value;
+  });
+  themes[nameInput.value] = colors;
+  storeThemes(themes);
+  populateThemeSelect();
+}
+
+function applyThemeFromSelect() {
+  const select = document.getElementById(themeSelectId);
+  if (!select) return;
+  const themes = getSavedThemes();
+  const theme = themes[select.value];
+  if (!theme) return;
+  Object.entries(theme).forEach(([k, val]) => {
+    const el = inputs[k];
+    if (el) {
+      el.value = val;
+      setCssVar(k, val);
+    }
+  });
+}
+
+function deleteSelectedTheme() {
+  const select = document.getElementById(themeSelectId);
+  if (!select) return;
+  const themes = getSavedThemes();
+  if (themes[select.value]) {
+    delete themes[select.value];
+    storeThemes(themes);
+    populateThemeSelect();
+  }
 }
 
 export async function initColorSettings() {
@@ -18,19 +87,30 @@ export async function initColorSettings() {
     inputs[key] = document.querySelector(sel);
   }
   const saveBtn = document.getElementById('saveColorConfig');
+  populateThemeSelect();
+  const saveThemeBtn = document.getElementById(saveThemeBtnId);
+  const applyThemeBtn = document.getElementById(applyThemeBtnId);
+  const deleteThemeBtn = document.getElementById(deleteThemeBtnId);
   if (!saveBtn) return;
   try {
     const { colors = {} } = await loadConfig(['colors']);
     Object.entries(inputs).forEach(([k, el]) => {
       if (!el) return;
-      if (colors[k]) {
-        el.value = colors[k];
-        setCssVar(k, colors[k]);
-      }
+      const current = getComputedStyle(document.documentElement)
+        .getPropertyValue(`--${k}-color`).trim();
+      el.value = colors[k] || current;
+      setCssVar(k, el.value);
       el.addEventListener('input', () => setCssVar(k, el.value));
     });
   } catch (err) {
     console.warn('Неуспешно зареждане на цветовете', err);
+    Object.entries(inputs).forEach(([k, el]) => {
+      if (!el) return;
+      const current = getComputedStyle(document.documentElement)
+        .getPropertyValue(`--${k}-color`).trim();
+      el.value = current;
+      el.addEventListener('input', () => setCssVar(k, el.value));
+    });
   }
 
   saveBtn.addEventListener('click', async () => {
@@ -46,6 +126,10 @@ export async function initColorSettings() {
       alert('Грешка при запис на цветовете.');
     }
   });
+
+  if (saveThemeBtn) saveThemeBtn.addEventListener('click', saveTheme);
+  if (applyThemeBtn) applyThemeBtn.addEventListener('click', applyThemeFromSelect);
+  if (deleteThemeBtn) deleteThemeBtn.addEventListener('click', deleteSelectedTheme);
 }
 
 document.addEventListener('DOMContentLoaded', initColorSettings);


### PR DESCRIPTION
## Summary
- introduce theme controls in admin panel
- store and apply color themes from localStorage
- default color inputs use current CSS vars
- style theme controls in admin CSS
- cover new behaviour with tests

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68843a66a0bc8326854361fcdfdef801