### PR TITLE
Resolve transparency mismatch in quest pages

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -40,9 +40,7 @@ body {
   max-width: 640px;
   margin: 0 auto;
   padding: 10px;
-  background-color: var(--quest-bg-color);
-  backdrop-filter: blur(4px);
-  border-radius: 10px;
+  background-color: transparent;
 }
 
 .question-text {


### PR DESCRIPTION
## Summary
- fix double background layer by making `#dynamicContainer` transparent

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6884db1e97308326912b83defb2e5a32