### PR TITLE
Обновено превключване на теми

### DIFF
--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -73,12 +73,16 @@ export function applyTheme(theme) {
     document.body.classList.add(theme === 'dark' ? 'dark-theme' : 'light-theme');
 }
 
-export function toggleTheme() {
+export async function toggleTheme() {
     const currentThemeIsDark = document.body.classList.contains('dark-theme');
     const newTheme = currentThemeIsDark ? 'light' : 'dark';
     localStorage.setItem('theme', newTheme);
     applyTheme(newTheme);
     updateThemeButtonText();
+    const { applyStoredTheme } = await import('./personalization.js');
+    applyStoredTheme('Dashboard');
+    if (document.body.id === 'body') applyStoredTheme('Index');
+    if (document.body.id === 'questPage') applyStoredTheme('Quest');
 }
 
 export function updateThemeButtonText() {


### PR DESCRIPTION
## Summary
- осъвременен `toggleTheme` да презарежда цветове от съхранената персонализация
- при смяна на темата, ако страницата е от групите Index или Quest, зареждат се и техните цветови настройки

## Testing
- `npm run lint`
- `npm test` *(част от тестовете се провалят)*

------
https://chatgpt.com/codex/tasks/task_e_688958f5e87883269a603f516c6b1463