### PR TITLE
Implement richer macroChart

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -214,6 +214,15 @@
   border-color: var(--accent-color);
 }
 
+#macroAnalyticsCard .macro-metric.active {
+  box-shadow: 0 0 8px var(--accent-color);
+  background: color-mix(in srgb, var(--surface-background) 80%, var(--accent-color));
+}
+
+body.dark-theme #macroAnalyticsCard .macro-metric.active {
+  background: color-mix(in srgb, var(--surface-background) 60%, var(--accent-color) 40%);
+}
+
 body.dark-theme #macroAnalyticsCard .macro-metric {
   background: color-mix(in srgb, var(--surface-background) 60%, var(--primary-color) 10%);
   border-color: color-mix(in srgb, var(--border-color) 70%, transparent);
@@ -245,9 +254,21 @@ body.dark-theme #macroAnalyticsCard .macro-metric {
   text-align: center;
 }
 
+#macroAnalyticsCard .macro-center-label {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: var(--text-color-primary);
+  pointer-events: none;
+}
+
 #macroAnalyticsCard canvas {
-  max-width: 250px;
-  max-height: 250px;
+  max-width: 280px;
+  max-height: 280px;
+  width: 100%;
   margin: 0 auto;
 }
 

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -9,6 +9,26 @@ export let macroChartInstance = null;
 export let progressChartInstance = null;
 let pendingMacroData = null;
 
+// Chart.js plugin to draw text in the center of the doughnut
+const centerTextPlugin = {
+    id: 'centerText',
+    beforeDraw(chart, args, opts) {
+        const text = opts?.text;
+        if (!text) return;
+        const { ctx, chartArea } = chart;
+        if (!chartArea) return;
+        const x = chartArea.left + chartArea.width / 2;
+        const y = chartArea.top + chartArea.height / 2;
+        ctx.save();
+        ctx.font = '600 1.1rem sans-serif';
+        ctx.fillStyle = getCssVar('--text-color-primary', '#333');
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(text, x, y);
+        ctx.restore();
+    }
+};
+
 export function populateUI() {
     const data = fullDashboardData; // Access global state
     if (!data || Object.keys(data).length === 0) {
@@ -240,6 +260,13 @@ function renderMacroAnalyticsCard(macros) {
     const canvas = document.createElement('canvas');
     canvas.id = 'macroChart';
     chartContainer.appendChild(canvas);
+
+    const centerDiv = document.createElement('div');
+    centerDiv.id = 'macroCenterLabel';
+    centerDiv.className = 'macro-center-label';
+    centerDiv.textContent = `${macros.calories} kcal`;
+    chartContainer.appendChild(centerDiv);
+
     card.appendChild(chartContainer);
 
     const grid = document.createElement('div');
@@ -305,6 +332,7 @@ export function renderPendingMacroChart() {
     }
     const m = pendingMacroData;
     const ctx = canvas.getContext('2d');
+    Chart.register(centerTextPlugin);
     macroChartInstance = new Chart(ctx, {
         type: 'doughnut',
         data: {
@@ -326,9 +354,11 @@ export function renderPendingMacroChart() {
         },
         options: {
             responsive: true,
+            animation: { easing: 'easeOutElastic', duration: 1200 },
             plugins: {
                 legend: { display: false },
-                title: { display: true, text: `Дневен прием (${m.calories} kcal)` }
+                title: { display: true, text: `Дневен прием (${m.calories} kcal)` },
+                centerText: { text: `${m.calories} kcal` }
             }
         }
     });
@@ -342,7 +372,14 @@ export function highlightMacro(metricElement) {
     metricElement.classList.add('active');
     const centerLabel = document.getElementById('macroCenterLabel');
     const label = metricElement.querySelector('.macro-label');
-    if (centerLabel && label) centerLabel.textContent = label.textContent;
+    const value = metricElement.querySelector('.macro-value');
+    const sub = metricElement.querySelector('.macro-subtitle');
+    const text = label ? `${label.textContent}: ${value?.textContent ?? ''} ${sub?.textContent ?? ''}`.trim() : '';
+    if (centerLabel) centerLabel.textContent = text;
+    if (macroChartInstance && macroChartInstance.options.plugins?.centerText) {
+        macroChartInstance.options.plugins.centerText.text = text;
+        macroChartInstance.update();
+    }
 }
 
 function populateDashboardMacros(macros) {


### PR DESCRIPTION
## Summary
- add center text plugin for macroChart
- display active macro in chart center
- animate doughnut chart and improve styling
- tweak CSS for chart area and active macro highlight

## Testing
- `npm run lint`
- `npm test` *(fails: submitQuestionnaireAnalysis.test.js, registerEmail.test.js, adminSendTests.test.js, maintenanceMode.test.js, clientProfileChart.test.js, passwordReset.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688958b8d44c8326b36accef355d1997