### PR TITLE
Synchronize mobile menu color with header

### DIFF
--- a/js/basicNav.js
+++ b/js/basicNav.js
@@ -3,11 +3,17 @@ export function initBasicNav() {
   const nav = document.getElementById('nav');
   const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
   if (mobileMenuBtn && nav) {
+    const applyHeaderColor = () => {
+      const header = document.getElementById('header');
+      const bg = header ? getComputedStyle(header).backgroundColor : '';
+      if (bg) nav.style.backgroundColor = bg;
+    };
     const close = () => {
       body.classList.remove('nav-open');
       mobileMenuBtn.setAttribute('aria-expanded', 'false');
     };
     const toggle = () => {
+      applyHeaderColor();
       const open = body.classList.toggle('nav-open');
       mobileMenuBtn.setAttribute('aria-expanded', open);
     };

--- a/script.js
+++ b/script.js
@@ -184,11 +184,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // 2. Мобилно меню
     if (mobileMenuBtn && nav) {
+        const applyHeaderColor = () => {
+            const bg = header ? getComputedStyle(header).backgroundColor : '';
+            if (bg) nav.style.backgroundColor = bg;
+        };
         const closeNav = () => {
             body.classList.remove('nav-open');
             mobileMenuBtn.setAttribute('aria-expanded', 'false');
         };
         const toggleNav = () => {
+            applyHeaderColor();
             const open = body.classList.toggle('nav-open');
             mobileMenuBtn.setAttribute('aria-expanded', open);
         };


### PR DESCRIPTION
## Summary
- ensure mobile menu uses same background color as header
- apply update across pages using `script.js` and `js/basicNav.js`

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688ad8db02288326885d7a5fb9523f0e