### PR TITLE
Enhance macro analytics card

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -119,6 +119,9 @@
 }
 .analytics-card {
   background: var(--card-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid color-mix(in srgb, var(--primary-color) 20%, transparent);
   border-radius: var(--radius-lg);
   padding: var(--space-md);
   box-shadow: var(--shadow-sm);
@@ -197,15 +200,27 @@
   margin-top: var(--space-sm);
 }
 #macroAnalyticsCard .macro-metric {
-  background: var(--surface-background);
+  background: color-mix(in srgb, var(--surface-background) 90%, transparent);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  border: 1px solid var(--border-color-soft);
   border-radius: var(--radius-md);
   padding: var(--space-sm);
   text-align: center;
-  box-shadow: var(--shadow-sm);
+  transition: transform 0.2s ease;
+}
+#macroAnalyticsCard .macro-metric:hover {
+  transform: scale(1.05);
+  border-color: var(--accent-color);
+}
+
+body.dark-theme #macroAnalyticsCard .macro-metric {
+  background: color-mix(in srgb, var(--surface-background) 60%, var(--primary-color) 10%);
+  border-color: color-mix(in srgb, var(--border-color) 70%, transparent);
 }
 #macroAnalyticsCard .macro-icon {
   display: block;
-  font-size: 1.4rem;
+  font-size: 1.5rem;
   margin: 0 auto var(--space-xs);
   color: var(--text-color-secondary);
 }
@@ -216,6 +231,7 @@
 #macroAnalyticsCard .macro-value {
   font-size: 1.1rem;
   font-weight: 700;
+  color: var(--text-color-primary);
 }
 #macroAnalyticsCard .macro-subtitle {
   color: var(--text-color-muted);

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -258,6 +258,15 @@ function renderMacroAnalyticsCard(macros) {
         const icon = document.createElement('span');
         icon.className = 'macro-icon';
         icon.setAttribute('aria-label', item.l);
+        const iconMap = {
+            'Калории': 'bi-fire',
+            'Белтъчини': 'bi-egg-fried',
+            'Въглехидрати': 'bi-basket',
+            'Мазнини': 'bi-droplet'
+        };
+        const i = document.createElement('i');
+        i.className = `bi ${iconMap[item.l] || 'bi-circle'}`;
+        icon.appendChild(i);
 
         const label = document.createElement('div');
         label.className = 'macro-label';


### PR DESCRIPTION
## Summary
- apply glass effect and hover styling to analytics cards
- modernize macro card styles with dark-theme overrides
- add Bootstrap icons for macro metrics

## Testing
- `npm run lint`
- `npm test` *(fails: adminConfigRelated.test.js and others)*

------
https://chatgpt.com/codex/tasks/task_e_688955a9c8248326bfbc6c40bbd81a3f