### PR TITLE
Fix header styling and remove scroll listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 <body id="body">
 
     <!-- Хедър - Непроменен -->
-    <header id="header">
+    <header id="header" class="scrolled">
         <div class="container header-container">
             <a href="#hero" class="logo-link">
                 <img src="https://radilovk.github.io/bodybest/img/logoindex.png" alt="MyBody.Best" class="logo" />

--- a/script.js
+++ b/script.js
@@ -180,10 +180,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- 📜 ЛОГИКА ОТ ОРИГИНАЛНИЯ ЛЕНДИНГ (ai_studio_code.js) ---
 
-    // 1. Хедър ефект при скрол
-    window.addEventListener('scroll', () => {
-        if (header) header.classList.toggle('scrolled', window.scrollY > 50);
-    });
+    // 1. Премахнат скрол слушател, добавяме класа директно в HTML
 
     // 2. Мобилно меню
     if (mobileMenuBtn && nav) {

--- a/style.css
+++ b/style.css
@@ -91,7 +91,7 @@ section { padding: 100px 0; }
 .btn:disabled { background-color: #ccc !important; color: #666 !important; cursor: not-allowed; box-shadow: none !important; transform: none !important; opacity: 0.65; }
 
 /* 4. ХЕДЪР И НАВИГАЦИЯ - ОТ ai_studio_code.css */
-header { position: fixed; top: 0; left: 0; width: 100%; padding: 25px 0; z-index: 1000; transition: all 0.3s ease-in-out; }
+header { position: fixed; top: 0; left: 0; width: 100%; padding: 25px 0; z-index: 1000; transition: all 0.3s ease-in-out; background: var(--card-bg); }
 header.scrolled { padding: 15px 0; background: var(--card-bg); backdrop-filter: blur(var(--glass-blur)); box-shadow: var(--shadow-md); }
 .header-container { display: flex; justify-content: space-between; align-items: center; }
 .logo-link { text-decoration: none; }


### PR DESCRIPTION
## Summary
- set consistent header background color
- remove scroll event handler
- default to `scrolled` header class on the main page

## Testing
- `npm run lint`
- `npm test` *(fails: adminConfigRelated.test.js, adminSendTests.test.js etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6889818eceb88326a4bf47009eeb7b92