### PR TITLE
Add light mode styles for stat icons

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -73,6 +73,14 @@
     --success-color: #388e3c;
     --success-bg: rgba(56, 142, 60, 0.1);
   }
+
+  /* Специални настройки за иконите в светъл режим */
+  .stat-icon {
+    background-color: var(--bg-secondary);
+    border-radius: 12px;
+    padding: 10px;
+    filter: drop-shadow(0 2px 4px var(--shadow-color));
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- adjust quest styles to enhance `.stat-icon` visuals in light mode

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=8192 npm test -- --testPathIgnorePatterns=node_modules`

------
https://chatgpt.com/codex/tasks/task_e_68861dfd95f08326b083ae43106490e5