### PR TITLE
Fix Chart.js load order

### DIFF
--- a/code.html
+++ b/code.html
@@ -1346,8 +1346,8 @@
     <!-- End #appWrapper -->
 
     <!-- Коригирана JavaScript Връзка -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
     <script type="module" src="js/app.js" defer></script>
     <script type="module" src="js/planModChat.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load Chart.js before the ES modules so `Chart` is ready when `renderMacroAnalyticsCard` runs

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6887b03d25248326820ec67b9b7c11e5