### PR TITLE
Add demo registration endpoints

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -13,6 +13,7 @@ export const workerBaseUrl = isLocalDevelopment
 export const apiEndpoints = {
     login: `${workerBaseUrl}/api/login`,
     register: `${workerBaseUrl}/api/register`,
+    registerDemo: `${workerBaseUrl}/api/registerDemo`,
     dashboard: `${workerBaseUrl}/api/dashboardData`,
     log: `${workerBaseUrl}/api/log`,
     chat: `${workerBaseUrl}/api/chat`,
@@ -50,6 +51,7 @@ export const apiEndpoints = {
     analyzeImage: `${workerBaseUrl}/api/analyzeImage`,
     sendTestEmail: `${workerBaseUrl}/api/sendTestEmail`,
     submitQuestionnaire: `${workerBaseUrl}/api/submitQuestionnaire`,
+    submitDemoQuestionnaire: `${workerBaseUrl}/api/submitDemoQuestionnaire`,
     reAnalyzeQuestionnaire: `${workerBaseUrl}/api/reAnalyzeQuestionnaire`,
     analysisStatus: `${workerBaseUrl}/api/analysisStatus`,
     getInitialAnalysis: `${workerBaseUrl}/api/getInitialAnalysis`


### PR DESCRIPTION
## Summary
- implement `handleRegisterDemoRequest` and `handleSubmitDemoQuestionnaire`
- wire new endpoints in worker router
- export newly added handlers
- expose new API URLs in `js/config.js`

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68875844356c8326b1855b999b0abfbd