### PR TITLE
Add theme toggle and light style for questionnaire

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -6,8 +6,8 @@
 body {
   margin: 0;
   font-family: var(--font-primary, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif);
-  background-color: #121212;
-  color: #E0E0E0;
+  background-color: var(--bg-color);
+  color: var(--text-color-primary);
   overflow-x: hidden;
 }
 
@@ -15,7 +15,7 @@ body {
   max-width: 600px;
   margin: 60px auto 20px;
   padding: 20px;
-  background-color: #1e1e1e;
+  background-color: var(--surface-background);
   border-radius: 10px;
   box-shadow: 0 0 15px rgba(0,0,0,0.6);
 }
@@ -31,8 +31,8 @@ body {
 }
 
 :root {
-  /* Полупрозрачен син фон, съответстващ на началната страница */
-  --quest-bg-color: rgba(44, 62, 80, 0.65);
+  /* Полупрозрачен фон, съобразен с активната тема */
+  --quest-bg-color: color-mix(in srgb, var(--secondary-color) 5%, var(--surface-background));
 }
 
 /* Специален контейнер за въпросника */
@@ -48,7 +48,7 @@ body {
 .question-text {
   font-size: 20px;
   font-weight: 600;
-  color: #80cbc4;
+  color: var(--secondary-color);
   margin-bottom: 20px;
   line-height: 1.4;
 }
@@ -61,26 +61,26 @@ body {
   padding: 10px;
   width: 80%;
   border-radius: 5px;
-  border: 1px solid #333;
+  border: 1px solid var(--border-color);
   cursor: pointer;
   transition: background-color 0.2s, border-color 0.2s;
 }
 
 .answer-label:hover {
-    background-color: rgba(79, 195, 161, 0.1);
-    border-color: #4fc3a1;
+    background-color: color-mix(in srgb, var(--secondary-color) 10%, transparent);
+    border-color: var(--secondary-color);
 }
 
 .section-title {
   font-size: 22px;
   text-align: center;
-  color: #4fc3a1;
+  color: var(--secondary-color);
   margin-bottom: 20px;
 }
 
 h1, h2 {
   text-align: center;
-  color: #80cbc4;
+  color: var(--secondary-color);
   margin-bottom: 20px;
 }
 
@@ -125,8 +125,8 @@ p {
 }
 
 button {
-  background-color: #4fc3a1;
-  color: #121212;
+  background-color: var(--secondary-color);
+  color: var(--text-color-on-secondary, #121212);
   border: none;
   padding: 12px 20px;
   font-size: 16px;
@@ -138,8 +138,8 @@ button {
 }
 
 button:hover {
-  background-color: #43a088;
-  box-shadow: 0 0 10px rgba(128, 203, 196, 0.5);
+  background-color: color-mix(in srgb, var(--secondary-color) 85%, black);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--secondary-color) 50%, transparent);
 }
 
 input[type="text"],
@@ -151,25 +151,25 @@ select {
   width: 80%;
   padding: 12px;
   margin: 10px auto 20px;
-  border: 1px solid #333;
+  border: 1px solid var(--border-color);
   border-radius: 5px;
-  background-color: #2a2a2a;
-  color: #E0E0E0;
+  background-color: var(--input-bg);
+  color: var(--text-color-primary);
   font-size: 16px;
   transition: border-color 0.3s, box-shadow 0.3s;
 }
 
 input:focus, select:focus, textarea:focus {
     outline: none;
-    border-color: #4fc3a1;
-    box-shadow: 0 0 8px rgba(79, 195, 161, 0.5);
+    border-color: var(--secondary-color);
+    box-shadow: 0 0 8px color-mix(in srgb, var(--secondary-color) 50%, transparent);
 }
 
 
 input[type="radio"],
 input[type="checkbox"] {
   margin-right: 10px;
-  accent-color: #4fc3a1;
+  accent-color: var(--secondary-color);
   transform: scale(1.2);
 }
 
@@ -186,16 +186,16 @@ input[type="checkbox"] {
 
 .message.error {
   display: block;
-  color: #e74c3c;
-  background-color: rgba(231, 76, 60, 0.1);
-  border-color: #e74c3c;
+  color: var(--color-danger);
+  background-color: var(--color-danger-bg);
+  border-color: var(--color-danger);
 }
 
 .message.success {
   display: block;
-  color: #2ecc71;
-  background-color: rgba(46, 204, 113, 0.1);
-  border-color: #2ecc71;
+  color: var(--color-success);
+  background-color: var(--color-success-bg);
+  border-color: var(--color-success);
 }
 
 .form-group {
@@ -259,7 +259,7 @@ input[type="checkbox"] {
     position: sticky;
     top: 0;
     z-index: 1000; /* Висок z-index, за да е винаги отгоре */
-    background-color: rgba(18, 18, 18, 0.5);
+    background-color: rgba(var(--surface-background-rgb), 0.5);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
     box-shadow: 0 2px 10px rgba(0,0,0,0.2);
@@ -283,7 +283,7 @@ input[type="checkbox"] {
   align-items: center;
   padding: 20px;
   box-sizing: border-box;
-  color: #fff;
+  color: var(--text-color-primary);
   /* Динамичен градиентен фон */
   background: linear-gradient(35deg,
     rgba(31, 44, 53, 0.55),
@@ -345,7 +345,7 @@ input[type="checkbox"] {
 .hero-title {
   font-size: 2.8rem;
   font-weight: 700;
-  color: #FFFFFF;
+  color: var(--text-color-primary);
   text-shadow: 2px 2px 8px rgba(0,0,0,0.3);
   margin-bottom: 15px;
   line-height: 1.2;
@@ -355,7 +355,7 @@ input[type="checkbox"] {
 .hero-subtitle {
   font-size: 1.3rem;
   font-weight: 300;
-  color: #E0E0E0;
+  color: var(--text-color-secondary);
   max-width: 550px;
   margin: 0 auto 40px auto;
   line-height: 1.6;
@@ -364,8 +364,8 @@ input[type="checkbox"] {
 /* Специфични стилове за бутона на началната страница */
 #page0.hero-start-page #startBtn {
   position: relative;
-  background-color: #4fc3a1;
-  color: #121212;
+  background-color: var(--secondary-color);
+  color: var(--text-color-on-secondary, #121212);
   font-size: 1.2rem;
   font-weight: bold;
   padding: 16px 45px;
@@ -381,8 +381,8 @@ input[type="checkbox"] {
 
 #page0.hero-start-page #startBtn:hover {
   transform: translateY(-4px);
-  box-shadow: 0 10px 25px rgba(79, 195, 161, 0.5);
-  background-color: #5dd4b5; /* Леко по-светъл при hover */
+  box-shadow: 0 10px 25px color-mix(in srgb, var(--secondary-color) 50%, transparent);
+  background-color: color-mix(in srgb, var(--secondary-color) 90%, white);
 }
 
 /* Пулсираща рамка за призив към действие */
@@ -391,7 +391,7 @@ input[type="checkbox"] {
   position: absolute;
   z-index: -1;
   top: -6px; left: -6px; right: -6px; bottom: -6px;
-  border: 2px solid rgba(79, 195, 161, 0.5);
+  border: 2px solid color-mix(in srgb, var(--secondary-color) 50%, transparent);
   border-radius: 50px;
   animation: pulse 2s infinite ease-out;
 }
@@ -402,7 +402,7 @@ input[type="checkbox"] {
     flex-direction: column;
     align-items: center;
     gap: 20px;
-    color: rgba(255, 255, 255, 0.8);
+    color: color-mix(in srgb, var(--text-color-primary) 80%, transparent);
     user-select: none;
 }
 

--- a/css/quest_theme.css
+++ b/css/quest_theme.css
@@ -2,7 +2,5 @@
 
 :root {
   --font-primary: 'Inter', 'Nunito Sans', system-ui, sans-serif;
-  --secondary-color: #5BC0BE;
-  --surface-background: #1e1e1e;
   --radius-sm: 0.3rem;
 }

--- a/quest.html
+++ b/quest.html
@@ -4,9 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Въпросник за хранителни навици (Dynamic)</title>
+  <link href="css/base_styles.css" rel="stylesheet">
   <link href="css/quest_theme.css" rel="stylesheet">
   <link href="css/quest_styles.css" rel="stylesheet">
   <link href="css/components_styles.css" rel="stylesheet">
+  <link href="css/responsive_styles.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
   <!-- === НАЧАЛО: НОВИ СТИЛОВЕ ЗА ВЪЗДЕЙСТВАЩА НАЧАЛНА СТРАНИЦА === -->
@@ -16,7 +18,7 @@
         position: sticky;
         top: 0;
         z-index: 1000; /* Висок z-index, за да е винаги отгоре */
-        background-color: rgba(18, 18, 18, 0.8); /* Леко прозрачен фон */
+        background-color: rgba(var(--surface-background-rgb), 0.8); /* Леко прозрачен фон */
         backdrop-filter: blur(5px); /* Модерен blur ефект */
         -webkit-backdrop-filter: blur(5px);
     }
@@ -252,6 +254,8 @@
   </div>
 </div>
 
+<button id="theme-toggle" type="button" class="button button-secondary" style="display:block;margin:20px auto;">Смени тема</button>
+
 <div id="persistentStats" class="stats-bar">
   <div class="stat-item">
     <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/aibrain.png" alt="AI Algorithm">
@@ -271,7 +275,7 @@
 <div id="secretTapArea" style="position: fixed; top: 0; left: 0; width: 30px; height: 30px; opacity: 0; z-index: 9999;"></div>
 
 <!-- Скрит Admin бутон -->
-<a href="admin.html" id="adminLink" style="display:none; position: fixed; bottom: 10px; right: 10px; background: #4fc3a1; color: #121212; padding: 5px 10px; border-radius: 5px; text-decoration: none;">
+<a href="admin.html" id="adminLink" style="display:none; position: fixed; bottom: 10px; right: 10px; background: var(--secondary-color); color: var(--text-color-on-secondary, #121212); padding: 5px 10px; border-radius: 5px; text-decoration: none;">
   Admin
 </a>
 
@@ -284,6 +288,7 @@
   import { setupRegistration } from "./js/register.js";
   import { showMessage, hideMessage } from "./js/messageUtils.js";
   import { updateStepProgress } from "./js/stepProgress.js";
+  import { toggleTheme, initializeTheme } from "./js/uiHandlers.js";
   
   /***** Глобални променливи (без промяна) *****/
   let rawQuestions = [];
@@ -792,6 +797,11 @@
 
   // --- Зареждане на въпросника при старт (без промяна) ---
    document.addEventListener('DOMContentLoaded', () => {
+     const themeToggleBtn = document.getElementById('theme-toggle');
+     if (themeToggleBtn) {
+       initializeTheme();
+       themeToggleBtn.addEventListener('click', toggleTheme);
+     }
      fetch('questions.json')
        .then(res => {
          if (!res.ok) throw new Error(`HTTP ${res.status} при зареждане на questions.json`);


### PR DESCRIPTION
## Summary
- support global theme variables in questionnaire styles
- include base styles and responsive stylesheet in `quest.html`
- add theme toggle button and initialize theme on page load
- adjust admin link and sticky bar colors to follow active theme

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6884f72956ac83269f10edd2ac1dc0e3