### PR TITLE
Fix macro chart rendering

### DIFF
--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -10,7 +10,7 @@ import {
 import { handleLogout } from './auth.js';
 import { openExtraMealModal } from './extraMealForm.js';
 import { apiEndpoints } from './config.js';
-import { macroChartInstance, progressChartInstance } from './populateUI.js';
+import { macroChartInstance, progressChartInstance, renderPendingMacroChart } from './populateUI.js';
 import {
     handleSaveLog, handleFeedbackFormSubmit, // from app.js
     handleChatSend, handleChatInputKeypress, // from app.js / chat.js
@@ -125,7 +125,11 @@ export function setupStaticEventListeners() {
                 this.setAttribute('aria-expanded', !isOpen); this.classList.toggle('open', !isOpen);
                 const arrow = this.querySelector('.arrow'); if (arrow) arrow.style.transform = isOpen ? 'rotate(0deg)' : 'rotate(90deg)';
                 if (accContent) { accContent.style.display = isOpen ? 'none' : 'block'; accContent.classList.toggle('open-active', !isOpen); }
-                if (!isOpen) { macroChartInstance?.resize(); progressChartInstance?.resize(); }
+                if (!isOpen) {
+                    renderPendingMacroChart();
+                    macroChartInstance?.resize();
+                    progressChartInstance?.resize();
+                }
              });
              header.addEventListener('keydown', function(e) {
                 if(e.key === 'Enter' || e.key === ' ') {
@@ -133,7 +137,11 @@ export function setupStaticEventListeners() {
                     this.setAttribute('aria-expanded', !isOpen); this.classList.toggle('open', !isOpen);
                     const arrow = this.querySelector('.arrow'); if (arrow) arrow.style.transform = isOpen ? 'rotate(0deg)' : 'rotate(90deg)';
                     if (accContent) { accContent.style.display = isOpen ? 'none' : 'block'; accContent.classList.toggle('open-active', !isOpen); }
-                    if (!isOpen) { macroChartInstance?.resize(); progressChartInstance?.resize(); }
+                    if (!isOpen) {
+                        renderPendingMacroChart();
+                        macroChartInstance?.resize();
+                        progressChartInstance?.resize();
+                    }
                 }
             });
         }

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -7,6 +7,7 @@ import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAna
 
 export let macroChartInstance = null;
 export let progressChartInstance = null;
+let pendingMacroData = null;
 
 export function populateUI() {
     const data = fullDashboardData; // Access global state
@@ -258,40 +259,49 @@ function renderMacroAnalyticsCard(macros) {
     });
     card.appendChild(grid);
 
-    if (typeof Chart !== 'undefined') {
-        const ctx = canvas.getContext('2d');
-        macroChartInstance = new Chart(ctx, {
-            type: 'doughnut',
-            data: {
-                labels: [
-                    `Протеини (${macros.protein_percent}%)`,
-                    `Въглехидрати (${macros.carbs_percent}%)`,
-                    `Мазнини (${macros.fat_percent}%)`
-                ],
-                datasets: [{
-                    label: 'Разпределение на макроси',
-                    data: [macros.protein_grams, macros.carbs_grams, macros.fat_grams],
-                    backgroundColor: [
-                        getCssVar('--macro-protein-color', 'rgb(54,162,235)'),
-                        getCssVar('--macro-carbs-color', 'rgb(255,205,86)'),
-                        getCssVar('--macro-fat-color', 'rgb(255,99,132)')
-                    ],
-                    hoverOffset: 4
-                }]
-            },
-            options: {
-                responsive: true,
-                plugins: {
-                    legend: { position: 'top' },
-                    title: { display: true, text: `Дневен прием (${macros.calories} kcal)` }
-                }
-            }
-        });
-    } else {
-        console.warn('Chart.js is not loaded.');
-    }
+    // Chart will be initialized when the accordion is opened
 
     return card;
+}
+
+export function renderPendingMacroChart() {
+    if (!pendingMacroData) return;
+    const canvas = document.getElementById('macroChart');
+    if (!canvas || typeof Chart === 'undefined') return;
+    if (macroChartInstance) {
+        macroChartInstance.destroy();
+        macroChartInstance = null;
+    }
+    const m = pendingMacroData;
+    const ctx = canvas.getContext('2d');
+    macroChartInstance = new Chart(ctx, {
+        type: 'doughnut',
+        data: {
+            labels: [
+                `Протеини (${m.protein_percent}%)`,
+                `Въглехидрати (${m.carbs_percent}%)`,
+                `Мазнини (${m.fat_percent}%)`
+            ],
+            datasets: [{
+                label: 'Разпределение на макроси',
+                data: [m.protein_grams, m.carbs_grams, m.fat_grams],
+                backgroundColor: [
+                    getCssVar('--macro-protein-color', 'rgb(54,162,235)'),
+                    getCssVar('--macro-carbs-color', 'rgb(255,205,86)'),
+                    getCssVar('--macro-fat-color', 'rgb(255,99,132)')
+                ],
+                hoverOffset: 4
+            }]
+        },
+        options: {
+            responsive: true,
+            plugins: {
+                legend: { position: 'top' },
+                title: { display: true, text: `Дневен прием (${m.calories} kcal)` }
+            }
+        }
+    });
+    macroChartInstance.resize();
 }
 
 function populateDashboardMacros(macros) {
@@ -304,9 +314,14 @@ function populateDashboardMacros(macros) {
             macroChartInstance = null;
         }
     }
+    pendingMacroData = macros || null;
     if (macros) {
         const card = renderMacroAnalyticsCard(macros);
         selectors.analyticsCardsContainer.prepend(card);
+        const header = selectors.detailedAnalyticsAccordion?.querySelector('.accordion-header');
+        if (header && header.getAttribute('aria-expanded') === 'true') {
+            renderPendingMacroChart();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure macro chart is drawn when the detailed analytics accordion opens
- trigger chart creation during accordion toggle

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6887e80d9c4c8326a54ae12cdfb8654a