### PR TITLE
Update quest icon background in light theme

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -49,6 +49,7 @@
     --bg-surface: #f2f2f2;
     --bg-progress-bar: rgba(255, 255, 255, 0.7);
     --bg-quest-container: rgba(255, 255, 255, 0.7);
+    --bg-stat-icon: #f0f0f0;
     --hero-gradient: linear-gradient(135deg, #eefdf7, #e8f9ed, #f7f6f4);
 
     /* ТЕКСТ */
@@ -76,7 +77,7 @@
 
   /* Специални настройки за иконите в светъл режим */
   .stat-icon {
-    background-color: var(--bg-secondary);
+    background-color: var(--bg-stat-icon);
     border-radius: 12px;
     padding: 10px;
     filter: drop-shadow(0 2px 4px var(--shadow-color));


### PR DESCRIPTION
## Summary
- adjust quest stat icon styles so the darker neutral background only applies in light mode

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68862669aa7083269d6204721df8b19d