### PR TITLE
Add code theme colors

### DIFF
--- a/code.html
+++ b/code.html
@@ -21,9 +21,19 @@
     <link href="css/extra_meal_form_styles.css" rel="stylesheet" />
     <link href="css/plan_mod_chat_styles.css" rel="stylesheet" />
     <link href="css/responsive_styles.css" rel="stylesheet" />
+    <style>
+      body.code-page {
+        background: var(--code-bg);
+        color: var(--code-text-primary);
+      }
+      .code-page h1,
+      .code-page a {
+        color: var(--code-accent);
+      }
+    </style>
     <!-- Chart.js - зарежда се в края на body за по-добра производителност -->
   </head>
-  <body>
+  <body class="code-page">
     <!-- ======================================================================= -->
     <!-- ========================= SVG ICONS DEFINITION ======================== -->
     <!-- ======================================================================= -->

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -135,6 +135,10 @@
   --metric-value-group-bg-initial: color-mix(in srgb, var(--surface-background) 95%, var(--border-color-soft));
   --metric-value-group-bg-expected: color-mix(in srgb, var(--surface-background) 95%, var(--accent-color) 20%);
   --metric-value-group-bg-current: color-mix(in srgb, var(--surface-background) 95%, var(--secondary-color) 25%);
+  /* Цветове за code.html */
+  --code-bg: #f5f5f5;
+  --code-text-primary: #333333;
+  --code-accent: #5BC0BE;
 }
 
 body.dark-theme {
@@ -224,6 +228,9 @@ body.dark-theme {
   --metric-value-group-bg-initial: color-mix(in srgb, var(--surface-background) 90%, var(--border-color-soft) 50%);
   --metric-value-group-bg-expected: color-mix(in srgb, var(--surface-background) 90%, var(--accent-color) 25%);
   --metric-value-group-bg-current: color-mix(in srgb, var(--surface-background) 90%, var(--secondary-color) 30%);
+  --code-bg: #1e1e1e;
+  --code-text-primary: #e0e0e0;
+  --code-accent: #ff3366;
 }
 
 body.vivid-theme {
@@ -306,6 +313,9 @@ body.vivid-theme {
   --metric-value-group-bg-initial: color-mix(in srgb, var(--surface-background) 90%, var(--border-color-soft) 50%);
   --metric-value-group-bg-expected: color-mix(in srgb, var(--surface-background) 90%, var(--accent-color) 25%);
   --metric-value-group-bg-current: color-mix(in srgb, var(--surface-background) 90%, var(--secondary-color) 30%);
+  --code-bg: #001122;
+  --code-text-primary: #ffffff;
+  --code-accent: #ff6600;
 }
 
 /* По-ярките основни цветове правят заглавията трудни за четене.

--- a/js/__tests__/adminConfigRelated.test.js
+++ b/js/__tests__/adminConfigRelated.test.js
@@ -62,7 +62,7 @@ describe('adminColors.initColorSettings', () => {
       saveConfig: mockSave
     }));
     global.fetch = jest.fn().mockResolvedValue({
-      text: async () => ':root{--primary-color:#000;--secondary-color:#000;}body.dark-theme{--primary-color:#fff;--secondary-color:#fff;}'
+      text: async () => ':root{--primary-color:#000;--secondary-color:#000;--code-bg:#ccc;--code-text-primary:#111;--code-accent:#222;}body.dark-theme{--primary-color:#fff;--secondary-color:#fff;--code-bg:#ddd;--code-text-primary:#eee;--code-accent:#bbb;}'
     });
     ({ initColorSettings } = await import('../adminColors.js'));
   });
@@ -122,6 +122,8 @@ describe('adminColors.initColorSettings', () => {
     expect(themes.Light['primary-color']).toBe('#000');
     expect(themes.Dark['primary-color']).toBe('#fff');
     expect(themes.Vivid['primary-color']).toBe('#5BC0BE');
+    expect(themes.Light['code-bg']).toBe('#ccc');
+    expect(themes.Dark['code-bg']).toBe('#ddd');
     const opts = Array.from(document.getElementById('savedThemes').options).map(o => o.value);
     expect(opts).toEqual(expect.arrayContaining(['Light', 'Dark', 'Vivid']));
   });


### PR DESCRIPTION
## Summary
- add `--code-bg`, `--code-text-primary`, and `--code-accent` to each theme in `base_styles.css`
- style `code.html` with the new variables
- extend admin color tests with code theme defaults

## Testing
- `npm run lint`
- `npm test` *(fails: adminConfigRelated.test.js, workerEmail.test.js, personalizationTemplates.test.js, and others)*

------
https://chatgpt.com/codex/tasks/task_e_688a75849230832691e6043dc4dc4e92