### PR TITLE
Update questionnaire email tests

### DIFF
--- a/js/__tests__/submitQuestionnaireEmail.test.js
+++ b/js/__tests__/submitQuestionnaireEmail.test.js
@@ -23,7 +23,16 @@ test('sends analysis email on questionnaire submit', async () => {
       put: jest.fn()
     }
   }
-  const req = { json: async () => ({ email: 'user@site.bg', name: 'Иван' }) }
+  const req = { json: async () => ({
+    email: 'user@site.bg',
+    name: 'Иван',
+    gender: 'm',
+    age: 30,
+    height: 180,
+    weight: 80,
+    goal: 'gain',
+    medicalConditions: ['Нямам']
+  }) }
   const res = await handleSubmitQuestionnaire(req, env)
   expect(res.success).toBe(true)
   expect(fetch).toHaveBeenCalledWith('https://mail.example.com', expect.any(Object))
@@ -37,7 +46,15 @@ test('works without explicit mail configuration', async () => {
       put: jest.fn()
     }
   }
-  const req = { json: async () => ({ email: 'x@x.bg' }) }
+  const req = { json: async () => ({
+    email: 'x@x.bg',
+    gender: 'f',
+    age: 22,
+    height: 165,
+    weight: 55,
+    goal: 'tone',
+    medicalConditions: ['Нямам']
+  }) }
   const res = await handleSubmitQuestionnaire(req, env)
   expect(res.success).toBe(true)
   expect(fetch).toHaveBeenCalled()
@@ -52,7 +69,15 @@ test('ignores SEND_QUESTIONNAIRE_EMAIL flag', async () => {
       put: jest.fn()
     }
   }
-  const req = { json: async () => ({ email: 'a@b.bg' }) }
+  const req = { json: async () => ({
+    email: 'a@b.bg',
+    gender: 'f',
+    age: 35,
+    height: 170,
+    weight: 70,
+    goal: 'lose',
+    medicalConditions: ['Нямам']
+  }) }
   const res = await handleSubmitQuestionnaire(req, env)
   expect(res.success).toBe(true)
   expect(fetch).toHaveBeenCalled()

--- a/js/__tests__/submitQuestionnaireReadyStatus.test.js
+++ b/js/__tests__/submitQuestionnaireReadyStatus.test.js
@@ -25,7 +25,16 @@ describe('analysis status ready when ctx missing', () => {
       AI: { run: jest.fn().mockResolvedValue({ response: '{"score":1}' }) }
     }
     kvStore['email_to_uuid_a@b.bg'] = 'u1'
-    const req = { json: async () => ({ email: 'a@b.bg', name: 'A' }) }
+    const req = { json: async () => ({
+      email: 'a@b.bg',
+      name: 'A',
+      gender: 'm',
+      age: 28,
+      height: 175,
+      weight: 70,
+      goal: 'gain',
+      medicalConditions: ['Нямам']
+    }) }
     const res = await worker.handleSubmitQuestionnaire(req, env)
     expect(res.success).toBe(true)
     expect(kvStore['u1_analysis_status']).toBe('ready')
@@ -50,7 +59,16 @@ describe('analysis status ready when ctx missing', () => {
       AI: { run: jest.fn().mockResolvedValue({ response: '{"score":1}' }) }
     }
     kvStore['email_to_uuid_a@b.bg'] = 'u1'
-    const req = { json: async () => ({ email: 'a@b.bg', name: 'A' }) }
+    const req = { json: async () => ({
+      email: 'a@b.bg',
+      name: 'A',
+      gender: 'f',
+      age: 29,
+      height: 165,
+      weight: 60,
+      goal: 'tone',
+      medicalConditions: ['Нямам']
+    }) }
     const res = await worker.handleSubmitDemoQuestionnaire(req, env)
     expect(res.success).toBe(true)
     expect(kvStore['u1_analysis_status']).toBe('ready')


### PR DESCRIPTION
## Summary
- update submitQuestionnaireEmail tests with full questionnaire data
- ensure ready status tests include all required fields

## Testing
- `npm run lint`
- `sh scripts/test.sh js/__tests__/submitQuestionnaireEmail.test.js`
- `sh scripts/test.sh js/__tests__/submitQuestionnaireReadyStatus.test.js`
- `npm test` *(failed: process killed or timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6887e004f0e0832686ea89ae1c10fa0a