### PR TITLE
Expand admin color controls

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -262,18 +262,7 @@
 
   <details id="colorSettings" class="card">
     <summary>Настройки на цветове</summary>
-    <label>Основен цвят
-      <input type="color" id="primaryColorInput">
-    </label>
-    <label>Вторичен цвят
-      <input type="color" id="secondaryColorInput">
-    </label>
-    <label>Акцентен цвят
-      <input type="color" id="accentColorInput">
-    </label>
-    <label>Терциерен цвят
-      <input type="color" id="tertiaryColorInput">
-    </label>
+    <div id="colorInputs"></div>
     <button id="saveColorConfig">Запази</button>
     <div class="theme-controls">
       <label>Име на тема

--- a/js/__tests__/adminColors.test.js
+++ b/js/__tests__/adminColors.test.js
@@ -8,10 +8,7 @@ let mockSave;
 beforeEach(async () => {
   jest.resetModules();
   document.body.innerHTML = `
-    <input id="primaryColorInput" type="color">
-    <input id="secondaryColorInput" type="color">
-    <input id="accentColorInput" type="color">
-    <input id="tertiaryColorInput" type="color">
+    <div id="colorInputs"></div>
     <button id="saveColorConfig"></button>
     <input id="themeNameInput" type="text">
     <button id="saveThemeLocal"></button>
@@ -19,26 +16,29 @@ beforeEach(async () => {
     <button id="applyThemeLocal"></button>
     <button id="deleteThemeLocal"></button>`;
 
-  mockLoad = jest.fn().mockResolvedValue({ colors: { primary: '#111111', secondary: '#222222' } });
+  mockLoad = jest.fn().mockResolvedValue({ colors: { 'primary-color': '#111111', 'secondary-color': '#222222' } });
   mockSave = jest.fn().mockResolvedValue({});
   jest.unstable_mockModule('../adminConfig.js', () => ({
     loadConfig: mockLoad,
     saveConfig: mockSave
   }));
+  global.fetch = jest.fn().mockResolvedValue({ text: async () => ':root{--primary-color:#000;--secondary-color:#000;}' });
   ({ initColorSettings } = await import('../adminColors.js'));
 });
 
 afterEach(() => {
   mockLoad.mockReset();
   mockSave.mockReset();
+  global.fetch.mockReset();
   document.documentElement.style.cssText = '';
   document.body.style.cssText = '';
 });
 
 test('initColorSettings loads config and sets CSS vars', async () => {
   await initColorSettings();
+  expect(global.fetch).toHaveBeenCalledWith('css/base_styles.css');
   expect(mockLoad).toHaveBeenCalledWith(['colors']);
-  expect(document.getElementById('primaryColorInput').value).toBe('#111111');
+  expect(document.getElementById('primary-colorInput').value).toBe('#111111');
   expect(document.documentElement.style.getPropertyValue('--primary-color')).toBe('#111111');
 });
 
@@ -46,31 +46,29 @@ test('falls back to computed colors when config missing', async () => {
   mockLoad.mockResolvedValue({ colors: {} });
   document.documentElement.style.setProperty('--primary-color', '#010203');
   await initColorSettings();
-  expect(document.getElementById('primaryColorInput').value).toBe('#010203');
+  expect(document.getElementById('primary-colorInput').value).toBe('#010203');
 });
 
 test('save button gathers colors and calls saveConfig', async () => {
   await initColorSettings();
-  document.getElementById('primaryColorInput').value = '#333333';
-  document.getElementById('secondaryColorInput').value = '#444444';
+  document.getElementById('primary-colorInput').value = '#333333';
+  document.getElementById('secondary-colorInput').value = '#444444';
   document.getElementById('saveColorConfig').click();
   expect(mockSave).toHaveBeenCalledWith({ colors: {
-    primary: '#333333',
-    secondary: '#444444',
-    accent: document.getElementById('accentColorInput').value,
-    tertiary: document.getElementById('tertiaryColorInput').value
+    'primary-color': '#333333',
+    'secondary-color': '#444444'
   } });
 });
 
 test('themes can be saved and applied', async () => {
   mockLoad.mockResolvedValue({ colors: {} });
   await initColorSettings();
-  document.getElementById('primaryColorInput').value = '#aaaaaa';
+  document.getElementById('primary-colorInput').value = '#aaaaaa';
   document.getElementById('themeNameInput').value = 't1';
   document.getElementById('saveThemeLocal').click();
-  expect(JSON.parse(localStorage.getItem('colorThemes')).t1.primary).toBe('#aaaaaa');
-  document.getElementById('primaryColorInput').value = '#bbbbbb';
+  expect(JSON.parse(localStorage.getItem('colorThemes')).t1['primary-color']).toBe('#aaaaaa');
+  document.getElementById('primary-colorInput').value = '#bbbbbb';
   document.getElementById('savedThemes').value = 't1';
   document.getElementById('applyThemeLocal').click();
-  expect(document.getElementById('primaryColorInput').value).toBe('#aaaaaa');
+  expect(document.getElementById('primary-colorInput').value).toBe('#aaaaaa');
 });

--- a/js/__tests__/loadAndApplyColors.test.js
+++ b/js/__tests__/loadAndApplyColors.test.js
@@ -6,7 +6,7 @@ let mockLoad;
 
 beforeEach(async () => {
   jest.resetModules();
-  mockLoad = jest.fn().mockResolvedValue({ colors: { primary: '#111111', accent: '#222222' } });
+  mockLoad = jest.fn().mockResolvedValue({ colors: { 'primary-color': '#111111', 'accent-color': '#222222' } });
   jest.unstable_mockModule('../adminConfig.js', () => ({ loadConfig: mockLoad }));
   jest.unstable_mockModule('../app.js', () => ({
     fullDashboardData: {},

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -95,8 +95,8 @@ export async function loadAndApplyColors() {
         const { colors = {} } = await loadConfig(['colors']);
         for (const [key, val] of Object.entries(colors)) {
             if (!val) continue;
-            document.documentElement.style.setProperty(`--${key}-color`, val);
-            document.body.style.setProperty(`--${key}-color`, val);
+            document.documentElement.style.setProperty(`--${key}`, val);
+            document.body.style.setProperty(`--${key}`, val);
         }
     } catch (err) {
         console.warn('Неуспешно зареждане на цветовата конфигурация', err);


### PR DESCRIPTION
## Summary
- detect all color variables in `base_styles.css`
- dynamically generate inputs in admin panel for these colors
- store and apply color settings by variable name
- adjust color tests

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6884c05267a083269e622c79d33e2b91