### PR TITLE
Hide placeholders while typing in login

### DIFF
--- a/css/index_styles.css
+++ b/css/index_styles.css
@@ -73,6 +73,11 @@
         .floating label { position: absolute; left: 0.8rem; top: 0.8rem; pointer-events: none; transition: transform 0.2s, color 0.2s; background: transparent; }
         .floating input:focus + label,
         .floating input:not(:placeholder-shown) + label { transform: translateY(-0.6rem) scale(0.85); color: var(--primary-color); }
+        /* Скриваме етикета за полетата във формата за вход, щом се въвежда текст */
+        #login-form .floating input:focus + label,
+        #login-form .floating input:not(:placeholder-shown) + label {
+            display: none;
+        }
         .password-strength { font-size: 0.75rem; margin-top: 0.3rem; }
         .strength-weak { color: var(--color-danger); }
         .strength-medium { color: var(--color-warning); }


### PR DESCRIPTION
## Summary
- hide login labels once user types in the field

## Testing
- `npm run lint`
- `npm test` *(fails: AI config usage, admin colors, plan generation logs, pending plan mod integration, populate UI)*

------
https://chatgpt.com/codex/tasks/task_e_6884439f26bc8326bb0c5f009e7c4df9