### PR TITLE
Fix mobile menu on content pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -91,7 +91,7 @@
       </div>
     </div>
   </footer>
-  <script src="script.js" type="module"></script>
+  <script src="js/basicNav.js" type="module"></script>
   <script type="module">
     import { applyStoredTheme } from './js/personalization.js';
     document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));

--- a/blog.html
+++ b/blog.html
@@ -96,7 +96,7 @@
       </div>
     </div>
   </footer>
-  <script src="script.js" type="module"></script>
+  <script src="js/basicNav.js" type="module"></script>
   <script type="module">
     import { applyStoredTheme } from './js/personalization.js';
     document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));

--- a/contact.html
+++ b/contact.html
@@ -99,7 +99,7 @@
       </div>
     </div>
   </footer>
-  <script src="script.js" type="module"></script>
+  <script src="js/basicNav.js" type="module"></script>
   <script type="module">
     import { applyStoredTheme } from './js/personalization.js';
     document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));

--- a/faq.html
+++ b/faq.html
@@ -102,7 +102,7 @@
       </div>
     </div>
   </footer>
-  <script src="script.js" type="module"></script>
+  <script src="js/basicNav.js" type="module"></script>
   <script type="module">
     import { applyStoredTheme } from './js/personalization.js';
     document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));

--- a/js/basicNav.js
+++ b/js/basicNav.js
@@ -1,0 +1,46 @@
+export function initBasicNav() {
+  const body = document.body;
+  const nav = document.getElementById('nav');
+  const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
+  if (mobileMenuBtn && nav) {
+    const toggle = () => {
+      const open = body.classList.toggle('nav-open');
+      mobileMenuBtn.setAttribute('aria-expanded', open);
+    };
+    mobileMenuBtn.addEventListener('click', toggle);
+    nav.querySelectorAll('.nav-link').forEach(link => {
+      link.addEventListener('click', () => {
+        if (body.classList.contains('nav-open')) {
+          toggle();
+        }
+      });
+    });
+  }
+  const themeToggleBtn = document.getElementById('theme-toggle');
+  if (themeToggleBtn) {
+    const updateIcon = () => {
+      const dark = document.body.classList.contains('dark-theme');
+      themeToggleBtn.innerHTML = dark
+        ? '<i class="bi bi-brightness-high-fill"></i>'
+        : '<i class="bi bi-moon-stars-fill"></i>';
+    };
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.body.classList.add(stored === 'dark' ? 'dark-theme' : 'light-theme');
+    }
+    updateIcon();
+    themeToggleBtn.addEventListener('click', () => {
+      document.body.classList.toggle('dark-theme');
+      document.body.classList.toggle('light-theme');
+      const isDark = document.body.classList.contains('dark-theme');
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      updateIcon();
+    });
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initBasicNav);
+} else {
+  initBasicNav();
+}

--- a/privacy.html
+++ b/privacy.html
@@ -91,7 +91,7 @@
       </div>
     </div>
   </footer>
-  <script src="script.js" type="module"></script>
+  <script src="js/basicNav.js" type="module"></script>
   <script type="module">
     import { applyStoredTheme } from './js/personalization.js';
     document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));

--- a/terms.html
+++ b/terms.html
@@ -93,7 +93,7 @@
       </div>
     </div>
   </footer>
-  <script src="script.js" type="module"></script>
+  <script src="js/basicNav.js" type="module"></script>
   <script type="module">
     import { applyStoredTheme } from './js/personalization.js';
     document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));


### PR DESCRIPTION
## Summary
- create `js/basicNav.js` for lightweight mobile menu and theme toggle
- use `basicNav.js` instead of heavy `script.js` on content pages

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688854eeef508326870767e3e9e818e8