### PR TITLE
Добавени цветове за макро диаграма

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -41,6 +41,8 @@
   --macro-protein-color: #36A2EB; /* Синьо за белтъчини */
   --macro-fat-color: #FFCD56;     /* Жълто за мазнини */
   --macro-carbs-color: #FF6384;   /* Червено за въглехидрати */
+  --macro-ring-highlight: #ffffff; /* Подчертаване на кръга */
+  --macro-stroke-color: #e0e0e0;   /* Рамка на диаграмата */
 
   --shadow-sm: 0 2px 4px rgba(0,0,0,0.05);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.07);
@@ -164,6 +166,13 @@ body.dark-theme {
   --shadow-soft: 0px 6px 18px rgba(var(--surface-background-rgb), 0.5), 0px 2px 7px rgba(var(--surface-background-rgb), 0.3);
 
   --progress-bar-bg-empty: #393E57;
+
+  /* Макро диаграма - тъмна тема */
+  --macro-protein-color: #36A2EB;
+  --macro-fat-color: #FFCD56;
+  --macro-carbs-color: #FF6384;
+  --macro-ring-highlight: #1C1F2E;
+  --macro-stroke-color: #444444;
 
   --toast-bg: rgba(37, 42, 65, 0.95); --toast-text: #F0F2F5;
   --modal-overlay-bg: rgba(0,0,0, 0.75);

--- a/js/themeConfig.js
+++ b/js/themeConfig.js
@@ -45,6 +45,16 @@ export const colorGroups = [
     ]
   },
   {
+    name: 'Цветове на макроси',
+    items: [
+      { var: 'macro-protein-color', label: 'Белтъчини' },
+      { var: 'macro-carbs-color', label: 'Въглехидрати' },
+      { var: 'macro-fat-color', label: 'Мазнини' },
+      { var: 'macro-ring-highlight', label: 'Акцент на пръстен' },
+      { var: 'macro-stroke-color', label: 'Цвят на рамка' }
+    ]
+  },
+  {
     name: 'Index',
     items: [
       { var: 'primary-color', label: 'Основен цвят' },
@@ -80,15 +90,30 @@ export const sampleThemes = {
   dashboard: {
     Light: {
       'primary-color': '#3A506B',
-      'secondary-color': '#5BC0BE'
+      'secondary-color': '#5BC0BE',
+      'macro-protein-color': '#36A2EB',
+      'macro-carbs-color': '#FF6384',
+      'macro-fat-color': '#FFCD56',
+      'macro-ring-highlight': '#ffffff',
+      'macro-stroke-color': '#e0e0e0'
     },
     Dark: {
       'primary-color': '#5BC0BE',
-      'secondary-color': '#3A506B'
+      'secondary-color': '#3A506B',
+      'macro-protein-color': '#36A2EB',
+      'macro-carbs-color': '#FF6384',
+      'macro-fat-color': '#FFCD56',
+      'macro-ring-highlight': '#1C1F2E',
+      'macro-stroke-color': '#444444'
     },
     Vivid: {
       'primary-color': '#ff0066',
-      'secondary-color': '#ffcc00'
+      'secondary-color': '#ffcc00',
+      'macro-protein-color': '#0099ff',
+      'macro-carbs-color': '#ff0066',
+      'macro-fat-color': '#ffcc00',
+      'macro-ring-highlight': '#ffffff',
+      'macro-stroke-color': '#333333'
     }
   },
   index: {


### PR DESCRIPTION
## Summary
- добавена е нова група **Цветове на макроси** в `themeConfig.js`
- разширени са примерните теми с новите променливи
- в `base_styles.css` са дефинирани стойности за светла и тъмна тема

## Testing
- `npm run lint`
- `npm test` *(неуспешно поради ограничение на средата)*

------
https://chatgpt.com/codex/tasks/task_e_688931b2bae88326a91d057dfce5d2c7