### PR TITLE
Move streak card and integrate analytics accordion

### DIFF
--- a/code.html
+++ b/code.html
@@ -454,70 +454,65 @@
                   </div>
                 </div>
               </div>
-              <div class="card index-card" id="streakCard">
-              <h4><i class="bi bi-award"></i> Моите успехи</h4>
-                <div id="streakGrid" class="streak-grid"></div>
+              <div
+                id="detailedAnalyticsAccordion"
+                class="card index-card accordion-container"
+              >
+                <div
+                  class="accordion-header"
+                  role="button"
+                  tabindex="0"
+                  aria-expanded="false"
+                  aria-controls="detailedAnalyticsContent"
+                >
+                  <span>📊 Детайлни Показатели и Анализ</span>
+                  <svg class="icon arrow">
+                    <use href="#icon-chevron-right"></use>
+                  </svg>
+                </div>
+                <div id="macroMetricsGrid" class="macro-metrics-grid"></div>
+                <div
+                  id="detailedAnalyticsContent"
+                  class="accordion-content"
+                  role="region"
+                >
+                  <div
+                    id="dashboardTextualAnalysis"
+                    style="margin-bottom: var(--space-lg)"
+                  >
+                    <p class="placeholder">Генериране на текстов анализ...</p>
+                  </div>
+                  <div class="card index-card" id="progressHistoryCard">
+                    <h4>
+                      <svg
+                        class="icon"
+                        style="width: 1em; height: 1em; margin-right: 0.3em"
+                      >
+                        <use href="#icon-chart-line"></use>
+                      </svg>
+                      История на Напредъка
+                    </h4>
+                    <div class="chart-container">
+                      <p class="placeholder">
+                        Зареждане на историята на напредъка...
+                      </p>
+                    </div>
+                  </div>
+                  <div id="analyticsCardsContainer" class="analytics-cards-grid">
+                    <div id="macroAnalyticsCard" class="analytics-card">
+                      <h5>Калории и Макронутриенти</h5>
+                      <div class="chart-container">
+                        <canvas id="macroChart"></canvas>
+                      </div>
+                    </div>
+                    <p class="placeholder">Зареждане на детайлните показатели...</p>
+                  </div>
+                </div>
               </div>
             </div>
             <!-- Край Основни Индекси -->
 
-            <!-- Акордеон за детайлни показатели -->
-            <div
-              id="detailedAnalyticsAccordion"
-              class="card accordion-container"
-            >
-              <div
-                class="accordion-header"
-                role="button"
-                tabindex="0"
-                aria-expanded="false"
-                aria-controls="detailedAnalyticsContent"
-              >
-                <span>📊 Детайлни Показатели и Анализ</span>
-                <svg class="icon arrow">
-                  <use href="#icon-chevron-right"></use>
-                </svg>
-              </div>
-              <div
-                id="detailedAnalyticsContent"
-                class="accordion-content"
-                role="region"
-              >
-                <div
-                  id="dashboardTextualAnalysis"
-                  style="margin-bottom: var(--space-lg)"
-                >
-                  <p class="placeholder">Генериране на текстов анализ...</p>
-                </div>
-                <div class="card index-card" id="progressHistoryCard">
-                  <h4>
-                    <svg
-                      class="icon"
-                      style="width: 1em; height: 1em; margin-right: 0.3em"
-                    >
-                      <use href="#icon-chart-line"></use>
-                    </svg>
-                    История на Напредъка
-                  </h4>
-                  <div class="chart-container">
-                    <p class="placeholder">
-                      Зареждане на историята на напредъка...
-                    </p>
-                  </div>
-                </div>
-                <div id="analyticsCardsContainer" class="analytics-cards-grid">
-                  <div id="macroAnalyticsCard" class="analytics-card">
-                    <h5>Калории и Макронутриенти</h5>
-                    <div class="chart-container">
-                      <canvas id="macroChart"></canvas>
-                    </div>
-                    <div id="macroMetricsGrid" class="macro-metrics-grid"></div>
-                  </div>
-                  <p class="placeholder">Зареждане на детайлните показатели...</p>
-                </div>
-              </div>
-            </div>
-            <!-- Край Акордеон детайлни показатели -->
+
 
             <!-- Меню -->
             <div class="card">
