### PR TITLE
Refactor quest colors with CSS vars

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -17,7 +17,7 @@ body {
   padding: 20px;
   background-color: var(--surface-background);
   border-radius: 10px;
-  box-shadow: 0 0 15px rgba(0,0,0,0.6);
+  box-shadow: var(--quest-box-shadow);
 }
 
 /* Прозрачни контейнери в страницата с въпросника */
@@ -258,7 +258,7 @@ input[type="checkbox"] {
     background-color: color-mix(in srgb, var(--bg-color) 80%, transparent);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
-    box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+    box-shadow: var(--step-indicator-shadow);
     /* Уверяваме се, че оригиналните стилове за padding/margin са нулирани, ако има такива */
     margin: 0;
     padding: 8px 15px; /* Малко вътрешно отстояние */
@@ -282,9 +282,9 @@ input[type="checkbox"] {
   color: var(--text-color-on-primary);
   /* Динамичен градиентен фон */
   background: linear-gradient(35deg,
-    rgba(31, 44, 53, 0.55),
-    rgba(44, 62, 80, 0.55),
-    rgba(70, 99, 104, 0.55)
+    var(--hero-grad-start),
+    var(--hero-grad-middle),
+    var(--hero-grad-end)
   );
   background-size: 200% 200%;
   animation: gradientAnimation 15s ease infinite;
@@ -342,7 +342,7 @@ input[type="checkbox"] {
   font-size: 2.8rem;
   font-weight: 700;
   color: var(--text-color-on-primary);
-  text-shadow: 2px 2px 8px rgba(0,0,0,0.3);
+  text-shadow: var(--hero-text-shadow);
   margin-bottom: 15px;
   line-height: 1.2;
 }

--- a/css/quest_theme.css
+++ b/css/quest_theme.css
@@ -6,8 +6,20 @@
   --surface-background: #1e1e1e;
   --radius-sm: 0.3rem;
   --quest-bg-color: rgba(44, 62, 80, 0.65);
+  --quest-box-shadow: 0 0 15px rgba(0,0,0,0.6);
+  --step-indicator-shadow: 0 2px 10px rgba(0,0,0,0.2);
+  --hero-grad-start: rgba(31, 44, 53, 0.55);
+  --hero-grad-middle: rgba(44, 62, 80, 0.55);
+  --hero-grad-end: rgba(70, 99, 104, 0.55);
+  --hero-text-shadow: 2px 2px 8px rgba(0,0,0,0.3);
 }
 
 body.dark-theme {
   --quest-bg-color: rgba(37, 42, 65, 0.75);
+  --quest-box-shadow: 0 0 15px rgba(0,0,0,0.8);
+  --step-indicator-shadow: 0 2px 10px rgba(0,0,0,0.5);
+  --hero-grad-start: rgba(31, 44, 53, 0.75);
+  --hero-grad-middle: rgba(44, 62, 80, 0.75);
+  --hero-grad-end: rgba(70, 99, 104, 0.75);
+  --hero-text-shadow: 2px 2px 8px rgba(0,0,0,0.5);
 }


### PR DESCRIPTION
## Summary
- use new variables for shadows and hero gradient in `quest_styles.css`
- define `--quest-box-shadow`, `--step-indicator-shadow`, `--hero-grad-*` and `--hero-text-shadow` in `quest_theme.css`

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6884e4585b9083269fd8eb6331dfa7bf