### PR TITLE
feat: enlarge quest stats icons on phones

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -567,6 +567,15 @@ button[id^="prevBtn"]:hover, button[id="regBackBtn"]:hover, button[id="restartBt
     font-size: 16px;
     min-height: 52px;
   }
+  /* Увеличени статистически икони за мобилни екрани */
+  .stats-bar .stat-icon {
+    width: 120px;
+    height: 120px;
+  }
+  #persistentStats .stat-icon {
+    width: 90px;
+    height: 90px;
+  }
 }
 
 @media (min-width: 769px) {


### PR DESCRIPTION
## Summary
- make stat icons 50% larger on small screens

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68862c28c94483269021393881fd7ec6