### PR TITLE
Add theme script to info pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -91,5 +91,10 @@
       </div>
     </div>
   </footer>
+  <script src="script.js" type="module"></script>
+  <script type="module">
+    import { applyStoredTheme } from './js/personalization.js';
+    document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
+  </script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -96,5 +96,10 @@
       </div>
     </div>
   </footer>
+  <script src="script.js" type="module"></script>
+  <script type="module">
+    import { applyStoredTheme } from './js/personalization.js';
+    document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
+  </script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -99,5 +99,10 @@
       </div>
     </div>
   </footer>
+  <script src="script.js" type="module"></script>
+  <script type="module">
+    import { applyStoredTheme } from './js/personalization.js';
+    document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
+  </script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -102,5 +102,10 @@
       </div>
     </div>
   </footer>
+  <script src="script.js" type="module"></script>
+  <script type="module">
+    import { applyStoredTheme } from './js/personalization.js';
+    document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
+  </script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -91,5 +91,10 @@
       </div>
     </div>
   </footer>
+  <script src="script.js" type="module"></script>
+  <script type="module">
+    import { applyStoredTheme } from './js/personalization.js';
+    document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
+  </script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -93,5 +93,10 @@
       </div>
     </div>
   </footer>
+  <script src="script.js" type="module"></script>
+  <script type="module">
+    import { applyStoredTheme } from './js/personalization.js';
+    document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- inject the personalization snippet before `</body>` on info pages
- run lint and tests

## Testing
- `npm run lint`
- `npx jest --runInBand` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68883f849c1c8326b68d88ccb3938ed9