### PR TITLE
Refactor metric info button styles

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -337,21 +337,3 @@ details[open] summary::after {
   margin-top: var(--space-sm);
 }
 
-.info-btn {
-  padding: 0 var(--space-xs);
-  color: var(--icon-color-muted);
-  line-height: 1;
-  margin-left: var(--space-xs);
-  background: none;
-  border: none;
-  cursor: help;
-}
-
-.info-btn svg.icon {
-  width: 1em;
-  height: 1em;
-}
-
-.info-btn:hover {
-  color: var(--primary-color);
-}

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -429,6 +429,19 @@ button:disabled, .button:disabled {
 body.dark-theme .button-icon-only:hover { background-color: rgba(255,255,255,0.08); }
 .button-icon-only svg.icon { width: 1.5em; height: 1.5em; }
 
+.info-btn {
+  padding: 0 var(--space-xs);
+  color: var(--icon-color-muted);
+  line-height: 1;
+  margin-left: var(--space-xs);
+  background: none;
+  border: none;
+  cursor: help;
+}
+
+.info-btn svg.icon { width: 1em; height: 1em; }
+.info-btn:hover { color: var(--primary-color); }
+
 .admin-reply-btn {
   padding: var(--space-xs) var(--space-sm);
   border: 1px solid var(--primary-color);

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -558,7 +558,7 @@ body.vivid-theme .meal-list li .meal-name {
   cursor: default; 
 }
 .tracker .metric-rating label[data-tooltip-key]:hover,
-.tracker .metric-rating label[data-tooltip-key]:focus-within .metric-info-btn { 
+.tracker .metric-rating label[data-tooltip-key]:focus-within .info-btn {
     cursor: help;
 }
 .tracker .metric-rating label .metric-icon {
@@ -580,21 +580,12 @@ body.vivid-theme .tracker .metric-rating .rating-value {
   color: color-mix(in srgb, var(--primary-color) 75%, var(--text-color-primary));
   background: color-mix(in srgb, var(--primary-color) 20%, transparent);
 }
-.tracker .metric-rating .metric-info-btn { 
-    padding: 0 var(--space-xs);
-    color: var(--icon-color-muted);
-    line-height: 1;
+.tracker .metric-rating .metric-info-btn {
     margin-left: var(--space-sm); /* Повече отстояние */
-    background: none;
-    border: none;
-    cursor: help;
 }
 .tracker .metric-rating .metric-info-btn svg.icon {
     width: 1.1em; /* Малко по-голяма икона */
     height: 1.1em;
-}
-.tracker .metric-rating .metric-info-btn:hover {
-    color: var(--primary-color);
 }
 
 

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -504,7 +504,7 @@ function populateDashboardLog(dailyLogs, currentStatus, initialData) {
     weightMetricDiv.innerHTML = `
         <label for="dailyLogWeightInput" data-tooltip-key="weight" title="${weightLabelTooltip}">
             <span class="metric-icon"><svg class="icon"><use href="#icon-scale"></use></svg></span> Тегло (кг):
-            <button class="button-icon-only metric-info-btn" aria-label="Информация за тегло">
+            <button class="button-icon-only info-btn metric-info-btn" aria-label="Информация за тегло">
                 <svg class="icon"><use href="#icon-info"></use></svg>
             </button>
         </label>
@@ -529,7 +529,7 @@ function populateDashboardLog(dailyLogs, currentStatus, initialData) {
             <label for="${metric.key}-rating-input" data-tooltip-key="${metric.key}" title="${labelTooltipText}">
                 <span class="metric-icon">${metric.icon}</span> ${metric.label}:
                 <span class="rating-value" id="${metric.key}-value">${currentValue}</span>
-                 <button class="button-icon-only metric-info-btn" aria-label="Информация за ${metric.label}">
+                 <button class="button-icon-only info-btn metric-info-btn" aria-label="Информация за ${metric.label}">
                     <svg class="icon"><use href="#icon-info"></use></svg>
                 </button>
             </label>


### PR DESCRIPTION
## Summary
- move `.info-btn` styling to base_styles.css
- reuse `.info-btn` for metrics
- remove duplicate rules from admin.css
- adjust JS templates to include the common class

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688aa1fd0cd48326bcb744bfc4ab510f