### PR TITLE
Remove deprecated worker sync script

### DIFF
--- a/scripts/check-worker-sync.js
+++ b/scripts/check-worker-sync.js
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-// Legacy no-op: worker.js is now the sole Worker script.


### PR DESCRIPTION
## Summary
- delete `scripts/check-worker-sync.js`

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6884d4273094832690e614f9ebe37752