### PR TITLE
Remove yellow back button on final page

### DIFF
--- a/quest.html
+++ b/quest.html
@@ -552,7 +552,6 @@
       <h2>Поздравления! <i class="bi bi-stars"></i><br> Току що направихте най-важната стъпка по пътя към промяната</h2>
       <p>Натиснете бутона, за да изпратите вашите отговори за обработка.</p>
       <div class="nav-buttons" style="justify-content: center;">
-        <button id="finalBackBtn" type="button">◀ Назад</button>
         <button id="submitBtn" type="button">Изпрати</button>
         <button id="restartBtn" type="button">Отначало</button>
       </div>
@@ -568,11 +567,9 @@
         if (!pageDiv) { console.error("Финалната страница не е намерена."); return; }
         const submitBtn = pageDiv.querySelector('#submitBtn');
         const restartBtn = pageDiv.querySelector('#restartBtn');
-        const backBtn = pageDiv.querySelector('#finalBackBtn');
         const submitMessage = pageDiv.querySelector('#submit-message');
-        if (!submitBtn || !restartBtn || !backBtn || !submitMessage) { console.error("Един или повече елементи липсват на финалната страница."); return; }
+        if (!submitBtn || !restartBtn || !submitMessage) { console.error("Един или повече елементи липсват на финалната страница."); return; }
         restartBtn.addEventListener('click', () => { clearProgress(); location.reload(); });
-        backBtn.addEventListener('click', () => { showPage(registrationPageIndex); });
         submitBtn.addEventListener('click', async () => {
             submitBtn.disabled = true;
             submitBtn.textContent = 'Изпращане...';


### PR DESCRIPTION
## Summary
- remove the final back button from the last questionnaire page
- drop associated listener in `setupFinalPageListener`

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68846882888083269a23a643686fbed5