@@ -596,6 +591,10 @@
               <ul id="profileGoals" class="profile-data-list">
                 <li class="placeholder">Зареждане на целите...</li>
               </ul>
+            </div>
+            <div class="card" id="streakCard">
+              <h3><span class="streak-emoji" aria-hidden="true">🏅</span> Моите успехи</h3>
+              <div id="streakGrid" class="streak-grid"></div>
             </div>
             <div class="card">
               <h3><i class="bi bi-clipboard-check"></i> Ключови Съображения от Въпросника</h3>

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -98,17 +98,19 @@ body.vivid-theme .index-card .index-value {
 
 /* Achievement Medals */
 .achievement-medal {
-  width: 24px;
-  height: 24px;
+  width: 32px;
+  height: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1rem;
+  font-size: 1.4rem;
   line-height: 1;
   cursor: pointer;
   transition: transform 0.3s ease;
 }
 .achievement-medal.new { animation: pop-in 0.6s ease; }
+
+.streak-emoji { font-size: 1.4rem; }
 
 @keyframes pop-in {
   0% { transform: scale(0); }
@@ -294,7 +296,21 @@ body.vivid-theme #macroAnalyticsCard .macro-label {
 }
 
 /* Детайлни Показатели на Таблото - Корекции */
-#detailedAnalyticsAccordion .accordion-content { background-color: transparent; padding: var(--space-md) 0; } 
+#detailedAnalyticsAccordion .accordion-content { background-color: transparent; padding: var(--space-md) 0; }
+#detailedAnalyticsAccordion .macro-metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-xs);
+  margin-top: var(--space-sm);
+}
+#detailedAnalyticsAccordion .macro-metric {
+  background: color-mix(in srgb, var(--surface-background) 90%, transparent);
+  border: 1px solid var(--border-color-soft);
+  border-radius: var(--radius-md);
+  padding: var(--space-xs);
+  text-align: center;
+  font-size: 0.9rem;
+}
 .detailed-metrics-list { padding: 0; margin: 0; list-style: none; }
 .detailed-metrics-list li.detailed-metric-item { 
     display: flex; flex-direction: column; gap: var(--space-sm); 

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -13,7 +13,8 @@ beforeEach(async () => {
     <div id="engagementProgressFill"></div><div id="engagementProgressBar"></div><span id="engagementProgressText"></span>
     <div id="healthProgressFill"></div><div id="healthProgressBar"></div><span id="healthProgressText"></span>
     <div id="streakGrid"></div>
-    <div id="macroAnalyticsCard"><div id="macroMetricsGrid"></div><div id="macroCenterLabel"></div></div>
+    <div id="detailedAnalyticsAccordion"><div id="macroMetricsGrid" class="macro-metrics-grid"></div></div>
+    <div id="macroAnalyticsCard"><div id="macroCenterLabel"></div></div>
     <h3 id="dailyPlanTitle"></h3>
     <ul id="dailyMealList"></ul>
   `;

--- a/js/achievements.js
+++ b/js/achievements.js
@@ -3,20 +3,13 @@ import { selectors } from './uiElements.js';
 import { openModal } from './uiHandlers.js';
 import { apiEndpoints } from './config.js';
 
-const medalIcons = [
-    '<i class="bi bi-award-fill"></i>',
-    '<i class="bi bi-trophy-fill"></i>',
-    '<i class="bi bi-fire"></i>',
-    '<i class="bi bi-stars"></i>',
-    '<i class="bi bi-patch-check-fill"></i>',
-    '<i class="bi bi-emoji-smile"></i>'
-];
+const medalIcons = ['🏅', '🥇', '🔥', '✨', '✅', '😊'];
 
 // Анимирано показване на иконка в модала за постижение
-function showAchievementEmoji(iconHtml) {
+function showAchievementEmoji(emoji) {
     const emojiEl = document.getElementById('achievementModalEmoji');
     if (!emojiEl) return;
-    emojiEl.innerHTML = iconHtml;
+    emojiEl.textContent = emoji;
     emojiEl.setAttribute('aria-hidden', 'false');
     emojiEl.style.animation = 'none';
     // Trigger reflow to restart animation
@@ -97,7 +90,7 @@ function renderAchievements(newIndex = -1) {
         const el = document.createElement('div');
         el.className = 'achievement-medal';
         if (index === newIndex) el.classList.add('new');
-        el.innerHTML = a.emoji || '<i class="bi bi-award"></i>';
+        el.textContent = a.emoji || '🏅';
         el.dataset.index = index;
         selectors.streakGrid.appendChild(el);
     });
@@ -128,7 +121,7 @@ export function handleAchievementClick(e) {
     const modalTitle = document.getElementById('achievementModalTitle');
     if (body) body.textContent = ach.message;
     if (modalTitle) modalTitle.textContent = ach.title;
-    showAchievementEmoji(ach.emoji || '<i class="bi bi-award"></i>');
+    showAchievementEmoji(ach.emoji || '🏅');
     openModal('achievementModal');
 }
 

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -226,27 +226,7 @@ function populateDashboardDetailedAnalytics(analyticsData) {
     }
 }
 
-function renderMacroAnalyticsCard(macros) {
-    const card = document.createElement('div');
-    card.id = 'macroAnalyticsCard';
-    card.className = 'analytics-card';
-    const header = document.createElement('h5');
-    header.textContent = 'Калории и Макронутриенти';
-    card.appendChild(header);
-
-    const chartContainer = document.createElement('div');
-    chartContainer.className = 'chart-container';
-
-    const canvas = document.createElement('canvas');
-    canvas.id = 'macroChart';
-    chartContainer.appendChild(canvas);
-
-    const centerLabel = document.createElement('div');
-    centerLabel.id = 'macroCenterLabel';
-    centerLabel.textContent = 'Калории';
-    chartContainer.appendChild(centerLabel);
-    card.appendChild(chartContainer);
-
+function createMacroMetricsGrid(macros) {
     const grid = document.createElement('div');
     grid.id = 'macroMetricsGrid';
     grid.className = 'macro-metrics-grid';
@@ -293,7 +273,29 @@ function renderMacroAnalyticsCard(macros) {
         div.addEventListener('click', () => highlightMacro(div, idx - 1));
         grid.appendChild(div);
     });
-    card.appendChild(grid);
+    return grid;
+}
+
+function renderMacroAnalyticsCard() {
+    const card = document.createElement('div');
+    card.id = 'macroAnalyticsCard';
+    card.className = 'analytics-card';
+    const header = document.createElement('h5');
+    header.textContent = 'Калории и Макронутриенти';
+    card.appendChild(header);
+
+    const chartContainer = document.createElement('div');
+    chartContainer.className = 'chart-container';
+
+    const canvas = document.createElement('canvas');
+    canvas.id = 'macroChart';
+    chartContainer.appendChild(canvas);
+
+    const centerLabel = document.createElement('div');
+    centerLabel.id = 'macroCenterLabel';
+    centerLabel.textContent = 'Калории';
+    chartContainer.appendChild(centerLabel);
+    card.appendChild(chartContainer);
 
     // Chart will be initialized when the accordion is opened
 
@@ -378,7 +380,13 @@ function populateDashboardMacros(macros) {
     }
     pendingMacroData = macros || null;
     if (macros) {
-        const card = renderMacroAnalyticsCard(macros);
+        const gridContainer = document.getElementById('macroMetricsGrid');
+        if (gridContainer) {
+            const newGrid = createMacroMetricsGrid(macros);
+            gridContainer.className = newGrid.className;
+            gridContainer.replaceChildren(...newGrid.children);
+        }
+        const card = renderMacroAnalyticsCard();
         selectors.analyticsCardsContainer.prepend(card);
         const header = selectors.detailedAnalyticsAccordion?.querySelector('.accordion-header');
         if (header && header.getAttribute('aria-expanded') === 'true') {


### PR DESCRIPTION
## Summary
- relocate streak card into profile panel
- embed detailed analytics accordion in main index grid
- use emoji for achievements and enlarge display
- show macro metrics grid even when accordion is collapsed
- adjust populateUI logic and update tests

## Testing
- `npm run lint`
- `npm test` *(fails: adminConfigRelated.test.js, passwordReset.test.js, personalizationTemplates.test.js, clientProfileChart.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688ac81e19ac83269757adc082b808c5