### PR TITLE
Fix analysis status pending before processing

### DIFF
--- a/js/__tests__/submitQuestionnaireReadyStatus.test.js
+++ b/js/__tests__/submitQuestionnaireReadyStatus.test.js
@@ -1,0 +1,58 @@
+import { jest } from '@jest/globals'
+import * as worker from '../../worker.js'
+
+afterEach(() => {
+  global.fetch && global.fetch.mockRestore()
+})
+
+describe('analysis status ready when ctx missing', () => {
+  test('handleSubmitQuestionnaire sets ready status without ctx', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    const kvStore = {}
+    const env = {
+      MAILER_ENDPOINT_URL: 'https://mail.example.com',
+      USER_METADATA_KV: {
+        get: jest.fn(key => kvStore[key] ?? null),
+        put: jest.fn((key, val) => { kvStore[key] = val; return Promise.resolve() })
+      },
+      RESOURCES_KV: {
+        get: jest.fn(key => {
+          if (key === 'prompt_questionnaire_analysis') return 'Analyze %%ANSWERS_JSON%%'
+          if (key === 'model_questionnaire_analysis') return '@cf/test-model'
+          return null
+        })
+      },
+      AI: { run: jest.fn().mockResolvedValue({ response: '{"score":1}' }) }
+    }
+    kvStore['email_to_uuid_a@b.bg'] = 'u1'
+    const req = { json: async () => ({ email: 'a@b.bg', name: 'A' }) }
+    const res = await worker.handleSubmitQuestionnaire(req, env)
+    expect(res.success).toBe(true)
+    expect(kvStore['u1_analysis_status']).toBe('ready')
+  })
+
+  test('handleSubmitDemoQuestionnaire sets ready status without ctx', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    const kvStore = {}
+    const env = {
+      MAILER_ENDPOINT_URL: 'https://mail.example.com',
+      USER_METADATA_KV: {
+        get: jest.fn(key => kvStore[key] ?? null),
+        put: jest.fn((key, val) => { kvStore[key] = val; return Promise.resolve() })
+      },
+      RESOURCES_KV: {
+        get: jest.fn(key => {
+          if (key === 'prompt_questionnaire_analysis') return 'Analyze %%ANSWERS_JSON%%'
+          if (key === 'model_questionnaire_analysis') return '@cf/test-model'
+          return null
+        })
+      },
+      AI: { run: jest.fn().mockResolvedValue({ response: '{"score":1}' }) }
+    }
+    kvStore['email_to_uuid_a@b.bg'] = 'u1'
+    const req = { json: async () => ({ email: 'a@b.bg', name: 'A' }) }
+    const res = await worker.handleSubmitDemoQuestionnaire(req, env)
+    expect(res.success).toBe(true)
+    expect(kvStore['u1_analysis_status']).toBe('ready')
+  })
+})

--- a/worker.js
+++ b/worker.js
@@ -818,13 +818,12 @@ async function handleSubmitQuestionnaire(request, env, ctx) {
             env
         );
 
+        await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'pending');
         const analysisTask = handleAnalyzeInitialAnswers(userId, env);
         if (ctx) {
             ctx.waitUntil(analysisTask);
-            await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'pending');
         } else {
             await analysisTask;
-            await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'pending');
         }
         return { success: true, message: 'Данните са приети. Вашият индивидуален план ще бъде генериран скоро.' };
     } catch (error) {
@@ -868,13 +867,12 @@ async function handleSubmitDemoQuestionnaire(request, env, ctx) {
             env
         );
 
+        await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'pending');
         const analysisTask = handleAnalyzeInitialAnswers(userId, env);
         if (ctx) {
             ctx.waitUntil(analysisTask);
-            await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'pending');
         } else {
             await analysisTask;
-            await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'pending');
         }
         return { success: true, message: 'Данните са приети. Анализът ще бъде готов скоро.' };
     } catch (error) {


### PR DESCRIPTION
## Summary
- store analysis status as `pending` before running analysis
- stop overwriting status after analysis completes
- add test verifying ready status when ctx is undefined for questionnaire endpoints

## Testing
- `npm run lint`
- `sh ./scripts/test.sh js/__tests__/submitQuestionnaireReadyStatus.test.js`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6887b4718d5c8326965d03cd176786c7