### PR TITLE
Update vivid theme colors

### DIFF
--- a/js/__tests__/adminConfigRelated.test.js
+++ b/js/__tests__/adminConfigRelated.test.js
@@ -121,7 +121,7 @@ describe('adminColors.initColorSettings', () => {
     const themes = JSON.parse(localStorage.getItem('colorThemes'));
     expect(themes.Light['primary-color']).toBe('#000');
     expect(themes.Dark['primary-color']).toBe('#fff');
-    expect(themes.Vivid['primary-color']).toBe('#00FFFF');
+    expect(themes.Vivid['primary-color']).toBe('#5BC0BE');
     const opts = Array.from(document.getElementById('savedThemes').options).map(o => o.value);
     expect(opts).toEqual(expect.arrayContaining(['Light', 'Dark', 'Vivid']));
   });

--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -53,11 +53,12 @@ const exportThemeBtnId = 'exportTheme';
 const importThemeInputId = 'importTheme';
 const importThemeBtnId = 'importThemeBtn';
 
+// По-ярка тема, базирана на основните цветове на таблото
 const vividTheme = {
-  'primary-color': '#00FFFF',
-  'secondary-color': '#FFFF00',
-  'accent-color': '#008080',
-  'tertiary-color': '#AAAA55',
+  'primary-color': '#5BC0BE',
+  'secondary-color': '#FFD166',
+  'accent-color': '#FF6B6B',
+  'tertiary-color': '#FF9C9C',
   'progress-end-color': '#80FF80'
 };
 

--- a/js/themeConfig.js
+++ b/js/themeConfig.js
@@ -107,11 +107,11 @@ export const sampleThemes = {
       'macro-stroke-color': '#444444'
     },
     Vivid: {
-      'primary-color': '#ff0066',
-      'secondary-color': '#ffcc00',
-      'macro-protein-color': '#0099ff',
-      'macro-carbs-color': '#ff0066',
-      'macro-fat-color': '#ffcc00',
+      'primary-color': '#5BC0BE',
+      'secondary-color': '#FFD166',
+      'macro-protein-color': '#5BC0BE',
+      'macro-carbs-color': '#FF6B6B',
+      'macro-fat-color': '#FFD166',
       'macro-ring-highlight': '#ffffff',
       'macro-stroke-color': '#333333'
     }


### PR DESCRIPTION
## Summary
- switch vivid theme palette to #5BC0BE / #FFD166 / #FF6B6B
- keep base background
- update dashboard sample theme and related test

## Testing
- `npm run lint`
- `npm test` *(fails: adminConfigRelated.test.js et al.)*

------
https://chatgpt.com/codex/tasks/task_e_68898cc201fc83268fbfdbecf062358b