### PR TITLE
Update workflow test configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Test
         run: npm test
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
 
       - name: Prepare wrangler.toml
         run: node scripts/prepare-wrangler.js


### PR DESCRIPTION
## Summary
- increase memory limit for `npm test` in deploy workflow

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: out of memory)*
- `NODE_OPTIONS=--max-old-space-size=6144 npm test` *(fails: out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6884d1c99bc08326967a078d64586691