### PR TITLE
Добавен бутон за нулиране на цветовата персонализация

### DIFF
--- a/js/personalization.js
+++ b/js/personalization.js
@@ -109,6 +109,24 @@ export function deleteNamedTheme(groupName, name, variant = activeVariant) {
   }
 }
 
+export function resetTheme(groupName, variant = activeVariant) {
+  const themes = getSavedThemes(groupName, variant);
+  if (themes.Custom) {
+    delete themes.Custom;
+    storeThemes(groupName, variant, themes);
+  }
+  const groups = getGroups(groupName);
+  groups.forEach(g => {
+    g.items.forEach(item => {
+      document.documentElement.style.removeProperty(`--${item.var}`);
+      document.body.style.removeProperty(`--${item.var}`);
+      const el = inputs[`${groupName}-${item.var}-${variant}`];
+      if (el) el.value = getCurrentColor(item.var);
+    });
+  });
+  populateThemeSelect(groupName, variant);
+}
+
 function ensureSampleThemes() {
   const map = {
     Dashboard: sampleThemes.dashboard,
@@ -301,6 +319,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const saveBtn = document.getElementById('saveTheme');
   const loadBtn = document.getElementById('loadTheme');
   const deleteBtn = document.getElementById('deleteTheme');
+  const resetBtn = document.getElementById('resetTheme');
   const select = document.getElementById('themeSelect');
   if (saveBtn) {
     saveBtn.addEventListener('click', () => {
@@ -313,5 +332,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
   if (deleteBtn && select) {
     deleteBtn.addEventListener('click', () => deleteNamedTheme(activeGroup, select.value, activeVariant));
+  }
+  if (resetBtn) {
+    resetBtn.addEventListener('click', () => resetTheme(activeGroup, activeVariant));
   }
 });

--- a/personalization.html
+++ b/personalization.html
@@ -45,6 +45,7 @@
         <button type="button" class="button button-secondary" id="loadTheme">Зареди</button>
         <button type="button" class="button button-primary" id="saveTheme">Запази</button>
         <button type="button" class="button button-danger" id="deleteTheme">Изтрий</button>
+        <button type="button" class="button" id="resetTheme">Нулирай</button>
       </section>
     </div>
   </div>


### PR DESCRIPTION
## Резюме
- добавен бутон "Нулирай" в `personalization.html`
- имплементирана функция `resetTheme` и свързан слушател в `personalization.js`

## Тестване
- `npm run lint`
- `npm test` *(неуспешно поради OOM)*

------
https://chatgpt.com/codex/tasks/task_e_688908fc79a08326b4798b6a56638458