### PR TITLE
Refactor email settings

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -233,32 +233,32 @@
   <details id="emailSettingsSection" class="card">
     <summary>Настройки за имейли</summary>
     <form id="emailSettingsForm">
-      <label>Тема:<br><input id="welcomeEmailSubject" type="text"></label>
-      <label>Съдържание:<br><textarea id="welcomeEmailBody" rows="5"></textarea></label>
-      <div id="welcomeEmailPreview" class="email-preview"></div>
-      <label><input id="sendWelcomeEmail" type="checkbox" checked> Изпращай приветствен имейл</label>
-      <label>Тема на имейла след въпросник:<br><input id="questionnaireEmailSubject" type="text"></label>
-      <label>Съдържание:<br><textarea id="questionnaireEmailBody" rows="5"></textarea></label>
-      <div id="questionnaireEmailPreview" class="email-preview"></div>
-      <label><input id="sendQuestionnaireEmail" type="checkbox" checked> Изпращай имейл след въпросник</label>
-      <label>Тема на имейла за анализ:<br><input id="analysisEmailSubject" type="text"></label>
-      <label>Съдържание:<br><textarea id="analysisEmailBody" rows="5"></textarea></label>
-      <div id="analysisEmailPreview" class="email-preview"></div>
-      <label><input id="sendAnalysisEmail" type="checkbox" checked> Изпращай имейл при готов анализ</label>
-      <label><input id="sameEmailContent" type="checkbox"> Използвай същото съдържание за анализа</label>
+      <fieldset>
+        <legend>Приветствен имейл (след регистрация)</legend>
+        <label>Тема:<br><input id="welcomeEmailSubject" type="text" placeholder="Добре дошли в BodyBest!"></label>
+        <label>Съдържание:<br><textarea id="welcomeEmailBody" rows="5" placeholder="Здравейте {{name}}, благодарим за регистрацията..."></textarea></label>
+        <div id="welcomeEmailPreview" class="email-preview"></div>
+        <label><input id="sendWelcomeEmail" type="checkbox" checked> Изпращай приветствен имейл</label>
+      </fieldset>
+      <fieldset>
+        <legend>Потвърждение след въпросник</legend>
+        <label>Тема:<br><input id="questionnaireEmailSubject" type="text" placeholder="Благодарим за попълнения въпросник"></label>
+        <label>Съдържание:<br><textarea id="questionnaireEmailBody" rows="5" placeholder="Получихме отговорите и започваме обработка..."></textarea></label>
+        <div id="questionnaireEmailPreview" class="email-preview"></div>
+        <label><input id="sendQuestionnaireEmail" type="checkbox" checked> Изпращай имейл след въпросник</label>
+      </fieldset>
+      <fieldset>
+        <legend>Имейл при готов анализ</legend>
+        <label>Тема:<br><input id="analysisEmailSubject" type="text" placeholder="Вашият анализ е готов"></label>
+        <label>Съдържание:<br><textarea id="analysisEmailBody" rows="5" placeholder="Здравейте {{name}}, анализът ви е готов."></textarea></label>
+        <div id="analysisEmailPreview" class="email-preview"></div>
+        <label><input id="sendAnalysisEmail" type="checkbox" checked> Изпращай имейл при готов анализ</label>
+        <label><input id="sameEmailContent" type="checkbox"> Използвай същото съдържание за анализа</label>
+      </fieldset>
       <button type="submit">Запази</button>
     </form>
   </details>
 
-  <details id="contentThemeSection" class="card">
-    <summary>Съдържание и тема</summary>
-    <form id="contentThemeForm">
-      <label>Тема на имейла за анализ:<br><input id="contentAnalysisSubject" type="text"></label>
-      <label>Съдържание:<br><textarea id="contentAnalysisBody" rows="5"></textarea></label>
-      <div id="contentAnalysisPreview" class="email-preview"></div>
-      <button type="submit">Запази</button>
-    </form>
-  </details>
 
   <details id="colorSettings" class="card">
     <summary>Настройки на цветове</summary>

--- a/css/admin.css
+++ b/css/admin.css
@@ -130,6 +130,11 @@ details[open] summary::after {
   border: 1px solid #ccc;
   padding: 8px;
 }
+#emailSettingsForm fieldset {
+  border: 1px solid #ccc;
+  padding: 8px;
+  margin-bottom: 10px;
+}
 #aiConfigForm input[type="text"] {
   width: 100%;
   max-width: 300px;

