### PR TITLE
Добавяне на валидиране на въпросник

### DIFF
--- a/js/__tests__/submitQuestionnaireValidation.test.js
+++ b/js/__tests__/submitQuestionnaireValidation.test.js
@@ -1,0 +1,69 @@
+import { jest } from '@jest/globals';
+import { handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire } from '../../worker.js';
+
+const makeEnv = () => ({
+  USER_METADATA_KV: {
+    get: jest.fn(async key => (key === 'email_to_uuid_a@b.bg' ? 'u1' : null)),
+    put: jest.fn()
+  }
+});
+
+const baseData = {
+  email: 'a@b.bg',
+  gender: 'Мъж',
+  age: 30,
+  height: 180,
+  weight: 80,
+  goal: 'Поддържане',
+  medicalConditions: ['Нямам']
+};
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  if (global.fetch && global.fetch.mockRestore) global.fetch.mockRestore();
+});
+
+describe('questionnaire field validation', () => {
+  const fields = ['gender', 'age', 'height', 'weight', 'goal', 'medicalConditions'];
+
+  test.each(fields)('handleSubmitQuestionnaire fails when %s is missing', async field => {
+    const data = { ...baseData };
+    delete data[field];
+    const env = makeEnv();
+    const req = { json: async () => data };
+    const res = await handleSubmitQuestionnaire(req, env);
+    expect(res.success).toBe(false);
+    expect(res.statusHint).toBe(400);
+  });
+
+  test.each(fields)('handleSubmitQuestionnaire fails when %s is empty', async field => {
+    const data = { ...baseData, [field]: field === 'medicalConditions' ? [] : '' };
+    const env = makeEnv();
+    const req = { json: async () => data };
+    const res = await handleSubmitQuestionnaire(req, env);
+    expect(res.success).toBe(false);
+    expect(res.statusHint).toBe(400);
+  });
+
+  test.each(fields)('handleSubmitDemoQuestionnaire fails when %s is missing', async field => {
+    const data = { ...baseData };
+    delete data[field];
+    const env = makeEnv();
+    const req = { json: async () => data };
+    const res = await handleSubmitDemoQuestionnaire(req, env);
+    expect(res.success).toBe(false);
+    expect(res.statusHint).toBe(400);
+  });
+
+  test.each(fields)('handleSubmitDemoQuestionnaire fails when %s is empty', async field => {
+    const data = { ...baseData, [field]: field === 'medicalConditions' ? [] : '' };
+    const env = makeEnv();
+    const req = { json: async () => data };
+    const res = await handleSubmitDemoQuestionnaire(req, env);
+    expect(res.success).toBe(false);
+    expect(res.statusHint).toBe(400);
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -797,6 +797,13 @@ async function handleSubmitQuestionnaire(request, env, ctx) {
         if (!userEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(userEmail)) {
             return { success: false, message: 'Липсва/невалиден имейл.', statusHint: 400 };
         }
+        const required = ['gender', 'age', 'height', 'weight', 'goal', 'medicalConditions'];
+        for (const field of required) {
+            const val = questionnaireData[field];
+            if (val === undefined || val === null || (typeof val === 'string' && val.trim() === '') || (Array.isArray(val) && val.length === 0)) {
+                return { success: false, statusHint: 400 };
+            }
+        }
         const userId = await env.USER_METADATA_KV.get(`email_to_uuid_${userEmail}`);
         if (!userId) {
             return { success: false, message: 'Потребителят не е регистриран.', statusHint: 403 };
@@ -846,6 +853,13 @@ async function handleSubmitDemoQuestionnaire(request, env, ctx) {
         const userEmail = questionnaireData.email ? String(questionnaireData.email).trim().toLowerCase() : null;
         if (!userEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(userEmail)) {
             return { success: false, message: 'Липсва/невалиден имейл.', statusHint: 400 };
+        }
+        const required = ['gender', 'age', 'height', 'weight', 'goal', 'medicalConditions'];
+        for (const field of required) {
+            const val = questionnaireData[field];
+            if (val === undefined || val === null || (typeof val === 'string' && val.trim() === '') || (Array.isArray(val) && val.length === 0)) {
+                return { success: false, statusHint: 400 };
+            }
         }
         const userId = await env.USER_METADATA_KV.get(`email_to_uuid_${userEmail}`);
         if (!userId) {


### PR DESCRIPTION
## Summary
- добавени проверки за задължителните полета в `handleSubmitQuestionnaire` и `handleSubmitDemoQuestionnaire`
- създадени unit тестове за пропуснати или празни стойности

## Testing
- `npm run lint`
- `sh ./scripts/test.sh --runTestsByPath js/__tests__/submitQuestionnaireValidation.test.js`
- `npm test` *(failed: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6887c6d66160832689e5ecea17166927