### PR TITLE
Add quest theme init test

### DIFF
--- a/js/__tests__/questThemeInit.test.js
+++ b/js/__tests__/questThemeInit.test.js
@@ -1,0 +1,37 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import vm from 'node:vm';
+
+let toggleThemeMock;
+let initializeThemeMock;
+let snippet;
+
+beforeAll(() => {
+  const html = fs.readFileSync(path.resolve(__dirname, '../../quest.html'), 'utf8');
+  const match = html.match(/const themeToggleBtn[\s\S]*?themeToggleBtn.addEventListener\('click', toggleTheme\);/);
+  snippet = match ? match[0] : '';
+});
+
+beforeEach(async () => {
+  jest.resetModules();
+  toggleThemeMock = jest.fn();
+  initializeThemeMock = jest.fn();
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    toggleTheme: toggleThemeMock,
+    initializeTheme: initializeThemeMock
+  }));
+  document.body.innerHTML = '<button id="theme-toggle"></button>';
+  const { initializeTheme, toggleTheme } = await import('../uiHandlers.js');
+  vm.runInNewContext(snippet, { document, initializeTheme, toggleTheme });
+});
+
+test('initializeTheme се извиква при зареждане', () => {
+  expect(initializeThemeMock).toHaveBeenCalled();
+});
+
+test('#theme-toggle активира toggleTheme', () => {
+  document.getElementById('theme-toggle').click();
+  expect(toggleThemeMock).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add unit test for theme initialization and toggle on quest page

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*


------
https://chatgpt.com/codex/tasks/task_e_6884ea886ab88326b0c2fed12f706a56