### PR TITLE
Fix quest instructions container style

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -21,13 +21,23 @@ body {
 }
 
 /* Прозрачни контейнери в страницата с въпросника */
-#questPage .container {
+#questPage .container:not(#dynamicContainer) {
   width: 100%;
   max-width: none;
   margin: 0;
   padding: 0;
   background-color: transparent;
   box-shadow: none;
+}
+
+/* Специален контейнер за въпросника */
+#dynamicContainer {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 10px;
+  background-color: rgba(30, 80, 140, 0.2);
+  backdrop-filter: blur(4px);
+  border-radius: 10px;
 }
 
 .question-text {
@@ -219,6 +229,10 @@ input[type="checkbox"] {
   .container {
     margin: 60px 15px 20px;
     padding: 15px;
+  }
+  #dynamicContainer {
+    margin: 0 10px;
+    padding: 8px;
   }
   .nav-buttons button {
     width: auto;

--- a/quest.html
+++ b/quest.html
@@ -199,7 +199,7 @@
 
     /* Инструкции за попълване */
     .quest-instructions {
-      margin: 20px auto;
+      margin: 0 0 15px 0;
       max-width: 600px;
       text-align: center;
       line-height: 1.4;
@@ -246,11 +246,10 @@
 
 <div class="container" id="dynamicContainer">
   <!-- Динамично генерираните "страници" ще се вмъкнат тук -->
-</div>
-
-<div id="questInstructions" class="quest-instructions">
-  За да получите индивидуален и максимално ефективен план за вас,
-  въведете коректна и изчерпателна информация
+  <div id="questInstructions" class="quest-instructions">
+    За да получите индивидуален и максимално ефективен план за вас,
+    въведете коректна и изчерпателна информация
+  </div>
 </div>
 
 <div id="persistentStats" class="stats-bar">


### PR DESCRIPTION
## Summary
- exclude #dynamicContainer from quest page container reset
- keep instructions inside container without extra margin

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6884398a3b788326889b473ade6c40ba