### PR TITLE
Restore older color palette

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -9,10 +9,10 @@
    ========================================================================== */
 :root {
   /* === Светла Тема (Default) === */
-  --primary-color: #3A506B;
-  --secondary-color: #5BC0BE;
-  --accent-color: #778DA9;
-  --tertiary-color: #CBBADD;
+  --primary-color: #00FFFF;
+  --secondary-color: #FFFF00;
+  --accent-color: #008080;
+  --tertiary-color: #AAAA55;
 
   --text-color-primary: #2c3e50;
   --text-color-secondary: #555;
@@ -22,7 +22,7 @@
   --text-color-disabled: #6c757d;
 
   --bg-color: #F0F4F8;
-  --bg-gradient: linear-gradient(135deg, #e6eff5 0%, #f0f4f8 100%);
+  --bg-gradient: linear-gradient(135deg, #00FFFF 0%, #FFFF00 100%);
   --surface-background: #FFFFFF;
   --surface-background-rgb: 255,255,255; /* За rgba overlay */
   --card-bg-opacity: 0.85;
@@ -123,7 +123,7 @@
   --note-success-bg: #e8f5e9; --note-success-text: #1b5e20; --note-success-border: #2e7d32;
   --supplement-card-bg: #e7f7ce;
 
-  --primary-rgb: 58, 80, 107;
+  --primary-rgb: 0, 255, 255;
   --header-height: 60px;
   --tabs-height: 65px;
   --tips-collapsed-height: 4.5rem;
@@ -135,10 +135,10 @@
 
 body.dark-theme {
   /* Органична и спокойна тъмна тема */
-  --primary-color: #84A98C;
-  --secondary-color: #E4725C;
-  --accent-color: #B5A3C3;
-  --tertiary-color: #8E6CC3;
+  --primary-color: #00FFFF;
+  --secondary-color: #FFFF00;
+  --accent-color: #008080;
+  --tertiary-color: #AAAA55;
 
   --text-color-primary: #F0F2F5;
   --text-color-secondary: #A0A5B9;
@@ -148,7 +148,7 @@ body.dark-theme {
   --text-color-disabled: #adb5bd;
 
   --bg-color: #1C1F2E;
-  --bg-gradient: linear-gradient(135deg, #1C1F2E 0%, #252A41 100%);
+  --bg-gradient: linear-gradient(135deg, #008080 0%, #AAAA55 100%);
   --surface-background: #252A41;
   --surface-background-rgb: 37,42,65; /* За rgba overlay */
   --card-bg-opacity: 0.75;
@@ -207,7 +207,7 @@ body.dark-theme {
   --note-success-bg: rgba(46, 125, 50, 0.2); --note-success-text: #a5d6a7; --note-success-border: #2e7d32;
   --supplement-card-bg: rgba(132, 169, 140, 0.25);
 
-  --primary-rgb: 132, 169, 140;
+  --primary-rgb: 0, 255, 255;
 
   --metric-value-group-bg-initial: color-mix(in srgb, var(--surface-background) 90%, var(--border-color-soft) 50%);
   --metric-value-group-bg-expected: color-mix(in srgb, var(--surface-background) 90%, var(--accent-color) 25%);

--- a/css/index_styles.css
+++ b/css/index_styles.css
@@ -1,19 +1,19 @@
         :root {
-            --primary-color: #3A506B; --secondary-color: #5BC0BE; --accent-color: #778DA9;
-            --bg-color: #F0F4F8; --bg-gradient: linear-gradient(135deg, #e0e8f0 0%, #f0f4f8 100%);
+            --primary-color: #00FFFF; --secondary-color: #FFFF00; --accent-color: #008080;
+            --bg-color: #F0F4F8; --bg-gradient: linear-gradient(135deg, #00FFFF 0%, #FFFF00 100%);
             --card-bg: rgba(255, 255, 255, 0.8); --text-color-primary: #333; --text-color-secondary: #555;
             --border-color: #d0d8e0; --glass-blur: 9px; --space-lg: 1.5rem; --radius-lg: 0.8rem;
             --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.07); --shadow-lg: 0 6px 24px rgba(0, 0, 0, 0.12);
             --color-danger: #e74c3c; --color-success: #2ecc71;
-            --primary-rgb: 58, 80, 107; /* Добавено за :focus стила */
+            --primary-rgb: 0, 255, 255; /* Добавено за :focus стила */
         }
         .dark-theme {
-            --primary-color: #5BC0BE; --secondary-color: #3A506B; --accent-color: #88a1c4;
+            --primary-color: #00FFFF; --secondary-color: #FFFF00; --accent-color: #008080;
             --text-color-primary: #E0E0E0; --text-color-secondary: #bdc3c7;
-            --bg-color: #1A1A2E; --bg-gradient: linear-gradient(135deg, #16213E 0%, #1A1A2E 100%);
+            --bg-color: #1A1A2E; --bg-gradient: linear-gradient(135deg, #008080 0%, #AAAA55 100%);
             --card-bg: rgba(40, 40, 60, 0.75); --glass-blur: 12px; --border-color: #444;
             --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.20); --shadow-lg: 0 6px 24px rgba(0, 0, 0, 0.25);
-            --primary-rgb: 91, 192, 190;
+            --primary-rgb: 0, 255, 255;
         }
         *, *::before, *::after { box-sizing: border-box; }
         html { font-size: 100%; }

--- a/style.css
+++ b/style.css
@@ -10,11 +10,11 @@
 
 /* 1. ПРОМЕНЛИВИ И ТЕМИ - ОТ ai_studio_code.css */
 :root {
-    --primary-color: #5BC0BE;
-    --secondary-color: #3A506B;
-    --accent-color: #7D9D9C; 
+    --primary-color: #00FFFF;
+    --secondary-color: #FFFF00;
+    --accent-color: #008080;
     --bg-color: #F0F4F8;
-    --bg-gradient: linear-gradient(135deg, #e9eff5 0%, #f0f4f8 100%);
+    --bg-gradient: linear-gradient(135deg, #00FFFF 0%, #FFFF00 100%);
     --card-bg: rgba(255, 255, 255, 0.8);
     --text-color-primary: #1b263b;
     --text-color-secondary: #415a77;
@@ -25,7 +25,7 @@
     --shadow-sm: 0 4px 8px rgba(58, 80, 107, 0.08);
     --shadow-md: 0 8px 20px rgba(58, 80, 107, 0.12);
     --shadow-lg: 0 15px 30px rgba(58, 80, 107, 0.18);
-    --primary-rgb: 91, 192, 190;
+    --primary-rgb: 0, 255, 255;
     --transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
     --radius-md: 16px;
     --radius-lg: 24px;
@@ -36,10 +36,11 @@
 }
 
 .dark-theme {
-    --secondary-color: #8fa6c9; 
-    --accent-color: #7D9D9C;
+    --primary-color: #00FFFF;
+    --secondary-color: #FFFF00;
+    --accent-color: #008080;
     --bg-color: #16213E;
-    --bg-gradient: linear-gradient(135deg, #16213E 0%, #1A1A2E 100%);
+    --bg-gradient: linear-gradient(135deg, #008080 0%, #AAAA55 100%);
     --card-bg: rgba(40, 40, 60, 0.75);
     --text-color-primary: #e0e6f0;
     --text-color-secondary: #a0b0c5;


### PR DESCRIPTION
## Summary
- return the previous palette used across main stylesheets
- update light and dark theme variables

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68897ccc3264832684bc83d7c2365b00