### PR TITLE
Make clients list section collapsible

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -21,26 +21,28 @@
     <ul id="notificationsList"></ul>
   </section>
   <div class="layout">
-  <aside class="sidebar card" id="clientsSection">
-    <h2>Клиенти</h2>
-    <input id="clientSearch" placeholder="Търсене по име">
-    <select id="statusFilter">
-      <option value="all">Всички</option>
-      <option value="pending">pending</option>
-      <option value="processing">processing</option>
-      <option value="ready">ready</option>
-    </select>
-    <select id="tagFilter" multiple>
-      <option value="all">Всички етикети</option>
-    </select>
-    <select id="sortOrder">
-      <option value="name">Сортирай по име</option>
-      <option value="date">Сортирай по дата</option>
-    </select>
+  <details class="sidebar card" id="clientsSection">
+    <summary class="clients-summary">Клиенти</summary>
+    <div id="clientsControls" class="clients-controls">
+      <input id="clientSearch" placeholder="Търсене по име">
+      <select id="statusFilter">
+        <option value="all">Всички</option>
+        <option value="pending">pending</option>
+        <option value="processing">processing</option>
+        <option value="ready">ready</option>
+      </select>
+      <select id="tagFilter" multiple>
+        <option value="all">Всички етикети</option>
+      </select>
+      <select id="sortOrder">
+        <option value="name">Сортирай по име</option>
+        <option value="date">Сортирай по дата</option>
+      </select>
+      <button id="showStats">Покажи статистика</button>
+    </div>
     <p id="clientsCount"></p>
-    <button id="showStats">Покажи статистика</button>
     <ul id="clientsList"></ul>
-  </aside>
+  </details>
 
   <main id="clientDetails" class="main-content card hidden">
     <h2 id="clientName">Клиент</h2>

--- a/css/admin.css
+++ b/css/admin.css
@@ -18,8 +18,16 @@ body {
   width: 100%;
   text-align: left;
 }
-#clientSearch { margin-right: 5px; }
-#statusFilter { margin-left: 5px; }
+#clientsControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+#clientsControls > * {
+  flex: 1 1 auto;
+  min-width: 120px;
+}
 #adminNotes { width: 100%; }
 #clientDetails { margin-top: 20px; position: relative; }
 #closeProfile {
@@ -73,6 +81,10 @@ details summary {
   padding: 5px;
   background: #e9ecef;
   border-radius: 4px;
+}
+#clientsSection summary {
+  font-size: 1.1rem;
+  padding: 8px 5px;
 }
 details summary::after {
   content: '\25BC';


### PR DESCRIPTION
## Summary
- transform clients sidebar to a `<details>` accordion collapsed by default
- group client filters inside a new `clientsControls` container
- add minimal CSS for the accordion and controls

## Testing
- `npm run lint`
- `npm install`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68843fdc43148326a5c775324bbd313c