### PR TITLE
Add dynamic color loading

### DIFF
--- a/js/__tests__/adminColors.test.js
+++ b/js/__tests__/adminColors.test.js
@@ -31,6 +31,8 @@ beforeEach(async () => {
 afterEach(() => {
   mockLoad.mockReset();
   mockSave.mockReset();
+  document.documentElement.style.cssText = '';
+  document.body.style.cssText = '';
 });
 
 test('initColorSettings loads config and sets CSS vars', async () => {

--- a/js/__tests__/assistantIconWiggle.test.js
+++ b/js/__tests__/assistantIconWiggle.test.js
@@ -16,6 +16,7 @@ beforeEach(async () => {
   jest.unstable_mockModule('../utils.js', () => ({ safeParseFloat: jest.fn(), escapeHtml: jest.fn(), fileToDataURL: jest.fn() }));
   jest.unstable_mockModule('../uiHandlers.js', () => ({
     initializeTheme: jest.fn(),
+    loadAndApplyColors: jest.fn(),
     activateTab: jest.fn(),
     openModal: jest.fn(),
     closeModal: jest.fn(),

--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -11,7 +11,8 @@ beforeEach(async () => {
     showLoading: jest.fn(),
     showToast: showToastMock,
     openModal: jest.fn(),
-    closeModal: jest.fn()
+    closeModal: jest.fn(),
+    loadAndApplyColors: jest.fn()
   }));
   jest.unstable_mockModule('../config.js', () => ({
     apiEndpoints: { logExtraMeal: '/api' }

--- a/js/__tests__/handleChatSendPlanMod.test.js
+++ b/js/__tests__/handleChatSendPlanMod.test.js
@@ -61,7 +61,8 @@ beforeEach(async () => {
     handleTrackerTooltipHide: jest.fn(),
     showLoading: jest.fn(),
     showToast: jest.fn(),
-    updateTabsOverflowIndicator: jest.fn()
+    updateTabsOverflowIndicator: jest.fn(),
+    loadAndApplyColors: jest.fn()
   }));
   jest.unstable_mockModule('../config.js', () => ({
     isLocalDevelopment: false,

--- a/js/__tests__/loadAndApplyColors.test.js
+++ b/js/__tests__/loadAndApplyColors.test.js
@@ -1,0 +1,39 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let loadAndApplyColors;
+let mockLoad;
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockLoad = jest.fn().mockResolvedValue({ colors: { primary: '#111111', accent: '#222222' } });
+  jest.unstable_mockModule('../adminConfig.js', () => ({ loadConfig: mockLoad }));
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: {},
+    activeTooltip: null,
+    setActiveTooltip: jest.fn()
+  }));
+  ({ loadAndApplyColors } = await import('../uiHandlers.js'));
+});
+
+afterEach(() => {
+  mockLoad.mockReset();
+  document.documentElement.style.cssText = '';
+  document.body.style.cssText = '';
+});
+
+test('зарежда и прилага цветовете', async () => {
+  await loadAndApplyColors();
+  expect(mockLoad).toHaveBeenCalledWith(['colors']);
+  expect(document.documentElement.style.getPropertyValue('--primary-color')).toBe('#111111');
+  expect(document.body.style.getPropertyValue('--accent-color')).toBe('#222222');
+});
+
+
+test('не променя цветовете при грешка', async () => {
+  document.documentElement.style.setProperty('--primary-color', '#000000');
+  document.body.style.setProperty('--primary-color', '#000000');
+  mockLoad.mockRejectedValue(new Error('fail'));
+  await loadAndApplyColors();
+  expect(document.documentElement.style.getPropertyValue('--primary-color')).toBe('#000000');
+});

--- a/js/__tests__/openPlanModificationChat.test.js
+++ b/js/__tests__/openPlanModificationChat.test.js
@@ -30,6 +30,7 @@ beforeEach(async () => {
     hideTrackerTooltip: jest.fn(),
     handleTrackerTooltipShow: jest.fn(),
     handleTrackerTooltipHide: jest.fn(),
+    loadAndApplyColors: jest.fn(),
     showLoading: jest.fn(),
     showToast: showToastMock,
     updateTabsOverflowIndicator: jest.fn()

--- a/js/__tests__/planModChatCloseReset.test.js
+++ b/js/__tests__/planModChatCloseReset.test.js
@@ -75,6 +75,7 @@ beforeEach(async () => {
     hideTrackerTooltip: jest.fn(),
     handleTrackerTooltipShow: jest.fn(),
     handleTrackerTooltipHide: jest.fn(),
+    loadAndApplyColors: jest.fn(),
     showToast: jest.fn(),
     showLoading: jest.fn(),
     applyTheme: jest.fn(),

--- a/js/__tests__/planModChatHistory.test.js
+++ b/js/__tests__/planModChatHistory.test.js
@@ -28,6 +28,7 @@ beforeEach(async () => {
     hideTrackerTooltip: jest.fn(),
     handleTrackerTooltipShow: jest.fn(),
     handleTrackerTooltipHide: jest.fn(),
+    loadAndApplyColors: jest.fn(),
     showLoading: jest.fn(),
     showToast: jest.fn(),
     updateTabsOverflowIndicator: jest.fn()

--- a/js/__tests__/planModPromptFailModalClose.test.js
+++ b/js/__tests__/planModPromptFailModalClose.test.js
@@ -32,6 +32,7 @@ beforeEach(async () => {
     hideTrackerTooltip: jest.fn(),
     handleTrackerTooltipShow: jest.fn(),
     handleTrackerTooltipHide: jest.fn(),
+    loadAndApplyColors: jest.fn(),
     showLoading: jest.fn(),
     showToast: showToastMock,
     updateTabsOverflowIndicator: jest.fn()

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -54,7 +54,8 @@ beforeEach(async () => {
     showLoading: jest.fn(),
     handleTrackerTooltipShow: jest.fn(),
     handleTrackerTooltipHide: jest.fn(),
-    showToast: jest.fn()
+    showToast: jest.fn(),
+    loadAndApplyColors: jest.fn()
   }));
   jest.unstable_mockModule('../extraMealForm.js', () => ({ openExtraMealModal: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({

--- a/js/__tests__/shareAchievement.test.js
+++ b/js/__tests__/shareAchievement.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 import { jest } from '@jest/globals';
 jest.unstable_mockModule('../uiElements.js', () => ({ selectors: {} }));
-jest.unstable_mockModule('../uiHandlers.js', () => ({ openModal: jest.fn(), openInstructionsModal: jest.fn() }));
+jest.unstable_mockModule('../uiHandlers.js', () => ({ openModal: jest.fn(), openInstructionsModal: jest.fn(), loadAndApplyColors: jest.fn() }));
 jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
 
 let shareAchievement;

--- a/js/app.js
+++ b/js/app.js
@@ -4,6 +4,7 @@ import { safeParseFloat, escapeHtml, fileToDataURL } from './utils.js';
 import { selectors, initializeSelectors, loadInfoTexts } from './uiElements.js';
 import {
     initializeTheme,
+    loadAndApplyColors,
     activateTab,
     openModal, closeModal,
     showLoading, showToast, updateTabsOverflowIndicator
@@ -323,6 +324,7 @@ async function initializeApp() {
         setupStaticEventListeners(); // from eventListeners.js
         initializeCollapsibleCards();
         initializeTheme(); // from uiHandlers.js
+        loadAndApplyColors();
         loadDashboardData();
         if (isLocalDevelopment) console.log("initializeApp finished successfully.");
     } catch (error) {

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -1,5 +1,6 @@
 // uiHandlers.js - Управление на UI елементи (Меню, Тема, Табове, Модали, Tooltips и др.)
 import { selectors } from './uiElements.js';
+import { loadConfig } from './adminConfig.js';
 import {
     fullDashboardData,
     activeTooltip, // state from app.js that this module will modify
@@ -87,6 +88,19 @@ export function updateThemeButtonText() {
     const isDark = document.body.classList.contains('dark-theme');
     if (themeTextSpan) themeTextSpan.textContent = isDark ? 'Светла Тема' : 'Тъмна Тема';
     if (themeIconSpan) themeIconSpan.innerHTML = isDark ? '<i class="bi bi-sun"></i>' : '<i class="bi bi-moon"></i>';
+}
+
+export async function loadAndApplyColors() {
+    try {
+        const { colors = {} } = await loadConfig(['colors']);
+        for (const [key, val] of Object.entries(colors)) {
+            if (!val) continue;
+            document.documentElement.style.setProperty(`--${key}-color`, val);
+            document.body.style.setProperty(`--${key}-color`, val);
+        }
+    } catch (err) {
+        console.warn('Неуспешно зареждане на цветовата конфигурация', err);
+    }
 }
 
 export function activateTab(activeTabButton) {


### PR DESCRIPTION
## Summary
- apply color config on startup via `loadAndApplyColors`
- hook new loader into the app initialisation
- cover color loader with unit test
- update existing mocks for new export

## Testing
- `npm run lint`
- `npm test` *(fails: 5 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688443d571b08326af1e7b9d01c0e76c