### PR TITLE
Add macros doughnut chart

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -212,6 +212,19 @@
   font-size: var(--fs-sm);
 }
 
+#macroAnalyticsCard .chart-container {
+  min-height: 150px;
+  position: relative;
+  padding: var(--space-sm);
+  text-align: center;
+}
+
+#macroAnalyticsCard canvas {
+  max-width: 250px;
+  max-height: 250px;
+  margin: 0 auto;
+}
+
 /* Box with extra info for each metric */
 .metric-info-container {
   background: var(--color-info-bg);

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -108,6 +108,8 @@ test('renders macro analytics card', async () => {
   const metrics = document.querySelectorAll('#macroMetricsGrid .macro-metric');
   expect(metrics.length).toBe(4);
   expect(metrics[0].textContent).toContain('Калории');
+  const canvas = document.querySelector('#macroAnalyticsCard canvas');
+  expect(canvas).not.toBeNull();
 });
 
 test('hides modules when values are zero', async () => {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -229,6 +229,14 @@ function renderMacroAnalyticsCard(macros) {
     const header = document.createElement('h5');
     header.innerHTML = `<svg class="icon" style="width:1em;height:1em;margin-right:0.3em"><use href="#icon-scale"></use></svg> Калории и Макроси`;
     card.appendChild(header);
+
+    const chartContainer = document.createElement('div');
+    chartContainer.className = 'chart-container';
+    const canvas = document.createElement('canvas');
+    canvas.id = 'macroChart';
+    chartContainer.appendChild(canvas);
+    card.appendChild(chartContainer);
+
     const grid = document.createElement('div');
     grid.id = 'macroMetricsGrid';
     grid.className = 'macro-metrics-grid';
@@ -245,6 +253,36 @@ function renderMacroAnalyticsCard(macros) {
         grid.appendChild(div);
     });
     card.appendChild(grid);
+
+    if (typeof Chart !== 'undefined') {
+        const ctx = canvas.getContext('2d');
+        new Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels: [
+                    `Протеини (${macros.protein_percent}%)`,
+                    `Въглехидрати (${macros.carbs_percent}%)`,
+                    `Мазнини (${macros.fat_percent}%)`
+                ],
+                datasets: [{
+                    label: 'Разпределение на макроси',
+                    data: [macros.protein_grams, macros.carbs_grams, macros.fat_grams],
+                    backgroundColor: ['rgb(54,162,235)', 'rgb(255,205,86)', 'rgb(255,99,132)'],
+                    hoverOffset: 4
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: { position: 'top' },
+                    title: { display: true, text: `Дневен прием (${macros.calories} kcal)` }
+                }
+            }
+        });
+    } else {
+        console.warn('Chart.js is not loaded.');
+    }
+
     return card;
 }
 


### PR DESCRIPTION
## Summary
- show calories and macros chart on dashboard
- style macro analytics card for chart container
- test for canvas creation

## Testing
- `npm run lint`
- `npm test` *(fails: Reached heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_6887a9c34da083268221ffd4be12bc66