### PR TITLE
Apply theme background to header title

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -25,7 +25,7 @@
   --font-color-secondary: var(--text-color-secondary);
   --font-color-muted: var(--text-color-muted);
   --font-color-on-primary: var(--text-color-on-primary);
-  --header-title-color: var(--text-color-on-primary);
+  --header-title-color: var(--bg-color);
 
   --bg-color: #F0F4F8;
   --bg-gradient: linear-gradient(135deg, #e6eff5 0%, #f0f4f8 100%);
@@ -156,7 +156,7 @@ body.dark-theme {
   --text-color-on-primary: #1C1F2E;
   --text-color-on-secondary: #FFFFFF;
   --text-color-disabled: #adb5bd;
-  --header-title-color: var(--text-color-on-primary);
+  --header-title-color: var(--bg-color);
   --font-color-primary: var(--text-color-primary);
   --font-color-secondary: var(--text-color-secondary);
   --font-color-muted: var(--text-color-muted);
@@ -245,7 +245,7 @@ body.vivid-theme {
   --text-color-on-primary: #1C1F2E;
   --text-color-on-secondary: #FFFFFF;
   --text-color-disabled: #adb5bd;
-  --header-title-color: var(--text-color-on-primary);
+  --header-title-color: var(--bg-color);
 
   --bg-color: #1C1F2E;
   --bg-gradient: linear-gradient(135deg, #1C1F2E 0%, #252A41 100%);

--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@
     --color-success: #2ecc71;
     --color-warning: #f39c12;
     /* Заглавия в хедъра */
-    --header-title-color: var(--secondary-color);
+    --header-title-color: var(--bg-color);
 }
 
 .dark-theme {
@@ -51,7 +51,7 @@
     --shadow-sm: 0 4px 8px rgba(0, 0, 0, 0.2);
     --shadow-md: 0 8px 20px rgba(0, 0, 0, 0.25);
     --shadow-lg: 0 15px 30px rgba(0, 0, 0, 0.3);
-    --header-title-color: var(--light-text);
+    --header-title-color: var(--bg-color);
 }
 
 /* 2. БАЗОВИ СТИЛОВЕ И ДОСТЪПНОСТ - ОТ ai_studio_code.css */


### PR DESCRIPTION
## Summary
- use background color for `--header-title-color` in light and dark themes
- adjust universal styles for each theme

## Testing
- `npm run lint`
- `npm test` *(няколко теста се провалят)*

------
https://chatgpt.com/codex/tasks/task_e_688ad6b0563083268cc1c7c58ba56357