### PR TITLE
Изпращане на линк за анализ при подаване на въпросника

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,7 +880,7 @@ To send a test email задайте `WORKER_ADMIN_TOKEN`. Може да посо
 | `QUESTIONNAIRE_EMAIL_BODY` | Optional HTML body template for the confirmation email. `{{name}}` ще бъде заменено с името на потребителя. |
 | `SEND_QUESTIONNAIRE_EMAIL` | Set to `false` or `0` to disable sending the confirmation email. |
 | `SEND_WELCOME_EMAIL` | Set to `false` or `0` to skip the welcome message after registration. |
-| `SEND_ANALYSIS_EMAIL` | Set to `false` or `0` to skip the email when the initial analysis is ready. |
+| `SEND_ANALYSIS_EMAIL` | (deprecated) no effect – анализът се изпраща веднага след въпросника. |
 | `ANALYSIS_EMAIL_SUBJECT` | Subject for the email, sent when the personal analysis is ready. |
 | `ANALYSIS_EMAIL_BODY` | HTML body template for that email. Use `{{name}}` и `{{link}}` за персонализация. |
 | `ANALYSIS_PAGE_URL` | Base URL към `analyze.html` за генериране на линка в писмото. |
@@ -894,6 +894,8 @@ To send a test email задайте `WORKER_ADMIN_TOKEN`. Може да посо
 Файлът `data/welcomeEmailTemplate.html` съдържа готов дизайн за писмото "Добре дошли". Заменете `https://via.placeholder.com/200x50.png?text=Вашето+Лого` с реалното лого и използвайте плейсхолдърите `{{name}}` и `{{current_year}}` за персонализация. Преди изпращане е полезно HTML кодът да се обработи с **CSS inliner** инструмент (напр. Campaign Monitor Inliner или [Juice](https://github.com/Automattic/juice)), който прехвърля стиловете от `<style>` в елементите и така подобрява съвместимостта на имейл клиентите.
 
 #### Example: configuring analysis email
+
+Имейлът с линк към анализа се изпраща веднага след попълване на въпросника, без значение от `SEND_ANALYSIS_EMAIL`.
 
 Добавете следните променливи в `.env` или `wrangler.toml`:
 

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -658,7 +658,7 @@ Requests to this endpoint also require the admin token and are rate limited.</p>
 </tr>
 <tr>
 <td><code>SEND_ANALYSIS_EMAIL</code></td>
-<td>Set to <code>false</code> or <code>0</code> to skip the email when the initial analysis is ready.</td>
+<td>Deprecated. No effect – the analysis link is emailed right after submitting the questionnaire.</td>
 </tr>
 <tr>
 <td><code>ANALYSIS_EMAIL_SUBJECT</code></td>

--- a/js/__tests__/submitQuestionnaireEmail.test.js
+++ b/js/__tests__/submitQuestionnaireEmail.test.js
@@ -13,10 +13,11 @@ afterEach(() => {
   }
 })
 
-test('does not send questionnaire email when analysis email is used', async () => {
+test('sends analysis email on questionnaire submit', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true })
   const env = {
     MAILER_ENDPOINT_URL: 'https://mail.example.com',
+    ANALYSIS_PAGE_URL: 'https://app.example.com/analyze.html',
     USER_METADATA_KV: {
       get: jest.fn(async key => key === 'email_to_uuid_user@site.bg' ? 'u1' : null),
       put: jest.fn()
@@ -25,7 +26,7 @@ test('does not send questionnaire email when analysis email is used', async () =
   const req = { json: async () => ({ email: 'user@site.bg', name: 'Иван' }) }
   const res = await handleSubmitQuestionnaire(req, env)
   expect(res.success).toBe(true)
-  expect(fetch).not.toHaveBeenCalled()
+  expect(fetch).toHaveBeenCalledWith('https://mail.example.com', expect.any(Object))
 })
 
 test('works without explicit mail configuration', async () => {
@@ -39,10 +40,10 @@ test('works without explicit mail configuration', async () => {
   const req = { json: async () => ({ email: 'x@x.bg' }) }
   const res = await handleSubmitQuestionnaire(req, env)
   expect(res.success).toBe(true)
-  expect(fetch).not.toHaveBeenCalled()
+  expect(fetch).toHaveBeenCalled()
 })
 
-test('always skips questionnaire email when disabled', async () => {
+test('ignores SEND_QUESTIONNAIRE_EMAIL flag', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true })
   const env = {
     SEND_QUESTIONNAIRE_EMAIL: '0',
@@ -54,5 +55,5 @@ test('always skips questionnaire email when disabled', async () => {
   const req = { json: async () => ({ email: 'a@b.bg' }) }
   const res = await handleSubmitQuestionnaire(req, env)
   expect(res.success).toBe(true)
-  expect(fetch).not.toHaveBeenCalled()
+  expect(fetch).toHaveBeenCalled()
 })


### PR DESCRIPTION
## Summary
- изпращане на имейл за готов анализ при `handleSubmitQuestionnaire`
- премахнато дублиращо изпращане от `handleAnalyzeInitialAnswers`
- обновени тестове според новото поведение
- допълнена документация за променената логика и маркиран `SEND_ANALYSIS_EMAIL` като deprecated

## Testing
- `npm run lint`
- `npm test` *(failed: JavaScript heap out of memory)*
- `npm run test:related` *(failed: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688616658b008326b1e6c9819bfed73a