### PR TITLE
Fix final page button order

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -275,6 +275,11 @@ button:hover {
   margin-top: 25px;
 }
 
+/* Специални бутони за финалната страница */
+.nav-buttons.final-buttons {
+  flex-direction: column;
+}
+
 /* --- Йерархия на бутоните --- */
 /* Основен бутон (Напред, Изпрати) */
 button[id^="nextBtn"], button[id="regSubmitBtn"], button[id="submitBtn"] {
@@ -295,6 +300,15 @@ button[id^="prevBtn"], button[id="regBackBtn"], button[id="restartBtn"] {
 button[id^="prevBtn"]:hover, button[id="regBackBtn"]:hover, button[id="restartBtn"]:hover {
   background-color: var(--accent-primary);
   color: var(--text-on-accent);
+}
+
+/* Допълнително оцветяване за бутона за рестарт */
+#restartBtn {
+  color: var(--accent-secondary);
+  border-color: var(--accent-secondary);
+}
+#restartBtn:hover {
+  background-color: var(--accent-secondary);
 }
 
 /* =================================================================== */
@@ -526,6 +540,9 @@ button[id^="prevBtn"]:hover, button[id="regBackBtn"]:hover, button[id="restartBt
   }
   .nav-buttons {
       flex-direction: column-reverse; /* Назад е отгоре, Напред отдолу - по-удобно */
+  }
+  .nav-buttons.final-buttons {
+      flex-direction: column;
   }
   .question-text {
     font-size: 18px;

--- a/quest.html
+++ b/quest.html
@@ -319,7 +319,7 @@
     pageDiv.innerHTML = `
       <h2>Поздравления! <i class="bi bi-stars"></i><br> Току що направихте най-важната стъпка по пътя към промяната</h2>
       <p>Натиснете бутона, за да изпратите вашите отговори за обработка.</p>
-      <div class="nav-buttons" style="justify-content: center;">
+      <div class="nav-buttons final-buttons" style="justify-content: center;">
         <button id="submitBtn" type="button">Изпрати</button>
         <button id="restartBtn" type="button">Отначало</button>
       </div>


### PR DESCRIPTION
## Summary
- adjust final questionnaire page to place submit button above restart
- apply a distinct secondary accent color to restart button
- override mobile layout so submit stays on top

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test -- js/__tests__/utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68861f28ba8483269b03ca05c0023204