### PR TITLE
Add color reset option

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -278,6 +278,7 @@
       <button type="button" id="exportTheme">Изтегли тема</button>
       <input type="file" id="importTheme" accept="application/json" style="display:none">
       <button type="button" id="importThemeBtn">Качи тема</button>
+      <button type="button" id="resetColors">Нулирай</button>
     </div>
   </details>
 

--- a/js/__tests__/adminConfigRelated.test.js
+++ b/js/__tests__/adminConfigRelated.test.js
@@ -56,7 +56,8 @@ describe('adminColors.initColorSettings', () => {
       <select id="savedThemes"></select>
       <button id="applyThemeLocal"></button>
       <button id="deleteThemeLocal"></button>
-      <button id="renameThemeLocal"></button>`;
+      <button id="renameThemeLocal"></button>
+      <button id="resetColors"></button>`;
     mockLoad = jest.fn().mockResolvedValue({ colors: { 'primary-color': '#111111', 'secondary-color': '#222222' } });
     mockSave = jest.fn().mockResolvedValue({});
     jest.unstable_mockModule('../adminConfig.js', () => ({
@@ -161,6 +162,23 @@ describe('adminColors.initColorSettings', () => {
     expect(themes.Bright).toBeDefined();
     expect(themes.Light).toBeUndefined();
     expect(select.querySelector('option[value="Bright"]')).not.toBeNull();
+  });
+
+  test('reset button restores saved colors', async () => {
+    await initColorSettings();
+    const input = document.getElementById('primary-colorInput');
+    input.value = '#333333';
+    document.getElementById('resetColors').click();
+    expect(input.value).toBe('#111111');
+  });
+
+  test('reset falls back to Light theme when no config', async () => {
+    mockLoad.mockResolvedValue({ colors: {} });
+    await initColorSettings();
+    const input = document.getElementById('primary-colorInput');
+    input.value = '#444444';
+    document.getElementById('resetColors').click();
+    expect(input.value).toBe('#000000');
   });
 });
 


### PR DESCRIPTION
## Summary
- add Reset button in admin color settings
- implement reset logic to use saved colors or Light theme
- bind reset button handler
- test resetting behaviour

## Testing
- `npm run lint`
- `npm test` *(fails: personalizationTemplates.test.js, mailer.test.js and others)*

------
https://chatgpt.com/codex/tasks/task_e_688a9c538b948326bf4355a76b6afd22