### PR TITLE
Add macro metrics preview to collapsed analytics accordion

### DIFF
--- a/code.html
+++ b/code.html
@@ -454,25 +454,26 @@
             <!-- Акордеон за детайлни показатели -->
             <div
               id="detailedAnalyticsAccordion"
-              class="card accordion-container"
+              class="card index-card accordion-container"
             >
-              <div
-                class="accordion-header"
-                role="button"
-                tabindex="0"
-                aria-expanded="false"
-                aria-controls="detailedAnalyticsContent"
+            <div
+              class="accordion-header"
+              role="button"
+              tabindex="0"
+              aria-expanded="false"
+              aria-controls="detailedAnalyticsContent"
               >
-                <span>📊 Детайлни Показатели и Анализ</span>
-                <svg class="icon arrow">
-                  <use href="#icon-chevron-right"></use>
-                </svg>
-              </div>
-              <div
-                id="detailedAnalyticsContent"
-                class="accordion-content"
-                role="region"
-              >
+              <span>📊 Детайлни Показатели и Анализ</span>
+              <svg class="icon arrow">
+                <use href="#icon-chevron-right"></use>
+              </svg>
+            </div>
+            <div id="macroMetricsPreview" class="macro-metrics-grid macro-preview"></div>
+            <div
+              id="detailedAnalyticsContent"
+              class="accordion-content"
+              role="region"
+            >
                 <div
                   id="dashboardTextualAnalysis"
                   style="margin-bottom: var(--space-lg)"

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -260,6 +260,30 @@ body.vivid-theme #macroAnalyticsCard .macro-label {
   padding: var(--space-sm);
   text-align: center;
 }
