### PR TITLE
Fix test memory usage

### DIFF
--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -81,6 +81,10 @@ beforeEach(async () => {
   ({ populateUI } = await import('../populateUI.js'));
 });
 
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
 test('populates dashboard sections', () => {
   populateUI();
   expect(document.getElementById('headerTitle').textContent).toBe('Табло: Иван');

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,5 +10,15 @@ if [ ! -x node_modules/.bin/jest ]; then
 fi
 
 # Run Jest serially with increased memory limit and experimental VM modules
-NODE_OPTIONS="--max-old-space-size=4096 ${NODE_OPTIONS:-} --experimental-vm-modules" \
-  npx --no-install jest --runInBand "$@"
+# Execute each test file in a separate process to avoid memory leaks
+export NODE_OPTIONS="--max-old-space-size=4096 ${NODE_OPTIONS:-} --experimental-vm-modules"
+
+if [ "$#" -eq 0 ]; then
+  set -- $(npx --no-install jest --listTests)
+fi
+
+exit_code=0
+for test_file in "$@"; do
+  npx --no-install jest --runInBand "$test_file" || exit_code=1
+done
+exit $exit_code


### PR DESCRIPTION
## Summary
- avoid memory leaks in populateUI tests by clearing the DOM after each test
- run each jest file in a separate process to keep memory usage small

## Testing
- `npm run lint`
- `npm test` *(fails: handleSendEmailRequest and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68893cb9983c832691a063cd457d95f7