### PR TITLE
Add tooltip to admin color controls

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -355,3 +355,37 @@ details[open] summary::after {
 .info-btn:hover {
   color: var(--primary-color);
 }
+
+.tooltip-tracker {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(-var(--space-sm));
+  background-color: var(--toast-bg);
+  color: var(--toast-text);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  z-index: 10;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s, visibility 0.2s;
+  box-shadow: var(--shadow-md);
+  min-width: 180px;
+  text-align: left;
+}
+.tooltip-tracker.visible {
+  opacity: 1;
+  visibility: visible;
+}
+.tooltip-tracker::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: var(--toast-bg) transparent transparent transparent;
+}

--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -6,6 +6,7 @@ import {
   populateThemeSelect as fillThemeSelect
 } from './themeStorage.js';
 import { hexToRgb, contrastRatio } from './utils.js';
+import { showTrackerTooltip, hideTrackerTooltip } from './uiHandlers.js';
 
 const inputs = {};
 const contrastPairs = [
@@ -70,6 +71,17 @@ function createInput(item, container) {
   infoBtn.className = 'button-icon-only info-btn';
   infoBtn.innerHTML = '<svg class="icon"><use href="#icon-info"></use></svg>';
   infoBtn.title = item.description || 'Цвят на елемент';
+  if (item.description) {
+    const showTip = () => showTrackerTooltip(infoBtn, item.description);
+    infoBtn.addEventListener('pointerenter', showTip);
+    infoBtn.addEventListener('focus', showTip);
+    infoBtn.addEventListener('touchstart', showTip, { passive: true });
+    const hideTip = () => hideTrackerTooltip();
+    infoBtn.addEventListener('pointerleave', hideTip);
+    infoBtn.addEventListener('blur', hideTip);
+    infoBtn.addEventListener('touchend', hideTip);
+    infoBtn.addEventListener('touchcancel', hideTip);
+  }
   label.appendChild(infoBtn);
   const input = document.createElement('input');
   if (item.type === 'range') {


### PR DESCRIPTION
## Summary
- activate custom tooltip in admin color settings
- import tooltip methods from uiHandlers
- style tooltip for admin interface

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688aa1f85430832693dbb5a73c1b8e55