### PR TITLE
Remove same email content option

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -253,7 +253,6 @@
         <label>Съдържание:<br><textarea id="analysisEmailBody" rows="5" placeholder="Здравейте {{name}}, анализът ви е готов."></textarea></label>
         <div id="analysisEmailPreview" class="email-preview"></div>
         <label><input id="sendAnalysisEmail" type="checkbox" checked> Изпращай имейл при готов анализ</label>
-        <label><input id="sameEmailContent" type="checkbox"> Използвай същото съдържание за анализа</label>
       </fieldset>
       <button type="submit">Запази</button>
     </form>

--- a/js/admin.js
+++ b/js/admin.js
@@ -102,7 +102,6 @@ const analysisEmailBodyInput = document.getElementById('analysisEmailBody');
 const sendQuestionnaireEmailCheckbox = document.getElementById('sendQuestionnaireEmail');
 const sendWelcomeEmailCheckbox = document.getElementById('sendWelcomeEmail');
 const sendAnalysisEmailCheckbox = document.getElementById('sendAnalysisEmail');
-const sameEmailContentCheckbox = document.getElementById('sameEmailContent');
 const testEmailForm = document.getElementById('testEmailForm');
 const testEmailToInput = document.getElementById('testEmailTo');
 const testEmailSubjectInput = document.getElementById('testEmailSubject');
@@ -1311,8 +1310,8 @@ async function saveEmailSettings() {
             welcome_email_body: welcomeEmailBodyInput ? welcomeEmailBodyInput.value.trim() : '',
             questionnaire_email_subject: questionnaireEmailSubjectInput ? questionnaireEmailSubjectInput.value.trim() : '',
             questionnaire_email_body: questionnaireEmailBodyInput ? questionnaireEmailBodyInput.value.trim() : '',
-            analysis_email_subject: (sameEmailContentCheckbox?.checked ? questionnaireEmailSubjectInput?.value.trim() : analysisEmailSubjectInput?.value.trim()) || '',
-            analysis_email_body: (sameEmailContentCheckbox?.checked ? questionnaireEmailBodyInput?.value.trim() : analysisEmailBodyInput?.value.trim()) || '',
+            analysis_email_subject: analysisEmailSubjectInput?.value.trim() || '',
+            analysis_email_body: analysisEmailBodyInput?.value.trim() || '',
             send_questionnaire_email: sendQuestionnaireEmailCheckbox && sendQuestionnaireEmailCheckbox.checked ? '1' : '0',
             send_welcome_email: sendWelcomeEmailCheckbox && sendWelcomeEmailCheckbox.checked ? '1' : '0',
             send_analysis_email: sendAnalysisEmailCheckbox && sendAnalysisEmailCheckbox.checked ? '1' : '0'
@@ -1654,32 +1653,6 @@ document.addEventListener('DOMContentLoaded', () => {
     attachEmailPreview(questionnaireEmailBodyInput, questionnaireEmailPreview);
     attachEmailPreview(analysisEmailBodyInput, analysisEmailPreview);
     attachEmailPreview(testEmailBodyInput, testEmailPreview);
-
-    if (sameEmailContentCheckbox) {
-        const updateAnalysisFields = () => {
-            const checked = sameEmailContentCheckbox.checked;
-            analysisEmailSubjectInput.disabled = checked;
-            analysisEmailBodyInput.disabled = checked;
-            if (checked) {
-                analysisEmailSubjectInput.value = questionnaireEmailSubjectInput?.value || '';
-                analysisEmailBodyInput.value = questionnaireEmailBodyInput?.value || '';
-                if (analysisEmailPreview) analysisEmailPreview.innerHTML = sanitizeHTML(analysisEmailBodyInput.value);
-            }
-        };
-        sameEmailContentCheckbox.addEventListener('change', updateAnalysisFields);
-        questionnaireEmailSubjectInput?.addEventListener('input', () => {
-            if (sameEmailContentCheckbox.checked) {
-                analysisEmailSubjectInput.value = questionnaireEmailSubjectInput.value;
-            }
-        });
-        questionnaireEmailBodyInput?.addEventListener('input', () => {
-            if (sameEmailContentCheckbox.checked) {
-                analysisEmailBodyInput.value = questionnaireEmailBodyInput.value;
-                if (analysisEmailPreview) analysisEmailPreview.innerHTML = sanitizeHTML(analysisEmailBodyInput.value);
-            }
-        });
-        updateAnalysisFields();
-    }
 
     // Стартира асинхронните операции в отделен IIFE,
     // за да не блокират работата на интерфейса


### PR DESCRIPTION
## Summary
- drop sameEmailContent checkbox from the admin interface
- simplify related logic in `js/admin.js`

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68861b08d5a48326a6b4e39c845b3620