### PR TITLE
Add default color themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ The application will be available at `http://localhost:5173` by default.
 
 Интерфейсът следва системната светла/тъмна настройка. Ако в LocalStorage е избрана опцията "system", промяната на темата в операционната система се отразява моментално.
 
+### Цветови теми
+
+При първоначално зареждане админ панелът записва два шаблона "Light" и "Dark" в `localStorage.colorThemes`. Стойностите се извличат от `css/base_styles.css`. Ако има съществуващи теми със същите имена, те не се презаписват. Падащото меню `#savedThemes` се попълва автоматично с тези шаблони.
+
 ### Build
 
 Create an optimized production build in the `dist` folder:

--- a/js/__tests__/adminColors.test.js
+++ b/js/__tests__/adminColors.test.js
@@ -22,7 +22,9 @@ beforeEach(async () => {
     loadConfig: mockLoad,
     saveConfig: mockSave
   }));
-  global.fetch = jest.fn().mockResolvedValue({ text: async () => ':root{--primary-color:#000;--secondary-color:#000;}' });
+  global.fetch = jest.fn().mockResolvedValue({
+    text: async () => ':root{--primary-color:#000;--secondary-color:#000;}body.dark-theme{--primary-color:#fff;--secondary-color:#fff;}'
+  });
   ({ initColorSettings } = await import('../adminColors.js'));
 });
 
@@ -71,4 +73,14 @@ test('themes can be saved and applied', async () => {
   document.getElementById('savedThemes').value = 't1';
   document.getElementById('applyThemeLocal').click();
   expect(document.getElementById('primary-colorInput').value).toBe('#aaaaaa');
+});
+
+test('initializes default themes', async () => {
+  mockLoad.mockResolvedValue({ colors: {} });
+  await initColorSettings();
+  const themes = JSON.parse(localStorage.getItem('colorThemes'));
+  expect(themes.Light['primary-color']).toBe('#000');
+  expect(themes.Dark['primary-color']).toBe('#fff');
+  const opts = Array.from(document.getElementById('savedThemes').options).map(o => o.value);
+  expect(opts).toEqual(expect.arrayContaining(['Light', 'Dark']));
 });


### PR DESCRIPTION
## Summary
- parse default theme values from `css/base_styles.css`
- auto-save `Light` and `Dark` templates in localStorage on init
- test default theme population
- document theme templates in README

## Testing
- `npm run lint`
- `NODE_OPTIONS=--experimental-vm-modules npx jest js/__tests__/adminColors.test.js --runInBand`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: process killed due to resource usage)*

------
https://chatgpt.com/codex/tasks/task_e_6884ce873f908326ba8b5206005c69e4