### PR TITLE
Add maintenance mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,10 @@ Or in `wrangler.toml`:
 MAINTENANCE_MODE = "1"
 ```
 
+В админ панела има бутон „Режим на поддръжка", който използва
+ендпойнтите `/api/getMaintenanceMode` и `/api/setMaintenanceMode` за
+динамично включване или изключване на режима без промяна на конфигурационни файлове.
+
 Set to `0` or remove the variable to disable the mode.
 
 ### PHP API Environment Variables

--- a/admin.html
+++ b/admin.html
@@ -16,6 +16,7 @@
 <body>
   <h1>Администраторски панел <span id="notificationIndicator" class="notification-dot hidden"></span></h1>
   <p><a href="logout.html">Изход</a></p>
+  <p><button id="toggleMaintenance" class="button button-secondary button-small">Режим на поддръжка: <span id="maintenanceStatus">...</span></button></p>
   <section id="notificationsSection" class="card">
     <h2>Известия</h2>
     <ul id="notificationsList"></ul>

--- a/js/__tests__/maintenanceMode.test.js
+++ b/js/__tests__/maintenanceMode.test.js
@@ -1,0 +1,36 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+describe('maintenanceMode helpers', () => {
+  let loadMaintenanceFlag, setMaintenanceFlag;
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.unstable_mockModule('../config.js', () => ({
+      apiEndpoints: { getMaintenanceMode: '/getM', setMaintenanceMode: '/setM' }
+    }));
+    ({ loadMaintenanceFlag, setMaintenanceFlag } = await import('../maintenanceMode.js'));
+  });
+  afterEach(() => {
+    global.fetch && global.fetch.mockRestore();
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  test('loadMaintenanceFlag fetches flag', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, enabled: 1 }) });
+    const res = await loadMaintenanceFlag();
+    expect(global.fetch).toHaveBeenCalledWith('/getM');
+    expect(res).toBe(true);
+  });
+
+  test('setMaintenanceFlag posts with token', async () => {
+    sessionStorage.setItem('adminToken', 't');
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+    await setMaintenanceFlag(true);
+    expect(global.fetch).toHaveBeenCalledWith('/setM', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' },
+      body: JSON.stringify({ enabled: 1 })
+    }));
+  });
+});

--- a/js/__tests__/maintenanceWorker.test.js
+++ b/js/__tests__/maintenanceWorker.test.js
@@ -1,0 +1,31 @@
+import { jest } from '@jest/globals';
+import { handleGetMaintenanceMode, handleSetMaintenanceMode } from '../worker.js';
+
+function createStore(initial = {}) {
+  const store = { ...initial };
+  return {
+    get: jest.fn(async key => store[key] || null),
+    put: jest.fn(async (key, val) => { store[key] = String(val); }),
+    _store: store
+  };
+}
+
+test('getMaintenanceMode reads flag', async () => {
+  const kv = createStore({ maintenance_mode: '1' });
+  const env = { RESOURCES_KV: kv, MAINTENANCE_MODE: '0' };
+  const res = await handleGetMaintenanceMode({}, env);
+  expect(res.success).toBe(true);
+  expect(res.enabled).toBe(true);
+});
+
+test('setMaintenanceMode validates token and stores value', async () => {
+  const kv = createStore();
+  const env = { RESOURCES_KV: kv, WORKER_ADMIN_TOKEN: 's' };
+  const bad = { headers: { get: () => '' }, json: async () => ({ enabled: true }) };
+  const badRes = await handleSetMaintenanceMode(bad, env);
+  expect(badRes.success).toBe(false);
+  const good = { headers: { get: h => h === 'Authorization' ? 'Bearer s' : null }, json: async () => ({ enabled: true }) };
+  const goodRes = await handleSetMaintenanceMode(good, env);
+  expect(goodRes.success).toBe(true);
+  expect(kv._store['maintenance_mode']).toBe('1');
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -4,6 +4,7 @@ import { labelMap, statusMap } from './labelMap.js';
 import { fileToDataURL, fileToText, getProgressColor, animateProgressFill } from './utils.js';
 import { loadTemplateInto } from './templateLoader.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
+import { loadMaintenanceFlag, setMaintenanceFlag } from './maintenanceMode.js';
 
 async function ensureLoggedIn() {
     if (localStorage.getItem('adminSession') === 'true') {
@@ -38,6 +39,8 @@ const clientRepliesList = document.getElementById('clientRepliesList');
 const feedbackList = document.getElementById('feedbackList');
 const statsOutput = document.getElementById('statsOutput');
 const showStatsBtn = document.getElementById('showStats');
+const maintenanceBtn = document.getElementById('toggleMaintenance');
+const maintenanceStatus = document.getElementById('maintenanceStatus');
 const sortOrderSelect = document.getElementById('sortOrder');
 const initialAnswersPre = document.getElementById('initialAnswers');
 const planMenuPre = document.getElementById('planMenu');
@@ -1513,6 +1516,30 @@ async function sendTestQuestionnaire() {
     }
 }
 
+async function refreshMaintenanceStatus() {
+    if (!maintenanceBtn) return;
+    try {
+        const enabled = await loadMaintenanceFlag();
+        maintenanceBtn.dataset.enabled = enabled ? '1' : '0';
+        if (maintenanceStatus) maintenanceStatus.textContent = enabled ? 'включен' : 'изключен';
+    } catch (err) {
+        console.error('Error loading maintenance mode:', err);
+    }
+}
+
+async function toggleMaintenanceMode() {
+    if (!maintenanceBtn) return;
+    const enabled = maintenanceBtn.dataset.enabled === '1';
+    try {
+        await setMaintenanceFlag(!enabled);
+        maintenanceBtn.dataset.enabled = enabled ? '0' : '1';
+        if (maintenanceStatus) maintenanceStatus.textContent = !enabled ? 'включен' : 'изключен';
+    } catch (err) {
+        console.error('Error toggling maintenance mode:', err);
+        alert('Грешка при промяна на режима.');
+    }
+}
+
 async function loadAiPresets() {
     if (!presetSelect) return;
     try {
@@ -1727,6 +1754,11 @@ if (testQuestionnaireForm) {
         e.preventDefault();
         await sendTestQuestionnaire();
     });
+}
+
+if (maintenanceBtn) {
+    maintenanceBtn.addEventListener('click', toggleMaintenanceMode);
+    refreshMaintenanceStatus();
 }
 
 export {

--- a/js/config.js
+++ b/js/config.js
@@ -54,7 +54,9 @@ export const apiEndpoints = {
     submitDemoQuestionnaire: `${workerBaseUrl}/api/submitDemoQuestionnaire`,
     reAnalyzeQuestionnaire: `${workerBaseUrl}/api/reAnalyzeQuestionnaire`,
     analysisStatus: `${workerBaseUrl}/api/analysisStatus`,
-    getInitialAnalysis: `${workerBaseUrl}/api/getInitialAnalysis`
+    getInitialAnalysis: `${workerBaseUrl}/api/getInitialAnalysis`,
+    getMaintenanceMode: `${workerBaseUrl}/api/getMaintenanceMode`,
+    setMaintenanceMode: `${workerBaseUrl}/api/setMaintenanceMode`
 };
 
 // Cloudflare Account ID за използване в чат асистента

--- a/js/maintenanceMode.js
+++ b/js/maintenanceMode.js
@@ -1,0 +1,31 @@
+import { apiEndpoints } from './config.js';
+
+/**
+ * Зарежда стойността на режима за поддръжка.
+ * @returns {Promise<boolean>} true ако е включен.
+ */
+export async function loadMaintenanceFlag() {
+    const resp = await fetch(apiEndpoints.getMaintenanceMode);
+    const data = await resp.json();
+    if (!resp.ok || !data.success) throw new Error(data.message || 'Error');
+    return data.enabled === true || data.enabled === '1';
+}
+
+/**
+ * Записва режима за поддръжка.
+ * @param {boolean} enabled
+ * @returns {Promise<object>} Отговорът от API.
+ */
+export async function setMaintenanceFlag(enabled) {
+    const adminToken = sessionStorage.getItem('adminToken') || localStorage.getItem('adminToken') || '';
+    const headers = { 'Content-Type': 'application/json' };
+    if (adminToken) headers.Authorization = `Bearer ${adminToken}`;
+    const resp = await fetch(apiEndpoints.setMaintenanceMode, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ enabled: enabled ? 1 : 0 })
+    });
+    const data = await resp.json();
+    if (!resp.ok || !data.success) throw new Error(data.message || 'Error');
+    return data;
+}

--- a/worker.js
+++ b/worker.js
@@ -368,7 +368,8 @@ export default {
             return new Response(null, { status: 204, headers: corsHeaders });
         }
 
-        if (env.MAINTENANCE_MODE === '1') {
+        const kvFlag = env.RESOURCES_KV ? await env.RESOURCES_KV.get('maintenance_mode') : null;
+        if (env.MAINTENANCE_MODE === '1' || kvFlag === '1') {
             const maint = env.RESOURCES_KV ? await env.RESOURCES_KV.get('maintenance_page') : null;
             const html = maint || MAINTENANCE_FALLBACK_HTML;
             return new Response(html, {
@@ -482,6 +483,10 @@ export default {
                 responseBody = await handleTestAiModelRequest(request, env);
             } else if (method === 'POST' && path === '/api/sendTestEmail') {
                 responseBody = await handleSendTestEmailRequest(request, env);
+            } else if (method === 'GET' && path === '/api/getMaintenanceMode') {
+                responseBody = await handleGetMaintenanceMode(request, env);
+            } else if (method === 'POST' && path === '/api/setMaintenanceMode') {
+                responseBody = await handleSetMaintenanceMode(request, env);
             } else if (method === 'GET' && path === '/api/getFeedbackMessages') {
                 responseBody = await handleGetFeedbackMessagesRequest(request, env);
             } else {
@@ -2477,6 +2482,39 @@ async function handleSendTestEmailRequest(request, env) {
 }
 // ------------- END FUNCTION: handleSendTestEmailRequest -------------
 
+// ------------- START FUNCTION: handleGetMaintenanceMode -------------
+async function handleGetMaintenanceMode(request, env) {
+    try {
+        const val = env.RESOURCES_KV ? await env.RESOURCES_KV.get('maintenance_mode') : null;
+        const enabled = (val === '1') || env.MAINTENANCE_MODE === '1';
+        return { success: true, enabled };
+    } catch (error) {
+        console.error('Error in handleGetMaintenanceMode:', error.message, error.stack);
+        return { success: false, message: 'Грешка при зареждане.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleGetMaintenanceMode -------------
+
+// ------------- START FUNCTION: handleSetMaintenanceMode -------------
+async function handleSetMaintenanceMode(request, env) {
+    try {
+        const auth = request.headers.get('Authorization') || '';
+        const token = auth.replace(/^Bearer\s+/i, '').trim();
+        const expected = env[WORKER_ADMIN_TOKEN_SECRET_NAME];
+        if (expected && token !== expected) {
+            return { success: false, message: 'Невалиден токен.', statusHint: 403 };
+        }
+        const { enabled } = await request.json();
+        const val = enabled ? '1' : '0';
+        if (env.RESOURCES_KV) await env.RESOURCES_KV.put('maintenance_mode', val);
+        return { success: true };
+    } catch (error) {
+        console.error('Error in handleSetMaintenanceMode:', error.message, error.stack);
+        return { success: false, message: 'Грешка при запис.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleSetMaintenanceMode -------------
+
 
 // ------------- START BLOCK: PlanGenerationHeaderComment -------------
 // ===============================================
@@ -4365,4 +4403,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleRegisterRequest, handleRegisterDemoRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload };


### PR DESCRIPTION
## Summary
- allow maintenance mode dynamic toggling
- expose endpoints in config
- add admin panel control
- implement worker support
- cover with small tests

## Testing
- `npm run lint`
- `npm test` *(fails: FATAL ERROR: Reached heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_68893be5d5d483269ee5a96d859f2fe0