### PR TITLE
Improve icon visibility in light theme

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -76,10 +76,10 @@
 
   /* Специални настройки за иконите в светъл режим */
   .stat-icon {
-    background-color: var(--bg-secondary);
-    border-radius: 12px;
-    padding: 10px;
-    filter: drop-shadow(0 2px 4px var(--shadow-color));
+    background-color: var(--accent-secondary);
+    border-radius: 50%;
+    padding: 8px;
+    filter: drop-shadow(0 0 5px var(--accent-focus-shadow));
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak `.stat-icon` to use accent color background and glow in light mode

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68861d7458d0832699bcf207fd069c17