### PR TITLE
Добавен контейнер за диаграма на макросите

### DIFF
--- a/css/clientProfile.css
+++ b/css/clientProfile.css
@@ -244,3 +244,22 @@ body {
 .menu-table th {
   background: #f9f9f9;
 }
+
+.macro-chart-container {
+  min-height: 220px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  background: linear-gradient(90deg,
+      var(--macro-protein-color),
+      var(--macro-carbs-color),
+      var(--macro-fat-color));
+  color: var(--text-color-on-primary);
+  border-radius: 8px;
+}
+
+.macro-chart-container canvas {
+  max-width: 250px;
+  max-height: 250px;
+}

--- a/profileTemplate.html
+++ b/profileTemplate.html
@@ -514,6 +514,10 @@
                         </div>
                     </div>
                 </div>
+
+                <div class="macro-chart-container">
+                    <canvas id="macro-chart"></canvas>
+                </div>
                 
                 <h3 class="section-title"><i class="fas fa-calendar-alt me-2"></i>Седмично меню</h3>
                 


### PR DESCRIPTION
## Summary
- добавен HTML елемент за графиката на макронутриентите
- дефиниран CSS стил за `.macro-chart-container` с цветове от темата

## Testing
- `npm run lint`
- `npm test` *(неуспешно – грешка Out of Memory)*

------
https://chatgpt.com/codex/tasks/task_e_6887ce801c9083268c0b2921c243aa44