### PR TITLE
Update macro card insertion logic

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -106,10 +106,6 @@ function populateDashboardDetailedAnalytics(analyticsData) {
     cardsContainer.innerHTML = '';
     textualAnalysisContainer.innerHTML = '';
 
-    const macros = safeGet(fullDashboardData, 'planData.caloriesMacros');
-    if (macros) {
-        cardsContainer.appendChild(renderMacroAnalyticsCard(macros));
-    }
 
     const detailedMetrics = safeGet(analyticsData, 'detailed', []);
     const textualAnalysis = safeGet(analyticsData, 'textualAnalysis');


### PR DESCRIPTION
## Summary
- remove macro card creation from `populateDashboardDetailedAnalytics`
- keep card insertion in `populateDashboardMacros`

## Testing
- `npm run lint`
- `sh scripts/test.sh --runTestsByPath js/__tests__/populateUI.test.js` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6887a36bcfdc8326a71988bfee81b314