### PR TITLE
Add email toggle flags

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -236,6 +236,7 @@
       <label>Тема:<br><input id="welcomeEmailSubject" type="text"></label>
       <label>Съдържание:<br><textarea id="welcomeEmailBody" rows="5"></textarea></label>
       <div id="welcomeEmailPreview" class="email-preview"></div>
+      <label><input id="sendWelcomeEmail" type="checkbox" checked> Изпращай приветствен имейл</label>
       <label>Тема на имейла след въпросник:<br><input id="questionnaireEmailSubject" type="text"></label>
       <label>Съдържание:<br><textarea id="questionnaireEmailBody" rows="5"></textarea></label>
       <div id="questionnaireEmailPreview" class="email-preview"></div>
@@ -243,6 +244,7 @@
       <label>Тема на имейла за анализ:<br><input id="analysisEmailSubject" type="text"></label>
       <label>Съдържание:<br><textarea id="analysisEmailBody" rows="5"></textarea></label>
       <div id="analysisEmailPreview" class="email-preview"></div>
+      <label><input id="sendAnalysisEmail" type="checkbox" checked> Изпращай имейл при готов анализ</label>
       <label><input id="sameEmailContent" type="checkbox"> Използвай същото съдържание за анализа</label>
       <button type="submit">Запази</button>
     </form>

--- a/js/__tests__/emailSettingsFlags.test.js
+++ b/js/__tests__/emailSettingsFlags.test.js
@@ -1,0 +1,76 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+
+let loadEmailSettings, saveEmailSettings
+let mockLoad, mockSave
+
+beforeEach(async () => {
+  jest.resetModules()
+  document.body.innerHTML = `
+    <form id="emailSettingsForm"></form>
+    <input id="welcomeEmailSubject">
+    <textarea id="welcomeEmailBody"></textarea>
+    <input id="questionnaireEmailSubject">
+    <textarea id="questionnaireEmailBody"></textarea>
+    <input id="analysisEmailSubject">
+    <textarea id="analysisEmailBody"></textarea>
+    <div id="welcomeEmailPreview"></div>
+    <div id="questionnaireEmailPreview"></div>
+    <div id="analysisEmailPreview"></div>
+    <input id="sendQuestionnaireEmail" type="checkbox">
+    <input id="sendWelcomeEmail" type="checkbox">
+    <input id="sendAnalysisEmail" type="checkbox">
+    <button id="showStats"></button>
+  `
+  mockLoad = jest.fn().mockResolvedValue({
+    welcome_email_subject: 's1',
+    welcome_email_body: '<b>w</b>',
+    questionnaire_email_subject: 's2',
+    questionnaire_email_body: '<i>q</i>',
+    analysis_email_subject: 's3',
+    analysis_email_body: '<u>a</u>',
+    send_questionnaire_email: '0',
+    send_welcome_email: '1',
+    send_analysis_email: '0'
+  })
+  mockSave = jest.fn().mockResolvedValue({})
+  jest.unstable_mockModule('../adminConfig.js', () => ({
+    loadConfig: mockLoad,
+    saveConfig: mockSave
+  }))
+  ;({ loadEmailSettings, saveEmailSettings } = await import('../admin.js'))
+})
+
+afterEach(() => {
+  mockLoad.mockReset()
+  mockSave.mockReset()
+})
+
+test('loadEmailSettings populates form and flags', async () => {
+  await loadEmailSettings()
+  expect(mockLoad).toHaveBeenCalledWith([
+    'welcome_email_subject',
+    'welcome_email_body',
+    'questionnaire_email_subject',
+    'questionnaire_email_body',
+    'analysis_email_subject',
+    'analysis_email_body',
+    'send_questionnaire_email',
+    'send_welcome_email',
+    'send_analysis_email'
+  ])
+  expect(document.getElementById('sendWelcomeEmail').checked).toBe(true)
+  expect(document.getElementById('sendAnalysisEmail').checked).toBe(false)
+})
+
+test('saveEmailSettings sends updated flags', async () => {
+  document.getElementById('sendQuestionnaireEmail').checked = true
+  document.getElementById('sendWelcomeEmail').checked = false
+  document.getElementById('sendAnalysisEmail').checked = true
+  await saveEmailSettings()
+  expect(mockSave).toHaveBeenCalledWith(expect.objectContaining({
+    send_questionnaire_email: '1',
+    send_welcome_email: '0',
+    send_analysis_email: '1'
+  }))
+})

