### PR TITLE
Add macro chart to client profile

### DIFF
--- a/clientProfile.html
+++ b/clientProfile.html
@@ -12,6 +12,7 @@
 <body>
   <div id="profileContainer"></div>
 
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="js/initProfilePage.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script>

--- a/js/__tests__/clientProfileChart.test.js
+++ b/js/__tests__/clientProfileChart.test.js
@@ -1,0 +1,64 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+beforeEach(() => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <span id="currentWeightHeader"></span>
+    <span id="planStatus"></span>
+    <span id="planStatusBadge"></span>
+    <div id="macroCards"></div>
+    <canvas id="macro-chart"></canvas>
+    <textarea id="planJson"></textarea>
+    <div id="planMenu"></div>
+    <div id="allowedFoodsContainer"></div>
+    <div id="forbiddenFoodsContainer"></div>
+    <div id="principlesSection"></div>
+    <div id="hydrationContainer"></div>
+    <div id="cookingMethodsContainer"></div>
+    <table><tbody id="logsTableBody"></tbody></table>
+    <div id="analyticsInfo"></div>
+    <div id="goalProgress"></div>
+    <div id="engagementScore"></div>
+    <div id="healthScore"></div>
+    <div id="goalProgressBar"></div>
+    <div id="engagementBar"></div>
+    <div id="healthBar"></div>
+    <div id="streakCalendar"></div>
+  `;
+  jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+  jest.unstable_mockModule('../labelMap.js', () => ({ labelMap: {}, statusMap: {} }));
+  jest.unstable_mockModule('../planEditor.js', () => ({ initPlanEditor: jest.fn(), gatherPlanFormData: jest.fn(() => ({})) }));
+});
+
+test('fillDashboard initializes doughnut chart and destroys previous', async () => {
+  const first = { destroy: jest.fn() };
+  const second = { destroy: jest.fn() };
+  global.Chart = jest.fn().mockReturnValueOnce(first).mockReturnValueOnce(second);
+  const { fillDashboard } = await import('../clientProfile.js');
+  const data = {
+    planData: {
+      caloriesMacros: {
+        calories: 2000,
+        protein_percent: 40,
+        carbs_percent: 40,
+        fat_percent: 20,
+        protein_grams: 120,
+        carbs_grams: 200,
+        fat_grams: 44
+      },
+      week1Menu: {},
+      allowedForbiddenFoods: {},
+      hydrationCookingSupplements: {}
+    },
+    dailyLogs: [],
+    analytics: { streak: { dailyStatusArray: [] } },
+    currentStatus: {}
+  };
+
+  fillDashboard(data);
+  fillDashboard(data);
+  expect(first.destroy).toHaveBeenCalled();
+  expect(global.Chart.mock.calls[0][1].type).toBe('doughnut');
+  expect(global.Chart).toHaveBeenCalledTimes(2);
+});

--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -2,6 +2,8 @@ import { apiEndpoints } from './config.js';
 import { labelMap, statusMap } from './labelMap.js';
 import { initPlanEditor, gatherPlanFormData } from './planEditor.js';
 
+let macroChart;
+
 function $(id) {
   return document.getElementById(id);
 }
@@ -171,6 +173,33 @@ function fillDashboard(data) {
       col.appendChild(card);
       macrosContainer.appendChild(col);
     });
+  }
+
+  if (data.planData?.caloriesMacros) {
+    if (macroChart) macroChart.destroy();
+    const ctx = document.getElementById('macro-chart');
+    if (ctx && typeof Chart !== 'undefined') {
+      const m = data.planData.caloriesMacros;
+      macroChart = new Chart(ctx, {
+        type: 'doughnut',
+        data: {
+          labels: [`Протеини (${m.protein_percent}%)`, `Въглехидрати (${m.carbs_percent}%)`, `Мазнини (${m.fat_percent}%)`],
+          datasets: [{
+            label: 'Разпределение на макроси',
+            data: [m.protein_grams, m.carbs_grams, m.fat_grams],
+            backgroundColor: ['rgb(54,162,235)', 'rgb(255,205,86)', 'rgb(255,99,132)'],
+            hoverOffset: 4
+          }]
+        },
+        options: {
+          responsive: true,
+          plugins: {
+            legend: { position: 'top' },
+            title: { display: true, text: `Дневен прием (${m.calories} kcal)` }
+          }
+        }
+      });
+    }
   }
 
   $('planJson').value = JSON.stringify(data.planData || {}, null, 2);


### PR DESCRIPTION
## Summary
- include Chart.js in `clientProfile.html`
- render macros doughnut chart in `fillDashboard` with destruction of old chart
- cover new behaviour with `clientProfileChart.test.js`

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6887d4bb2f108326850437bbafcdbade