### PR TITLE
Add theme variables for hero text

### DIFF
--- a/quest.html
+++ b/quest.html
@@ -35,6 +35,8 @@
       --success-color: #2ecc71;
       --success-bg: rgba(46, 204, 113, 0.1);
       --hero-gradient: radial-gradient(ellipse at 50% 0%, rgba(44, 62, 80, 0.65) 0%, rgba(31, 44, 53, 0.65) 40%, transparent 80%);
+      --hero-title-color: #FFFFFF;
+      --hero-subtitle-color: #E0E0E0;
     }
 
     /* Светла тема (активира се автоматично) */
@@ -60,6 +62,8 @@
         --success-color: #388e3c;
         --success-bg: rgba(56, 142, 60, 0.1);
         --hero-gradient: radial-gradient(ellipse at 50% 0%, rgba(178, 223, 219, 0.5) 0%, rgba(224, 242, 241, 0.5) 40%, transparent 80%);
+        --hero-title-color: #121212;
+        --hero-subtitle-color: #1a1a1a;
       }
     }
 
@@ -351,8 +355,8 @@
     }
 
     .hero-image { max-width: 250px; margin: 0 auto 20px auto; }
-    .hero-title { font-size: 2.8rem; font-weight: 700; color: #FFFFFF; text-shadow: 2px 2px 8px rgba(0,0,0,0.3); margin-bottom: 15px; line-height: 1.2; }
-    .hero-subtitle { font-size: 1.3rem; font-weight: 300; color: #E0E0E0; max-width: 550px; margin: 0 auto 40px auto; line-height: 1.6; }
+    .hero-title { font-size: 2.8rem; font-weight: 700; color: var(--hero-title-color); text-shadow: 2px 2px 8px rgba(0,0,0,0.3); margin-bottom: 15px; line-height: 1.2; }
+    .hero-subtitle { font-size: 1.3rem; font-weight: 300; color: var(--hero-subtitle-color); max-width: 550px; margin: 0 auto 40px auto; line-height: 1.6; }
 
     /* Специфични стилове за бутона на началната страница */
     #page0.hero-start-page #startBtn {


### PR DESCRIPTION
## Summary
- define `--hero-title-color` and `--hero-subtitle-color` in `:root`
- change hero text colors to use the variables
- update light theme overrides

## Testing
- `npm run lint`
- `npx jest --runInBand` *(fails: SyntaxError "Cannot use import statement outside a module")*

------
https://chatgpt.com/codex/tasks/task_e_68853ec6a19c8326a8a0a7b5b9008957