### PR TITLE
Show macros in detailed analytics

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -185,6 +185,33 @@
   margin-top: var(--space-sm);
 }
 
+/* Macros Analytics Card */
+#macroAnalyticsCard .macro-metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+}
+#macroAnalyticsCard .macro-metric {
+  background: var(--surface-background);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm);
+  text-align: center;
+  box-shadow: var(--shadow-sm);
+}
+#macroAnalyticsCard .macro-label {
+  font-weight: 600;
+  color: var(--primary-color);
+}
+#macroAnalyticsCard .macro-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+#macroAnalyticsCard .macro-subtitle {
+  color: var(--text-color-muted);
+  font-size: var(--fs-sm);
+}
+
 /* Box with extra info for each metric */
 .metric-info-container {
   background: var(--color-info-bg);

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -13,6 +13,7 @@ beforeEach(async () => {
     <div id="engagementProgressFill"></div><div id="engagementProgressBar"></div><span id="engagementProgressText"></span>
     <div id="healthProgressFill"></div><div id="healthProgressBar"></div><span id="healthProgressText"></span>
     <div id="streakGrid"></div>
+    <div id="macroAnalyticsCard"><div id="macroMetricsGrid"></div></div>
     <h3 id="dailyPlanTitle"></h3>
     <ul id="dailyMealList"></ul>
   `;
@@ -33,6 +34,8 @@ beforeEach(async () => {
     healthProgressBar: document.getElementById('healthProgressBar'),
     healthProgressText: document.getElementById('healthProgressText'),
     streakGrid: document.getElementById('streakGrid'),
+    macroAnalyticsCard: document.getElementById('macroAnalyticsCard'),
+    macroMetricsGrid: document.getElementById('macroMetricsGrid'),
     dailyPlanTitle: document.getElementById('dailyPlanTitle'),
     dailyMealList: document.getElementById('dailyMealList')
   };
@@ -84,6 +87,27 @@ test('populates dashboard sections', () => {
   expect(document.getElementById('engagementProgressText').textContent).toBe('80%');
   expect(document.getElementById('healthProgressText').textContent).toBe('70%');
   expect(document.querySelectorAll('#streakGrid .streak-day.logged').length).toBe(1);
+});
+
+test('renders macro analytics card', async () => {
+  jest.resetModules();
+  const fullData = {
+    userName: 'Иван',
+    analytics: { current: {}, streak: {} },
+    planData: {
+      caloriesMacros: { calories: 1800, protein_grams: 120, protein_percent: 40, carbs_grams: 200, carbs_percent: 40, fat_grams: 50, fat_percent: 20 }
+    },
+    dailyLogs: [],
+    currentStatus: {},
+    initialData: {},
+    initialAnswers: {}
+  };
+  jest.unstable_mockModule('../app.js', () => ({ fullDashboardData: fullData, todaysMealCompletionStatus: {}, planHasRecContent: false }));
+  ({ populateUI } = await import('../populateUI.js'));
+  populateUI();
+  const metrics = document.querySelectorAll('#macroMetricsGrid .macro-metric');
+  expect(metrics.length).toBe(4);
+  expect(metrics[0].textContent).toContain('Калории');
 });
 
 test('hides modules when values are zero', async () => {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -13,6 +13,7 @@ export function populateUI() {
     try { populateUserInfo(data.userName); } catch(e) { console.error("Error in populateUserInfo:", e); }
     try { populateDashboardMainIndexes(data.analytics?.current); } catch(e) { console.error("Error in populateDashboardMainIndexes:", e); }
     try { populateDashboardDetailedAnalytics(data.analytics); } catch(e) { console.error("Error in populateDashboardDetailedAnalytics:", e); }
+    try { populateDashboardMacros(data.planData?.caloriesMacros); } catch(e) { console.error("Error in populateDashboardMacros:", e); }
     try { populateDashboardStreak(data.analytics?.streak); } catch(e) { console.error("Error in populateDashboardStreak:", e); }
     try { populateDashboardDailyPlan(data.planData?.week1Menu, data.dailyLogs, data.recipeData); } catch(e) { console.error("Error in populateDashboardDailyPlan:", e); }
     try { populateDashboardLog(data.dailyLogs, data.currentStatus, data.initialData); } catch(e) { console.error("Error in populateDashboardLog:", e); }
@@ -104,6 +105,11 @@ function populateDashboardDetailedAnalytics(analyticsData) {
     }
     cardsContainer.innerHTML = '';
     textualAnalysisContainer.innerHTML = '';
+
+    const macros = safeGet(fullDashboardData, 'planData.caloriesMacros');
+    if (macros) {
+        cardsContainer.appendChild(renderMacroAnalyticsCard(macros));
+    }
 
     const detailedMetrics = safeGet(analyticsData, 'detailed', []);
     const textualAnalysis = safeGet(analyticsData, 'textualAnalysis');
@@ -217,6 +223,42 @@ function populateDashboardDetailedAnalytics(analyticsData) {
                 accordionContent.classList.remove('open-active');
             }
         }
+    }
+}
+
+function renderMacroAnalyticsCard(macros) {
+    const card = document.createElement('div');
+    card.id = 'macroAnalyticsCard';
+    card.className = 'analytics-card';
+    const header = document.createElement('h5');
+    header.innerHTML = `<svg class="icon" style="width:1em;height:1em;margin-right:0.3em"><use href="#icon-scale"></use></svg> Калории и Макроси`;
+    card.appendChild(header);
+    const grid = document.createElement('div');
+    grid.id = 'macroMetricsGrid';
+    grid.className = 'macro-metrics-grid';
+    const list = [
+        { l: 'Калории', v: macros.calories, s: 'kcal дневно' },
+        { l: 'Протеини', v: macros.protein_grams, s: macros.protein_percent ? `${macros.protein_percent}%` : '' },
+        { l: 'Въглехидрати', v: macros.carbs_grams, s: macros.carbs_percent ? `${macros.carbs_percent}%` : '' },
+        { l: 'Мазнини', v: macros.fat_grams, s: macros.fat_percent ? `${macros.fat_percent}%` : '' }
+    ];
+    list.forEach(item => {
+        const div = document.createElement('div');
+        div.className = 'macro-metric';
+        div.innerHTML = `<div class="macro-label">${item.l}</div><div class="macro-value">${item.v ?? '--'}</div><div class="macro-subtitle">${item.s}</div>`;
+        grid.appendChild(div);
+    });
+    card.appendChild(grid);
+    return card;
+}
+
+function populateDashboardMacros(macros) {
+    if (!selectors.analyticsCardsContainer) return;
+    const existing = document.getElementById('macroAnalyticsCard');
+    if (existing) existing.remove();
+    if (macros) {
+        const card = renderMacroAnalyticsCard(macros);
+        selectors.analyticsCardsContainer.prepend(card);
     }
 }
 

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -47,6 +47,8 @@ export function initializeSelectors() {
         streakGrid: 'streakGrid',
         achievementShareBtn: 'achievementShareBtn',
         analyticsCardsContainer: 'analyticsCardsContainer',
+        macroAnalyticsCard: 'macroAnalyticsCard',
+        macroMetricsGrid: 'macroMetricsGrid',
         tooltipTracker: 'tooltip-tracker',
         toast: 'toast', chatFab: 'chat-fab', chatWidget: 'chat-widget', chatClose: 'chat-close',
         chatClear: 'chat-clear',
@@ -72,6 +74,7 @@ export function initializeSelectors() {
                 'planModChatSend', 'planModChatClose', 'planModChatClear',
                 'streakGrid', 'analyticsCardsContainer', 'achievementShareBtn',
                 'goalCard', 'engagementCard', 'healthCard', 'streakCard',
+                'macroAnalyticsCard', 'macroMetricsGrid',
                 'recFoodAllowedCard', 'recFoodLimitCard', 'recHydrationCard',
                 'recCookingMethodsCard', 'recSupplementsCard'
             ];


### PR DESCRIPTION
## Summary
- display plan macros at the top of dashboard analytics
- style macro cards with new grid and colors
- expose new selectors for macros
- test rendering of macro metrics

## Testing
- `npm run lint`
- `npm test` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_6887952424108326a1990ff42f2ec560