### PR TITLE
Fix mobile tab spacing

### DIFF
--- a/code.html
+++ b/code.html
@@ -357,7 +357,7 @@
           aria-selected="true"
           aria-controls="dash-panel"
         >
-          <svg class="tab-icon" aria-hidden="true"><use href="#icon-chart-line"></use></svg> <span class="tab-label">Табло</span>
+          <svg class="tab-icon" aria-hidden="true"><use href="#icon-chart-line"></use></svg><span class="tab-label">Табло</span>
         </button>
         <button
           id="profile-tab"
@@ -366,7 +366,7 @@
           aria-selected="false"
           aria-controls="profile-panel"
         >
-          <svg class="tab-icon" aria-hidden="true"><use href="#icon-user"></use></svg> <span class="tab-label">Профил</span>
+          <svg class="tab-icon" aria-hidden="true"><use href="#icon-user"></use></svg><span class="tab-label">Профил</span>
         </button>
         <button
           id="week-tab"
@@ -375,7 +375,7 @@
           aria-selected="false"
           aria-controls="week-panel"
         >
-          <svg class="tab-icon" aria-hidden="true"><use href="#icon-calendar"></use></svg> <span class="tab-label">План</span>
+          <svg class="tab-icon" aria-hidden="true"><use href="#icon-calendar"></use></svg><span class="tab-label">План</span>
         </button>
         <button
           id="recs-tab"
@@ -384,7 +384,7 @@
           aria-selected="false"
           aria-controls="recs-panel"
         >
-          <svg class="tab-icon" aria-hidden="true"><use href="#icon-lightbulb"></use></svg> <span class="tab-label">Съвети</span>
+          <svg class="tab-icon" aria-hidden="true"><use href="#icon-lightbulb"></use></svg><span class="tab-label">Съвети</span>
         </button>
       </nav>
       <!-- ======================= END TABS NAVIGATION ========================= -->

--- a/css/responsive_styles.css
+++ b/css/responsive_styles.css
@@ -55,6 +55,7 @@
 
   nav.tabs.styled-tabs .tab-btn {
     padding: 0.3rem 0.15rem;
+    gap: 0.1rem;
   }
   nav.tabs.styled-tabs .tab-btn .tab-icon {
     font-size: 1.2em;
@@ -186,6 +187,7 @@
 
   nav.tabs.styled-tabs .tab-btn {
     padding: 0.35rem 0.15rem;
+    gap: 0.1rem;
   }
   nav.tabs.styled-tabs .tab-btn .tab-icon {
     font-size: 1.1em;


### PR DESCRIPTION
## Summary
- tweak markup of mobile nav buttons to remove extra whitespace
- reduce icon/text gap on narrow screens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688aaeff94d48326a6ed48b7ead5cd30