### PR TITLE
Sync quest container color

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -30,8 +30,8 @@ body {
   box-shadow: none;
 }
 
-#:root {
-  --quest-bg-color: rgba(44, 62, 80, 0.45);
+:root {
+  --quest-bg-color: var(--card-bg);
 }
 
 /* Специален контейнер за въпросника */


### PR DESCRIPTION
## Summary
- set `--quest-bg-color` to match `--card-bg` from core styles

## Testing
- `npm run lint`
- `NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=4096' sh ./scripts/test.sh --runInBand` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_6884577d97508326a5af82cc45cab19a