### PR TITLE
Add menu macro dataset

### DIFF
--- a/js/__tests__/macroChart.test.js
+++ b/js/__tests__/macroChart.test.js
@@ -1,0 +1,17 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+import { updateMacroChart, setChartInstance } from '../macroChart.js';
+
+test('updateMacroChart updates datasets and calls chart.update', () => {
+  const chart = { data: { datasets: [{ data: [] }, { data: [] }, { data: [] }] }, update: jest.fn() };
+  setChartInstance(chart);
+  updateMacroChart({
+    target: { protein_grams: 1, carbs_grams: 2, fat_grams: 3 },
+    plan: { protein_grams: 4, carbs_grams: 5, fat_grams: 6 },
+    current: { protein_grams: 7, carbs_grams: 8, fat_grams: 9 }
+  });
+  expect(chart.data.datasets[0].data).toEqual([1,2,3]);
+  expect(chart.data.datasets[1].data).toEqual([4,5,6]);
+  expect(chart.data.datasets[2].data).toEqual([7,8,9]);
+  expect(chart.update).toHaveBeenCalled();
+});

--- a/js/app.js
+++ b/js/app.js
@@ -11,6 +11,7 @@ import {
     showLoading, showToast, updateTabsOverflowIndicator
 } from './uiHandlers.js';
 import { populateUI } from './populateUI.js';
+import { updateMacroChart } from './macroChart.js';
 // КОРЕКЦИЯ: Премахваме handleDelegatedClicks от импорта тук
 import { setupStaticEventListeners, setupDynamicEventListeners, initializeCollapsibleCards } from './eventListeners.js';
 import {
@@ -645,6 +646,12 @@ export async function handleSaveLog() { // Exported for eventListeners.js
                 }
             }
         }
+        await refreshDashboardData();
+        updateMacroChart({
+            target: fullDashboardData.planData?.caloriesMacros,
+            plan: fullDashboardData.planData?.caloriesMacros,
+            current: fullDashboardData.planData?.caloriesMacros
+        });
         populateUI();
         initializeAchievements(currentUserId);
         showToast(result.message || "Логът е запазен!", false);
@@ -685,6 +692,21 @@ export async function handleFeedbackFormSubmit(event) { // Exported for eventLis
     } finally {
         showLoading(false);
     }
+}
+
+export async function refreshDashboardData() {
+    if (!currentUserId) return null;
+    try {
+        const resp = await fetch(`${apiEndpoints.dashboard}?userId=${currentUserId}`);
+        const data = await resp.json();
+        if (resp.ok && data.success) {
+            fullDashboardData = data;
+            return data;
+        }
+    } catch (err) {
+        console.error('refreshDashboardData error:', err);
+    }
+    return null;
 }
 
 

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -2,7 +2,8 @@
 import { selectors } from './uiElements.js';
 import { showLoading, showToast, openModal as genericOpenModal, closeModal as genericCloseModal } from './uiHandlers.js';
 import { apiEndpoints } from './config.js';
-import { currentUserId } from './app.js'; // Accessing currentUserId from app.js
+import { currentUserId, refreshDashboardData, fullDashboardData } from './app.js'; // Accessing currentUserId from app.js
+import { updateMacroChart } from './macroChart.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 
 let extraMealFormLoaded = false;
@@ -350,6 +351,12 @@ export async function handleExtraMealFormSubmit(event) {
         const result = await response.json();
         if (!response.ok || !result.success) throw new Error(result.message || `HTTP ${response.status}`);
         showToast(result.message || "Храненето е записано!", false);
+        await refreshDashboardData();
+        updateMacroChart({
+            target: fullDashboardData.planData?.caloriesMacros,
+            plan: fullDashboardData.planData?.caloriesMacros,
+            current: fullDashboardData.planData?.caloriesMacros
+        });
         genericCloseModal('extraMealEntryModal');
     } catch (error) {
         showToast(`Грешка: ${error.message}`, true);

--- a/js/macroChart.js
+++ b/js/macroChart.js
@@ -1,0 +1,35 @@
+export let chartInstance = null;
+let pendingTarget = null;
+let pendingPlan = null;
+let pendingCurrent = null;
+
+export function setChartInstance(chart) {
+  chartInstance = chart;
+}
+export function setTargetData(data) {
+  pendingTarget = data;
+}
+export function setPlanData(data) {
+  pendingPlan = data;
+}
+export function setCurrentData(data) {
+  pendingCurrent = data;
+}
+
+export function updateMacroChart({ target, plan, current } = {}) {
+  if (target) pendingTarget = target;
+  if (plan) pendingPlan = plan;
+  if (current) pendingCurrent = current;
+  if (!chartInstance) return;
+  const ds = chartInstance.data?.datasets || [];
+  if (pendingTarget && ds[0]) {
+    ds[0].data = [pendingTarget.protein_grams, pendingTarget.carbs_grams, pendingTarget.fat_grams];
+  }
+  if (pendingPlan && ds[1]) {
+    ds[1].data = [pendingPlan.protein_grams, pendingPlan.carbs_grams, pendingPlan.fat_grams];
+  }
+  if (pendingCurrent && ds[2]) {
+    ds[2].data = [pendingCurrent.protein_grams, pendingCurrent.carbs_grams, pendingCurrent.fat_grams];
+  }
+  chartInstance.update();
+}

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -4,10 +4,12 @@ import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, getProgress
 import { generateId } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, planHasRecContent } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