--- a/js/admin.js
+++ b/js/admin.js
@@ -100,6 +100,8 @@ const questionnaireEmailBodyInput = document.getElementById('questionnaireEmailB
 const analysisEmailSubjectInput = document.getElementById('analysisEmailSubject');
 const analysisEmailBodyInput = document.getElementById('analysisEmailBody');
 const sendQuestionnaireEmailCheckbox = document.getElementById('sendQuestionnaireEmail');
+const sendWelcomeEmailCheckbox = document.getElementById('sendWelcomeEmail');
+const sendAnalysisEmailCheckbox = document.getElementById('sendAnalysisEmail');
 const sameEmailContentCheckbox = document.getElementById('sameEmailContent');
 const contentThemeForm = document.getElementById('contentThemeForm');
 const contentAnalysisSubjectInput = document.getElementById('contentAnalysisSubject');
@@ -1281,7 +1283,9 @@ async function loadEmailSettings() {
             'questionnaire_email_body',
             'analysis_email_subject',
             'analysis_email_body',
-            'send_questionnaire_email'
+            'send_questionnaire_email',
+            'send_welcome_email',
+            'send_analysis_email'
         ])
         if (welcomeEmailSubjectInput) welcomeEmailSubjectInput.value = cfg.welcome_email_subject || ''
         if (welcomeEmailBodyInput) {
@@ -1302,6 +1306,14 @@ async function loadEmailSettings() {
             const val = cfg.send_questionnaire_email
             sendQuestionnaireEmailCheckbox.checked = val !== '0' && val !== 'false'
         }
+        if (sendWelcomeEmailCheckbox) {
+            const val = cfg.send_welcome_email
+            sendWelcomeEmailCheckbox.checked = val !== '0' && val !== 'false'
+        }
+        if (sendAnalysisEmailCheckbox) {
+            const val = cfg.send_analysis_email
+            sendAnalysisEmailCheckbox.checked = val !== '0' && val !== 'false'
+        }
     } catch (err) {
         console.error('Error loading email settings:', err)
     }
@@ -1316,7 +1328,9 @@ async function saveEmailSettings() {
             questionnaire_email_body: questionnaireEmailBodyInput ? questionnaireEmailBodyInput.value.trim() : '',
             analysis_email_subject: (sameEmailContentCheckbox?.checked ? questionnaireEmailSubjectInput?.value.trim() : analysisEmailSubjectInput?.value.trim()) || '',
             analysis_email_body: (sameEmailContentCheckbox?.checked ? questionnaireEmailBodyInput?.value.trim() : analysisEmailBodyInput?.value.trim()) || '',
-            send_questionnaire_email: sendQuestionnaireEmailCheckbox && sendQuestionnaireEmailCheckbox.checked ? '1' : '0'
+            send_questionnaire_email: sendQuestionnaireEmailCheckbox && sendQuestionnaireEmailCheckbox.checked ? '1' : '0',
+            send_welcome_email: sendWelcomeEmailCheckbox && sendWelcomeEmailCheckbox.checked ? '1' : '0',
+            send_analysis_email: sendAnalysisEmailCheckbox && sendAnalysisEmailCheckbox.checked ? '1' : '0'
     }
     try {
         await saveConfig(updates)
@@ -1807,6 +1821,8 @@ export {
     sendTestQuestionnaire,
     sendAdminQuery,
     attachEmailPreview,
+    loadEmailSettings,
+    saveEmailSettings,
     loadContentThemeSettings,
     saveContentThemeSettings
 };

--- a/preworker.js
+++ b/preworker.js
@@ -274,6 +274,8 @@ const AI_CONFIG_KEYS = [
     'questionnaire_email_body',
     'analysis_email_subject',
     'analysis_email_body',
+    'send_welcome_email',
+    'send_analysis_email',
     'send_questionnaire_email',
     'colors'
 ];

--- a/worker.js
+++ b/worker.js
@@ -274,6 +274,8 @@ const AI_CONFIG_KEYS = [
     'questionnaire_email_body',
     'analysis_email_subject',
     'analysis_email_body',
+    'send_welcome_email',
+    'send_analysis_email',
     'send_questionnaire_email',
     'colors'
 ];


### PR DESCRIPTION
## Summary
- allow toggling welcome/analysis emails via new flags
- load and store the new flags in admin panel
- show checkboxes for the new options
- test admin email flag logic

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688464e276588326b9a1f1334618965c