### PR TITLE
Improve mobile menu detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -149,6 +149,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const body = document.body;
     const nav = document.getElementById('nav');
     const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
+    if (!mobileMenuBtn || !nav) {
+        console.warn('script.js: липсва елемент за мобилно меню', {
+            btnExists: !!mobileMenuBtn,
+            navExists: !!nav
+        });
+    }
     const themeToggleBtn = document.getElementById('theme-toggle');
     
     // Модален прозорец


### PR DESCRIPTION
## Summary
- log warning if mobile menu elements are missing

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: Reached heap limit Allocation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68884e3c51a483268ccb1f0193a00e1a