### PR TITLE
Increase Jest memory limit

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,6 +9,6 @@ if [ ! -x node_modules/.bin/jest ]; then
   exit 1
 fi
 
-# Run Jest serially with experimental VM modules
-NODE_OPTIONS="${NODE_OPTIONS:-} --experimental-vm-modules" \
+# Run Jest serially with increased memory limit and experimental VM modules
+NODE_OPTIONS="--max-old-space-size=4096 ${NODE_OPTIONS:-} --experimental-vm-modules" \
   npx --no-install jest --runInBand "$@"


### PR DESCRIPTION
## Summary
- set increased Node memory limit when running tests

## Testing
- `npm run lint`
- `npm test` *(fails due to heap out-of-memory)*

------
https://chatgpt.com/codex/tasks/task_e_68876ed040788326aa0ddc36147f1964