### PR TITLE
Align questionnaire layout colors

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -30,12 +30,16 @@ body {
   box-shadow: none;
 }
 
+#:root {
+  --quest-bg-color: rgba(44, 62, 80, 0.45);
+}
+
 /* Специален контейнер за въпросника */
 #dynamicContainer {
   max-width: 640px;
   margin: 0 auto;
   padding: 10px;
-  background-color: rgba(30, 80, 140, 0.2);
+  background-color: var(--quest-bg-color);
   backdrop-filter: blur(4px);
   border-radius: 10px;
 }
@@ -97,7 +101,7 @@ p {
 }
 
 #questPage .page:not(.hero-start-page) {
-  background-color: rgba(44, 62, 80, 0.45);
+  background-color: var(--quest-bg-color);
   backdrop-filter: blur(4px);
   border-radius: 10px;
   padding: 20px;


### PR DESCRIPTION
## Summary
- define `--quest-bg-color` variable in `quest_styles.css`
- use the variable for `#dynamicContainer` and internal pages

## Testing
- `npm test -- -w=1` *(fails: JavaScript heap out of memory)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68843f15a2fc8326ad8a7cb51a65a562