### PR TITLE
Adjust questionnaire background

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -31,7 +31,7 @@ body {
 }
 
 :root {
-  --quest-bg-color: var(--card-bg);
+  --quest-bg-color: rgba(var(--primary-rgb), 0.5);
 }
 
 /* Специален контейнер за въпросника */


### PR DESCRIPTION
## Summary
- tweak quest theme to use primary color mix with transparency

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68845ae638448326b96ca13b327dd8a9