### PR TITLE
Fix dashboard redirect constant

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,6 +33,9 @@ const Config = {
     }
 };
 
+// URL на таблото след успешен вход
+const dashboardUrl = 'code.html';
+
 /**
  * @description Универсални функции за съобщения (от messageUtils.js)
  */
@@ -411,8 +414,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 // В този случай, за целите на демото, просто показваме успех.
                 MessageUtils.showMessage(loginMessage, "Успешен вход! Пренасочване...", false);
                 setTimeout(() => {
-                    // TODO: Променете 'code.html' с реалния URL на таблото, ако е различен.
-                    window.location.href = 'code.html'; 
+                    window.location.href = dashboardUrl;
                 }, 1500);
 
             } catch (error) {


### PR DESCRIPTION
## Summary
- define `dashboardUrl` constant at top of script.js
- use the constant for login redirect

## Testing
- `npm run lint`
- `npm test` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6887959138348326a6988ad3b2db1360