### PR TITLE
Add maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,27 @@ ALLOWED_ORIGINS = "https://admin.example.com,https://myapp.example.com"
 
 This list is combined with the defaults when building the CORS headers.
 
+### Maintenance Mode
+
+Set `MAINTENANCE_MODE=1` to show a static maintenance page for every request.
+The worker looks for a KV entry `maintenance_page` and falls back to
+`maintenance.html` when the key is missing.
+
+Example `.env` value:
+
+```env
+MAINTENANCE_MODE=1
+```
+
+Or in `wrangler.toml`:
+
+```toml
+[vars]
+MAINTENANCE_MODE = "1"
+```
+
+Set to `0` or remove the variable to disable the mode.
+
 ### PHP API Environment Variables
 
 The PHP helper scripts expect the following variables set in the server environment:

--- a/maintenance.html
+++ b/maintenance.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MyBody.Best – Поддръжка</title>
+  <link rel="stylesheet" href="css/base_styles.css">
+  <link rel="stylesheet" href="css/index_styles.css">
+  <link rel="stylesheet" href="css/responsive_styles.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="landing-container">
+    <div class="card">
+      <h1>В момента обновяваме сайта</h1>
+      <p>Опитайте отново след малко и благодарим за разбирането.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/worker.js
+++ b/worker.js
@@ -285,6 +285,13 @@ const AI_CONFIG_KEYS = [
     'send_questionnaire_email',
     'colors'
 ];
+const MAINTENANCE_FALLBACK_HTML = `<!DOCTYPE html>
+<html lang="bg">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MyBody.Best – Поддръжка</title>
+</head>
+<body><h1>В момента обновяваме сайта</h1><p>Опитайте отново след малко.</p></body>
+</html>`;
 // ------------- END BLOCK: GlobalConstantsAndBindings -------------
 
 // ------------- START BLOCK: HelperFunctions -------------
@@ -359,6 +366,15 @@ export default {
 
         if (method === 'OPTIONS') {
             return new Response(null, { status: 204, headers: corsHeaders });
+        }
+
+        if (env.MAINTENANCE_MODE === '1') {
+            const maint = env.RESOURCES_KV ? await env.RESOURCES_KV.get('maintenance_page') : null;
+            const html = maint || MAINTENANCE_FALLBACK_HTML;
+            return new Response(html, {
+                status: 503,
+                headers: { ...corsHeaders, 'Content-Type': 'text/html' }
+            });
         }
 
         let responseBody = {};


### PR DESCRIPTION
## Summary
- create `maintenance.html`
- add check for `MAINTENANCE_MODE` in `worker.js`
- document how to enable maintenance mode in `README`

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688928dea4208326bb241910e07464dc