### PR TITLE
Add theme template management

### DIFF
--- a/js/__tests__/personalizationTemplates.test.js
+++ b/js/__tests__/personalizationTemplates.test.js
@@ -1,0 +1,42 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let saveNamedTheme, loadNamedTheme, deleteNamedTheme, switchTab;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <div id="colorControls"></div>
+    <select id="themeSelect"></select>
+    <button id="saveTheme"></button>
+    <button id="loadTheme"></button>
+    <button id="deleteTheme"></button>
+  `;
+  jest.unstable_mockModule('../uiHandlers.js', () => ({ loadAndApplyColors: jest.fn() }));
+  jest.unstable_mockModule('../themeConfig.js', () => ({
+    colorGroups: [{ name: 'Dashboard', items: [{ var: 'primary-color', label: '' }] }],
+    sampleThemes: { dashboard: { Light: { 'primary-color': '#010101' } } }
+  }));
+  ({ saveNamedTheme, loadNamedTheme, deleteNamedTheme, switchTab } = await import('../personalization.js'));
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  await Promise.resolve();
+  switchTab('Dashboard');
+});
+
+afterEach(() => {
+  localStorage.clear();
+  document.documentElement.style.cssText = '';
+  document.body.style.cssText = '';
+});
+
+test('saves, loads and deletes theme', () => {
+  const input = document.getElementById('Dashboard-primary-color');
+  input.value = '#aaaaaa';
+  saveNamedTheme('Dashboard', 't1');
+  expect(JSON.parse(localStorage.getItem('dashboardColorThemes')).t1['primary-color']).toBe('#aaaaaa');
+  input.value = '#bbbbbb';
+  loadNamedTheme('Dashboard', 't1');
+  expect(input.value).toBe('#aaaaaa');
+  deleteNamedTheme('Dashboard', 't1');
+  expect(JSON.parse(localStorage.getItem('dashboardColorThemes')).t1).toBeUndefined();
+});

--- a/personalization.html
+++ b/personalization.html
@@ -39,6 +39,12 @@
       <a href="code.html" class="button button-secondary back-link">← Назад</a>
       <h1>Основни цветове</h1>
       <div id="colorControls"></div>
+      <div class="theme-controls">
+        <select id="themeSelect"></select>
+        <button type="button" class="button button-secondary" id="loadTheme">Зареди</button>
+        <button type="button" class="button button-primary" id="saveTheme">Запази</button>
+        <button type="button" class="button button-danger" id="deleteTheme">Изтрий</button>
+      </div>
     </div>
   </div>
   <script type="module" src="js/personalization.js" defer></script>


### PR DESCRIPTION
## Summary
- add theme template dropdown and buttons in personalization page
- implement save, load and delete functions for themes
- preload sample themes on first load
- test color theme template logic

## Testing
- `npm run lint`
- `sh scripts/test.sh --runTestsByPath js/__tests__/personalizationTemplates.test.js`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6887c87d52f083268aa331b2e76d93f7