### PR TITLE
Add code theme group

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ The application will be available at `http://localhost:5173` by default.
 
 #### Персонализация за потребители
 В `personalization.html` цветoвите настройки са разделени по табове – Dashboard,
-Index и Quest. Всеки таб съдържа полета от съответната група от `themeConfig.js`.
+Index, Quest и Code. Всеки таб съдържа полета от съответната група от `themeConfig.js`.
 Промените се съхраняват отделно в `localStorage.dashboardColorThemes`,
-`localStorage.indexColorThemes` и `localStorage.questColorThemes`. При зареждане
+`localStorage.indexColorThemes`, `localStorage.questColorThemes` и `localStorage.codeColorThemes`. При зареждане
 на всяка страница избраните стойности се прилагат автоматично.
 
 ### Build

--- a/js/__tests__/personalizationTemplates.test.js
+++ b/js/__tests__/personalizationTemplates.test.js
@@ -14,8 +14,14 @@ beforeEach(async () => {
   `;
   jest.unstable_mockModule('../uiHandlers.js', () => ({ loadAndApplyColors: jest.fn() }));
   jest.unstable_mockModule('../themeConfig.js', () => ({
-    colorGroups: [{ name: 'Dashboard', items: [{ var: 'primary-color', label: '' }] }],
-    sampleThemes: { dashboard: { Light: { 'primary-color': '#010101' } } }
+    colorGroups: [
+      { name: 'Dashboard', items: [{ var: 'primary-color', label: '' }] },
+      { name: 'Code', items: [{ var: 'code-bg', label: '' }] }
+    ],
+    sampleThemes: {
+      dashboard: { Light: { 'primary-color': '#010101' } },
+      code: { Light: { 'code-bg': '#020202' } }
+    }
   }));
   ({ saveNamedTheme, loadNamedTheme, deleteNamedTheme, switchTab, switchVariant } = await import('../personalization.js'));
   document.dispatchEvent(new Event('DOMContentLoaded'));
@@ -46,4 +52,16 @@ test('variant navigation lists all three variants', () => {
   const buttons = document.querySelectorAll('.variant-buttons button');
   const labels = Array.from(buttons).map(b => b.textContent);
   expect(labels).toEqual(expect.arrayContaining(['Светла', 'Тъмна', 'Ярка']));
+});
+
+test('saves and loads theme for Code group', () => {
+  switchTab('Code');
+  switchVariant('Code', 'light');
+  const input = document.getElementById('Code-code-bg-light');
+  input.value = '#cccccc';
+  saveNamedTheme('Code', 'c1', 'light');
+  expect(JSON.parse(localStorage.getItem('codeColorThemes.light')).c1['code-bg']).toBe('#cccccc');
+  input.value = '#dddddd';
+  loadNamedTheme('Code', 'c1', 'light');
+  expect(input.value).toBe('#cccccc');
 });

--- a/js/personalization.js
+++ b/js/personalization.js
@@ -19,11 +19,12 @@ const variants = {
 const storageMap = {
   Index: 'indexColorThemes',
   Quest: 'questColorThemes',
+  Code: 'codeColorThemes',
   Dashboard: 'dashboardColorThemes'
 };
 
 function getGroups(name) {
-  if (name === 'Dashboard') return colorGroups.filter(g => !['Index', 'Quest'].includes(g.name));
+  if (name === 'Dashboard') return colorGroups.filter(g => !['Index', 'Quest', 'Code'].includes(g.name));
   return colorGroups.filter(g => g.name === name);
 }
 
@@ -136,7 +137,8 @@ function ensureSampleThemes() {
   const map = {
     Dashboard: sampleThemes.dashboard,
     Index: sampleThemes.index,
-    Quest: sampleThemes.quest
+    Quest: sampleThemes.quest,
+    Code: sampleThemes.code
   };
   Object.entries(map).forEach(([group, samples]) => {
     Object.keys(variants).forEach(variant => {
@@ -192,7 +194,7 @@ export function populate(groupName, variant = activeVariant) {
 function createTabNavigation(parent) {
   const nav = document.createElement('div');
   nav.className = 'tab-buttons';
-  ['Dashboard', 'Index', 'Quest'].forEach((name, idx) => {
+  ['Dashboard', 'Index', 'Quest', 'Code'].forEach((name, idx) => {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.textContent = name;
@@ -207,7 +209,7 @@ function createTabNavigation(parent) {
 function createTabContents(parent) {
   const contents = document.createElement('div');
   contents.className = 'tab-contents';
-  ['Dashboard', 'Index', 'Quest'].forEach((name, idx) => {
+  ['Dashboard', 'Index', 'Quest', 'Code'].forEach((name, idx) => {
     const panel = document.createElement('div');
     panel.id = `panel-${name}`;
     panel.className = 'tab-panel';
@@ -232,7 +234,7 @@ function createTabContents(parent) {
       varPanel.className = 'variant-panel';
       if (v !== activeVariant) varPanel.style.display = 'none';
       const groups = name === 'Dashboard'
-        ? colorGroups.filter(g => !['Index', 'Quest'].includes(g.name))
+        ? colorGroups.filter(g => !['Index', 'Quest', 'Code'].includes(g.name))
         : colorGroups.filter(g => g.name === name);
       groups.forEach(g => {
         g.items.forEach(item => {
@@ -318,7 +320,7 @@ export function applyStoredTheme(groupName) {
 
 document.addEventListener('DOMContentLoaded', async () => {
   await loadAndApplyColors();
-  ['Dashboard', 'Index', 'Quest'].forEach(applyStoredTheme);
+  ['Dashboard', 'Index', 'Quest', 'Code'].forEach(applyStoredTheme);
   const container = document.getElementById('colorControls');
   if (!container) return;
   ensureSampleThemes();

--- a/js/themeConfig.js
+++ b/js/themeConfig.js
@@ -83,6 +83,14 @@ export const colorGroups = [
       { var: 'error-color', label: 'Грешки' },
       { var: 'success-color', label: 'Успехи' }
     ]
+  },
+  {
+    name: 'Code',
+    items: [
+      { var: 'code-bg', label: 'Фон' },
+      { var: 'code-text-primary', label: 'Основен текст' },
+      { var: 'code-accent', label: 'Акцент' }
+    ]
   }
 ];
 
@@ -142,6 +150,23 @@ export const sampleThemes = {
     Vivid: {
       'accent-primary': '#ff3399',
       'bg-primary': '#222244'
+    }
+  },
+  code: {
+    Light: {
+      'code-bg': '#f5f5f5',
+      'code-text-primary': '#333333',
+      'code-accent': '#5BC0BE'
+    },
+    Dark: {
+      'code-bg': '#1e1e1e',
+      'code-text-primary': '#e0e0e0',
+      'code-accent': '#ff3366'
+    },
+    Vivid: {
+      'code-bg': '#001122',
+      'code-text-primary': '#ffffff',
+      'code-accent': '#ff6600'
     }
   }
 };


### PR DESCRIPTION
## Summary
- extend color configuration with new 'Code' group
- save code color templates in `localStorage.codeColorThemes`
- update personalization logic and tests
- document new storage key in README

## Testing
- `npm run lint`
- `npm test` *(fails: adminConfigRelated.test.js, adminSendTests.test.js, workerEmail.test.js, passwordReset.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688a6d0ce740832694c6fa5d826be8e5