### PR TITLE
Добавен демо въпросник

### DIFF
--- a/demo_questions.json
+++ b/demo_questions.json
@@ -1,0 +1,63 @@
+[
+    {
+        "id": "secDemo",
+        "type": "section",
+        "sectionTitle": "Демо въпроси"
+    },
+    {
+        "id": "name",
+        "text": "Въведете вашето име:",
+        "type": "text",
+        "options": [],
+        "children": []
+    },
+    {
+        "id": "email",
+        "text": "Въведете вашия имейл адрес:",
+        "type": "email",
+        "options": [],
+        "children": []
+    },
+    {
+        "id": "sleepHours",
+        "text": "Средно колко часа спите на денонощие?",
+        "type": "number",
+        "options": [],
+        "children": []
+    },
+    {
+        "id": "stressLevel",
+        "text": "Оценете нивото си на стрес:",
+        "type": "radio",
+        "options": ["Ниско", "Средно", "Високо"],
+        "children": []
+    },
+    {
+        "id": "physicalActivity",
+        "text": "Ниво на физическа активност:",
+        "type": "radio",
+        "options": ["Без активност", "Лека", "Умерена", "Интензивна"],
+        "children": []
+    },
+    {
+        "id": "waterIntake",
+        "text": "Колко чаши вода пиете дневно?",
+        "type": "number",
+        "options": [],
+        "children": []
+    },
+    {
+        "id": "overeatingFrequency",
+        "text": "Колко често преяждате?",
+        "type": "radio",
+        "options": ["Никога", "Понякога", "Често"],
+        "children": []
+    },
+    {
+        "id": "comparisson",
+        "text": "Сравнете сегашното си хранене с това от миналата година:",
+        "type": "textarea",
+        "options": [],
+        "children": []
+    }
+]