--- a/js/admin.js
+++ b/js/admin.js
@@ -103,10 +103,6 @@ const sendQuestionnaireEmailCheckbox = document.getElementById('sendQuestionnair
 const sendWelcomeEmailCheckbox = document.getElementById('sendWelcomeEmail');
 const sendAnalysisEmailCheckbox = document.getElementById('sendAnalysisEmail');
 const sameEmailContentCheckbox = document.getElementById('sameEmailContent');
-const contentThemeForm = document.getElementById('contentThemeForm');
-const contentAnalysisSubjectInput = document.getElementById('contentAnalysisSubject');
-const contentAnalysisBodyInput = document.getElementById('contentAnalysisBody');
-const contentAnalysisPreview = document.getElementById('contentAnalysisPreview');
 const testEmailForm = document.getElementById('testEmailForm');
 const testEmailToInput = document.getElementById('testEmailTo');
 const testEmailSubjectInput = document.getElementById('testEmailSubject');
@@ -1341,36 +1337,6 @@ async function saveEmailSettings() {
     }
 }
 
-async function loadContentThemeSettings() {
-    try {
-        const cfg = await loadConfig([
-            'analysis_email_subject',
-            'analysis_email_body'
-        ]);
-        if (contentAnalysisSubjectInput) contentAnalysisSubjectInput.value = cfg.analysis_email_subject || '';
-        if (contentAnalysisBodyInput) {
-            contentAnalysisBodyInput.value = cfg.analysis_email_body || '';
-            if (contentAnalysisPreview) contentAnalysisPreview.innerHTML = sanitizeHTML(contentAnalysisBodyInput.value);
-        }
-    } catch (err) {
-        console.error('Error loading content settings:', err);
-    }
-}
-
-async function saveContentThemeSettings() {
-    if (!contentThemeForm) return;
-    const updates = {
-        analysis_email_subject: contentAnalysisSubjectInput ? contentAnalysisSubjectInput.value.trim() : '',
-        analysis_email_body: contentAnalysisBodyInput ? contentAnalysisBodyInput.value.trim() : ''
-    };
-    try {
-        await saveConfig(updates);
-        alert('Съдържанието е записано.');
-    } catch (err) {
-        console.error('Error saving content settings:', err);
-        alert('Грешка при запис на съдържанието.');
-    }
-}
 
 let testEmailTemplateLoaded = false
 
@@ -1699,7 +1665,6 @@ document.addEventListener('DOMContentLoaded', () => {
     attachEmailPreview(questionnaireEmailBodyInput, questionnaireEmailPreview);
     attachEmailPreview(analysisEmailBodyInput, analysisEmailPreview);
     attachEmailPreview(testEmailBodyInput, testEmailPreview);
-    attachEmailPreview(contentAnalysisBodyInput, contentAnalysisPreview);
 
     if (sameEmailContentCheckbox) {
         const updateAnalysisFields = () => {
@@ -1737,7 +1702,6 @@ document.addEventListener('DOMContentLoaded', () => {
         loadAdminToken();
         await loadAiConfig();
         await loadAiPresets();
-        if (contentThemeForm) await loadContentThemeSettings();
         if (emailSettingsForm) await loadEmailSettings();
         if (testEmailSection?.open) await loadTestEmailTemplate();
         setInterval(checkForNotifications, 60000);
@@ -1770,12 +1734,6 @@ if (emailSettingsForm) {
     });
 }
 
-if (contentThemeForm) {
-    contentThemeForm.addEventListener('submit', async (e) => {
-        e.preventDefault();
-        await saveContentThemeSettings();
-    });
-}
 
 if (testEmailSection) {
     testEmailSection.addEventListener('toggle', () => {
@@ -1822,7 +1780,5 @@ export {
     sendAdminQuery,
     attachEmailPreview,
     loadEmailSettings,
-    saveEmailSettings,
-    loadContentThemeSettings,
-    saveContentThemeSettings
+    saveEmailSettings
 };


### PR DESCRIPTION
## Summary
- restructure email settings form with descriptive fieldsets
- merge analysis email fields and remove obsolete content section
- style fieldsets in admin CSS
- clean admin JS from removed form handlers

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test -- -w 1` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688468cc5bc08326831bdd8ba13e94fe