### PR TITLE
Display macro chart in analytics

### DIFF
--- a/js/__tests__/clientProfileChart.test.js
+++ b/js/__tests__/clientProfileChart.test.js
@@ -8,7 +8,8 @@ beforeEach(() => {
     <span id="planStatus"></span>
     <span id="planStatusBadge"></span>
     <div id="macroCards"></div>
-    <canvas id="macro-chart"></canvas>
+    <canvas id="macro-chart-plan"></canvas>
+    <canvas id="macro-chart-analytics"></canvas>
     <textarea id="planJson"></textarea>
     <div id="planMenu"></div>
     <div id="allowedFoodsContainer"></div>
@@ -31,10 +32,19 @@ beforeEach(() => {
   jest.unstable_mockModule('../planEditor.js', () => ({ initPlanEditor: jest.fn(), gatherPlanFormData: jest.fn(() => ({})) }));
 });
 
-test('fillDashboard initializes doughnut chart and destroys previous', async () => {
-  const first = { destroy: jest.fn() };
-  const second = { destroy: jest.fn() };
-  global.Chart = jest.fn().mockReturnValueOnce(first).mockReturnValueOnce(second);
+test('fillDashboard initializes doughnut charts and destroys previous', async () => {
+  const charts = [
+    { destroy: jest.fn() },
+    { destroy: jest.fn() },
+    { destroy: jest.fn() },
+    { destroy: jest.fn() }
+  ];
+  global.Chart = jest
+    .fn()
+    .mockReturnValueOnce(charts[0])
+    .mockReturnValueOnce(charts[1])
+    .mockReturnValueOnce(charts[2])
+    .mockReturnValueOnce(charts[3]);
   const { fillDashboard } = await import('../clientProfile.js');
   const data = {
     planData: {
@@ -58,7 +68,8 @@ test('fillDashboard initializes doughnut chart and destroys previous', async () 
 
   fillDashboard(data);
   fillDashboard(data);
-  expect(first.destroy).toHaveBeenCalled();
+  expect(charts[0].destroy).toHaveBeenCalled();
+  expect(charts[1].destroy).toHaveBeenCalled();
   expect(global.Chart.mock.calls[0][1].type).toBe('doughnut');
-  expect(global.Chart).toHaveBeenCalledTimes(2);
+  expect(global.Chart).toHaveBeenCalledTimes(4);
 });

--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -2,7 +2,8 @@ import { apiEndpoints } from './config.js';
 import { labelMap, statusMap } from './labelMap.js';
 import { initPlanEditor, gatherPlanFormData } from './planEditor.js';
 
-let macroChart;
+let macroChartPlan;
+let macroChartAnalytics;
 
 function $(id) {
   return document.getElementById(id);
@@ -176,11 +177,34 @@ function fillDashboard(data) {
   }
 
   if (data.planData?.caloriesMacros) {
-    if (macroChart) macroChart.destroy();
-    const ctx = document.getElementById('macro-chart');
-    if (ctx && typeof Chart !== 'undefined') {
-      const m = data.planData.caloriesMacros;
-      macroChart = new Chart(ctx, {
+    if (macroChartPlan) macroChartPlan.destroy();
+    if (macroChartAnalytics) macroChartAnalytics.destroy();
+    const m = data.planData.caloriesMacros;
+    const ctxPlan = document.getElementById('macro-chart-plan');
+    if (ctxPlan && typeof Chart !== 'undefined') {
+      macroChartPlan = new Chart(ctxPlan, {
+        type: 'doughnut',
+        data: {
+          labels: [`Протеини (${m.protein_percent}%)`, `Въглехидрати (${m.carbs_percent}%)`, `Мазнини (${m.fat_percent}%)`],
+          datasets: [{
+            label: 'Разпределение на макроси',
+            data: [m.protein_grams, m.carbs_grams, m.fat_grams],
+            backgroundColor: ['rgb(54,162,235)', 'rgb(255,205,86)', 'rgb(255,99,132)'],
+            hoverOffset: 4
+          }]
+        },
+        options: {
+          responsive: true,
+          plugins: {
+            legend: { position: 'top' },
+            title: { display: true, text: `Дневен прием (${m.calories} kcal)` }
+          }
+        }
+      });
+    }
+    const ctxAnal = document.getElementById('macro-chart-analytics');
+    if (ctxAnal && typeof Chart !== 'undefined') {
+      macroChartAnalytics = new Chart(ctxAnal, {
         type: 'doughnut',
         data: {
           labels: [`Протеини (${m.protein_percent}%)`, `Въглехидрати (${m.carbs_percent}%)`, `Мазнини (${m.fat_percent}%)`],

--- a/profileTemplate.html
+++ b/profileTemplate.html
@@ -516,7 +516,7 @@
                 </div>
 
                 <div class="macro-chart-container">
-                    <canvas id="macro-chart"></canvas>
+                    <canvas id="macro-chart-plan"></canvas>
                 </div>
                 
                 <h3 class="section-title"><i class="fas fa-calendar-alt me-2"></i>Седмично меню</h3>
@@ -664,7 +664,12 @@
                         </div>
                     </div>
                 </div>
-                
+
+                <h3 class="section-title"><i class="fas fa-chart-pie me-2"></i>Разпределение на макроелементите</h3>
+                <div class="macro-chart-container mb-4">
+                    <canvas id="macro-chart-analytics"></canvas>
+                </div>
+
                 <h3 class="section-title"><i class="fas fa-chart-bar me-2"></i>Детайлен анализ</h3>
                 
                 <div class="table-responsive">


### PR DESCRIPTION
## Summary
- show macro chart inside the analytics tab
- rename plan tab canvas and adjust chart logic
- support multiple charts in client profile script
- update chart tests

## Testing
- `npm run lint`
- `npm test` *(fails: FATAL ERROR: Reached heap limit Allocation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6887e40b74048326a30d963650173df3