### PR TITLE
Fix mobile menu interaction

### DIFF
--- a/js/basicNav.js
+++ b/js/basicNav.js
@@ -16,7 +16,7 @@ export function initBasicNav() {
       if (
         body.classList.contains('nav-open') &&
         !nav.contains(e.target) &&
-        e.target !== mobileMenuBtn
+        !mobileMenuBtn.contains(e.target)
       ) {
         close();
       }

--- a/script.js
+++ b/script.js
@@ -194,7 +194,11 @@ document.addEventListener('DOMContentLoaded', () => {
         };
         mobileMenuBtn.addEventListener('click', toggleNav);
         document.addEventListener('click', (e) => {
-            if (body.classList.contains('nav-open') && !nav.contains(e.target) && e.target !== mobileMenuBtn) {
+            if (
+                body.classList.contains('nav-open') &&
+                !nav.contains(e.target) &&
+                !mobileMenuBtn.contains(e.target)
+            ) {
                 closeNav();
             }
         });


### PR DESCRIPTION
## Summary
- prevent page-level click handler from closing the mobile menu when clicking its icon
- update mobile nav script in pages using `basicNav.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688acc1949a08326b33818a655fa68e6