### PR TITLE
Добавяне на tooltip при цветови настройки

### DIFF
--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -61,6 +61,24 @@ function readDefaultTheme(variant) {
   return theme;
 }
 
+let tooltipEl;
+function showColorTooltip(target, text) {
+  if (!tooltipEl) {
+    tooltipEl = document.createElement('div');
+    tooltipEl.className = 'tooltip-tracker';
+    document.body.appendChild(tooltipEl);
+  }
+  tooltipEl.textContent = text;
+  const r = target.getBoundingClientRect();
+  tooltipEl.style.left = `${r.left + window.scrollX}px`;
+  tooltipEl.style.top = `${r.top + window.scrollY - tooltipEl.offsetHeight - 5}px`;
+  tooltipEl.classList.add('visible');
+}
+
+function hideColorTooltip() {
+  if (tooltipEl) tooltipEl.classList.remove('visible');
+}
+
 function createInput(item, container) {
   const label = document.createElement('label');
   label.textContent = item.label || item.var;
@@ -72,6 +90,16 @@ function createInput(item, container) {
   infoBtn.dataset.key = item.var;
   infoBtn.dataset.type = 'colorVar';
   infoBtn.setAttribute('aria-label', `Информация за ${item.label || item.var}`);
+  if (item.description) {
+    const showTip = () => showColorTooltip(infoBtn, item.description);
+    const hideTip = () => hideColorTooltip();
+    infoBtn.addEventListener('pointerenter', showTip);
+    infoBtn.addEventListener('focus', showTip);
+    infoBtn.addEventListener('pointerleave', hideTip);
+    infoBtn.addEventListener('blur', hideTip);
+    infoBtn.addEventListener('touchstart', showTip);
+    infoBtn.addEventListener('touchend', hideTip);
+  }
   label.appendChild(infoBtn);
   const input = document.createElement('input');
   if (item.type === 'range') {


### PR DESCRIPTION
## Обобщение
- внедрена е функция `showColorTooltip` в `adminColors.js`
- при задържане/докосване на бутона за информация се показва tooltip с текста от `item.description`
- валидиран е успешен lint и тестове

## Тестове
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688aa78168f08326ac0be19f44152752