### PR TITLE
Improve mobile nav toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ For a quick overview in Bulgarian, see [docs/DEV_GUIDE_BG.md](docs/DEV_GUIDE_BG.
 npm install
 ```
 
+3. Проверете кода и тестовете:
+
+```bash
+npm run lint
+npm test
+```
+
 ### Start Development Server
 
 Run the Vite dev server which provides hot reload:
@@ -26,6 +33,10 @@ API requests to paths starting with `/api` are automatically proxied to
 `https://openapichatbot.radilov-k.workers.dev` when running the dev server.
 
 The application will be available at `http://localhost:5173` by default.
+
+### Мобилна навигация
+
+Менюто вече превърта страницата до горе при отваряне и се показва над заглавката благодарение на `z-index: 1100`. Уверете се, че всяка страница зарежда `script.js` или `js/basicNav.js`.
 
 ### Динамична тема
 

--- a/js/basicNav.js
+++ b/js/basicNav.js
@@ -6,6 +6,7 @@ export function initBasicNav() {
     const toggle = () => {
       const open = body.classList.toggle('nav-open');
       mobileMenuBtn.setAttribute('aria-expanded', open);
+      if (open) window.scrollTo({ top: 0 });
     };
     mobileMenuBtn.addEventListener('click', toggle);
     nav.querySelectorAll('.nav-link').forEach(link => {

--- a/script.js
+++ b/script.js
@@ -188,8 +188,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // 2. Мобилно меню
     if (mobileMenuBtn && nav) {
         const toggleNav = () => {
-            body.classList.toggle('nav-open');
-            mobileMenuBtn.setAttribute('aria-expanded', body.classList.contains('nav-open'));
+            const open = body.classList.toggle('nav-open');
+            mobileMenuBtn.setAttribute('aria-expanded', open);
+            if (open) window.scrollTo({ top: 0 });
         };
         mobileMenuBtn.addEventListener('click', toggleNav);
         nav.addEventListener('click', (e) => { if (e.target === nav) toggleNav(); });

--- a/style.css
+++ b/style.css
@@ -203,7 +203,7 @@ footer { background: var(--dark-bg); color: var(--light-text); padding: 80px 0 3
     .section-title h2 { font-size: 2rem; }
     .cta h2 { font-size: 2.2rem; }
     .mobile-menu-btn { display: flex; align-items: center; justify-content: center; width: 40px; height: 40px; }
-    nav { position: fixed; top: 0; left: -100%; width: 100%; height: 100%; background: var(--card-bg); backdrop-filter: blur(10px); display: flex; align-items: center; justify-content: center; opacity: 0; visibility: hidden; transition: opacity 0.4s ease, left 0.4s ease, visibility 0.4s; z-index: 1000; }
+    nav { position: fixed; top: 0; left: -100%; width: 100%; height: 100%; background: var(--card-bg); backdrop-filter: blur(10px); display: flex; align-items: center; justify-content: center; opacity: 0; visibility: hidden; transition: opacity 0.4s ease, left 0.4s ease, visibility 0.4s; z-index: 1100; }
     .nav-open nav { left: 0; opacity: 1; visibility: visible; }
     nav ul { flex-direction: column; text-align: center; }
     nav ul li { margin: 15px 0; }


### PR DESCRIPTION
## Summary
- scroll to top when opening mobile menu
- layer mobile nav above header
- add lint/test steps to dev guide
- note new mobile nav behaviour in README

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError in multiple tests)*
- `npm run test:related` *(fails: OOM and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68885d913f20832693616d202f10997d