### PR TITLE
Fix duplicate admin color fields

### DIFF
--- a/js/__tests__/adminConfigRelated.test.js
+++ b/js/__tests__/adminConfigRelated.test.js
@@ -126,9 +126,6 @@ describe('adminColors.initColorSettings', () => {
     expect(themes.Light['primary-color']).toBe('#000');
     expect(themes.Dark['primary-color']).toBe('#fff');
     expect(themes.Vivid['primary-color']).toBe('#f00');
-    expect(themes.Light['code-bg']).toBe('#ccc');
-    expect(themes.Dark['code-bg']).toBe('#ddd');
-    expect(themes.Vivid['code-bg']).toBe('#eee');
     const opts = Array.from(document.getElementById('savedThemes').options).map(o => o.value);
     expect(opts).toEqual(expect.arrayContaining(['Light', 'Dark', 'Vivid']));
   });
@@ -141,18 +138,15 @@ describe('adminColors.initColorSettings', () => {
 
     select.value = 'Dark';
     applyBtn.click();
-    expect(document.getElementById('primary-colorInput').value).toBe('#fff');
-    expect(document.getElementById('code-bgInput').value).toBe('#ddd');
+    expect(document.getElementById('primary-colorInput').value).toBe('#ffffff');
 
     select.value = 'Vivid';
     applyBtn.click();
-    expect(document.getElementById('primary-colorInput').value).toBe('#f00');
-    expect(document.getElementById('code-bgInput').value).toBe('#eee');
+    expect(document.getElementById('primary-colorInput').value).toBe('#ff0000');
 
     select.value = 'Light';
     applyBtn.click();
-    expect(document.getElementById('primary-colorInput').value).toBe('#000');
-    expect(document.getElementById('code-bgInput').value).toBe('#ccc');
+    expect(document.getElementById('primary-colorInput').value).toBe('#000000');
   });
 
   test('selected theme can be renamed', async () => {

--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -71,11 +71,19 @@ function setCssVar(key, val) {
   document.body.style.setProperty(`--${key}`, val);
 }
 
+function normalizeColor(val) {
+  const m = /^#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])$/.exec(val);
+  if (m) {
+    return `#${m[1]}${m[1]}${m[2]}${m[2]}${m[3]}${m[3]}`;
+  }
+  return val;
+}
+
 function getCurrentColor(key) {
-  const bodyVal = getComputedStyle(document.body)
+  const rootVal = getComputedStyle(document.documentElement)
     .getPropertyValue(`--${key}`).trim();
-  if (bodyVal) return bodyVal;
-  return getComputedStyle(document.documentElement)
+  if (rootVal) return rootVal;
+  return getComputedStyle(document.body)
     .getPropertyValue(`--${key}`).trim();
 }
 
@@ -113,8 +121,9 @@ function applyThemeFromSelect() {
   Object.entries(theme).forEach(([k, val]) => {
     const el = inputs[k];
     if (el) {
-      el.value = val;
-      setCssVar(k, val);
+      const norm = normalizeColor(val);
+      el.value = norm;
+      setCssVar(k, norm);
     }
   });
 }
@@ -186,7 +195,10 @@ function importThemeFile(file) {
 export async function initColorSettings() {
   const container = document.getElementById('colorInputs');
   if (container) {
-    colorGroups.forEach(group => {
+    const filteredGroups = colorGroups.filter(
+      g => !['Index', 'Quest', 'Code'].includes(g.name)
+    );
+    filteredGroups.forEach(group => {
       const fs = document.createElement('fieldset');
       const lg = document.createElement('legend');
       lg.textContent = group.name;


### PR DESCRIPTION
## Summary
- filter out Index, Quest and Code groups when rendering color fields
- normalize 3-digit color codes before applying themes
- update admin tests for new color handling

## Testing
- `npm run lint`
- `npm test` *(fails: clientProfileChart.test.js missing fillDashboard, mailer.test.js expectation mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_688a8ff0e8c48326819afb0c7c81cfd0