### PR TITLE
Centralize theme storage helpers

### DIFF
--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -1,5 +1,10 @@
 import { loadConfig, saveConfig } from './adminConfig.js';
 import { colorGroups } from './themeConfig.js';
+import {
+  getSavedThemes as loadThemes,
+  storeThemes as saveThemes,
+  populateThemeSelect as fillThemeSelect
+} from './themeStorage.js';
 
 const inputs = {};
 
@@ -74,28 +79,15 @@ function getCurrentColor(key) {
 }
 
 function getSavedThemes() {
-  try {
-    return JSON.parse(localStorage.getItem('colorThemes') || '{}');
-  } catch {
-    return {};
-  }
+  return loadThemes();
 }
 
 function storeThemes(themes) {
-  localStorage.setItem('colorThemes', JSON.stringify(themes));
+  saveThemes(themes);
 }
 
 function populateThemeSelect() {
-  const select = document.getElementById(themeSelectId);
-  if (!select) return;
-  select.innerHTML = '';
-  const themes = getSavedThemes();
-  Object.keys(themes).sort().forEach(name => {
-    const opt = document.createElement('option');
-    opt.value = name;
-    opt.textContent = name;
-    select.appendChild(opt);
-  });
+  fillThemeSelect(themeSelectId);
 }
 
 function saveTheme() {

--- a/js/personalization.js
+++ b/js/personalization.js
@@ -1,6 +1,11 @@
 // personalization.js - Настройки на основни цветове за потребителя
 import { colorGroups, sampleThemes } from './themeConfig.js';
 import { loadAndApplyColors } from './uiHandlers.js';
+import {
+  getSavedThemes as loadThemes,
+  storeThemes as saveThemes,
+  populateThemeSelect as fillThemeSelect
+} from './themeStorage.js';
 
 const inputs = {};
 let activeGroup = 'Dashboard';
@@ -42,30 +47,15 @@ function getCurrentColor(key) {
 }
 
 function getSavedThemes(groupName, variant = activeVariant) {
-  const key = getStorageKey(groupName, variant);
-  try {
-    return JSON.parse(localStorage.getItem(key) || '{}');
-  } catch {
-    return {};
-  }
+  return loadThemes(getStorageKey(groupName, variant));
 }
 
 function storeThemes(groupName, variant, themes) {
-  const key = getStorageKey(groupName, variant);
-  localStorage.setItem(key, JSON.stringify(themes));
+  saveThemes(getStorageKey(groupName, variant), themes);
 }
 
 export function populateThemeSelect(groupName, variant = activeVariant) {
-  const select = document.getElementById('themeSelect');
-  if (!select) return;
-  select.innerHTML = '';
-  const themes = getSavedThemes(groupName, variant);
-  Object.keys(themes).sort().forEach(name => {
-    const opt = document.createElement('option');
-    opt.value = name;
-    opt.textContent = name;
-    select.appendChild(opt);
-  });
+  fillThemeSelect('themeSelect', getStorageKey(groupName, variant));
 }
 
 export function saveNamedTheme(groupName, name, variant = activeVariant) {

--- a/js/themeStorage.js
+++ b/js/themeStorage.js
@@ -1,0 +1,30 @@
+export const DEFAULT_KEY = 'colorThemes';
+
+export function getSavedThemes(storageKey = DEFAULT_KEY) {
+  try {
+    return JSON.parse(localStorage.getItem(storageKey) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+export function storeThemes(storageKey, themes) {
+  if (typeof themes === 'undefined') {
+    themes = storageKey;
+    storageKey = DEFAULT_KEY;
+  }
+  localStorage.setItem(storageKey, JSON.stringify(themes));
+}
+
+export function populateThemeSelect(selectId = 'savedThemes', storageKey = DEFAULT_KEY) {
+  const select = typeof selectId === 'string' ? document.getElementById(selectId) : selectId;
+  if (!select) return;
+  select.innerHTML = '';
+  const themes = getSavedThemes(storageKey);
+  Object.keys(themes).sort().forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    select.appendChild(opt);
+  });
+}


### PR DESCRIPTION
## Summary
- add `themeStorage.js` with reusable helpers
- import helpers in `adminColors.js` and `personalization.js`
- use centralized versions of `getSavedThemes`, `storeThemes` and `populateThemeSelect`

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: adminConfigRelated.test.js, passwordReset.test.js, personalizationTemplates.test.js, maintenanceMode.test.js, mailer.test.js, submitQuestionnaireAnalysis.test.js, registerEmail.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688a8aab976c8326831761528f512681