### PR TITLE
Adjust vivid palette contrast

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -287,6 +287,15 @@ body.vivid-theme {
   --metric-value-group-bg-current: color-mix(in srgb, var(--surface-background) 90%, var(--secondary-color) 30%);
 }
 
+/* По-ярките основни цветове правят заглавията трудни за четене.
+   Смесваме ги с основния текстов цвят за по-добър контраст */
+body.vivid-theme h1,
+body.vivid-theme h2,
+body.vivid-theme h3,
+body.vivid-theme h4 {
+  color: color-mix(in srgb, var(--primary-color) 75%, var(--text-color-primary));
+}
+
 /* Глобален box-sizing */
 *, *::before, *::after { box-sizing: border-box; }
 html { font-size: 100%; scroll-behavior: smooth; }

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -64,6 +64,9 @@
   justify-content: space-between; align-items: center;
   border-bottom: 1px solid transparent; transition: background-color 0.2s, border-color 0.2s;
 }
+.vivid-theme .accordion-header {
+  color: color-mix(in srgb, var(--primary-color) 75%, var(--text-color-primary));
+}
 .accordion-header:hover { background-color: color-mix(in srgb, var(--surface-background) 90%, var(--primary-color)); }
 .accordion-header.open { border-bottom-color: var(--primary-color); }
 .accordion-header .arrow { transition: transform 0.3s ease; font-size: 0.8em; } 

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -69,10 +69,15 @@
   to { width: var(--target-width); }
 }
 .index-card .index-value {
-  font-size: 1.2rem; font-weight: 700; color: var(--primary-color);
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--primary-color);
   text-align: center;
   margin-top: var(--space-sm);
   margin-bottom: var(--space-xs);
+}
+body.vivid-theme .index-card .index-value {
+  color: color-mix(in srgb, var(--primary-color) 75%, var(--text-color-primary));
 }
 
 /* Streak Card */
@@ -236,6 +241,9 @@ body.dark-theme #macroAnalyticsCard .macro-metric {
   font-weight: 600;
   color: var(--primary-color);
 }
+body.vivid-theme #macroAnalyticsCard .macro-label {
+  color: color-mix(in srgb, var(--primary-color) 75%, var(--text-color-primary));
+}
 #macroAnalyticsCard .macro-value {
   font-size: 1.1rem;
   font-weight: 700;
@@ -299,6 +307,9 @@ body.dark-theme #macroAnalyticsCard .macro-metric {
     margin-bottom: var(--space-lg); /* Увеличено разстояние */
 }
 .detailed-metric-item .metric-label { font-weight: 700; color: var(--primary-color); font-size: 1.15em; } /* Леко увеличен шрифт */
+body.vivid-theme .detailed-metric-item .metric-label {
+  color: color-mix(in srgb, var(--primary-color) 75%, var(--text-color-primary));
+}
 
 .detailed-metric-item .metric-item-values {
     display: grid; 
@@ -444,6 +455,9 @@ body.dark-theme .detailed-metric-item .value-current {
   margin-top: 0; /* Override global h2 margin to align text with top of card */
   margin-bottom: var(--space-xs);
 }
+body.vivid-theme .meal-list li .meal-name {
+  color: color-mix(in srgb, var(--primary-color) 75%, var(--text-color-primary));
+}
 
 .meal-list li .meal-items {
   font-size: 1.1em; /* Запазваме вашия размер */
@@ -561,6 +575,10 @@ body.dark-theme .detailed-metric-item .value-current {
   padding: var(--space-xs) var(--space-sm); border-radius: var(--radius-sm);
   margin-left: var(--space-xs); margin-right: var(--space-xs);
   min-width: 1.5em; text-align: center;
+}
+body.vivid-theme .tracker .metric-rating .rating-value {
+  color: color-mix(in srgb, var(--primary-color) 75%, var(--text-color-primary));
+  background: color-mix(in srgb, var(--primary-color) 20%, transparent);
 }
 .tracker .metric-rating .metric-info-btn { 
     padding: 0 var(--space-xs);


### PR DESCRIPTION
## Summary
- improve heading visibility in vivid theme
- adjust accordion header text contrast
- tweak dashboard panel styles for vivid readability

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688a677621548326ae4f6ecdd8470534