### PR TITLE
Revert color personalization

### DIFF
--- a/about.html
+++ b/about.html
@@ -92,9 +92,5 @@
     </div>
   </footer>
   <script src="js/basicNav.js" type="module"></script>
-  <script type="module">
-    import { applyStoredTheme } from './js/personalization.js';
-    document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
-  </script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -99,9 +99,5 @@
     </div>
   </footer>
   <script src="js/basicNav.js" type="module"></script>
-  <script type="module">
-    import { applyStoredTheme } from './js/personalization.js';
-    document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
-  </script>
 </body>
 </html>

--- a/code.html
+++ b/code.html
@@ -297,11 +297,6 @@
             </a>
           </li>
           <li>
-            <a href="personalization.html" id="menu-personalization-link">
-              <svg class="menu-icon" aria-hidden="true"><use href="#icon-settings"></use></svg>Индивидуализация
-            </a>
-          </li>
-          <li>
             <button id="menu-feedback-btn" aria-label="Обратна връзка">
               <svg class="menu-icon" aria-hidden="true"><use href="#icon-feedback"></use></svg>Обратна връзка
             </button>
@@ -1354,9 +1349,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
     <script type="module" src="js/app.js" defer></script>
     <script type="module" src="js/planModChat.js" defer></script>
-    <script type="module">
-      import { applyStoredTheme } from './js/personalization.js';
-      document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Dashboard'));
-    </script>
+    
   </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -102,9 +102,5 @@
     </div>
   </footer>
   <script src="js/basicNav.js" type="module"></script>
-  <script type="module">
-    import { applyStoredTheme } from './js/personalization.js';
-    document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
-  </script>
 </body>
 </html>

--- a/demoquest.html
+++ b/demoquest.html
@@ -68,13 +68,11 @@
 <script type="module">
   import { initQuestionnaire } from './js/questionnaireCore.js';
   import { apiEndpoints } from './js/config.js';
-  import { applyStoredTheme } from './js/personalization.js';
   document.addEventListener('DOMContentLoaded', () => {
     initQuestionnaire({
       questionsUrl: 'demo_questions.json',
       submitUrl: apiEndpoints.submitDemoQuestionnaire
     });
-    applyStoredTheme('Quest');
   });
 </script>
 </body>

--- a/faq.html
+++ b/faq.html
@@ -105,9 +105,5 @@
     </div>
   </footer>
   <script src="js/basicNav.js" type="module"></script>
-  <script type="module">
-    import { applyStoredTheme } from './js/personalization.js';
-    document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
-  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -318,9 +318,5 @@
     
     <!-- НОВ, ОБЕДИНЕН JS ФАЙЛ (ще го създадем в следващата стъпка) -->
     <script src="script.js" type="module"></script>
-    <script type="module">
-      import { applyStoredTheme } from './js/personalization.js';
-      document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
-    </script>
 </body>
 </html>

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -79,10 +79,6 @@ export async function toggleTheme() {
     localStorage.setItem('theme', newTheme);
     applyTheme(newTheme);
     updateThemeButtonText();
-    const { applyStoredTheme } = await import('./personalization.js');
-    applyStoredTheme('Dashboard');
-    if (document.body.id === 'body') applyStoredTheme('Index');
-    if (document.body.id === 'questPage') applyStoredTheme('Quest');
 }
 
 export function updateThemeButtonText() {

--- a/privacy.html
+++ b/privacy.html
@@ -94,9 +94,5 @@
     </div>
   </footer>
   <script src="js/basicNav.js" type="module"></script>
-  <script type="module">
-    import { applyStoredTheme } from './js/personalization.js';
-    document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
-  </script>
 </body>
 </html>

--- a/quest.html
+++ b/quest.html
@@ -68,13 +68,11 @@
 <script type="module">
   import { initQuestionnaire } from './js/questionnaireCore.js';
   import { apiEndpoints } from './js/config.js';
-  import { applyStoredTheme } from './js/personalization.js';
   document.addEventListener('DOMContentLoaded', () => {
     initQuestionnaire({
       questionsUrl: 'questions.json',
       submitUrl: apiEndpoints.submitQuestionnaire
     });
-    applyStoredTheme('Quest');
   });
 </script>
 </body>

--- a/terms.html
+++ b/terms.html
@@ -96,9 +96,5 @@
     </div>
   </footer>
   <script src="js/basicNav.js" type="module"></script>
-  <script type="module">
-    import { applyStoredTheme } from './js/personalization.js';
-    document.addEventListener('DOMContentLoaded', () => applyStoredTheme('Index'));
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- drop all applyStoredTheme script imports
- remove personalization navigation link
- stop toggleTheme from reapplying stored user colors

## Testing
- `npm run lint`
- `npm test` *(fails: sendTestEmail posts form data)*

------
https://chatgpt.com/codex/tasks/task_e_6889795ac5ec83268d0b7715a50f737a