--- a/demoquest.html
+++ b/demoquest.html
@@ -1,0 +1,603 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Демо въпросник за хранителни навици</title>
+  
+  <!-- Връзки към файловете със стилове (тук ще се реализира новият дизайн) -->
+  <link href="css/quest_theme.css" rel="stylesheet">
+  <link href="css/quest_styles.css" rel="stylesheet">
+  <link href="css/components_styles.css" rel="stylesheet">
+  
+  <!-- Връзка за икони -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+</head>
+<body id="questPage">
+
+<!-- 
+  Прогрес барът е ключов компонент от навигацията и остава.
+  Стилът му ще се управлява от quest_styles.css.
+-->
+<div class="step-indicator-container">
+  <span class="step-indicator-label">Стъпка <span id="questCurrentStep">0</span> от <span id="questTotalSteps">0</span></span>
+  <div class="progress-bar-steps"><div id="questProgressBar" class="step-progress-bar"></div></div>
+</div>
+
+<!-- 
+  Това е основният контейнер, който JavaScript попълва динамично със страниците на въпросника.
+  Началната инструкция също е тук, както се очаква от скрипта.
+-->
+<div class="container" id="dynamicContainer">
+  <div id="questInstructions" class="quest-instructions">
+    За да получите индивидуален и максимално ефективен план за вас,
+    въведете коректна и изчерпателна информация.
+  </div>
+</div>
+
+<!-- 
+  Лентата със статистики, която се показва след началната страница.
+  Структурата е запазена, за да може JS да я управлява, а CSS да я стилизира.
+-->
+<div id="persistentStats" class="stats-bar">
+  <div class="stat-item">
+    <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/aibrain.png" alt="AI Algorithm">
+    <div class="stat-label">AI Med Алгоритъм</div>
+  </div>
+  <div class="stat-item">
+    <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/medic.png" alt="Medical Experts">
+    <div class="stat-label">Реални специалисти</div>
+  </div>
+  <div class="stat-item">
+    <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/clock.png" alt="24/7 Assistant">
+    <div class="stat-label">24/7 Личен асистент</div>
+  </div>
+</div>
+
+<!-- Скрити функционални елементи (запазени непроменени) -->
+<div id="secretTapArea" style="position: fixed; top: 0; left: 0; width: 30px; height: 30px; opacity: 0; z-index: 9999;"></div>
+<a href="admin.html" id="adminLink" style="display:none; position: fixed; bottom: 10px; right: 10px; background: #4fc3a1; color: #121212; padding: 5px 10px; border-radius: 5px; text-decoration: none;">
+  Admin
+</a>
+
+<!-- 
+  Основният JavaScript модул, който управлява цялата логика на въпросника.
+  Той остава напълно непроменен, за да се гарантира функционалността.
+-->
+<script type="module">
+  import { workerBaseUrl, apiEndpoints } from './js/config.js';
+  import { setupRegistration } from "./js/register.js";
+  import { showMessage, hideMessage } from "./js/messageUtils.js";
+  import { updateStepProgress } from "./js/stepProgress.js";
+  
+  /***** Глобални променливи (без промяна) *****/
+  let rawQuestions = [];
+  let flatPages = [];
+  let currentPageIndex = 0;
+  let totalPages = 0;
+  let registrationPageIndex = 0;
+  const responses = {};
+  // Използваме демо регистрация
+  apiEndpoints.register = apiEndpoints.registerDemo;
+  const numericRanges = {
+    age: { min: 10, max: 120 }, height: { min: 100, max: 250 }, weight: { min: 30, max: 300 }, lossKg: { min: 1, max: 100 },
+    q1745847247058: { min: 1, max: 300 }, q1745847190198: { min: 1, max: 300 }, q1745847315231: { min: 1, max: 300 }
+  };
+  const requiredFields = [
+    'name','gender','age','height','weight','goal','lossKg','motivation','weightChange','weightChangeDetails',
+    'dietHistory','dietType','dietResult','sleepHours','sleepInterrupt','chronotype','q1745878295708','stressLevel',
+    'physicalActivity','activityTypeDaily','q1745847247058','activityTypeWeekly','q1745847190198','activityTypeRare',
+    'q1745847315231','q1745877358368','q1745878063775','q1745890775342','waterIntake','waterReplaceFreq','q1745891342178',
+    'q1745891468155','q1745891537884','overeatingFrequency','foodCravings','foodCravingsDetails','foodTriggers',
+    'q1745891178105','nighteat','q1745891865984','compensationmethod','q1745806296700','comparisson','q1745805447648',
+    'q1745805721482','alcoholFrequency','foodPreference','q1745806409218','q1745806494081','mainChallenge','q1745892518511',
+    'medicalConditions','q1745804366749','medications','medicationsList','supplementsList'
+  ];
+
+  /***** Функция за рекурсивно сплескване на въпросите (без промяна) *****/
+  function flattenQuestions(questions) {
+    let output = [];
+    questions.forEach(q => {
+      let qCopy = Object.assign({}, q);
+      delete qCopy.children;
+      if (qCopy.type !== 'section') { output.push(qCopy); }
+      if (q.children && Array.isArray(q.children)) {
+        output = output.concat(flattenQuestions(q.children));
+      } else if (q.children && typeof q.children === 'object') {
+        for (const answer in q.children) {
+          let childArray = q.children[answer];
+          if (Array.isArray(childArray)) {
+             childArray.forEach(child => { child.dependency = { question: q.id, value: answer }; });
+             output = output.concat(flattenQuestions(childArray));
+          } else { console.warn(`Expected an array for children under key '${answer}' in question '${q.id}', but got:`, typeof childArray); }
+        }
+      }
+    });
+    return output;
+  }
+
+  /***** Функция за изграждане на страниците (без промяна) *****/
+  function buildDynamicPages() {
+    const container = document.getElementById('dynamicContainer');
+    const instr = document.getElementById('questInstructions');
+    if (!container) { console.error("Container #dynamicContainer not found!"); return; }
+    container.innerHTML = "";
+    createStartPage();
+    flatPages = flattenQuestions(rawQuestions).filter(q => q.id !== 'email' && q.type !== 'section');
+    flatPages.forEach((q, idx) => { createQuestionPage(q, idx + 1); });
+    createRegistrationPage();
+    createFinalPage();
+    setupFinalPageListener();
+    if (instr) { container.appendChild(instr); }
+    totalPages = 1 + flatPages.length + 2;
+    console.log("Общо страници (включително старт и финал):", totalPages);
+    updateStepProgress(
+      document.getElementById('questProgressBar'), 0, totalPages > 1 ? totalPages - 1 : 1,
+      document.getElementById('questCurrentStep'), document.getElementById('questTotalSteps')
+    );
+    showPage(0);
+  }
+
+  /***** СЪЗДАВАНЕ НА СТАРТОВА СТРАНИЦА (ОРИГИНАЛНА ВЕРСИЯ - без particles.js) *****/
+  function createStartPage() {
+    const container = document.getElementById('dynamicContainer');
+    if (!container) return;
+    const pageDiv = document.createElement('div');
+    pageDiv.className = 'page hero-start-page'; 
+    pageDiv.id = 'page0';
+
+    pageDiv.innerHTML = `
+      <div class="hero-content">
+        <img class="hero-image" id="heroImage" src="https://radilovk.github.io/bodybest/img/myquest.png" alt="Hero">
+        
+        <p class="hero-subtitle">
+          Разкажи ни повече за теб и твоите цели.<br>
+          Ние ще ти помогнем да ги постигнеш!
+        </p>
+        
+        <div class="cta-container">
+          <button id="startBtn" type="button">
+            Начало
+          </button>
+        </div>
+        
+        <div class="stats-bar">
+          <div class="stat-item">
+            <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/aibrain.png" alt="AI Algorithm">
+            <div class="stat-label">AI Med Алгоритъм</div>
+          </div>
+          <div class="stat-item">
+            <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/medic.png" alt="Medical Experts">
+            <div class="stat-label">Реални специалисти</div>
+          </div>
+          <div class="stat-item">
+            <img class="stat-icon" src="https://radilovk.github.io/bodybest/img/clock.png" alt="24/7 Assistant">
+            <div class="stat-label">24/7 Личен асистент</div>
+          </div>
+        </div>
+      </div>
+    `;
+    container.appendChild(pageDiv);
+
+    // Логиката за бутона остава същата, за да работи с Вашата система
+    const startBtn = pageDiv.querySelector('#startBtn');
+    if (startBtn) {
+        startBtn.addEventListener('click', () => {
+          console.log("Бутон 'Начало' е натиснат.");
+          pageDiv.classList.remove('hero-start-page');
+          showPage(1); // Преминаваме към първия въпрос
+        });
+    } else {
+        console.error("Start button not found on the new hero start page.");
+    }
+  }
+
+
+  /***************************************************************************/
+  /*                                                                         */
+  /*   ТУК СЛЕДВА ОСТАНАЛАТА ЧАСТ ОТ ВАШИЯ ОРИГИНАЛЕН JAVASCRIPT КОД         */
+  /*   (createQuestionPage, createRegistrationPage, showPage, и т.н.)        */
+  /*   КОЯТО ОСТАВА НАПЪЛНО НЕПРОМЕНЕНА                                      */
+  /*                                                                         */
+  /***************************************************************************/
+
+
+  /***** Създаване на страница за всеки въпрос (без промяна) *****/
+  function createQuestionPage(question, pageIndex) {
+    const container = document.getElementById('dynamicContainer');
+     if (!container || !question || !question.id) {
+         console.error("Missing container or question data for page", pageIndex);
+         return;
+     };
+    const pageDiv = document.createElement('div');
+    pageDiv.className = 'page';
+    pageDiv.id = 'page' + pageIndex;
+    let html = '';
+    if (question.type === 'section') {
+      html += `<div class="section-title">${question.sectionTitle || question.text || ''}</div>`;
+    } else {
+      html += `<div class="question-text">${question.text || 'Липсва текст на въпроса'}</div>`;
+    }
+    const isRequired = requiredFields.includes(question.id);
+    if (question.type === 'section') {
+    } else if (['text','number','email'].includes(question.type)) {
+      const range = numericRanges[question.id];
+      const rangeAttrs = (question.type === 'number' && range) ? `min="${range.min}" max="${range.max}"` : '';
+      html += `<input id="${question.id}" type="${question.type}" placeholder="" ${rangeAttrs} ${isRequired ? 'required' : ''} ${question.type === 'email' ? 'autocomplete="email"' : ''}>`;
+    } else if (question.type === 'textarea') {
+      html += `<textarea id="${question.id}" rows="4" ${isRequired ? 'required' : ''}></textarea>`;
+    } else if (question.type === 'select') {
+      html += `<select id="${question.id}" ${isRequired ? 'required' : ''}><option value="">Изберете</option>`;
+      (question.options || []).forEach(opt => {
+        html += `<option value="${String(opt)}">${String(opt)}</option>`;
+      });
+      html += `</select>`;
+    } else if (question.type === 'radio') {
+      (question.options || []).forEach((opt, index) => {
+          const optionValue = String(opt);
+        html += `<label class="answer-label">
+                   <input name="${question.id}" type="radio" value="${optionValue}" ${isRequired && index === 0 ? 'required' : ''}> ${optionValue}
+                 </label>`;
+      });
+    } else if (question.type === 'checkbox') {
+      (question.options || []).forEach(opt => {
+          const optionValue = String(opt);
+        html += `<label class="answer-label">
+                   <input name="${question.id}" type="checkbox" value="${optionValue}"> ${optionValue}
+                 </label>`;
+      });
+    } else if (question.type !== 'section') {
+        console.warn(`Unsupported question type: ${question.type} for question ID: ${question.id}`);
+        html += `<p style="color: red;">Грешка: Неподдържан тип въпрос.</p>`;
+    }
+    if (question.dependency) {
+      // Допълнителен текст за разработчици, скрит от крайния потребител
+      // html += `<div class="fs-xs text-muted" style="margin-top: 10px;">(Показва се ако '${question.dependency.question}' е '${question.dependency.value}')</div>`;
+    }
+    html += `<div class="nav-buttons">
+               ${pageIndex > 1 ? `<button type="button" id="prevBtn${pageIndex}">◀ Назад</button>` : ''}
+               <button type="button" id="nextBtn${pageIndex}">Напред ▶</button>
+             </div>`;
+    pageDiv.innerHTML = html;
+    container.appendChild(pageDiv);
+    const nextBtn = pageDiv.querySelector(`#nextBtn${pageIndex}`);
+    if (nextBtn) {
+        nextBtn.addEventListener('click', () => {
+          if (question.type !== 'section' && !validateAnswer(question)) { return; }
+          if (question.type !== 'section') { saveAnswer(question); }
+          console.log(`Преминаване от страница ${pageIndex} към ${pageIndex + 1}`);
+          showPage(pageIndex + 1);
+        });
+    } else { console.error(`Next button not found for page ${pageIndex}`); }
+    const prevBtn = pageDiv.querySelector(`#prevBtn${pageIndex}`);
+    if (prevBtn) {
+        prevBtn.addEventListener('click', () => {
+           console.log(`Връщане от страница ${pageIndex} към ${pageIndex - 1}`);
+           if (question.type !== 'section') { saveAnswer(question); }
+           showPage(pageIndex - 1);
+        });
+    }
+  }
+
+  /***** Създаване на страница за регистрация (без промяна) *****/
+  function createRegistrationPage() {
+    const container = document.getElementById('dynamicContainer');
+    if (!container) return;
+    const regIndex = flatPages.length + 1;
+    registrationPageIndex = regIndex;
+    const pageDiv = document.createElement('div');
+    pageDiv.className = 'page';
+    pageDiv.id = 'page' + regIndex;
+    pageDiv.innerHTML = `
+      <h2>Регистрация</h2>
+      <form id="register-form-q" novalidate>
+        <div class="form-group"><label for="register-email-q">Имейл:</label><input type="email" id="register-email-q" required autocomplete="email"></div>
+        <div class="form-group"><label for="register-password-q">Парола (мин. 8 знака):</label><input type="password" id="register-password-q" required minlength="8"></div>
+        <div class="form-group"><label for="confirm-password-q">Потвърди Парола:</label><input type="password" id="confirm-password-q" required minlength="8"></div>
+        <div id="register-message-q" class="message" role="alert"></div>
+        <div class="nav-buttons"><button type="button" id="regBackBtn">◀ Назад</button><button type="submit" id="regSubmitBtn">Регистрация</button></div>
+      </form>
+    `;
+    container.appendChild(pageDiv);
+    const emailInput = pageDiv.querySelector('#register-email-q');
+    if (emailInput && responses.email) emailInput.value = responses.email;
+    pageDiv.querySelector('#regBackBtn').addEventListener('click', () => { showPage(regIndex - 1); });
+    setupRegistration("#register-form-q", "#register-message-q");
+    pageDiv.querySelector("#register-form-q").addEventListener("registrationSuccess", (event) => {
+      responses.email = event.detail.email;
+      saveProgress();
+      showPage(regIndex + 1);
+    });
+  }
+
+  /***** Създаване на финална страница (без промяна) *****/
+  function createFinalPage() {
+    const container = document.getElementById('dynamicContainer');
+    if (!container) return;
+    const finalIndex = flatPages.length + 2;
+    const pageDiv = document.createElement('div');
+    pageDiv.className = 'page';
+    pageDiv.id = 'page' + finalIndex;
+    pageDiv.innerHTML = `
+      <h2>Поздравления! <i class="bi bi-stars"></i><br> Току що направихте най-важната стъпка по пътя към промяната</h2>
+      <p>Натиснете бутона, за да изпратите вашите отговори за обработка.</p>
+      <div class="nav-buttons final-buttons" style="justify-content: center;">
+        <button id="submitBtn" type="button">Изпрати</button>
+        <button id="restartBtn" type="button">Отначало</button>
+      </div>
+       <div id="submit-message" class="message" style="margin-top: 15px; text-align: center; font-weight: bold; word-wrap: break-word;"></div>
+    `;
+    container.appendChild(pageDiv);
+  }
+
+  /***** Listener за финална страница (без промяна) *****/
+  function setupFinalPageListener() {
+        const finalIndex = flatPages.length + 2;
+        const pageDiv = document.getElementById('page' + finalIndex);
+        if (!pageDiv) { console.error("Финалната страница не е намерена."); return; }
+        const submitBtn = pageDiv.querySelector('#submitBtn');
+        const restartBtn = pageDiv.querySelector('#restartBtn');
+        const submitMessage = pageDiv.querySelector('#submit-message');
+        if (!submitBtn || !restartBtn || !submitMessage) { console.error("Един или повече елементи липсват на финалната страница."); return; }
+        restartBtn.addEventListener('click', () => { clearProgress(); location.reload(); });
+        submitBtn.addEventListener('click', async () => {
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Изпращане...';
+            hideMessage(submitMessage);
+            try {
+                const result = await submitResponses();
+                showMessage(submitMessage, result.message || "Отговорите са изпратени успешно за обработка!", false);
+                const link = document.createElement('a');
+                link.href = 'analyze.html';
+                link.textContent = 'Виж анализа';
+                link.style.display = 'block';
+                link.style.marginTop = '10px';
+                submitMessage.appendChild(link);
+                submitBtn.style.display = "none";
+                restartBtn.disabled = false;
+                restartBtn.textContent = "Попълни отново";
+            } catch (error) {
+                console.error("Error caught in submitBtn listener:", error);
+                showMessage(submitMessage, `Грешка: ${error.message || 'Неуспешно изпращане.'}`, true);
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Опитай отново';
+            }
+        });
+   }
+
+  /***** Показване на страница с условна логика (без промяна) *****/
+  function showPage(index) {
+    const pages = document.querySelectorAll('.page');
+    if (!pages || pages.length === 0) { console.error("Не са намерени страници за показване."); return; }
+    if (index > currentPageIndex) {
+        let targetIndex = index;
+        while (targetIndex < pages.length - 1) {
+             const question = flatPages[targetIndex - 1];
+            if (question && question.dependency) {
+                const parentAnswer = responses[question.dependency.question];
+                const dependencyValue = question.dependency.value;
+                let shouldShow = Array.isArray(parentAnswer) ? parentAnswer.includes(dependencyValue) : parentAnswer === dependencyValue;
+                if (!shouldShow) {
+                    console.log(`Прескачане напред: стр. ${targetIndex}`);
+                    targetIndex++; continue;
+                 }
+            }
+             break;
+         }
+         index = targetIndex;
+     } else if (index < currentPageIndex) {
+         let targetIndex = index;
+         while (targetIndex > 0) {
+            const question = flatPages[targetIndex - 1];
+             if (question && question.dependency) {
+                 const parentAnswer = responses[question.dependency.question];
+                 const dependencyValue = question.dependency.value;
+                 let shouldShow = Array.isArray(parentAnswer) ? parentAnswer.includes(dependencyValue) : parentAnswer === dependencyValue;
+                 if (!shouldShow) {
+                     console.log(`Прескачане назад: стр. ${targetIndex}`);
+                     targetIndex--; continue;
+                 }
+             }
+             break;
+         }
+         index = targetIndex;
+     }
+    if (index < 0) index = 0;
+    if (index >= pages.length) index = pages.length - 1;
+     if (currentPageIndex > 0 && currentPageIndex < pages.length -1) {
+         const previousQuestion = flatPages[currentPageIndex - 1];
+         if (previousQuestion) { saveAnswer(previousQuestion); }
+     }
+    currentPageIndex = index;
+    pages.forEach((pg, idx) => {
+        pg.classList.toggle('active', idx === currentPageIndex);
+    });
+    const activePage = pages[currentPageIndex];
+    if (activePage) {
+        const firstInput = activePage.querySelector('input, select, textarea');
+        if (firstInput) {
+             setTimeout(() => { try { firstInput.focus(); } catch (e) { console.warn("Неуспешен опит за фокусиране:", e); } }, 50);
+         }
+    } else { console.error(`Грешка: Активна страница с индекс ${currentPageIndex} не е намерена.`); }
+    updateProgress();
+    const instr = document.getElementById('questInstructions');
+    const stats = document.getElementById('persistentStats');
+    if (instr && stats) {
+      if (currentPageIndex === 0) {
+        instr.style.display = 'none';
+        stats.style.display = 'none';
+      } else {
+        instr.style.display = 'block';
+        stats.style.display = 'flex';
+      }
+    }
+    console.log("Показване на страница:", currentPageIndex, `(ID: page${currentPageIndex})`);
+  }
+
+  /***** Останалите помощни функции (без промяна) *****/
+  function updateProgress() {
+    const progressBar = document.getElementById('questProgressBar');
+    const currentLabel = document.getElementById('questCurrentStep');
+    const totalLabel = document.getElementById('questTotalSteps');
+    if (!progressBar || totalPages <= 1) return;
+    const currentStep = currentPageIndex;
+    const totalSteps = totalPages > 1 ? totalPages - 1 : 1;
+    updateStepProgress(progressBar, currentStep, totalSteps, currentLabel, totalLabel);
+  }
+  function saveProgress() {
+    try {
+      localStorage.setItem('questResponses', JSON.stringify(responses));
+      localStorage.setItem('questCurrentPage', String(currentPageIndex));
+    } catch (e) { console.warn('Неуспешно записване в localStorage:', e); }
+  }
+  function loadProgress() {
+    try {
+      const savedResponses = localStorage.getItem('questResponses');
+      const savedPage = localStorage.getItem('questCurrentPage');
+      if (savedResponses) Object.assign(responses, JSON.parse(savedResponses));
+      if (savedPage !== null) {
+        const idx = parseInt(savedPage, 10);
+        if (!Number.isNaN(idx)) currentPageIndex = idx;
+      }
+    } catch (e) { console.warn('Неуспешно зареждане от localStorage:', e); }
+  }
+  function applySavedResponses() {
+    for (const [qId, answer] of Object.entries(responses)) {
+      const question = flatPages.find(q => q.id === qId);
+      if (!question) continue;
+      const el = document.getElementById(qId);
+      if (['text', 'number', 'email', 'textarea', 'select'].includes(question.type)) {
+        if (el) el.value = answer;
+      } else if (question.type === 'radio') {
+        const radio = document.querySelector(`input[name="${qId}"][value="${answer}"]`);
+        if (radio) radio.checked = true;
+      } else if (question.type === 'checkbox' && Array.isArray(answer)) {
+        answer.forEach(val => {
+          const chk = document.querySelector(`input[name="${qId}"][value="${val}"]`);
+          if (chk) chk.checked = true;
+        });
+      }
+    }
+  }
+  function clearProgress() {
+    localStorage.removeItem('questResponses');
+    localStorage.removeItem('questCurrentPage');
+    for (const key in responses) delete responses[key];
+    currentPageIndex = 0;
+  }
+  function saveAnswer(question) {
+      if (!question || !question.id) { return; }
+      const qId = question.id; let answer;
+      const element = document.getElementById(qId);
+      if (['text', 'number', 'email', 'textarea'].includes(question.type)) { if (element) answer = element.value.trim(); } 
+      else if (question.type === 'select') { if(element) answer = element.value; } 
+      else if (question.type === 'radio') {
+        const checkedRadio = document.querySelector(`input[name="${qId}"]:checked`);
+        answer = checkedRadio ? checkedRadio.value : null;
+      } else if (question.type === 'checkbox') {
+        const checked = document.querySelectorAll(`input[name="${qId}"]:checked`);
+        answer = Array.from(checked).map(ch => ch.value);
+      }
+      if (answer !== undefined) { responses[qId] = answer; saveProgress(); } 
+      else { console.warn(`Не е намерен контрол за въпрос с ID: ${qId}`); }
+  }
+  function validateAnswer(question) {
+    if (!question || !question.id) return true;
+    const qId = question.id;
+    let isValid = true;
+    let errorMessage = '';
+    const element = document.getElementById(qId);
+    const isRequired = requiredFields.includes(qId);
+    let value = '';
+    if (['text', 'number', 'email', 'textarea'].includes(question.type)) {
+        if (element) value = element.value.trim();
+        if (isRequired && !value) { isValid = false; errorMessage = "Моля, попълнете това поле."; }
+        else if (question.type === 'number') {
+            const num = Number(value);
+            if (value && isNaN(num)) { isValid = false; errorMessage = "Моля, въведете число."; }
+            else { const range = numericRanges[qId]; if (range && (num < range.min || num > range.max)) { isValid = false; errorMessage = `Стойността трябва да е между ${range.min} и ${range.max}.`; } }
+        }
+    } else if (question.type === 'select') {
+         if (element) value = element.value;
+         if (isRequired && !value) { isValid = false; errorMessage = "Моля, направете избор."; }
+     } else if (question.type === 'radio') {
+        if (isRequired && !document.querySelector(`input[name="${qId}"]:checked`)) { isValid = false; errorMessage = "Моля, изберете една от опциите."; }
+    } else if (question.type === 'checkbox') {
+        if (isRequired && document.querySelectorAll(`input[name="${qId}"]:checked`).length === 0) { isValid = false; errorMessage = "Моля, изберете поне една опция."; }
+    }
+    const errorElementId = `error-${qId}`;
+    let errorElement = document.getElementById(errorElementId);
+    const pageElement = document.getElementById('page' + (flatPages.findIndex(p => p.id === qId) + 1));
+    if (!isValid) {
+        if (!errorElement && pageElement) {
+            errorElement = document.createElement('div');
+            errorElement.id = errorElementId;
+            errorElement.className = 'validation-error';
+            errorElement.style.color = '#e74c3c';
+            errorElement.style.fontSize = '0.9em';
+            errorElement.style.marginTop = '5px';
+            errorElement.setAttribute('role', 'alert');
+            const navButtons = pageElement.querySelector('.nav-buttons');
+            if(navButtons) { pageElement.insertBefore(errorElement, navButtons); }
+            else { pageElement.appendChild(errorElement); }
+        }
+        if (errorElement) { errorElement.textContent = errorMessage; }
+    } else if (errorElement) { errorElement.remove(); }
+    return isValid;
+  }
+  async function submitResponses() {
+      responses.submissionDate = new Date().toISOString();
+      console.log("Starting submitResponses...", JSON.stringify(responses, null, 2));
+      const userEmail = String(responses.email || (document.getElementById('register-email-q') ? document.getElementById('register-email-q').value : '')).trim().toLowerCase();
+      responses.email = userEmail;
+       try {
+            const workerResponse = await fetch(`${workerBaseUrl}/api/submitDemoQuestionnaire`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(responses)
+            });
+            const responseData = await workerResponse.json();
+            if (!workerResponse.ok) { throw new Error(responseData.message || `Worker отговори със статус ${workerResponse.status}`); }
+            delete responses.submissionDate;
+            return responseData;
+        } catch (error) {
+             delete responses.submissionDate;
+             throw new Error(`Грешка при комуникация със сървъра: ${error.message}`);
+        }
+  }
+
+  // --- Зареждане на въпросника при старт (без промяна) ---
+   document.addEventListener('DOMContentLoaded', () => {
+     fetch('demo_questions.json')
+       .then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status} при зареждане на demo_questions.json`);
+         const contentType = res.headers.get("content-type");
+         if (contentType && !contentType.includes("application/json")) { throw new TypeError(`Очакван JSON, но получен ${contentType}`); }
+         return res.json();
+       })
+       .then(data => {
+        if (!Array.isArray(data) || data.length === 0) { throw new Error("demo_questions.json е празен или невалиден масив."); }
+         rawQuestions = data;
+         buildDynamicPages();
+         loadProgress();
+         applySavedResponses();
+         showPage(currentPageIndex);
+       })
+       .catch(err => {
+          console.error('Грешка при зареждане или обработка на demo_questions.json:', err);
+           const container = document.getElementById('dynamicContainer');
+           if(container) { container.innerHTML = `<div style="color: #e74c3c; text-align: center; padding: 20px;">Възникна грешка при зареждане на въпросника. (${err.message})</div>`; }
+        });
+       const secretArea = document.getElementById('secretTapArea');
+       const adminLink = document.getElementById('adminLink');
+       if(secretArea && adminLink) {
+           secretArea.addEventListener('click', function() {
+             adminLink.style.display = 'block';
+             setTimeout(() => { adminLink.style.display = 'none'; }, 10000);
+           });
+       }
+   });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `demo_questions.json` with simplified questions
- create `demoquest.html` that loads demo questions
- use demo API routes and show link to `analyze.html` after sending answers

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688760e6bfe4832686ca657f5dfbaff4