### PR TITLE
Align styled tabs with header color

### DIFF
--- a/css/layout_styles.css
+++ b/css/layout_styles.css
@@ -142,6 +142,17 @@ nav.tabs.has-overflow::after {
   background: linear-gradient(to left, var(--surface-background), transparent);
 }
 
+nav.tabs.styled-tabs {
+  background: var(--primary-color);
+  color: var(--text-color-on-primary);
+  border-bottom: none;
+  box-shadow: var(--shadow-sm);
+}
+
+nav.tabs.styled-tabs.has-overflow::after {
+  background: linear-gradient(to left, var(--primary-color), transparent);
+}
+
 nav.tabs.styled-tabs .tab-btn {
   display: flex; 
   flex-direction: column; 
@@ -152,7 +163,7 @@ nav.tabs.styled-tabs .tab-btn {
   flex-basis: 0; 
   transition: color 0.25s, background-color 0.2s;
   background: transparent; border-top: none; border-left: none; border-right: none;
-  color: var(--text-color-secondary);
+  color: var(--text-color-on-primary);
   font-weight: 500;
   text-align: center; 
   line-height: 1.3;
@@ -166,7 +177,7 @@ nav.tabs.styled-tabs .tab-btn::after {
     left: 50%;
     width: 70%;
     height: 3px;
-    background-color: var(--primary-color);
+    background-color: var(--text-color-on-primary);
     transform: translateX(-50%) scaleX(0);
     transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
@@ -184,15 +195,15 @@ nav.tabs.styled-tabs .tab-btn .tab-label {
   white-space: nowrap;
 }
 nav.tabs.styled-tabs .tab-btn:hover {
-  color: var(--primary-color);
-  background-color: color-mix(in srgb, var(--primary-color) 5%, transparent);
+  color: var(--text-color-on-primary);
+  background-color: color-mix(in srgb, var(--text-color-on-primary) 10%, var(--primary-color));
 }
 nav.tabs.styled-tabs .tab-btn:hover .tab-icon {
   transform: scale(1.1);
 }
 nav.tabs.styled-tabs .tab-btn[aria-selected="true"] {
-  color: var(--primary-color);
-  font-weight: 700; 
+  color: var(--text-color-on-primary);
+  font-weight: 700;
 }
 nav.tabs.styled-tabs .tab-btn[aria-selected="true"]::after {
     transform: translateX(-50%) scaleX(1);

--- a/css/responsive_styles.css
+++ b/css/responsive_styles.css
@@ -48,6 +48,9 @@
     width: 100%;
     z-index: 999;
   }
+  nav.tabs.styled-tabs {
+    box-shadow: 0 -2px 4px rgba(0,0,0,0.15);
+  }
   body { padding-bottom: var(--tabs-height); }
 
   nav.tabs.styled-tabs .tab-btn { padding: 0.5rem 0.3rem; } 


### PR DESCRIPTION
## Summary
- match styled-tab background with header using theme variables
- ensure tab text and indicators adapt to light/dark themes
- add subtle shadow for fixed bottom tabs

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: sendTestEmail posts form data)*

------
https://chatgpt.com/codex/tasks/task_e_6889879bfd8c832688b2c8975d2184e5