### PR TITLE
Update macro chart visuals

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -38,9 +38,9 @@
   --input-focus-shadow: rgba(58, 80, 107, 0.25);
 
   /* Цветове за макро диаграмата */
-  --macro-protein-color: #36A2EB;
-  --macro-carbs-color: #FFCD56;
-  --macro-fat-color: #FF6384;
+  --macro-protein-color: #36A2EB; /* Синьо за белтъчини */
+  --macro-fat-color: #FFCD56;     /* Жълто за мазнини */
+  --macro-carbs-color: #FF6384;   /* Червено за въглехидрати */
 
   --shadow-sm: 0 2px 4px rgba(0,0,0,0.05);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.07);

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -167,7 +167,8 @@
 .analytics-card .mini-progress-fill.animate-progress {
   animation: progress-grow 0.8s forwards;
 }
-.analytics-card { cursor: pointer; }
+.analytics-card { cursor: pointer; transition: transform 0.3s ease; }
+.analytics-card.open { transform: scale(1.03); }
 .metric-current-text {
   margin-bottom: var(--space-sm);
   font-weight: 600;
@@ -177,7 +178,7 @@
   overflow: hidden;
   max-height: 0;
   opacity: 0;
-  transition: max-height 0.3s ease, opacity 0.3s ease;
+  transition: max-height 0.4s ease, opacity 0.4s ease;
 }
 .analytics-card.open .analytics-card-details {
   max-height: 500px;

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -247,14 +247,26 @@ function renderMacroAnalyticsCard(macros) {
     grid.className = 'macro-metrics-grid';
     const list = [
         { l: 'Калории', v: macros.calories, s: 'kcal дневно' },
-        { l: 'Протеини', v: macros.protein_grams, s: macros.protein_percent ? `${macros.protein_percent}%` : '' },
-        { l: 'Въглехидрати', v: macros.carbs_grams, s: macros.carbs_percent ? `${macros.carbs_percent}%` : '' },
-        { l: 'Мазнини', v: macros.fat_grams, s: macros.fat_percent ? `${macros.fat_percent}%` : '' }
+        { l: 'Белтъчини', v: macros.protein_grams, s: macros.protein_percent ? `${macros.protein_percent}%` : '', c: '--macro-protein-color' },
+        { l: 'Въглехидрати', v: macros.carbs_grams, s: macros.carbs_percent ? `${macros.carbs_percent}%` : '', c: '--macro-carbs-color' },
+        { l: 'Мазнини', v: macros.fat_grams, s: macros.fat_percent ? `${macros.fat_percent}%` : '', c: '--macro-fat-color' }
     ];
     list.forEach(item => {
         const div = document.createElement('div');
         div.className = 'macro-metric';
-        div.innerHTML = `<div class="macro-label">${item.l}</div><div class="macro-value">${item.v ?? '--'}</div><div class="macro-subtitle">${item.s}</div>`;
+        const label = document.createElement('div');
+        label.className = 'macro-label';
+        if (item.c) label.style.color = getCssVar(item.c);
+        label.textContent = item.l;
+        const valueDiv = document.createElement('div');
+        valueDiv.className = 'macro-value';
+        valueDiv.textContent = item.v ?? '--';
+        const subDiv = document.createElement('div');
+        subDiv.className = 'macro-subtitle';
+        subDiv.textContent = item.s;
+        div.appendChild(label);
+        div.appendChild(valueDiv);
+        div.appendChild(subDiv);
         grid.appendChild(div);
     });
     card.appendChild(grid);
@@ -278,7 +290,7 @@ export function renderPendingMacroChart() {
         type: 'doughnut',
         data: {
             labels: [
-                `Протеини (${m.protein_percent}%)`,
+                `Белтъчини (${m.protein_percent}%)`,
                 `Въглехидрати (${m.carbs_percent}%)`,
                 `Мазнини (${m.fat_percent}%)`
             ],
@@ -296,7 +308,7 @@ export function renderPendingMacroChart() {
         options: {
             responsive: true,
             plugins: {
-                legend: { position: 'top' },
+                legend: { display: false },
                 title: { display: true, text: `Дневен прием (${m.calories} kcal)` }
             }
         }


### PR DESCRIPTION
## Summary
- tweak macro color variables
- emphasize analytics card open animation
- color macro labels to match chart
- hide legend in macro chart

## Testing
- `npm run lint`
- `npm test` *(fails: showToastMock not called)*

------
https://chatgpt.com/codex/tasks/task_e_6888557bb3ac83269623335e9e4c5d3a