### PR TITLE
Add tooltip buttons for admin color inputs

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -336,3 +336,22 @@ details[open] summary::after {
   align-items: center;
   margin-top: var(--space-sm);
 }
+
+.info-btn {
+  padding: 0 var(--space-xs);
+  color: var(--icon-color-muted);
+  line-height: 1;
+  margin-left: var(--space-xs);
+  background: none;
+  border: none;
+  cursor: help;
+}
+
+.info-btn svg.icon {
+  width: 1em;
+  height: 1em;
+}
+
+.info-btn:hover {
+  color: var(--primary-color);
+}

--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -31,7 +31,13 @@ function readDefaultTheme(variant) {
 function createInput(item, container) {
   const label = document.createElement('label');
   label.textContent = item.label || item.var;
-  if (item.description) label.title = item.description;
+
+  const infoBtn = document.createElement('button');
+  infoBtn.type = 'button';
+  infoBtn.className = 'button-icon-only info-btn';
+  infoBtn.innerHTML = '<svg class="icon"><use href="#icon-info"></use></svg>';
+  infoBtn.title = item.description || 'Цвят на елемент';
+  label.appendChild(infoBtn);
   const input = document.createElement('input');
   if (item.type === 'range') {
     input.type = 'range';


### PR DESCRIPTION
## Summary
- show info buttons next to each color setting in `adminColors`
- style `.info-btn` to match existing icon buttons

## Testing
- `npm run lint`
- `npm test` *(fails to complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_688a9a48840c83269d0c640d73628a62