### PR TITLE
Fix header transparency and mobile menu

### DIFF
--- a/js/basicNav.js
+++ b/js/basicNav.js
@@ -3,17 +3,26 @@ export function initBasicNav() {
   const nav = document.getElementById('nav');
   const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
   if (mobileMenuBtn && nav) {
+    const close = () => {
+      body.classList.remove('nav-open');
+      mobileMenuBtn.setAttribute('aria-expanded', 'false');
+    };
     const toggle = () => {
       const open = body.classList.toggle('nav-open');
       mobileMenuBtn.setAttribute('aria-expanded', open);
     };
     mobileMenuBtn.addEventListener('click', toggle);
+    document.addEventListener('click', e => {
+      if (
+        body.classList.contains('nav-open') &&
+        !nav.contains(e.target) &&
+        e.target !== mobileMenuBtn
+      ) {
+        close();
+      }
+    });
     nav.querySelectorAll('.nav-link').forEach(link => {
-      link.addEventListener('click', () => {
-        if (body.classList.contains('nav-open')) {
-          toggle();
-        }
-      });
+      link.addEventListener('click', close);
     });
   }
   const themeToggleBtn = document.getElementById('theme-toggle');

--- a/script.js
+++ b/script.js
@@ -184,14 +184,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // 2. Мобилно меню
     if (mobileMenuBtn && nav) {
+        const closeNav = () => {
+            body.classList.remove('nav-open');
+            mobileMenuBtn.setAttribute('aria-expanded', 'false');
+        };
         const toggleNav = () => {
-            body.classList.toggle('nav-open');
-            mobileMenuBtn.setAttribute('aria-expanded', body.classList.contains('nav-open'));
+            const open = body.classList.toggle('nav-open');
+            mobileMenuBtn.setAttribute('aria-expanded', open);
         };
         mobileMenuBtn.addEventListener('click', toggleNav);
-        nav.addEventListener('click', (e) => { if (e.target === nav) toggleNav(); });
+        document.addEventListener('click', (e) => {
+            if (body.classList.contains('nav-open') && !nav.contains(e.target) && e.target !== mobileMenuBtn) {
+                closeNav();
+            }
+        });
+        nav.addEventListener('click', (e) => { if (e.target === nav) closeNav(); });
         nav.querySelectorAll('.nav-link').forEach(link => {
-            link.addEventListener('click', () => { if(body.classList.contains('nav-open')) toggleNav(); });
+            link.addEventListener('click', closeNav);
         });
     }
 

--- a/style.css
+++ b/style.css
@@ -16,6 +16,7 @@
     --bg-color: #F0F4F8;
     --bg-gradient: linear-gradient(135deg, #e9eff5 0%, #f0f4f8 100%);
     --card-bg: rgba(255, 255, 255, 0.8);
+    --header-bg: rgba(255, 255, 255, 0.7);
     --text-color-primary: #1b263b;
     --text-color-secondary: #415a77;
     --border-color: rgba(58, 80, 107, 0.15);
@@ -41,6 +42,7 @@
     --bg-color: #16213E;
     --bg-gradient: linear-gradient(135deg, #16213E 0%, #1A1A2E 100%);
     --card-bg: rgba(40, 40, 60, 0.75);
+    --header-bg: rgba(40, 40, 60, 0.65);
     --text-color-primary: #e0e6f0;
     --text-color-secondary: #a0b0c5;
     --border-color: rgba(91, 192, 190, 0.2);
@@ -91,8 +93,8 @@ section { padding: 100px 0; }
 .btn:disabled { background-color: #ccc !important; color: #666 !important; cursor: not-allowed; box-shadow: none !important; transform: none !important; opacity: 0.65; }
 
 /* 4. ХЕДЪР И НАВИГАЦИЯ - ОТ ai_studio_code.css */
-header { position: fixed; top: 0; left: 0; width: 100%; padding: 25px 0; z-index: 1000; transition: all 0.3s ease-in-out; background: var(--card-bg); }
-header.scrolled { padding: 15px 0; background: var(--card-bg); backdrop-filter: blur(var(--glass-blur)); box-shadow: var(--shadow-md); }
+header { position: fixed; top: 0; left: 0; width: 100%; padding: 25px 0; z-index: 1000; transition: all 0.3s ease-in-out; background: var(--header-bg); }
+header.scrolled { padding: 15px 0; background: var(--header-bg); backdrop-filter: blur(var(--glass-blur)); box-shadow: var(--shadow-md); }
 .header-container { display: flex; justify-content: space-between; align-items: center; }
 .logo-link { text-decoration: none; }
 .logo { width: 225px; height: auto; display: block; }
@@ -200,11 +202,12 @@ footer { background: var(--dark-bg); color: var(--light-text); padding: 80px 0 3
 }
 @media (max-width: 768px) {
     body.nav-open { overflow: hidden; }
+    body.nav-open::before { content: ''; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 999; }
     .section-title h2 { font-size: 2rem; }
     .cta h2 { font-size: 2.2rem; }
     .mobile-menu-btn { display: flex; align-items: center; justify-content: center; width: 40px; height: 40px; }
-    nav { position: fixed; top: 0; left: -100%; width: 100%; height: 100%; background: var(--card-bg); backdrop-filter: blur(10px); display: flex; align-items: center; justify-content: center; opacity: 0; visibility: hidden; transition: opacity 0.4s ease, left 0.4s ease, visibility 0.4s; z-index: 1000; }
-    .nav-open nav { left: 0; opacity: 1; visibility: visible; }
+    nav { position: fixed; top: 0; right: -75%; width: 75%; height: 100%; background: var(--header-bg); backdrop-filter: blur(10px); display: flex; flex-direction: column; align-items: flex-start; justify-content: flex-start; padding-top: 80px; opacity: 0; visibility: hidden; transition: opacity 0.4s ease, right 0.4s ease, visibility 0.4s; z-index: 1000; }
+    .nav-open nav { right: 0; opacity: 1; visibility: visible; }
     nav ul { flex-direction: column; text-align: center; }
     nav ul li { margin: 15px 0; }
     nav ul li a { font-size: 1.8rem; }


### PR DESCRIPTION
## Summary
- adjust header background transparency
- slide the mobile nav in from the right
- close nav when clicking outside or on a link

## Testing
- `npm run lint`
- `npm test` *(fails: workerEmail.test.js, submitQuizErrorReset.test.js, submitQuestionnaireEmailFlag.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68898627d89c8326b2d41e095dec6891