### PR TITLE
Refactor nav menu into common module

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ The application will be available at `http://localhost:5173` by default.
 ### Мобилна навигация
 
 Менюто вече превърта страницата до горе при отваряне и се показва над заглавката благодарение на `z-index: 1100`. Уверете се, че всяка страница зарежда `script.js` или `js/basicNav.js`.
+Общият код за управлението му е изнесен в `js/navMenu.js`. Може да го използвате така:
+
+```javascript
+import { initNavMenu } from './js/navMenu.js';
+initNavMenu();
+```
 
 ### Динамична тема
 

--- a/js/basicNav.js
+++ b/js/basicNav.js
@@ -1,22 +1,7 @@
+import { initNavMenu } from './navMenu.js';
+
 export function initBasicNav() {
-  const body = document.body;
-  const nav = document.getElementById('nav');
-  const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
-  if (mobileMenuBtn && nav) {
-    const toggle = () => {
-      const open = body.classList.toggle('nav-open');
-      mobileMenuBtn.setAttribute('aria-expanded', open);
-      if (open) window.scrollTo({ top: 0 });
-    };
-    mobileMenuBtn.addEventListener('click', toggle);
-    nav.querySelectorAll('.nav-link').forEach(link => {
-      link.addEventListener('click', () => {
-        if (body.classList.contains('nav-open')) {
-          toggle();
-        }
-      });
-    });
-  }
+  initNavMenu();
   const themeToggleBtn = document.getElementById('theme-toggle');
   if (themeToggleBtn) {
     const updateIcon = () => {

--- a/js/navMenu.js
+++ b/js/navMenu.js
@@ -1,0 +1,30 @@
+export function updateMenuIcon(btn, open) {
+  if (!btn) return;
+  const icon = btn.querySelector('i');
+  if (!icon) return;
+  icon.classList.toggle('fa-bars', !open);
+  icon.classList.toggle('fa-times', open);
+}
+
+export function toggleNav(body = document.body, nav = document.getElementById('nav'), btn = document.querySelector('.mobile-menu-btn')) {
+  if (!btn || !nav) return false;
+  const open = body.classList.toggle('nav-open');
+  btn.setAttribute('aria-expanded', open);
+  if (open) window.scrollTo({ top: 0 });
+  updateMenuIcon(btn, open);
+  return open;
+}
+
+export function initNavMenu() {
+  const nav = document.getElementById('nav');
+  const btn = document.querySelector('.mobile-menu-btn');
+  if (!nav || !btn) return;
+  const toggle = () => toggleNav(document.body, nav, btn);
+  btn.addEventListener('click', toggle);
+  nav.querySelectorAll('.nav-link').forEach(link => {
+    link.addEventListener('click', () => {
+      if (document.body.classList.contains('nav-open')) toggle();
+    });
+  });
+  updateMenuIcon(btn, document.body.classList.contains('nav-open'));
+}

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@
 // --- ЧАСТ 1: ИНТЕГРИРАНИ МОДУЛИ (от отделните JS файлове) ---
 
 import { toggleTheme, initializeTheme } from './js/uiHandlers.js';
+import { initNavMenu } from './js/navMenu.js';
 
 /**
  * @description Конфигурация и глобални променливи (от config.js)
@@ -146,15 +147,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- ⚙️ СЕЛЕКТОРИ НА ЕЛЕМЕНТИ ---
     const header = document.getElementById('header');
-    const body = document.body;
-    const nav = document.getElementById('nav');
-    const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
-    if (!mobileMenuBtn || !nav) {
-        console.warn('script.js: липсва елемент за мобилно меню', {
-            btnExists: !!mobileMenuBtn,
-            navExists: !!nav
-        });
-    }
+    // Навигационно меню
     const themeToggleBtn = document.getElementById('theme-toggle');
     
     // Модален прозорец
@@ -186,18 +179,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // 2. Мобилно меню
-    if (mobileMenuBtn && nav) {
-        const toggleNav = () => {
-            const open = body.classList.toggle('nav-open');
-            mobileMenuBtn.setAttribute('aria-expanded', open);
-            if (open) window.scrollTo({ top: 0 });
-        };
-        mobileMenuBtn.addEventListener('click', toggleNav);
-        nav.addEventListener('click', (e) => { if (e.target === nav) toggleNav(); });
-        nav.querySelectorAll('.nav-link').forEach(link => {
-            link.addEventListener('click', () => { if(body.classList.contains('nav-open')) toggleNav(); });
-        });
-    }
+    initNavMenu();
 
     // 3. Плавно превъртане
     document.querySelectorAll('a[href^="#"]').forEach(anchor => {


### PR DESCRIPTION
## Summary
- create `js/navMenu.js` for opening/closing the mobile nav and switching the menu icon
- use the new module in `script.js` and `js/basicNav.js`
- document the new module in README

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: adminConfigRelated.test.js, adminSendTests.test.js, workerEmail.test.js, stripPlanModSignature.test.js, passwordReset.test.js, registerEmail.test.js, mailer.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68895bec9c3c83269e19643f793890f5