### PR TITLE
Replace PNG assistant icon with SVG

### DIFF
--- a/assistant.html
+++ b/assistant.html
@@ -29,7 +29,7 @@
 </svg>
 <div id="chat-widget" class="chat-widget visible" role="log" aria-live="polite">
     <div class="chat-header">
-        <h4><img src="img/assisticon.png" class="icon assistant-icon" alt="" aria-hidden="true"> Cloudflare Асистент</h4>
+        <h4><svg class="icon assistant-icon" aria-hidden="true"><use href="#icon-assistant"></use></svg> Cloudflare Асистент</h4>
         <button id="chat-clear" class="chat-clear-btn" aria-label="Изчисти чата">
             <svg class="icon"><use href="#icon-trash"></use></svg>
         </button>

--- a/code.html
+++ b/code.html
@@ -1264,7 +1264,7 @@
       >
         <div class="modal-content plan-mod-chat-content">
           <div class="plan-mod-chat-header">
-            <h4 id="planModChatTitle"><img src="img/assisticon.png" class="icon assistant-icon" alt="" aria-hidden="true"> Промяна на план</h4>
+            <h4 id="planModChatTitle"><svg class="icon assistant-icon" aria-hidden="true"><use href="#icon-assistant"></use></svg> Промяна на план</h4>
             <div class="chat-actions">
               <button
                 id="planModChatClear"
@@ -1313,7 +1313,7 @@
         aria-expanded="false"
         aria-controls="chat-widget"
       >
-        <img src="img/assisticon.png" class="icon assistant-icon" alt="" aria-hidden="true">
+        <svg class="icon assistant-icon" aria-hidden="true"><use href="#icon-assistant"></use></svg>
       </button>
       <!-- ======================= END FLOATING ACTION BUTTONS =================== -->
 
@@ -1322,7 +1322,7 @@
       <!-- ======================================================================= -->
       <div id="chat-widget" class="chat-widget" role="log" aria-live="polite">
         <div class="chat-header">
-          <h4><img src="img/assisticon.png" class="icon assistant-icon" alt="" aria-hidden="true"> Чат с Асистент</h4>
+          <h4><svg class="icon assistant-icon" aria-hidden="true"><use href="#icon-assistant"></use></svg> Чат с Асистент</h4>
           <div class="chat-actions">
             <button
               id="chat-clear"

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -329,6 +329,7 @@ body.dark-theme .chat-messages .message.bot { color: #e0e0e0; }
   0%,100% { transform: scale(1); }
   50%     { transform: scale(1.05); }
 }
+.assistant-icon { fill: currentColor; }
 #chat-fab .assistant-icon {
   width: 32px;
   height: 32px;


### PR DESCRIPTION
## Summary
- switch assistant icon `<img>` tags to inline `<svg>`
- set `.assistant-icon` style to use `fill: currentColor`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ae29c961483268add4bd7b7355838