### PR TITLE
Add header title color variables

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -156,7 +156,7 @@ body.dark-theme {
   --text-color-on-primary: #1C1F2E;
   --text-color-on-secondary: #FFFFFF;
   --text-color-disabled: #adb5bd;
-  --header-title-color: #FFFFFF;
+  --header-title-color: var(--text-color-on-primary);
   --font-color-primary: var(--text-color-primary);
   --font-color-secondary: var(--text-color-secondary);
   --font-color-muted: var(--text-color-muted);
@@ -245,7 +245,7 @@ body.vivid-theme {
   --text-color-on-primary: #1C1F2E;
   --text-color-on-secondary: #FFFFFF;
   --text-color-disabled: #adb5bd;
-  --header-title-color: #FFFFFF;
+  --header-title-color: var(--text-color-on-primary);
 
   --bg-color: #1C1F2E;
   --bg-gradient: linear-gradient(135deg, #1C1F2E 0%, #252A41 100%);

--- a/style.css
+++ b/style.css
@@ -34,6 +34,8 @@
     --color-danger: #e74c3c;
     --color-success: #2ecc71;
     --color-warning: #f39c12;
+    /* Заглавия в хедъра */
+    --header-title-color: var(--secondary-color);
 }
 
 .dark-theme {
@@ -49,6 +51,7 @@
     --shadow-sm: 0 4px 8px rgba(0, 0, 0, 0.2);
     --shadow-md: 0 8px 20px rgba(0, 0, 0, 0.25);
     --shadow-lg: 0 15px 30px rgba(0, 0, 0, 0.3);
+    --header-title-color: var(--light-text);
 }
 
 /* 2. БАЗОВИ СТИЛОВЕ И ДОСТЪПНОСТ - ОТ ai_studio_code.css */


### PR DESCRIPTION
## Summary
- add `--header-title-color` variable to landing styles
- tune theme overrides for header title color in base styles

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ad1b7f53483269caf92b140e1657c