### PR TITLE
Fix macro chart visibility in detailed analysis

### DIFF
--- a/code.html
+++ b/code.html
@@ -485,9 +485,19 @@
                   </div>
                 </div>
                 <div id="analyticsCardsContainer" class="analytics-cards-grid">
-                  <p class="placeholder">
-                    Зареждане на детайлните показатели...
-                  </p>
+                  <div id="macroAnalyticsCard" class="analytics-card">
+                    <h5>
+                      <svg class="icon" style="width:1em;height:1em;margin-right:0.3em">
+                        <use href="#icon-scale"></use>
+                      </svg>
+                      Калории и Макроси
+                    </h5>
+                    <div class="chart-container">
+                      <canvas id="macroChart"></canvas>
+                    </div>
+                    <div id="macroMetricsGrid" class="macro-metrics-grid"></div>
+                  </div>
+                  <p class="placeholder">Зареждане на детайлните показатели...</p>
                 </div>
               </div>
             </div>

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -37,6 +37,11 @@
   --input-focus-border: var(--primary-color);
   --input-focus-shadow: rgba(58, 80, 107, 0.25);
 
+  /* Цветове за макро диаграмата */
+  --macro-protein-color: #36A2EB;
+  --macro-carbs-color: #FFCD56;
+  --macro-fat-color: #FF6384;
+
   --shadow-sm: 0 2px 4px rgba(0,0,0,0.05);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.07);
   --shadow-lg: 0 6px 24px rgba(0, 0, 0, 0.12);

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,6 +1,6 @@
 // populateUI.js - Попълване на UI с данни
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
-import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, getProgressColor, animateProgressFill } from './utils.js';
+import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, getProgressColor, animateProgressFill, getCssVar } from './utils.js';
 import { generateId } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, planHasRecContent } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
@@ -271,7 +271,11 @@ function renderMacroAnalyticsCard(macros) {
                 datasets: [{
                     label: 'Разпределение на макроси',
                     data: [macros.protein_grams, macros.carbs_grams, macros.fat_grams],
-                    backgroundColor: ['rgb(54,162,235)', 'rgb(255,205,86)', 'rgb(255,99,132)'],
+                    backgroundColor: [
+                        getCssVar('--macro-protein-color', 'rgb(54,162,235)'),
+                        getCssVar('--macro-carbs-color', 'rgb(255,205,86)'),
+                        getCssVar('--macro-fat-color', 'rgb(255,99,132)')
+                    ],
                     hoverOffset: 4
                 }]
             },

--- a/js/utils.js
+++ b/js/utils.js
@@ -146,3 +146,15 @@ export function animateProgressFill(el, percent) {
     }, { once: true });
 }
 
+/**
+ * Взема стойност на CSS променлива от :root.
+ * @param {string} name Името на променливата (например '--primary-color').
+ * @param {string} [fallback=''] Резервна стойност при липса.
+ * @returns {string} Стойността на променливата или fallback.
+ */
+export function getCssVar(name, fallback = '') {
+    if (typeof window === 'undefined') return fallback;
+    const val = getComputedStyle(document.documentElement).getPropertyValue(name);
+    return val ? val.trim() : fallback;
+}
+


### PR DESCRIPTION
## Summary
- add CSS variables for macro chart colors
- provide `getCssVar` helper
- adapt macro chart colors to theme variables
- include default macro chart container in `code.html`

## Testing
- `npm run lint`
- `npx jest --runInBand` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6887c48f27f88326bfa4f134a16e5626