### PR TITLE
Add page-specific color theme personalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ The application will be available at `http://localhost:5173` by default.
 Така настройките засягат само публичната част на сайта и са по-лесни за управление.
 
 #### Персонализация за потребители
-От страницата `personalization.html` всеки може да настрои основните цветове чрез
-цветови палитри и плъзгачи за нюанс и яркост. Избраните стойности се записват в
-`localStorage.colorThemes['Custom']` и се прилагат при следващо посещение на
-таблото.
+В `personalization.html` цветoвите настройки са разделени по табове – Dashboard,
+Index и Quest. Всеки таб съдържа полета от съответната група от `themeConfig.js`.
+Промените се съхраняват отделно в `localStorage.dashboardColorThemes`,
+`localStorage.indexColorThemes` и `localStorage.questColorThemes`. При зареждане
+на всяка страница избраните стойности се прилагат автоматично.
 
 ### Build
 

--- a/code.html
+++ b/code.html
@@ -1349,5 +1349,9 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
     <script type="module" src="js/app.js" defer></script>
     <script type="module" src="js/planModChat.js" defer></script>
+    <script type="module">
+      import { applyStoredTheme } from './js/personalization.js';
+      document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Dashboard'));
+    </script>
   </body>
 </html>

--- a/index1.html
+++ b/index1.html
@@ -279,5 +279,9 @@
             }, 2500);
         });
     </script>
+    <script type="module">
+      import { applyStoredTheme } from './js/personalization.js';
+      document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
+    </script>
 </body>
 </html>

--- a/js/personalization.js
+++ b/js/personalization.js
@@ -3,120 +3,134 @@ import { colorGroups } from './themeConfig.js';
 import { loadAndApplyColors } from './uiHandlers.js';
 
 const inputs = {};
-const hueSliders = {};
-const lightSliders = {};
 
