### PR TITLE
Add color info button modal

### DIFF
--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -69,7 +69,9 @@ function createInput(item, container) {
   infoBtn.type = 'button';
   infoBtn.className = 'button-icon-only info-btn';
   infoBtn.innerHTML = '<svg class="icon"><use href="#icon-info"></use></svg>';
-  infoBtn.title = item.description || 'Цвят на елемент';
+  infoBtn.dataset.key = item.var;
+  infoBtn.dataset.type = 'colorVar';
+  infoBtn.setAttribute('aria-label', `Информация за ${item.label || item.var}`);
   label.appendChild(infoBtn);
   const input = document.createElement('input');
   if (item.type === 'range') {

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -284,7 +284,7 @@ function handleDelegatedClicks(event) {
     const target = event.target;
     if (target.closest('.modal-content') && !target.closest('[data-modal-close]')) return;
 
-    const infoButton = target.closest('button.info, button.metric-info-btn');
+    const infoButton = target.closest('button.info, button.metric-info-btn, button.info-btn');
     if (infoButton) {
         event.stopPropagation();
         let type = null; let key = null;
@@ -295,6 +295,9 @@ function handleDelegatedClicks(event) {
                 type = 'trackerMetricInfo';
                 key = label.dataset.tooltipKey;
             }
+        } else if (infoButton.classList.contains('info-btn')) {
+            type = infoButton.dataset.type || 'colorVar';
+            key = infoButton.dataset.key;
         }
         if (type && key) openInfoModalWithDetails(key, type);
         return;

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -7,6 +7,7 @@ import {
     setActiveTooltip // function from app.js to update activeTooltip state
 } from './app.js';
 import { trackerInfoTexts, detailedMetricInfoTexts, mainIndexInfoTexts } from './uiElements.js';
+import { colorGroups } from './themeConfig.js';
 import { capitalizeFirstLetter, safeGet, escapeHtml } from './utils.js';
 
 // Продължителност на анимацията при скриване/показване на модали
@@ -14,6 +15,18 @@ const MODAL_TRANSITION_MS = 300;
 
 // Variable to hold the toast timeout ID, managed locally within this module
 let toastTimeoutUiHandlers;
+
+const colorInfoTexts = {};
+colorGroups.forEach(group => {
+    group.items.forEach(item => {
+        if (item.description) {
+            colorInfoTexts[item.var] = {
+                title: item.label || item.var,
+                text: item.description
+            };
+        }
+    });
+});
 
 
 export function toggleMenu() {
@@ -235,6 +248,10 @@ export function openInfoModalWithDetails(key, type) {
         if (metricInfo?.levels) {
             body += "\n\nСтойности:\n" + Object.values(metricInfo.levels).join("\n");
         }
+    } else if (type === 'colorVar') {
+        const info = colorInfoTexts[key];
+        title = info?.title || key;
+        body = info?.text || 'Няма допълнителна информация.';
     }
     const escapedTitle = escapeHtml(title);
     const escapedBody = escapeHtml(body).replace(/\n/g, '<br>');


### PR DESCRIPTION
## Summary
- support `.info-btn` in delegated click handler
- use dataset values for theme color info buttons
- show color info in `openInfoModalWithDetails`

## Testing
- `npm run lint`
- `sh ./scripts/test.sh js/__tests__/adminConfigRelated.test.js`
- `npm test` *(fails: FATAL ERROR: Reached heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_688aa1f28948832697547fa8082a3a80