### PR TITLE
Add status info to listClients

### DIFF
--- a/js/__tests__/adminNotifications.test.js
+++ b/js/__tests__/adminNotifications.test.js
@@ -50,9 +50,6 @@ function setupFetchWithNotifications(clients, now) {
     if (url.includes('getFeedbackMessages')) {
       return Promise.resolve({ ok: true, json: async () => ({ success: true, feedback: [{ message: 'f1', timestamp: now }] }) });
     }
-    if (url.includes('planStatus')) {
-      return Promise.resolve({ ok: true, json: async () => ({ planStatus: 'ready' }) });
-    }
     if (url.includes('profileTemplate.html')) {
       return Promise.resolve({
         ok: true,
@@ -72,7 +69,7 @@ async function importAdmin() {
 
 describe('admin notifications', () => {
   test('adds notification indicator for users with new items', async () => {
-    const clients = [{ userId: 'u1', name: 'User 1' }];
+    const clients = [{ userId: 'u1', name: 'User 1', status: 'ready', tags: [], lastUpdated: '' }];
     const now = new Date().toISOString();
     setupFetchWithNotifications(clients, now);
     await importAdmin();
@@ -85,7 +82,7 @@ describe('admin notifications', () => {
   });
 
   test('opening client clears notification indicator', async () => {
-    const clients = [{ userId: 'u2', name: 'User 2' }];
+    const clients = [{ userId: 'u2', name: 'User 2', status: 'pending', tags: [], lastUpdated: '' }];
     const now = new Date().toISOString();
     setupFetchWithNotifications(clients, now);
     await importAdmin();

--- a/js/admin.js
+++ b/js/admin.js
@@ -517,31 +517,20 @@ async function loadClients() {
         const data = await resp.json();
         if (resp.ok && data.success) {
             const clientsArr = Array.isArray(data.clients) ? data.clients : [];
-            const withStatus = await Promise.all(
-                clientsArr.map(async c => {
-                    try {
-                        const dResp = await fetch(`${apiEndpoints.dashboard}?userId=${c.userId}`);
-                        const dData = await dResp.json();
-                        return {
-                            ...c,
-                            status: dData.planStatus || 'unknown',
-                            tags: dData.currentStatus?.adminTags || [],
-                            lastUpdated: dData.currentStatus?.lastUpdated || ''
-                        };
-                    } catch {
-                        return { ...c, status: 'unknown', tags: [] };
-                    }
-                })
-            );
-            allClients = withStatus;
+            allClients = clientsArr.map(c => ({
+                ...c,
+                status: c.status || 'unknown',
+                tags: c.tags || [],
+                lastUpdated: c.lastUpdated || ''
+            }));
             updateTagFilterOptions();
             populateTestQClientOptions();
             renderClients();
             const stats = {
-                clients: withStatus.length,
-                ready: withStatus.filter(c => c.status === 'ready').length,
-                pending: withStatus.filter(c => c.status === 'pending').length,
-                processing: withStatus.filter(c => c.status === 'processing').length
+                clients: allClients.length,
+                ready: allClients.filter(c => c.status === 'ready').length,
+                pending: allClients.filter(c => c.status === 'pending').length,
+                processing: allClients.filter(c => c.status === 'processing').length
             };
             if (statsOutput) statsOutput.textContent = JSON.stringify(stats, null, 2);
             updateStatusChart(stats);


### PR DESCRIPTION
## Summary
- augment worker handleListClientsRequest with status and tag retrieval
- return new fields directly in clients list
- simplify loadClients in admin.js to use new data
- update notification tests for revised response shape

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688615e1716c832684758313618a09d7