### PR TITLE
Fix duplicate CSS variables in dark theme

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -159,10 +159,6 @@ body.dark-theme {
   --font-color-secondary: var(--text-color-secondary);
   --font-color-muted: var(--text-color-muted);
   --font-color-on-primary: var(--text-color-on-primary);
-  --font-color-primary: var(--text-color-primary);
-  --font-color-secondary: var(--text-color-secondary);
-  --font-color-muted: var(--text-color-muted);
-  --font-color-on-primary: var(--text-color-on-primary);
 
   --bg-color: #1C1F2E;
   --bg-gradient: linear-gradient(135deg, #1C1F2E 0%, #252A41 100%);


### PR DESCRIPTION
## Summary
- clean up `body.dark-theme` in `base_styles.css`
- run linters and tests

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: adminConfigRelated.test.js, adminSendTests.test.js, workerEmail.test.js, initialAnalysis.test.js, passwordReset.test.js, personalizationTemplates.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688a844bcd40832680a42e178566e2f6