+import { setChartInstance, setTargetData, setPlanData, setCurrentData, updateMacroChart } from './macroChart.js';
 
 export let macroChartInstance = null;
 export let progressChartInstance = null;
 let pendingMacroData = null;
+let pendingMenuMacroData = null;
 
 export function populateUI() {
     const data = fullDashboardData; // Access global state
@@ -304,6 +306,7 @@ export function renderPendingMacroChart() {
         macroChartInstance = null;
     }
     const m = pendingMacroData;
+    const plan = pendingMenuMacroData || m;
     const ctx = canvas.getContext('2d');
     macroChartInstance = new Chart(ctx, {
         type: 'doughnut',
@@ -313,16 +316,44 @@ export function renderPendingMacroChart() {
                 `Въглехидрати (${m.carbs_percent}%)`,
                 `Мазнини (${m.fat_percent}%)`
             ],
-            datasets: [{
-                label: 'Разпределение на макроси',
-                data: [m.protein_grams, m.carbs_grams, m.fat_grams],
-                backgroundColor: [
-                    getCssVar('--macro-protein-color', 'rgb(54,162,235)'),
-                    getCssVar('--macro-carbs-color', 'rgb(255,205,86)'),
-                    getCssVar('--macro-fat-color', 'rgb(255,99,132)')
-                ],
-                hoverOffset: 4
-            }]
+            datasets: [
+                {
+                    label: 'Цел (гр)',
+                    data: [m.protein_grams, m.carbs_grams, m.fat_grams],
+                    backgroundColor: [
+                        getCssVar('--macro-protein-color', 'rgb(54,162,235)') + '40',
+                        getCssVar('--macro-carbs-color', 'rgb(255,205,86)') + '40',
+                        getCssVar('--macro-fat-color', 'rgb(255,99,132)') + '40'
+                    ],
+                    borderWidth: 0,
+                    cutout: '80%'
+                },
+                {
+                    label: 'Меню (гр)',
+                    data: [plan.protein_grams, plan.carbs_grams, plan.fat_grams],
+                    backgroundColor: [
+                        getCssVar('--macro-protein-color', 'rgb(54,162,235)') + '80',
+                        getCssVar('--macro-carbs-color', 'rgb(255,205,86)') + '80',
+                        getCssVar('--macro-fat-color', 'rgb(255,99,132)') + '80'
+                    ],
+                    borderWidth: 0,
+                    cutout: '72%'
+                },
+                {
+                    label: 'Прием (гр)',
+                    data: [m.protein_grams, m.carbs_grams, m.fat_grams],
+                    backgroundColor: [
+                        getCssVar('--macro-protein-color', 'rgb(54,162,235)'),
+                        getCssVar('--macro-carbs-color', 'rgb(255,205,86)'),
+                        getCssVar('--macro-fat-color', 'rgb(255,99,132)')
+                    ],
+                    borderColor: getCssVar('--card-bg'),
+                    borderWidth: 4,
+                    borderRadius: 8,
+                    cutout: '65%',
+                    hoverOffset: 12
+                }
+            ]
         },
         options: {
             responsive: true,
@@ -332,6 +363,10 @@ export function renderPendingMacroChart() {
             }
         }
     });
+    setChartInstance(macroChartInstance);
+    setTargetData(m);
+    setPlanData(plan);
+    setCurrentData(m);
     macroChartInstance.resize();
 }
 
@@ -356,6 +391,11 @@ function populateDashboardMacros(macros) {
         }
     }
     pendingMacroData = macros || null;
+    pendingMenuMacroData = macros || null;
+    if (macros) {
+        setTargetData(macros);
+        setPlanData(macros);
+    }
     if (macros) {
         const card = renderMacroAnalyticsCard(macros);
         selectors.analyticsCardsContainer.prepend(card);

--- a/macroChart.html
+++ b/macroChart.html
@@ -107,6 +107,10 @@
       border: 2px solid var(--text-secondary-color); /* Представлява външния пръстен */
     }
 
