### PR TITLE
Enable custom email sender name

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ node scripts/view-usage-logs.js sendTestEmail 5
 | `questionnaire_email_subject` | Тема на имейла след попълнен въпросник |
 | `questionnaire_email_body` | HTML съдържание за потвърждението на въпросника |
 | `send_questionnaire_email` | "1" или "0" за включване или изключване на потвърждението |
+| `from_email_name` | Име на подателя в изпращаните имейли |
 | `question_definitions` | JSON с дефиниции на всички въпроси |
 | `recipe_data` | Данни за примерни рецепти |
 
@@ -399,6 +400,7 @@ Before deploying, configure the following secrets in Cloudflare (via the dashboa
 - `CF_AI_TOKEN` – API token used for Cloudflare AI requests
 - `OPENAI_API_KEY` – set via `wrangler secret put OPENAI_API_KEY`, used by `worker.js`
 - `FROM_EMAIL` – optional sender address for outgoing emails
+- `FROM_NAME` – optional display name shown in the "From" header
 
 Без тази стойност част от AI функционалностите няма да работят.
 
@@ -874,6 +876,7 @@ To send a test email задайте `WORKER_ADMIN_TOKEN`. Може да посо
 | `MAIL_PHP_URL` | Legacy PHP endpoint if you prefer your own backend. Defaults to `https://mybody.best/mailer/mail.php`. |
 | `EMAIL_PASSWORD` | Password used by `mailer.js` when authenticating with the SMTP server. |
 | `FROM_EMAIL` | Sender address used by `mailer.js` and the PHP backend. |
+| `FROM_NAME` | Optional display name for the sender shown in outgoing emails. |
 | `WELCOME_EMAIL_SUBJECT` | Optional custom subject for welcome emails sent by `mailer.js`. |
 | `WELCOME_EMAIL_BODY` | Optional HTML body template for welcome emails. The string `{{name}}` will be replaced with the recipient's name. |
 | `QUESTIONNAIRE_EMAIL_SUBJECT` | Optional subject for the confirmation email sent след изпращане на въпросника. |

--- a/admin.html
+++ b/admin.html
@@ -233,6 +233,7 @@
   <details id="emailSettingsSection" class="card">
     <summary>Настройки за имейли</summary>
     <form id="emailSettingsForm">
+      <label>Име на подател:<br><input id="fromEmailName" type="text" placeholder="MyBody"></label>
       <fieldset>
         <legend>Приветствен имейл (след регистрация)</legend>
         <label>Тема:<br><input id="welcomeEmailSubject" type="text" placeholder="Добре дошли в BodyBest!"></label>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -286,6 +286,7 @@ the page.</p>
 <li><code>CF_AI_TOKEN</code> – API token used for Cloudflare AI requests</li>
 <li><code>OPENAI_API_KEY</code> – set via <code>wrangler secret put OPENAI_API_KEY</code>, used by <code>worker.js</code></li>
 <li><code>FROM_EMAIL</code> – optional sender address for outgoing emails</li>
+<li><code>FROM_NAME</code> – optional display name for the sender</li>
 </ul>
 <p>Без тази стойност част от AI функционалностите няма да работят.</p>
 <p>Optionally set <code>CF_ACCOUNT_ID</code> via <code>wrangler secret put</code> if it differs from the value in <code>wrangler.toml</code>. Ако липсва, работникът използва стойността от <code>wrangler.toml</code>.</p>
@@ -631,6 +632,10 @@ Requests to this endpoint also require the admin token and are rate limited.</p>
 <tr>
 <td><code>FROM_EMAIL</code></td>
 <td>Sender address used by <code>mailer.js</code> and the PHP backend.</td>
+</tr>
+<tr>
+<td><code>FROM_NAME</code></td>
+<td>Optional display name for the sender used in outgoing emails.</td>
 </tr>
 <tr>
 <td><code>WELCOME_EMAIL_SUBJECT</code></td>

--- a/docs/mail.php
+++ b/docs/mail.php
@@ -44,7 +44,9 @@ if (preg_match("/[\r\n]/", $to) || preg_match("/[\r\n]/", $subject)) {
 $headers = "MIME-Version: 1.0\r\n";
 $headers .= "Content-type: text/html; charset=UTF-8\r\n";
 $fromEmail = getenv('FROM_EMAIL') ?: 'info@mybody.best';
-$headers .= "From: {$fromEmail}\r\n";
+$fromName = isset($data['fromName']) ? $data['fromName'] : (getenv('FROM_NAME') ?: '');
+$fromHeader = $fromName ? "$fromName <{$fromEmail}>" : $fromEmail;
+$headers .= "From: {$fromHeader}\r\n";
 $headers .= "Reply-To: {$fromEmail}\r\n";
 
 // Изпращане

--- a/docs/mail_smtp.php
+++ b/docs/mail_smtp.php
@@ -51,7 +51,12 @@ try {
     $mail->Password = getenv('EMAIL_PASSWORD');
 
     $fromEmail = getenv('FROM_EMAIL') ?: 'info@mybody.best';
-    $mail->setFrom($fromEmail);
+    $fromName = $data['fromName'] ?? (getenv('FROM_NAME') ?: '');
+    if ($fromName) {
+        $mail->setFrom($fromEmail, $fromName);
+    } else {
+        $mail->setFrom($fromEmail);
+    }
     $mail->addAddress($to);
     $mail->Subject = $subject;
     $mail->isHTML(true);

--- a/js/admin.js
+++ b/js/admin.js
@@ -93,6 +93,7 @@ const analysisModelInput = document.getElementById('analysisModel');
 const analysisPromptInput = document.getElementById('analysisPrompt');
 const testAnalysisBtn = document.getElementById('testAnalysisModel');
 const emailSettingsForm = document.getElementById('emailSettingsForm');
+const fromEmailNameInput = document.getElementById('fromEmailName');
 const welcomeEmailSubjectInput = document.getElementById('welcomeEmailSubject');
 const welcomeEmailBodyInput = document.getElementById('welcomeEmailBody');
 const questionnaireEmailSubjectInput = document.getElementById('questionnaireEmailSubject');
@@ -1262,6 +1263,7 @@ async function saveAiConfig() {
 async function loadEmailSettings() {
     try {
         const cfg = await loadConfig([
+            'from_email_name',
             'welcome_email_subject',
             'welcome_email_body',
             'questionnaire_email_subject',
@@ -1272,6 +1274,7 @@ async function loadEmailSettings() {
             'send_welcome_email',
             'send_analysis_email'
         ])
+        if (fromEmailNameInput) fromEmailNameInput.value = cfg.from_email_name || ''
         if (welcomeEmailSubjectInput) welcomeEmailSubjectInput.value = cfg.welcome_email_subject || ''
         if (welcomeEmailBodyInput) {
             welcomeEmailBodyInput.value = cfg.welcome_email_body || ''
@@ -1307,6 +1310,7 @@ async function loadEmailSettings() {
 async function saveEmailSettings() {
     if (!emailSettingsForm) return
     const updates = {
+            from_email_name: fromEmailNameInput ? fromEmailNameInput.value.trim() : '',
             welcome_email_subject: welcomeEmailSubjectInput ? welcomeEmailSubjectInput.value.trim() : '',
             welcome_email_body: welcomeEmailBodyInput ? welcomeEmailBodyInput.value.trim() : '',
             questionnaire_email_subject: questionnaireEmailSubjectInput ? questionnaireEmailSubjectInput.value.trim() : '',

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -54,10 +54,11 @@ async function checkRateLimit(env, identifier, limit = 3, windowMs = 60000) {
 
 async function sendViaPhp(to, subject, message, env = {}) {
   const url = env[MAIL_PHP_URL_VAR_NAME] || 'https://mybody.best/mailer/mail.php';
+  const fromName = env.FROM_NAME || '';
   const resp = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ to, subject, message, body: message })
+    body: JSON.stringify({ to, subject, message, body: message, fromName })
   });
   if (!resp.ok) {
     throw new Error(`PHP mailer error ${resp.status}`);

--- a/worker.js
+++ b/worker.js
@@ -17,11 +17,13 @@
 async function sendEmailUniversal(to, subject, body, env = {}) {
   const endpoint = env.MAILER_ENDPOINT_URL ||
     globalThis['process']?.env?.MAILER_ENDPOINT_URL;
+  const fromName = env.FROM_NAME || env.from_email_name ||
+    globalThis['process']?.env?.FROM_NAME;
   if (endpoint) {
     const resp = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ to, subject, message: body, body })
+      body: JSON.stringify({ to, subject, message: body, body, fromName })
     });
     if (!resp.ok) {
       throw new Error(`Mailer responded with ${resp.status}`);
@@ -30,7 +32,10 @@ async function sendEmailUniversal(to, subject, body, env = {}) {
   }
 
   const { sendEmail } = await import('./sendEmailWorker.js');
-  const phpEnv = { MAIL_PHP_URL: env.MAIL_PHP_URL || globalThis['process']?.env?.MAIL_PHP_URL };
+  const phpEnv = {
+    MAIL_PHP_URL: env.MAIL_PHP_URL || globalThis['process']?.env?.MAIL_PHP_URL,
+    FROM_NAME: fromName
+  };
   await sendEmail(to, subject, body, phpEnv);
 }
 import { parseJsonSafe } from './utils/parseJsonSafe.js';
@@ -274,6 +279,7 @@ const AI_CONFIG_KEYS = [
     'questionnaire_email_body',
     'analysis_email_subject',
     'analysis_email_body',
+    'from_email_name',
     'send_welcome_email',
     'send_analysis_email',
     'send_questionnaire_email',


### PR DESCRIPTION
## Summary
- allow specifying `FROM_NAME` for PHP mail scripts
- document `FROM_NAME` env variable
- surface `from_email_name` setting in admin UI and JS logic
- forward custom sender name from worker to backend

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68861c054c0c8326bc1a727229f62f15