### PR TITLE
Remove extra back button

### DIFF
--- a/quest.html
+++ b/quest.html
@@ -581,34 +581,7 @@
                 const result = await submitResponses();
                 showMessage(submitMessage, result.message || "Отговорите са изпратени успешно за обработка!", false);
                 submitBtn.style.display = "none";
-                const lastQuestionPageIndex = totalPages - 3;
-                if (lastQuestionPageIndex >= 0) {
-                    const backToEditBtn = document.createElement('button');
-                    backToEditBtn.textContent = '◀ Назад';
-                    backToEditBtn.type = 'button';
-                    backToEditBtn.style.marginTop = '15px';
-                    backToEditBtn.style.backgroundColor = '#f39c12';
-                    backToEditBtn.style.color = '#1e1e1e';
-                    backToEditBtn.onclick = () => {
-                        if (submitMessage) { hideMessage(submitMessage); }
-                        backToEditBtn.remove();
-                        if (submitBtn) {
-                            submitBtn.style.display = 'block';
-                            submitBtn.disabled = false;
-                            submitBtn.textContent = 'Изпрати отново';
-                        }
-                        if (restartBtn) { restartBtn.disabled = false; }
-                        showPage(lastQuestionPageIndex);
-                    };
-                    submitMessage.parentNode.insertBefore(backToEditBtn, submitMessage.nextSibling);
-                    submitBtn.style.display = "none";
-                     restartBtn.disabled = false;
-                     restartBtn.textContent = "Започни наново";
-                } else {
-                     submitBtn.style.display = "none";
-                     restartBtn.disabled = false;
-                     restartBtn.textContent = "Започни наново";
-                }
+                restartBtn.disabled = false;
                 restartBtn.textContent = "Попълни отново";
             } catch (error) {
                 console.error("Error caught in submitBtn listener:", error);


### PR DESCRIPTION
## Summary
- remove dynamic `Назад` button on final page

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test -- -w=1` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688465a708d08326a3ca68ea30b8b493