### PR TITLE
Remove final back button

### DIFF
--- a/quest.html
+++ b/quest.html
@@ -551,11 +551,10 @@
     pageDiv.innerHTML = `
       <h2>Поздравления! <i class="bi bi-stars"></i><br> Току що направихте най-важната стъпка по пътя към промяната</h2>
       <p>Натиснете бутона, за да изпратите вашите отговори за обработка.</p>
-      <div class="nav-buttons" style="justify-content: center;">
-        <button id="finalBackBtn" type="button">◀ Назад</button>
-        <button id="submitBtn" type="button">Изпрати</button>
-        <button id="restartBtn" type="button">Отначало</button>
-      </div>
+        <div class="nav-buttons" style="justify-content: center;">
+          <button id="submitBtn" type="button">Изпрати</button>
+          <button id="restartBtn" type="button">Отначало</button>
+        </div>
        <div id="submit-message" class="message" style="margin-top: 15px; text-align: center; font-weight: bold; word-wrap: break-word;"></div>
     `;
     container.appendChild(pageDiv);
@@ -568,11 +567,9 @@
         if (!pageDiv) { console.error("Финалната страница не е намерена."); return; }
         const submitBtn = pageDiv.querySelector('#submitBtn');
         const restartBtn = pageDiv.querySelector('#restartBtn');
-        const backBtn = pageDiv.querySelector('#finalBackBtn');
         const submitMessage = pageDiv.querySelector('#submit-message');
-        if (!submitBtn || !restartBtn || !backBtn || !submitMessage) { console.error("Един или повече елементи липсват на финалната страница."); return; }
+        if (!submitBtn || !restartBtn || !submitMessage) { console.error("Един или повече елементи липсват на финалната страница."); return; }
         restartBtn.addEventListener('click', () => { clearProgress(); location.reload(); });
-        backBtn.addEventListener('click', () => { showPage(registrationPageIndex); });
         submitBtn.addEventListener('click', async () => {
             submitBtn.disabled = true;
             submitBtn.textContent = 'Изпращане...';

--- a/quest.html
+++ b/quest.html
@@ -552,6 +552,7 @@
       <h2>Поздравления! <i class="bi bi-stars"></i><br> Току що направихте най-важната стъпка по пътя към промяната</h2>
       <p>Натиснете бутона, за да изпратите вашите отговори за обработка.</p>
         <div class="nav-buttons" style="justify-content: center;">
+          <button id="finalBackBtn" type="button">◀ Назад</button>
           <button id="submitBtn" type="button">Изпрати</button>
           <button id="restartBtn" type="button">Отначало</button>
         </div>
@@ -567,9 +568,11 @@
         if (!pageDiv) { console.error("Финалната страница не е намерена."); return; }
         const submitBtn = pageDiv.querySelector('#submitBtn');
         const restartBtn = pageDiv.querySelector('#restartBtn');
+        const backBtn = pageDiv.querySelector('#finalBackBtn');
         const submitMessage = pageDiv.querySelector('#submit-message');
-        if (!submitBtn || !restartBtn || !submitMessage) { console.error("Един или повече елементи липсват на финалната страница."); return; }
+        if (!submitBtn || !restartBtn || !backBtn || !submitMessage) { console.error("Един или повече елементи липсват на финалната страница."); return; }
         restartBtn.addEventListener('click', () => { clearProgress(); location.reload(); });
+        backBtn.addEventListener('click', () => { showPage(registrationPageIndex); });
         submitBtn.addEventListener('click', async () => {
             submitBtn.disabled = true;
             submitBtn.textContent = 'Изпращане...';
@@ -578,34 +581,7 @@
                 const result = await submitResponses();
                 showMessage(submitMessage, result.message || "Отговорите са изпратени успешно за обработка!", false);
                 submitBtn.style.display = "none";
-                const lastQuestionPageIndex = totalPages - 3;
-                if (lastQuestionPageIndex >= 0) {
-                    const backToEditBtn = document.createElement('button');
-                    backToEditBtn.textContent = '◀ Назад';
-                    backToEditBtn.type = 'button';
-                    backToEditBtn.style.marginTop = '15px';
-                    backToEditBtn.style.backgroundColor = '#f39c12';
-                    backToEditBtn.style.color = '#1e1e1e';
-                    backToEditBtn.onclick = () => {
-                        if (submitMessage) { hideMessage(submitMessage); }
-                        backToEditBtn.remove();
-                        if (submitBtn) {
-                            submitBtn.style.display = 'block';
-                            submitBtn.disabled = false;
-                            submitBtn.textContent = 'Изпрати отново';
-                        }
-                        if (restartBtn) { restartBtn.disabled = false; }
-                        showPage(lastQuestionPageIndex);
-                    };
-                    submitMessage.parentNode.insertBefore(backToEditBtn, submitMessage.nextSibling);
-                    submitBtn.style.display = "none";
-                     restartBtn.disabled = false;
-                     restartBtn.textContent = "Започни наново";
-                } else {
-                     submitBtn.style.display = "none";
-                     restartBtn.disabled = false;
-                     restartBtn.textContent = "Започни наново";
-                }
+                restartBtn.disabled = false;
                 restartBtn.textContent = "Попълни отново";
             } catch (error) {
                 console.error("Error caught in submitBtn listener:", error);


### PR DESCRIPTION
## Summary
- remove the 'Назад' button from the final questionnaire page
- update final page logic since button is gone

## Testing
- `npm run lint`
- `npm test` *(fails: populateUI.test.js ran out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68845bbcd78083269070a9bd7ccd3228