+#macroMetricsPreview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+  gap: var(--space-xs);
+  margin-top: var(--space-xs);
+}
+#detailedAnalyticsAccordion:not(.index-card) #macroMetricsPreview {
+  display: none;
+}
+#macroMetricsPreview .macro-metric {
+  padding: var(--space-xs);
+}
+#macroMetricsPreview .macro-icon {
+  font-size: 1rem;
+}
+#macroMetricsPreview .macro-label {
+  font-size: 0.75rem;
+}
+#macroMetricsPreview .macro-value {
+  font-size: 0.9rem;
+}
+#macroMetricsPreview .macro-subtitle {
+  font-size: 0.7rem;
+}
 #macroCenterLabel {
   position: absolute;
   top: 50%;

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -13,6 +13,7 @@ beforeEach(async () => {
     <div id="engagementProgressFill"></div><div id="engagementProgressBar"></div><span id="engagementProgressText"></span>
     <div id="healthProgressFill"></div><div id="healthProgressBar"></div><span id="healthProgressText"></span>
     <div id="streakGrid"></div>
+    <div id="macroMetricsPreview"></div>
     <div id="macroAnalyticsCard"><div id="macroMetricsGrid"></div><div id="macroCenterLabel"></div></div>
     <h3 id="dailyPlanTitle"></h3>
     <ul id="dailyMealList"></ul>
@@ -36,6 +37,7 @@ beforeEach(async () => {
     streakGrid: document.getElementById('streakGrid'),
     macroAnalyticsCard: document.getElementById('macroAnalyticsCard'),
     macroMetricsGrid: document.getElementById('macroMetricsGrid'),
+    macroMetricsPreview: document.getElementById('macroMetricsPreview'),
     macroCenterLabel: document.getElementById('macroCenterLabel'),
     dailyPlanTitle: document.getElementById('dailyPlanTitle'),
     dailyMealList: document.getElementById('dailyMealList')

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -109,6 +109,8 @@ export function setupStaticEventListeners() {
 
     if (selectors.detailedAnalyticsAccordion) {
         const header = selectors.detailedAnalyticsAccordion.querySelector('.accordion-header');
+        const accContent = selectors.detailedAnalyticsContent;
+        const preview = selectors.macroMetricsPreview;
         if (header) {
             // Assuming handleAccordionToggle is imported or available globally if needed outside populateUI
             // For now, it's used by renderAccordionGroup in populateUI.js
@@ -119,12 +121,13 @@ export function setupStaticEventListeners() {
             // Let's assume handleAccordionToggle from populateUI.js can be used if it's made more generic
             // or this specific one can be handled here.
             // Re-using the logic from populateUI's handleAccordionToggle:
-             const accContent = header.nextElementSibling;
              header.addEventListener('click', function() {
                 const isOpen = this.getAttribute('aria-expanded') === 'true';
                 this.setAttribute('aria-expanded', !isOpen); this.classList.toggle('open', !isOpen);
                 const arrow = this.querySelector('.arrow'); if (arrow) arrow.style.transform = isOpen ? 'rotate(0deg)' : 'rotate(90deg)';
                 if (accContent) { accContent.style.display = isOpen ? 'none' : 'block'; accContent.classList.toggle('open-active', !isOpen); }
+                if (preview) preview.style.display = isOpen ? 'grid' : 'none';
+                selectors.detailedAnalyticsAccordion.classList.toggle('index-card', isOpen);
                 if (!isOpen) {
                     renderPendingMacroChart();
                     macroChartInstance?.resize();
@@ -137,6 +140,8 @@ export function setupStaticEventListeners() {
                     this.setAttribute('aria-expanded', !isOpen); this.classList.toggle('open', !isOpen);
                     const arrow = this.querySelector('.arrow'); if (arrow) arrow.style.transform = isOpen ? 'rotate(0deg)' : 'rotate(90deg)';
                     if (accContent) { accContent.style.display = isOpen ? 'none' : 'block'; accContent.classList.toggle('open-active', !isOpen); }
+                    if (preview) preview.style.display = isOpen ? 'grid' : 'none';
+                    selectors.detailedAnalyticsAccordion.classList.toggle('index-card', isOpen);
                     if (!isOpen) {
                         renderPendingMacroChart();
                         macroChartInstance?.resize();

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -366,6 +366,52 @@ export function highlightMacro(metricElement, index) {
     }
 }
 
+function renderMacroPreviewGrid(macros) {
+    const preview = selectors.macroMetricsPreview;
+    if (!preview) return;
+    preview.innerHTML = '';
+    if (!macros) {
+        preview.classList.add('hidden');
+        return;
+    }
+    preview.classList.remove('hidden');
+    const list = [
+        { l: 'Калории', v: macros.calories, s: 'kcal' },
+        { l: 'Белтъчини', v: macros.protein_grams, s: 'g' },
+        { l: 'Въглехидрати', v: macros.carbs_grams, s: 'g' },
+        { l: 'Мазнини', v: macros.fat_grams, s: 'g' }
+    ];
+    const iconMap = {
+        'Калории': 'bi-fire',
+        'Белтъчини': 'bi-egg-fried',
+        'Въглехидрати': 'bi-basket',
+        'Мазнини': 'bi-droplet'
+    };
+    list.forEach(item => {
+        const div = document.createElement('div');
+        div.className = 'macro-metric';
+        const icon = document.createElement('span');
+        icon.className = 'macro-icon';
+        const i = document.createElement('i');
+        i.className = `bi ${iconMap[item.l] || 'bi-circle'}`;
+        icon.appendChild(i);
+        const label = document.createElement('div');
+        label.className = 'macro-label';
+        label.textContent = item.l;
+        const value = document.createElement('div');
+        value.className = 'macro-value';
+        value.textContent = item.v ?? '--';
+        const sub = document.createElement('div');
+        sub.className = 'macro-subtitle';
+        sub.textContent = item.s;
+        div.appendChild(icon);
+        div.appendChild(label);
+        div.appendChild(value);
+        div.appendChild(sub);
+        preview.appendChild(div);
+    });
+}
+
 function populateDashboardMacros(macros) {
     if (!selectors.analyticsCardsContainer) return;
     const existing = document.getElementById('macroAnalyticsCard');
@@ -377,6 +423,7 @@ function populateDashboardMacros(macros) {
         }
     }
     pendingMacroData = macros || null;
+    renderMacroPreviewGrid(macros);
     if (macros) {
         const card = renderMacroAnalyticsCard(macros);
         selectors.analyticsCardsContainer.prepend(card);

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -49,6 +49,7 @@ export function initializeSelectors() {
         analyticsCardsContainer: 'analyticsCardsContainer',
         macroAnalyticsCard: 'macroAnalyticsCard',
         macroMetricsGrid: 'macroMetricsGrid',
+        macroMetricsPreview: 'macroMetricsPreview',
         tooltipTracker: 'tooltip-tracker',
         toast: 'toast', chatFab: 'chat-fab', chatWidget: 'chat-widget', chatClose: 'chat-close',
         chatClear: 'chat-clear',
@@ -75,6 +76,7 @@ export function initializeSelectors() {
                 'streakGrid', 'analyticsCardsContainer', 'achievementShareBtn',
                 'goalCard', 'engagementCard', 'healthCard', 'streakCard',
                 'macroAnalyticsCard', 'macroMetricsGrid',
+                'macroMetricsPreview',
                 'recFoodAllowedCard', 'recFoodLimitCard', 'recHydrationCard',
                 'recCookingMethodsCard', 'recSupplementsCard'
             ];


### PR DESCRIPTION
## Summary
- show macro metrics grid when the detailed analytics accordion is collapsed
- keep accordion styled as an index card while closed
- adjust icons and text in the preview grid for compact display
- update event listeners and UI population logic
- extend UI tests to support the preview grid

## Testing
- `npm run lint`
- `sh ./scripts/test.sh js/__tests__/populateUI.test.js` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_688ad30485388326bee44f2c3299bdad