### PR TITLE
Adjust hero text colors

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -322,7 +322,7 @@ input[type="checkbox"] {
   align-items: center;
   padding: 20px;
   box-sizing: border-box;
-  color: #fff;
+  color: var(--text-primary);
   /* Статичен, но красив градиент */
   background: var(--hero-gradient), linear-gradient(35deg, #1f2c35, #2c3e50, #466368);
   background-blend-mode: overlay;

--- a/quest.html
+++ b/quest.html
@@ -328,7 +328,7 @@
       align-items: center;
       padding: 20px;
       box-sizing: border-box;
-      color: #fff;
+      color: var(--text-primary);
       /* Статичен, но красив градиент */
       background: var(--hero-gradient), linear-gradient(35deg, #1f2c35, #2c3e50, #466368);
       background-blend-mode: overlay;


### PR DESCRIPTION
## Summary
- use `var(--text-primary)` for hero page text
- confirm CSS variables define `--text-primary` for both themes

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68854133c83c8326a63f772a8a3835e8