### PR TITLE
Add theme toggle to questionnaire

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -6,8 +6,8 @@
 body {
   margin: 0;
   font-family: var(--font-primary, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif);
-  background-color: #121212;
-  color: #E0E0E0;
+  background-color: var(--bg-color);
+  color: var(--text-color-primary);
   overflow-x: hidden;
 }
 
@@ -15,7 +15,7 @@ body {
   max-width: 600px;
   margin: 60px auto 20px;
   padding: 20px;
-  background-color: #1e1e1e;
+  background-color: var(--surface-background);
   border-radius: 10px;
   box-shadow: 0 0 15px rgba(0,0,0,0.6);
 }
@@ -30,10 +30,6 @@ body {
   box-shadow: none;
 }
 
-:root {
-  /* Полупрозрачен син фон, съответстващ на началната страница */
-  --quest-bg-color: rgba(44, 62, 80, 0.65);
-}
 
 /* Специален контейнер за въпросника */
 #dynamicContainer {
@@ -48,7 +44,7 @@ body {
 .question-text {
   font-size: 20px;
   font-weight: 600;
-  color: #80cbc4;
+  color: var(--secondary-color);
   margin-bottom: 20px;
   line-height: 1.4;
 }
@@ -61,26 +57,26 @@ body {
   padding: 10px;
   width: 80%;
   border-radius: 5px;
-  border: 1px solid #333;
+  border: 1px solid var(--border-color);
   cursor: pointer;
   transition: background-color 0.2s, border-color 0.2s;
 }
 
 .answer-label:hover {
-    background-color: rgba(79, 195, 161, 0.1);
-    border-color: #4fc3a1;
+    background-color: color-mix(in srgb, var(--secondary-color) 15%, transparent);
+    border-color: var(--secondary-color);
 }
 
 .section-title {
   font-size: 22px;
   text-align: center;
-  color: #4fc3a1;
+  color: var(--secondary-color);
   margin-bottom: 20px;
 }
 
 h1, h2 {
   text-align: center;
-  color: #80cbc4;
+  color: var(--secondary-color);
   margin-bottom: 20px;
 }
 
@@ -125,8 +121,8 @@ p {
 }
 
 button {
-  background-color: #4fc3a1;
-  color: #121212;
+  background-color: var(--secondary-color);
+  color: var(--text-color-on-secondary);
   border: none;
   padding: 12px 20px;
   font-size: 16px;
@@ -138,8 +134,8 @@ button {
 }
 
 button:hover {
-  background-color: #43a088;
-  box-shadow: 0 0 10px rgba(128, 203, 196, 0.5);
+  background-color: color-mix(in srgb, var(--secondary-color) 85%, black);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--secondary-color) 50%, transparent);
 }
 
 input[type="text"],
@@ -151,25 +147,25 @@ select {
   width: 80%;
   padding: 12px;
   margin: 10px auto 20px;
-  border: 1px solid #333;
+  border: 1px solid var(--border-color);
   border-radius: 5px;
-  background-color: #2a2a2a;
-  color: #E0E0E0;
+  background-color: var(--input-bg);
+  color: var(--text-color-primary);
   font-size: 16px;
   transition: border-color 0.3s, box-shadow 0.3s;
 }
 
 input:focus, select:focus, textarea:focus {
     outline: none;
-    border-color: #4fc3a1;
-    box-shadow: 0 0 8px rgba(79, 195, 161, 0.5);
+    border-color: var(--secondary-color);
+    box-shadow: 0 0 8px color-mix(in srgb, var(--secondary-color) 50%, transparent);
 }
 
 
 input[type="radio"],
 input[type="checkbox"] {
   margin-right: 10px;
-  accent-color: #4fc3a1;
+  accent-color: var(--secondary-color);
   transform: scale(1.2);
 }
 
