### PR TITLE
Add macro chart animations

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -643,3 +643,20 @@ body.dark-theme .detailed-metric-item .value-current {
     padding: var(--space-md);
   }
 }
+@keyframes ring-grow {
+  from { transform: scale(0.8); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+.chart-ring-animate {
+  animation: ring-grow 1.2s ease-in-out;
+}
+
+#macroAnalyticsCard canvas.ring-active {
+  box-shadow: 0 0 0 3px var(--macro-ring-highlight);
+}
+
+#macroAnalyticsCard .macro-metric:hover,
+#macroAnalyticsCard .macro-metric.active {
+  box-shadow: 0 0 0 3px var(--macro-ring-highlight);
+}

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -113,8 +113,10 @@ test('renders macro analytics card', async () => {
   const metrics = document.querySelectorAll('#macroMetricsGrid .macro-metric');
   expect(metrics.length).toBe(4);
   expect(metrics[0].textContent).toContain('Калории');
+  expect(metrics[0].dataset.index).toBe('0');
   const canvas = document.querySelector('#macroAnalyticsCard canvas');
   expect(canvas).not.toBeNull();
+  expect(canvas.classList.contains('chart-ring-animate')).toBe(true);
 });
 
 test('macro metric click highlights element and updates center label', async () => {
@@ -137,6 +139,8 @@ test('macro metric click highlights element and updates center label', async () 
   metric.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   expect(metric.classList.contains('active')).toBe(true);
   expect(document.getElementById('macroCenterLabel').textContent).toBe('Калории');
+  const canvas = document.querySelector('#macroAnalyticsCard canvas');
+  expect(canvas.classList.contains('ring-active')).toBe(true);
 });
 
 test('hides modules when values are zero', async () => {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -251,9 +251,10 @@ function renderMacroAnalyticsCard(macros) {
         { l: 'Въглехидрати', v: macros.carbs_grams, s: macros.carbs_percent ? `${macros.carbs_percent}%` : '', c: '--macro-carbs-color' },
         { l: 'Мазнини', v: macros.fat_grams, s: macros.fat_percent ? `${macros.fat_percent}%` : '', c: '--macro-fat-color' }
     ];
-    list.forEach(item => {
+    list.forEach((item, idx) => {
         const div = document.createElement('div');
         div.className = 'macro-metric';
+        div.dataset.index = idx;
 
         const icon = document.createElement('span');
         icon.className = 'macro-icon';
@@ -317,6 +318,20 @@ export function renderPendingMacroChart() {
         },
         options: {
             responsive: true,
+            onHover: (evt, els) => {
+                if (els.length) {
+                    const idx = els[0].index;
+                    const el = document.querySelector(`.macro-metric[data-index="${idx}"]`);
+                    if (el) highlightMacro(el);
+                }
+            },
+            onClick: (evt, els) => {
+                if (els.length) {
+                    const idx = els[0].index;
+                    const el = document.querySelector(`.macro-metric[data-index="${idx}"]`);
+                    if (el) highlightMacro(el);
+                }
+            },
             plugins: {
                 legend: { display: false },
                 title: { display: true, text: `Дневен прием (${m.calories} kcal)` }
@@ -324,13 +339,24 @@ export function renderPendingMacroChart() {
         }
     });
     macroChartInstance.resize();
+    canvas.classList.add('chart-ring-animate');
 }
 
 export function highlightMacro(metricElement) {
     const grid = document.getElementById('macroMetricsGrid');
-    if (!grid || !metricElement) return;
+    const canvas = document.getElementById('macroChart');
+    if (!grid || !metricElement || !canvas) return;
     grid.querySelectorAll('.macro-metric').forEach(el => el.classList.remove('active'));
     metricElement.classList.add('active');
+
+    const index = Number(metricElement.dataset.index);
+    if (macroChartInstance && Number.isInteger(index)) {
+        macroChartInstance.setActiveElements([{ datasetIndex: 0, index }]);
+        macroChartInstance.update();
+    }
+
+    canvas.classList.add('ring-active', 'chart-ring-animate');
+
     const centerLabel = document.getElementById('macroCenterLabel');
     const label = metricElement.querySelector('.macro-label');
     if (centerLabel && label) centerLabel.textContent = label.textContent;


### PR DESCRIPTION
## Summary
- animate macro chart ring using new `ring-grow` keyframes
- highlight macro metrics and chart on hover or tap
- expose dataset index in DOM for macros
- test for ring animation and highlight effects

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*
- `sh scripts/test.sh js/__tests__/populateUI.test.js` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68894083ce0083268d13fd705ee165df