### PR TITLE
Fix header title color for dark themes

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -25,6 +25,7 @@
   --font-color-secondary: var(--text-color-secondary);
   --font-color-muted: var(--text-color-muted);
   --font-color-on-primary: var(--text-color-on-primary);
+  --header-title-color: var(--text-color-on-primary);
 
   --bg-color: #F0F4F8;
   --bg-gradient: linear-gradient(135deg, #e6eff5 0%, #f0f4f8 100%);
@@ -155,6 +156,7 @@ body.dark-theme {
   --text-color-on-primary: #1C1F2E;
   --text-color-on-secondary: #FFFFFF;
   --text-color-disabled: #adb5bd;
+  --header-title-color: #FFFFFF;
   --font-color-primary: var(--text-color-primary);
   --font-color-secondary: var(--text-color-secondary);
   --font-color-muted: var(--text-color-muted);
@@ -243,6 +245,7 @@ body.vivid-theme {
   --text-color-on-primary: #1C1F2E;
   --text-color-on-secondary: #FFFFFF;
   --text-color-disabled: #adb5bd;
+  --header-title-color: #FFFFFF;
 
   --bg-color: #1C1F2E;
   --bg-gradient: linear-gradient(135deg, #1C1F2E 0%, #252A41 100%);

--- a/css/layout_styles.css
+++ b/css/layout_styles.css
@@ -22,15 +22,15 @@
    3. ХЕДЪР И ГЛАВНО МЕНЮ
    ========================================================================== */
 header {
-  background: var(--primary-color); color: var(--text-color-on-primary);
+  background: var(--primary-color); color: var(--header-title-color);
   padding: var(--space-md) var(--space-lg); display: flex;
   align-items: center; justify-content: space-between; box-shadow: var(--shadow-md);
   position: sticky; top: 0; z-index: 1000;
   height: var(--header-height); 
 }
-header h1 { color: var(--text-color-on-primary); margin: 0; font-size: clamp(1.3rem, 3.5vw, 1.7rem); }
+header h1 { color: var(--header-title-color); margin: 0; font-size: clamp(1.3rem, 3.5vw, 1.7rem); }
 #menu-toggle {
-  color: var(--text-color-on-primary); padding: var(--space-sm); margin-left: var(--space-md);
+  color: var(--header-title-color); padding: var(--space-sm); margin-left: var(--space-md);
   background: transparent; border: none; cursor: pointer;
 }
 #menu-toggle svg { width: 28px; height: 28px; display: block; }


### PR DESCRIPTION
## Summary
- tweak style variables for header title color per theme
- apply `--header-title-color` to header styles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ace1f03a4832699f75e0c5b7adbf7