### PR TITLE
Fix macro chart detection

### DIFF
--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -158,7 +158,7 @@ function fillDashboard(data) {
   const macrosContainer = $('macroCards');
   if (macrosContainer) {
     macrosContainer.innerHTML = '';
-    const macros = data.planData?.caloriesMacros || {};
+    const macros = data.planData?.caloriesMacros || data.planData?.calories_macros || {};
     const list = [
       { l: 'Калории', v: macros.calories, s: 'kcal дневно' },
       { l: 'Протеини', v: macros.protein_grams, s: macros.protein_percent ? `${macros.protein_percent}% от калориите` : '' },
@@ -176,10 +176,11 @@ function fillDashboard(data) {
     });
   }
 
-  if (data.planData?.caloriesMacros) {
+  const macroData = data.planData?.caloriesMacros || data.planData?.calories_macros;
+  if (macroData) {
     if (macroChartPlan) macroChartPlan.destroy();
     if (macroChartAnalytics) macroChartAnalytics.destroy();
-    const m = data.planData.caloriesMacros;
+    const m = macroData;
     const ctxPlan = document.getElementById('macro-chart-plan');
     if (ctxPlan && typeof Chart !== 'undefined') {
       macroChartPlan = new Chart(ctxPlan, {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -16,7 +16,8 @@ export function populateUI() {
     try { populateUserInfo(data.userName); } catch(e) { console.error("Error in populateUserInfo:", e); }
     try { populateDashboardMainIndexes(data.analytics?.current); } catch(e) { console.error("Error in populateDashboardMainIndexes:", e); }
     try { populateDashboardDetailedAnalytics(data.analytics); } catch(e) { console.error("Error in populateDashboardDetailedAnalytics:", e); }
-    try { populateDashboardMacros(data.planData?.caloriesMacros); } catch(e) { console.error("Error in populateDashboardMacros:", e); }
+    const macroData = data.planData?.caloriesMacros || data.planData?.calories_macros;
+    try { populateDashboardMacros(macroData); } catch(e) { console.error("Error in populateDashboardMacros:", e); }
     try { populateDashboardStreak(data.analytics?.streak); } catch(e) { console.error("Error in populateDashboardStreak:", e); }
     try { populateDashboardDailyPlan(data.planData?.week1Menu, data.dailyLogs, data.recipeData); } catch(e) { console.error("Error in populateDashboardDailyPlan:", e); }
     try { populateDashboardLog(data.dailyLogs, data.currentStatus, data.initialData); } catch(e) { console.error("Error in populateDashboardLog:", e); }


### PR DESCRIPTION
## Summary
- ensure both `caloriesMacros` and `calories_macros` work for macro charts

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max_old_space_size=4096 npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6887e818df088326853340292a3d49ad