+    .legend-dot.dot-menu {
+      background-color: var(--accent-main); opacity: 0.6;
+    }
+
     .legend-dot.dot-intake {
       background-color: var(--accent-main); /* Представлява вътрешния, плътен пръстен */
     }
@@ -219,7 +223,7 @@
     <summary>Описание и логика (обновена)</summary>
     <p>Модулът визуализира препоръчан дневен прием (цел) и текущ прием на макронутриенти. Добавена е легенда за по-добра яснота.</p>
     <ul>
-      <li><code>renderMacroAnalyticsCard(target, current)</code> – създава HTML структурата, попълва стойностите и генерира легендата за диаграмата.</li>
+      <li><code>renderMacroAnalyticsCard(target, menu, current)</code> – създава HTML структурата, попълва стойностите и генерира легендата за диаграмата.</li>
       <li><code>renderMacroChart()</code> – инициализира двойна кръгова диаграма. Външният пръстен е целта, вътрешният е текущия прием.</li>
       <li><code>highlightMacro(el, index)</code> – маркира избрания елемент в решетката и съответния сегмент в диаграмата.</li>
     </ul>
@@ -237,6 +241,12 @@
       carbs_percent: 45,
       fat_percent: 30
     };
+    const menuData = {
+      calories: 1800,
+      protein_grams: 120,
+      carbs_grams: 200,
+      fat_grams: 60,
+    };
     const currentData = {
       calories: 950,
       protein_grams: 70,
@@ -247,6 +257,7 @@
     // --- ГЛОБАЛНИ ПРОМЕНЛИВИ ---
     let macroChartInstance = null;
     let pendingTargetData = null;
+    let pendingMenuData = null;
     let pendingCurrentData = null;
     let activeMacroIndex = null;
 
@@ -277,13 +288,13 @@
       }
 
       if (macroChartInstance && index !== null && index > -1) {
-        macroChartInstance.setActiveElements([{ datasetIndex: 1, index: index }]);
+        macroChartInstance.setActiveElements([{ datasetIndex: 2, index: index }]);
       }
 
       if (macroChartInstance) macroChartInstance.update();
     }
 
-    function renderMacroAnalyticsCard(target, current) {
+    function renderMacroAnalyticsCard(target, menu, current) {
       const grid = document.getElementById('macroMetricsGrid');
       const centerText = document.getElementById('chartCenterText');
       const legendContainer = document.getElementById('chartLegendContainer'); // НОВО
@@ -298,6 +309,7 @@
       legendContainer.innerHTML = `
         <div class="chart-legend">
           <span class="legend-item"><span class="legend-dot dot-goal"></span> Цел</span>
+          <span class="legend-item"><span class="legend-dot dot-menu"></span> Меню</span>
           <span class="legend-item"><span class="legend-dot dot-intake"></span> Прием</span>
         </div>
       `;
@@ -335,11 +347,12 @@
       });
 
       pendingTargetData = target;
+      pendingMenuData = menu;
       pendingCurrentData = current;
     }
 
     function renderMacroChart() {
-      if (!pendingTargetData || !pendingCurrentData) return;
+      if (!pendingTargetData || !pendingMenuData || !pendingCurrentData) return;
       const canvas = document.getElementById('macroChart');
       if (!canvas || typeof Chart === 'undefined') return;
       if (macroChartInstance) {
@@ -347,6 +360,7 @@
       }
       
       const target = pendingTargetData;
+      const menu = pendingMenuData;
       const current = pendingCurrentData;
       const ctx = canvas.getContext('2d');
 
@@ -371,6 +385,13 @@
               backgroundColor: macroColors.map(color => `${color}40`),
               borderWidth: 0,
               cutout: '80%',
+            },
+            {
+              label: 'Меню (гр)',
+              data: [menu.protein_grams, menu.carbs_grams, menu.fat_grams],
+              backgroundColor: macroColors.map(color => `${color}80`),
+              borderWidth: 0,
+              cutout: '72%',
             },
             {
               label: 'Прием (гр)',
@@ -419,7 +440,7 @@
     }
 
     // --- ИНИЦИАЛИЗАЦИЯ НА ПРИМЕРА ---
-    renderMacroAnalyticsCard(targetData, currentData);
+    renderMacroAnalyticsCard(targetData, menuData, currentData);
     renderMacroChart();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- extend macroChart demo with menu dataset and legend update
- update populateUI to use new macroChart utilities
- introduce shared macroChart module
- refresh dashboard macros after log/extra meal
- add unit test for updateMacroChart

## Testing
- `npm run lint`
- `npm test` *(fails: heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688973a52bb08326b9eb74910e7a6aff