### PR TITLE
Add script for running related tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ npm run test:watch
 npx jest
 # или пуснете конкретен тестов файл
 npm run test:file js/__tests__/adminConfig.test.js
+# или изпълнете тестове, свързани със стейджнатите файлове
+npm run test:related
 ```
 Препоръчително е за локална работа да използвате `npm run test:watch`,
 тъй като изпълнява само променените тестове и ускорява процеса.

--- a/docs/DEV_GUIDE_BG.md
+++ b/docs/DEV_GUIDE_BG.md
@@ -21,6 +21,7 @@ npm run lint      # проверява стила със ESLint
 npm test          # изпълнява Jest тестовете
 npm run test:watch # пуска само модифицираните тестове
 npm run test:file js/__tests__/adminConfig.test.js # пуска конкретен файл
+npm run test:related # пуска тестове за стейджнатите файлове
 npm run build     # създава оптимизиран билд в папка dist/
 npm run docs      # генерира API документация в docs/api
 ```
@@ -30,6 +31,7 @@ npm run docs      # генерира API документация в docs/api
 Препоръчително е за локална работа да използвате `npm run test:watch`,
 защото стартира само променените тестове и ускорява процеса.
 А ако искате да стартирате само конкретен файл, ползвайте `npm run test:file <път>`.
+За тестове, свързани със стейджнатите файлове, използвайте `npm run test:related`.
 
 
 1. Извикайте `npm run dev` и отворете `http://localhost:5173`.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "sh ./scripts/test.sh",
     "test:watch": "sh ./scripts/test.sh --watch",
     "test:file": "node scripts/test.sh --runTestsByPath",
+    "test:related": "node scripts/test-related.js",
     "coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "docs": "typedoc"
   },

--- a/scripts/test-related.js
+++ b/scripts/test-related.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import { spawnSync } from 'child_process';
+
+function getChangedFiles() {
+  const diff = spawnSync('git', ['diff', '--name-only', '--cached'], { encoding: 'utf8' });
+  if (diff.status !== 0) {
+    console.error(diff.stderr);
+    process.exit(diff.status ?? 1);
+  }
+  return diff.stdout
+    .split('\n')
+    .filter((f) => f.endsWith('.js') || f.endsWith('.ts'))
+    .filter(Boolean);
+}
+
+const changed = getChangedFiles();
+
+if (changed.length === 0) {
+  console.log('No staged JS/TS files found. Running full test suite...');
+  const full = spawnSync('sh', ['scripts/test.sh'], { stdio: 'inherit' });
+  process.exit(full.status ?? 0);
+}
+
+const args = ['scripts/test.sh', '--findRelatedTests', ...changed];
+const result = spawnSync('sh', args, { stdio: 'inherit' });
+process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary
- add `test:related` npm script
- implement `scripts/test-related.js`
- document related test usage in README and DEV_GUIDE_BG

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6884dc1872688326bf7340925336d3bb