-function getMainColors() {
-  const group = colorGroups.find(g => g.name === 'Основни цветове');
-  return group ? group.items.map(it => it.var) : ['primary-color','secondary-color','accent-color','tertiary-color'];
+const storageMap = {
+  Index: 'indexColorThemes',
+  Quest: 'questColorThemes',
+  Dashboard: 'dashboardColorThemes'
+};
+
+function getStorageKey(groupName) {
+  return storageMap[groupName] || storageMap.Dashboard;
 }
 
 function getCurrentColor(key) {
-  const bodyVal = getComputedStyle(document.body).getPropertyValue(`--${key}`).trim();
+  const bodyVal = getComputedStyle(document.body)
+    .getPropertyValue(`--${key}`).trim();
   if (bodyVal) return bodyVal;
-  return getComputedStyle(document.documentElement).getPropertyValue(`--${key}`).trim();
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(`--${key}`).trim();
 }
 
-function hexToHsl(hex) {
-  let h,r,g,b;
-  hex = hex.replace('#','');
-  if (hex.length === 3) hex = hex.split('').map(c => c + c).join('');
-  r = parseInt(hex.slice(0,2),16)/255;
-  g = parseInt(hex.slice(2,4),16)/255;
-  b = parseInt(hex.slice(4,6),16)/255;
-  const max = Math.max(r,g,b), min = Math.min(r,g,b);
-  let l = (max+min)/2; let s = 0; h = 0;
-  if (max !== min) {
-    const d = max - min;
-    s = l > 0.5 ? d/(2-max-min) : d/(max+min);
-    switch(max){
-      case r: h = (g-b)/d + (g < b ? 6 : 0); break;
-      case g: h = (b-r)/d + 2; break;
-      default: h = (r-g)/d + 4;
-    }
-    h *= 60;
-  }
-  return { h, s: s*100, l: l*100 };
-}
-
-function hslToHex(h, s, l) {
-  s /= 100; l /= 100;
-  const C = (1 - Math.abs(2*l-1))*s;
-  const X = C * (1 - Math.abs((h/60)%2 -1));
-  const m = l - C/2;
-  let r=0,g=0,b=0;
-  if (0<=h && h<60){ r=C; g=X; }
-  else if (60<=h && h<120){ r=X; g=C; }
-  else if (120<=h && h<180){ g=C; b=X; }
-  else if (180<=h && h<240){ g=X; b=C; }
-  else if (240<=h && h<300){ r=X; b=C; }
-  else if (300<=h && h<360){ r=C; b=X; }
-  r = Math.round((r+m)*255);
-  g = Math.round((g+m)*255);
-  b = Math.round((b+m)*255);
-  const toHex = n => n.toString(16).padStart(2,'0');
-  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
-}
-
-function applyAndStore() {
+export function applyAndStore(groupName) {
+  const group = colorGroups.find(g => g.name === groupName);
+  if (!group) return;
   const theme = {};
-  getMainColors().forEach(key => {
-    const base = inputs[key].value;
-    const hue = parseInt(hueSliders[key].value, 10);
-    const light = parseInt(lightSliders[key].value, 10);
-    const { h,s,l } = hexToHsl(base);
-    const newH = (h + hue + 360) % 360;
-    const newL = Math.min(100, Math.max(0, l + light));
-    const hex = hslToHex(newH, s, newL);
-    document.documentElement.style.setProperty(`--${key}`, hex);
-    document.body.style.setProperty(`--${key}`, hex);
-    theme[key] = hex;
+  group.items.forEach(item => {
+    const el = inputs[`${groupName}-${item.var}`];
+    if (el) {
+      document.documentElement.style.setProperty(`--${item.var}`, el.value);
+      document.body.style.setProperty(`--${item.var}`, el.value);
+      theme[item.var] = el.value;
+    }
   });
-  const all = JSON.parse(localStorage.getItem('colorThemes') || '{}');
-  all.Custom = theme;
-  localStorage.setItem('colorThemes', JSON.stringify(all));
+  const key = getStorageKey(groupName);
+  const stored = JSON.parse(localStorage.getItem(key) || '{}');
+  stored.Custom = theme;
+  localStorage.setItem(key, JSON.stringify(stored));
 }
 
-function populate() {
-  const themes = JSON.parse(localStorage.getItem('colorThemes') || '{}');
+export function populate(groupName) {
+  const group = colorGroups.find(g => g.name === groupName);
+  if (!group) return;
+  const key = getStorageKey(groupName);
+  const themes = JSON.parse(localStorage.getItem(key) || '{}');
   const custom = themes.Custom || {};
-  getMainColors().forEach(key => {
-    const color = custom[key] || getCurrentColor(key);
-    inputs[key].value = color;
-    hueSliders[key].value = 0;
-    lightSliders[key].value = 0;
+  group.items.forEach(item => {
+    const el = inputs[`${groupName}-${item.var}`];
+    if (!el) return;
+    el.value = custom[item.var] || getCurrentColor(item.var);
   });
-  applyAndStore();
+  applyAndStore(groupName);
+}
+
+function createTabNavigation(parent) {
+  const nav = document.createElement('div');
+  nav.className = 'tab-buttons';
+  colorGroups.forEach((group, idx) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = group.name;
+    btn.addEventListener('click', () => switchTab(group.name));
+    if (idx === 0) btn.classList.add('active-tab');
+    nav.appendChild(btn);
+  });
+  parent.appendChild(nav);
+  return nav;
+}
+
+function createTabContents(parent) {
+  const contents = document.createElement('div');
+  contents.className = 'tab-contents';
+  colorGroups.forEach((group, idx) => {
+    const panel = document.createElement('div');
+    panel.id = `panel-${group.name}`;
+    panel.className = 'tab-panel';
+    if (idx !== 0) panel.style.display = 'none';
+    group.items.forEach(item => {
+      const wrap = document.createElement('div');
+      wrap.className = 'form-group';
+      const label = document.createElement('label');
+      label.textContent = item.label || item.var;
+      const input = document.createElement('input');
+      input.type = 'color';
+      input.id = `${group.name}-${item.var}`;
+      wrap.appendChild(label);
+      wrap.appendChild(input);
+      panel.appendChild(wrap);
+      inputs[input.id] = input;
+      input.addEventListener('input', () => applyAndStore(group.name));
+    });
+    contents.appendChild(panel);
+  });
+  parent.appendChild(contents);
+}
+
+export function switchTab(name) {
+  const nav = document.querySelector('.tab-buttons');
+  const panels = document.querySelectorAll('.tab-panel');
+  nav.querySelectorAll('button').forEach(btn => {
+    const isActive = btn.textContent === name;
+    btn.classList.toggle('active-tab', isActive);
+  });
+  panels.forEach(panel => {
+    const show = panel.id === `panel-${name}`;
+    panel.style.display = show ? 'block' : 'none';
+    if (show) populate(name);
+  });
+}
+
+export function applyStoredTheme(groupName) {
+  const group = colorGroups.find(g => g.name === groupName);
+  if (!group) return;
+  const key = getStorageKey(groupName);
+  const themes = JSON.parse(localStorage.getItem(key) || '{}');
+  const custom = themes.Custom || {};
+  group.items.forEach(item => {
+    const val = custom[item.var];
+    if (val) {
+      document.documentElement.style.setProperty(`--${item.var}`, val);
+      document.body.style.setProperty(`--${item.var}`, val);
+    }
+  });
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
   await loadAndApplyColors();
   const container = document.getElementById('colorControls');
   if (!container) return;
-  getMainColors().forEach(key => {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'form-group';
-    const label = document.createElement('label');
-    label.textContent = key;
-    const colorInput = document.createElement('input');
-    colorInput.type = 'color';
-    const hue = document.createElement('input');
-    hue.type = 'range';
-    hue.min = -180; hue.max = 180; hue.value = 0;
-    const light = document.createElement('input');
-    light.type = 'range';
-    light.min = -50; light.max = 50; light.value = 0;
-    wrapper.appendChild(label);
-    wrapper.appendChild(colorInput);
-    wrapper.appendChild(hue);
-    wrapper.appendChild(light);
-    container.appendChild(wrapper);
-    inputs[key] = colorInput;
-    hueSliders[key] = hue;
-    lightSliders[key] = light;
-    colorInput.addEventListener('input', applyAndStore);
-    hue.addEventListener('input', applyAndStore);
-    light.addEventListener('input', applyAndStore);
-  });
-  populate();
+  const nav = createTabNavigation(container);
+  createTabContents(container);
+  const first = nav.querySelector('button');
+  if (first) switchTab(first.textContent);
 });

--- a/js/themeConfig.js
+++ b/js/themeConfig.js
@@ -43,5 +43,80 @@ export const colorGroups = [
       { var: 'progress-end-color', label: 'Краен цвят на прогрес' },
       { var: 'progress-bar-bg-empty', label: 'Празен прогрес бар' }
     ]
+  },
+  {
+    name: 'Index',
+    items: [
+      { var: 'primary-color', label: 'Основен цвят' },
+      { var: 'secondary-color', label: 'Втори цвят' },
+      { var: 'accent-color', label: 'Акцентен цвят' },
+      { var: 'bg-color', label: 'Фон на страницата' },
+      { var: 'card-bg', label: 'Фон на карти' },
+      { var: 'text-color-primary', label: 'Основен текст' },
+      { var: 'text-color-secondary', label: 'Втори текст' },
+      { var: 'border-color', label: 'Рамки' },
+      { var: 'color-danger', label: 'Грешки' },
+      { var: 'color-success', label: 'Успехи' }
+    ]
+  },
+  {
+    name: 'Quest',
+    items: [
+      { var: 'bg-primary', label: 'Фон основен' },
+      { var: 'bg-secondary', label: 'Фон втори' },
+      { var: 'bg-surface', label: 'Фон на съдържание' },
+      { var: 'accent-primary', label: 'Акцент' },
+      { var: 'accent-secondary', label: 'Допълнителен акцент' },
+      { var: 'text-primary', label: 'Основен текст' },
+      { var: 'text-secondary', label: 'Втори текст' },
+      { var: 'border-color', label: 'Рамки' },
+      { var: 'error-color', label: 'Грешки' },
+      { var: 'success-color', label: 'Успехи' }
+    ]
   }
 ];
+
+export const sampleThemes = {
+  dashboard: {
+    Light: {
+      'primary-color': '#3A506B',
+      'secondary-color': '#5BC0BE'
+    },
+    Dark: {
+      'primary-color': '#5BC0BE',
+      'secondary-color': '#3A506B'
+    },
+    Vivid: {
+      'primary-color': '#ff0066',
+      'secondary-color': '#ffcc00'
+    }
+  },
+  index: {
+    Light: {
+      'primary-color': '#3A506B',
+      'secondary-color': '#5BC0BE'
+    },
+    Dark: {
+      'primary-color': '#5BC0BE',
+      'secondary-color': '#3A506B'
+    },
+    Vivid: {
+      'primary-color': '#ff3366',
+      'secondary-color': '#00e0ff'
+    }
+  },
+  quest: {
+    Light: {
+      'accent-primary': '#43a088',
+      'bg-primary': '#f4f7f6'
+    },
+    Dark: {
+      'accent-primary': '#4fc3a1',
+      'bg-primary': '#121212'
+    },
+    Vivid: {
+      'accent-primary': '#ff3399',
+      'bg-primary': '#222244'
+    }
+  }
+};

--- a/quest.html
+++ b/quest.html
@@ -588,7 +588,11 @@
              setTimeout(() => { adminLink.style.display = 'none'; }, 10000);
            });
        }
-   });
+  });
+</script>
+<script type="module">
+  import { applyStoredTheme } from './js/personalization.js';
+  document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Quest'));
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- extend `themeConfig.js` with Index and Quest groups and sample themes
- overhaul `personalization.js` with tabbed interface and local storage per page
- load saved colors on Index, Quest and Dashboard pages
- document new workflow in README

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6887b9f00d248326a803c2a3ca3842e7