### PR TITLE
Allow admin during maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,9 +462,12 @@ This list is combined with the defaults when building the CORS headers.
 
 ### Maintenance Mode
 
-Set `MAINTENANCE_MODE=1` to show a static maintenance page for every request.
+Set `MAINTENANCE_MODE=1` to show a static maintenance page for most requests.
 The worker looks for a KV entry `maintenance_page` and falls back to
-`maintenance.html` when the key is missing.
+`maintenance.html` when the key is missing. Requests to the admin panel
+(`admin.html`, `js/admin.js`, `js/maintenanceMode.js`) and the endpoints
+`/api/getMaintenanceMode` and `/api/setMaintenanceMode` remain accessible so you
+can disable maintenance from the UI.
 
 Example `.env` value:
 

--- a/js/__tests__/maintenanceWorker.test.js
+++ b/js/__tests__/maintenanceWorker.test.js
@@ -1,5 +1,6 @@
+/** @jest-environment node */
 import { jest } from '@jest/globals';
-import { handleGetMaintenanceMode, handleSetMaintenanceMode } from '../worker.js';
+import { handleGetMaintenanceMode, handleSetMaintenanceMode } from '../../worker.js';
 
 function createStore(initial = {}) {
   const store = { ...initial };
@@ -28,4 +29,15 @@ test('setMaintenanceMode validates token and stores value', async () => {
   const goodRes = await handleSetMaintenanceMode(good, env);
   expect(goodRes.success).toBe(true);
   expect(kv._store['maintenance_mode']).toBe('1');
+});
+
+test('admin panel allowed during maintenance', async () => {
+  const { default: worker } = await import('../../worker.js');
+  const kv = createStore({ maintenance_mode: '1' });
+  const env = { RESOURCES_KV: kv, MAINTENANCE_MODE: '0' };
+  const req = { url: 'https://x/admin.html', method: 'GET', headers: { get: () => null } };
+  const res = await worker.fetch(req, env);
+  expect(res.status).not.toBe(503);
+  const text = await res.text();
+  expect(text).not.toContain('обновяваме сайта');
 });

--- a/worker.js
+++ b/worker.js
@@ -369,13 +369,22 @@ export default {
         }
 
         const kvFlag = env.RESOURCES_KV ? await env.RESOURCES_KV.get('maintenance_mode') : null;
+        const skipPaths = new Set([
+            '/admin.html',
+            '/js/admin.js',
+            '/js/maintenanceMode.js',
+            '/api/getMaintenanceMode',
+            '/api/setMaintenanceMode'
+        ]);
         if (env.MAINTENANCE_MODE === '1' || kvFlag === '1') {
-            const maint = env.RESOURCES_KV ? await env.RESOURCES_KV.get('maintenance_page') : null;
-            const html = maint || MAINTENANCE_FALLBACK_HTML;
-            return new Response(html, {
-                status: 503,
-                headers: { ...corsHeaders, 'Content-Type': 'text/html' }
-            });
+            if (!skipPaths.has(path)) {
+                const maint = env.RESOURCES_KV ? await env.RESOURCES_KV.get('maintenance_page') : null;
+                const html = maint || MAINTENANCE_FALLBACK_HTML;
+                return new Response(html, {
+                    status: 503,
+                    headers: { ...corsHeaders, 'Content-Type': 'text/html' }
+                });
+            }
         }
 
         let responseBody = {};


### PR DESCRIPTION
## Summary
- allow selected admin paths when maintenance mode is active
- test worker logic for admin panel access during maintenance
- clarify admin availability in maintenance instructions

## Testing
- `npm run lint`
- `npm test js/__tests__/maintenanceWorker.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688944b154048326ad66aa8a8d85caf5