### PR TITLE
Add theme rename option

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -274,6 +274,7 @@
       <select id="savedThemes"></select>
       <button type="button" id="applyThemeLocal">Зареди</button>
       <button type="button" id="deleteThemeLocal">Изтрий</button>
+      <button type="button" id="renameThemeLocal">Преименувай</button>
       <button type="button" id="exportTheme">Изтегли тема</button>
       <input type="file" id="importTheme" accept="application/json" style="display:none">
       <button type="button" id="importThemeBtn">Качи тема</button>

--- a/js/__tests__/adminConfigRelated.test.js
+++ b/js/__tests__/adminConfigRelated.test.js
@@ -55,7 +55,8 @@ describe('adminColors.initColorSettings', () => {
       <button id="saveThemeLocal"></button>
       <select id="savedThemes"></select>
       <button id="applyThemeLocal"></button>
-      <button id="deleteThemeLocal"></button>`;
+      <button id="deleteThemeLocal"></button>
+      <button id="renameThemeLocal"></button>`;
     mockLoad = jest.fn().mockResolvedValue({ colors: { 'primary-color': '#111111', 'secondary-color': '#222222' } });
     mockSave = jest.fn().mockResolvedValue({});
     jest.unstable_mockModule('../adminConfig.js', () => ({
@@ -76,6 +77,7 @@ describe('adminColors.initColorSettings', () => {
     if (styleEl) styleEl.remove();
     document.documentElement.style.cssText = '';
     document.body.style.cssText = '';
+    delete global.prompt;
   });
 
   test('initColorSettings loads config and sets CSS vars', async () => {
@@ -151,6 +153,20 @@ describe('adminColors.initColorSettings', () => {
     applyBtn.click();
     expect(document.getElementById('primary-colorInput').value).toBe('#000');
     expect(document.getElementById('code-bgInput').value).toBe('#ccc');
+  });
+
+  test('selected theme can be renamed', async () => {
+    mockLoad.mockResolvedValue({ colors: {} });
+    await initColorSettings();
+    const select = document.getElementById('savedThemes');
+    const renameBtn = document.getElementById('renameThemeLocal');
+    select.value = 'Light';
+    global.prompt = jest.fn().mockReturnValue('Bright');
+    renameBtn.click();
+    const themes = JSON.parse(localStorage.getItem('colorThemes'));
+    expect(themes.Bright).toBeDefined();
+    expect(themes.Light).toBeUndefined();
+    expect(select.querySelector('option[value="Bright"]')).not.toBeNull();
   });
 });
 

--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -46,6 +46,7 @@ const themeNameId = 'themeNameInput';
 const saveThemeBtnId = 'saveThemeLocal';
 const applyThemeBtnId = 'applyThemeLocal';
 const deleteThemeBtnId = 'deleteThemeLocal';
+const renameThemeBtnId = 'renameThemeLocal';
 const previewThemeBtnId = 'previewTheme';
 const exportThemeBtnId = 'exportTheme';
 const importThemeInputId = 'importTheme';
@@ -137,6 +138,25 @@ function deleteSelectedTheme() {
   }
 }
 
+function renameSelectedTheme() {
+  const select = document.getElementById(themeSelectId);
+  if (!select) return;
+  const themes = getSavedThemes();
+  const oldName = select.value;
+  if (!themes[oldName]) return;
+  const newName = prompt('Ново име на тема:', oldName);
+  if (!newName || newName === oldName) return;
+  if (themes[newName]) {
+    alert('Вече съществува тема с това име.');
+    return;
+  }
+  themes[newName] = themes[oldName];
+  delete themes[oldName];
+  storeThemes(themes);
+  populateThemeSelect();
+  select.value = newName;
+}
+
 function previewCurrentTheme() {
   Object.entries(inputs).forEach(([k, el]) => {
     if (el) setCssVar(k, el.value);
@@ -202,6 +222,7 @@ export async function initColorSettings() {
   const saveThemeBtn = document.getElementById(saveThemeBtnId);
   const applyThemeBtn = document.getElementById(applyThemeBtnId);
   const deleteThemeBtn = document.getElementById(deleteThemeBtnId);
+  const renameThemeBtn = document.getElementById(renameThemeBtnId);
   const previewBtn = document.getElementById(previewThemeBtnId);
   const exportBtn = document.getElementById(exportThemeBtnId);
   const importInput = document.getElementById(importThemeInputId);
@@ -245,6 +266,7 @@ export async function initColorSettings() {
   if (saveThemeBtn) saveThemeBtn.addEventListener('click', saveTheme);
   if (applyThemeBtn) applyThemeBtn.addEventListener('click', applyThemeFromSelect);
   if (deleteThemeBtn) deleteThemeBtn.addEventListener('click', deleteSelectedTheme);
+  if (renameThemeBtn) renameThemeBtn.addEventListener('click', renameSelectedTheme);
   if (previewBtn) previewBtn.addEventListener('click', previewCurrentTheme);
   if (exportBtn) exportBtn.addEventListener('click', exportThemeToFile);
   if (importBtn && importInput) {


### PR DESCRIPTION
## Summary
- allow renaming themes from admin panel
- wire rename button in color settings
- test theme renaming logic

## Testing
- `npm run lint`
- `sh ./scripts/test.sh js/__tests__/adminConfigRelated.test.js` *(fails: 4 failed, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688a8c3172308326b2e08ae37d433ded