### PR TITLE
Fix personalization theme override

### DIFF
--- a/js/personalization.js
+++ b/js/personalization.js
@@ -309,6 +309,7 @@ export function applyStoredTheme(groupName) {
 
 document.addEventListener('DOMContentLoaded', async () => {
   await loadAndApplyColors();
+  ['Dashboard', 'Index', 'Quest'].forEach(applyStoredTheme);
   const container = document.getElementById('colorControls');
   if (!container) return;
   ensureSampleThemes();


### PR DESCRIPTION
## Summary
- ensure personalization page loads user's saved colors

## Testing
- `npm run lint`
- `npm test` *(fails: killed during jest run)*

------
https://chatgpt.com/codex/tasks/task_e_68891d06f2e08326a45226427df79526