### PR TITLE
Add CI workflow for lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'


### PR DESCRIPTION
## Summary
- add GitHub Action `CI` workflow to run `npm run lint` and `npm test`
- enable npm cache with `actions/setup-node`

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6887fa0ac89c8326b320c3c450154271