### PR TITLE
UI tweaks for macro preview

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -275,6 +275,10 @@ body.vivid-theme #macroAnalyticsCard .macro-label {
 #macroMetricsPreview .macro-icon {
   font-size: 1rem;
 }
+#macroAnalyticsCard .macro-metric.calories .macro-icon,
+#macroMetricsPreview .macro-metric.calories .macro-icon {
+  color: var(--text-color-primary);
+}
 #macroMetricsPreview .macro-label {
   font-size: 0.75rem;
 }
@@ -284,6 +288,12 @@ body.vivid-theme #macroAnalyticsCard .macro-label {
 #macroMetricsPreview .macro-subtitle {
   font-size: 0.7rem;
 }
+#macroMetricsPreview .macro-value,
+#macroMetricsPreview .macro-subtitle {
+  display: inline-block;
+  vertical-align: baseline;
+}
+#macroMetricsPreview .macro-value { margin-right: 0.1em; }
 #macroCenterLabel {
   position: absolute;
   top: 50%;

--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -188,9 +188,8 @@ function applyThemeFromSelect() {
   Object.entries(theme).forEach(([k, val]) => {
     const el = inputs[k];
     if (el) {
-      const norm = normalizeColor(val);
-      el.value = norm;
-      setCssVar(k, norm);
+      el.value = val;
+      setCssVar(k, val);
     }
   });
 }

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -251,7 +251,7 @@ function renderMacroAnalyticsCard(macros) {
     grid.id = 'macroMetricsGrid';
     grid.className = 'macro-metrics-grid';
     const list = [
-        { l: 'Калории', v: macros.calories, s: 'kcal дневно' },
+        { l: 'Калории', v: macros.calories, s: 'kcal дневно', cls: 'calories' },
         {
             l: 'Белтъчини',
             v: macros.protein_grams,
@@ -273,7 +273,7 @@ function renderMacroAnalyticsCard(macros) {
     ];
     list.forEach((item, idx) => {
         const div = document.createElement('div');
-        div.className = 'macro-metric';
+        div.className = 'macro-metric' + (item.cls ? ` ${item.cls}` : '');
 
         const icon = document.createElement('span');
         icon.className = 'macro-icon';
@@ -290,7 +290,7 @@ function renderMacroAnalyticsCard(macros) {
 
         const label = document.createElement('div');
         label.className = 'macro-label';
-        const color = item.c ? getCssVar(item.c) : getCssVar('--primary-color');
+        const color = item.c ? getCssVar(item.c) : null;
         if (color) {
             label.style.color = color;
             icon.style.color = color;
@@ -395,7 +395,7 @@ function renderMacroPreviewGrid(macros) {
     }
     preview.classList.remove('hidden');
     const list = [
-        { l: 'Калории', v: macros.calories, s: 'kcal' },
+        { l: 'Калории', v: macros.calories, s: 'kcal', cls: 'calories' },
         { l: 'Белтъчини', v: macros.protein_percent, s: '%' },
         { l: 'Въглехидрати', v: macros.carbs_percent, s: '%' },
         { l: 'Мазнини', v: macros.fat_percent, s: '%' }
@@ -413,7 +413,7 @@ function renderMacroPreviewGrid(macros) {
     };
     list.forEach(item => {
         const div = document.createElement('div');
-        div.className = 'macro-metric';
+        div.className = 'macro-metric' + (item.cls ? ` ${item.cls}` : '');
         const icon = document.createElement('span');
         icon.className = 'macro-icon';
         const i = document.createElement('i');
@@ -422,7 +422,7 @@ function renderMacroPreviewGrid(macros) {
         const label = document.createElement('div');
         label.className = 'macro-label';
         const clrVar = colorMap[item.l];
-        const clr = clrVar ? getCssVar(clrVar) : getCssVar('--primary-color');
+        const clr = clrVar ? getCssVar(clrVar) : null;
         if (clr) {
             label.style.color = clr;
             icon.style.color = clr;


### PR DESCRIPTION
## Summary
- keep percent value and symbol on one line in `macroMetricsPreview`
- color calories icon neutrally across themes
- avoid hex normalization when applying stored color themes

## Testing
- `npm run lint`
- `npm test` *(fails: handlePerformPasswordReset and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_688adc04d7008326b90907e7c70a01e8