### PR TITLE
Add color contrast utilities and warnings

### DIFF
--- a/js/__tests__/adminColorsContrast.test.js
+++ b/js/__tests__/adminColorsContrast.test.js
@@ -1,0 +1,60 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+describe('adminColors contrast warnings', () => {
+  let initColorSettings;
+  beforeEach(async () => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <div id="colorInputs"></div>
+      <button id="saveColorConfig"></button>
+      <input id="themeNameInput" type="text">
+      <button id="saveThemeLocal"></button>
+      <select id="savedThemes"></select>
+      <button id="applyThemeLocal"></button>
+      <button id="deleteThemeLocal"></button>
+      <button id="renameThemeLocal"></button>
+      <button id="previewTheme"></button>
+      <button id="exportTheme"></button>
+      <input id="importTheme" type="file">
+      <button id="importThemeBtn"></button>`;
+    jest.unstable_mockModule('../adminConfig.js', () => ({
+      loadConfig: jest.fn().mockResolvedValue({ colors: {} }),
+      saveConfig: jest.fn()
+    }));
+    jest.unstable_mockModule('../themeConfig.js', () => ({
+      colorGroups: [
+        { name: 'Test', items: [
+          { var: 'text-color-primary', label: 'T' },
+          { var: 'bg-color', label: 'B' }
+        ] }
+      ]
+    }));
+    jest.unstable_mockModule('../themeStorage.js', () => ({
+      getSavedThemes: jest.fn(() => ({})),
+      storeThemes: jest.fn(),
+      populateThemeSelect: jest.fn()
+    }));
+    ({ initColorSettings } = await import('../adminColors.js'));
+    await initColorSettings();
+  });
+
+  test('shows and removes contrast warning', () => {
+    const textInput = document.getElementById('text-color-primaryInput');
+    const bgInput = document.getElementById('bg-colorInput');
+    // Low contrast
+    textInput.value = '#777777';
+    bgInput.value = '#777777';
+    textInput.dispatchEvent(new Event('input'));
+    let warning = textInput.parentNode.querySelector('.contrast-warning');
+    expect(warning).not.toBeNull();
+    expect(warning.textContent).toMatch(/контраст/i);
+
+    // High contrast
+    textInput.value = '#ffffff';
+    bgInput.value = '#000000';
+    textInput.dispatchEvent(new Event('input'));
+    warning = textInput.parentNode.querySelector('.contrast-warning');
+    expect(warning).toBeNull();
+  });
+});

--- a/js/__tests__/utils.test.js
+++ b/js/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, lightenColor } from '../utils.js';
+import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, lightenColor, hexToRgb, calcLuminance, contrastRatio } from '../utils.js';
 
 describe('utils', () => {
   test('safeGet returns nested value', () => {
@@ -46,5 +46,19 @@ describe('utils', () => {
 
   test('lightenColor returns original when no fallback', () => {
     expect(lightenColor('invalid')).toBe('invalid');
+  });
+
+  test('hexToRgb parses colors', () => {
+    expect(hexToRgb('#fff')).toEqual({ r: 255, g: 255, b: 255 });
+    expect(hexToRgb('#123456')).toEqual({ r: 18, g: 52, b: 86 });
+  });
+
+  test('calcLuminance returns values between 0 and 1', () => {
+    expect(calcLuminance('#000')).toBeCloseTo(0);
+    expect(calcLuminance('#fff')).toBeCloseTo(1);
+  });
+
+  test('contrastRatio calculates ratio', () => {
+    expect(contrastRatio('#000', '#fff')).toBeCloseTo(21);
   });
 });

--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -5,8 +5,41 @@ import {
   storeThemes as saveThemes,
   populateThemeSelect as fillThemeSelect
 } from './themeStorage.js';
+import { hexToRgb, contrastRatio } from './utils.js';
 
 const inputs = {};
+const contrastPairs = [
+  ['text-color-primary', 'bg-color'],
+  ['text-color-secondary', 'bg-color'],
+  ['text-color-on-primary', 'primary-color'],
+  ['text-color-on-secondary', 'secondary-color']
+];
+
+function showContrastWarning(input, ratio) {
+  let span = input.parentNode.querySelector('.contrast-warning');
+  if (ratio < 4.5) {
+    if (!span) {
+      span = document.createElement('span');
+      span.className = 'contrast-warning';
+      span.style.color = 'red';
+      span.style.marginLeft = '6px';
+      input.insertAdjacentElement('afterend', span);
+    }
+    span.textContent = `\u26A0 Нисък контраст (${ratio.toFixed(1)})`;
+  } else if (span) {
+    span.remove();
+  }
+}
+
+function checkAllContrast() {
+  contrastPairs.forEach(([textVar, bgVar]) => {
+    const textInput = inputs[textVar];
+    const bgInput = inputs[bgVar];
+    if (!textInput || !bgInput) return;
+    const ratio = contrastRatio(hexToRgb(textInput.value), hexToRgb(bgInput.value));
+    if (ratio !== null) showContrastWarning(textInput, ratio);
+  });
+}
 
 function getAllVars() {
   return colorGroups.flatMap(g => g.items.filter(it => it.type !== 'range').map(it => it.var));
@@ -240,7 +273,10 @@ export async function initColorSettings() {
       el.value = colors[k] || current;
       if (el.type === 'range' && !el.value) el.value = 1;
       setCssVar(k, el.value);
-      el.addEventListener('input', () => setCssVar(k, el.value));
+      el.addEventListener('input', () => {
+        setCssVar(k, el.value);
+        checkAllContrast();
+      });
     });
   } catch (err) {
     console.warn('Неуспешно зареждане на цветовете', err);
@@ -249,9 +285,14 @@ export async function initColorSettings() {
       const current = getCurrentColor(k);
       el.value = current;
       if (el.type === 'range' && !el.value) el.value = 1;
-      el.addEventListener('input', () => setCssVar(k, el.value));
+      el.addEventListener('input', () => {
+        setCssVar(k, el.value);
+        checkAllContrast();
+      });
     });
   }
+
+  checkAllContrast();
 
   saveBtn.addEventListener('click', async () => {
     const colors = {};


### PR DESCRIPTION
## Summary
- implement `hexToRgb`, `calcLuminance`, `contrastRatio` helpers
- warn for low contrast in admin color settings
- add tests for new helpers and for contrast warnings

## Testing
- `npm run lint`
- `sh scripts/test.sh js/__tests__/adminColorsContrast.test.js`
- `npm test` *(fails: passwordReset.test.js, personalizationTemplates.test.js, clientProfileChart.test.js, registerEmail.test.js, submitQuestionnaireAnalysis.test.js, maintenanceMode.test.js, mailer.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688a9a4f72c883268787166371080002