@@ -186,16 +182,16 @@ input[type="checkbox"] {
 
 .message.error {
   display: block;
-  color: #e74c3c;
-  background-color: rgba(231, 76, 60, 0.1);
-  border-color: #e74c3c;
+  color: var(--color-danger);
+  background-color: var(--color-danger-bg);
+  border-color: var(--color-danger);
 }
 
 .message.success {
   display: block;
-  color: #2ecc71;
-  background-color: rgba(46, 204, 113, 0.1);
-  border-color: #2ecc71;
+  color: var(--color-success);
+  background-color: var(--color-success-bg);
+  border-color: var(--color-success);
 }
 
 .form-group {
@@ -259,7 +255,7 @@ input[type="checkbox"] {
     position: sticky;
     top: 0;
     z-index: 1000; /* Висок z-index, за да е винаги отгоре */
-    background-color: rgba(18, 18, 18, 0.5);
+    background-color: color-mix(in srgb, var(--bg-color) 80%, transparent);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
     box-shadow: 0 2px 10px rgba(0,0,0,0.2);
@@ -283,7 +279,7 @@ input[type="checkbox"] {
   align-items: center;
   padding: 20px;
   box-sizing: border-box;
-  color: #fff;
+  color: var(--text-color-on-primary);
   /* Динамичен градиентен фон */
   background: linear-gradient(35deg,
     rgba(31, 44, 53, 0.55),
@@ -345,7 +341,7 @@ input[type="checkbox"] {
 .hero-title {
   font-size: 2.8rem;
   font-weight: 700;
-  color: #FFFFFF;
+  color: var(--text-color-on-primary);
   text-shadow: 2px 2px 8px rgba(0,0,0,0.3);
   margin-bottom: 15px;
   line-height: 1.2;
@@ -355,7 +351,7 @@ input[type="checkbox"] {
 .hero-subtitle {
   font-size: 1.3rem;
   font-weight: 300;
-  color: #E0E0E0;
+  color: var(--text-color-primary);
   max-width: 550px;
   margin: 0 auto 40px auto;
   line-height: 1.6;
@@ -364,8 +360,8 @@ input[type="checkbox"] {
 /* Специфични стилове за бутона на началната страница */
 #page0.hero-start-page #startBtn {
   position: relative;
-  background-color: #4fc3a1;
-  color: #121212;
+  background-color: var(--secondary-color);
+  color: var(--text-color-on-secondary);
   font-size: 1.2rem;
   font-weight: bold;
   padding: 16px 45px;
@@ -373,7 +369,7 @@ input[type="checkbox"] {
   border: none;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   cursor: pointer;
-  box-shadow: 0 5px 20px rgba(79, 195, 161, 0.3);
+  box-shadow: 0 5px 20px color-mix(in srgb, var(--secondary-color) 30%, transparent);
   display: inline-flex;
   align-items: center;
   gap: 10px;
@@ -381,8 +377,8 @@ input[type="checkbox"] {
 
 #page0.hero-start-page #startBtn:hover {
   transform: translateY(-4px);
-  box-shadow: 0 10px 25px rgba(79, 195, 161, 0.5);
-  background-color: #5dd4b5; /* Леко по-светъл при hover */
+  box-shadow: 0 10px 25px color-mix(in srgb, var(--secondary-color) 50%, transparent);
+  background-color: color-mix(in srgb, var(--secondary-color) 90%, white); /* Леко по-светъл при hover */
 }
 
 /* Пулсираща рамка за призив към действие */
@@ -391,7 +387,7 @@ input[type="checkbox"] {
   position: absolute;
   z-index: -1;
   top: -6px; left: -6px; right: -6px; bottom: -6px;
-  border: 2px solid rgba(79, 195, 161, 0.5);
+  border: 2px solid color-mix(in srgb, var(--secondary-color) 50%, transparent);
   border-radius: 50px;
   animation: pulse 2s infinite ease-out;
 }
@@ -402,7 +398,7 @@ input[type="checkbox"] {
     flex-direction: column;
     align-items: center;
     gap: 20px;
-    color: rgba(255, 255, 255, 0.8);
+    color: color-mix(in srgb, var(--text-color-on-primary) 80%, transparent);
     user-select: none;
 }
 

--- a/css/quest_theme.css
+++ b/css/quest_theme.css
@@ -5,4 +5,9 @@
   --secondary-color: #5BC0BE;
   --surface-background: #1e1e1e;
   --radius-sm: 0.3rem;
+  --quest-bg-color: rgba(44, 62, 80, 0.65);
+}
+
+body.dark-theme {
+  --quest-bg-color: rgba(37, 42, 65, 0.75);
 }

--- a/quest.html
+++ b/quest.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Въпросник за хранителни навици (Dynamic)</title>
+  <link href="css/base_styles.css" rel="stylesheet">
   <link href="css/quest_theme.css" rel="stylesheet">
   <link href="css/quest_styles.css" rel="stylesheet">
   <link href="css/components_styles.css" rel="stylesheet">
@@ -242,6 +243,7 @@
 <div class="step-indicator-container">
   <span class="step-indicator-label">Стъпка <span id="questCurrentStep">0</span> от <span id="questTotalSteps">0</span></span>
   <div class="progress-bar-steps"><div id="questProgressBar" class="step-progress-bar"></div></div>
+  <button id="theme-toggle" class="button button-secondary">Смени тема</button>
 </div>
 
 <div class="container" id="dynamicContainer">
@@ -284,6 +286,7 @@
   import { setupRegistration } from "./js/register.js";
   import { showMessage, hideMessage } from "./js/messageUtils.js";
   import { updateStepProgress } from "./js/stepProgress.js";
+  import { toggleTheme, initializeTheme } from "./js/uiHandlers.js";
   
   /***** Глобални променливи (без промяна) *****/
   let rawQuestions = [];
@@ -306,6 +309,7 @@
     'q1745805721482','alcoholFrequency','foodPreference','q1745806409218','q1745806494081','mainChallenge','q1745892518511',
     'medicalConditions','q1745804366749','medications','medicationsList','supplementsList'
   ];
+  const themeToggleBtn = document.getElementById('theme-toggle');
 
   /***** Функция за рекурсивно сплескване на въпросите (без промяна) *****/
   function flattenQuestions(questions) {
@@ -820,7 +824,10 @@
              setTimeout(() => { adminLink.style.display = 'none'; }, 10000);
            });
        }
-   });
+  });
+
+  initializeTheme();
+  if (themeToggleBtn) themeToggleBtn.addEventListener('click', toggleTheme);
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- load base styles in `quest.html` and add theme toggle button
- use CSS variables throughout `quest_styles.css`
- declare theme-specific variables in `quest_theme.css`
- init theme toggle logic via `uiHandlers.js`

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max_old_space_size=4096 npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6884e10f89d88326bf6961b7d51d948e