### PR TITLE
Add container styles for dashboard panels

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -314,6 +314,33 @@ body.vivid-theme #macroAnalyticsCard .macro-label {
   }
 }
 
+/* Основни контейнери на таблото */
+#detailedAnalyticsAccordion { margin-bottom: var(--space-xl); }
+#dailyMenuCard   { margin-bottom: var(--space-xl); }
+
+#detailedAnalyticsAccordion {
+  background: color-mix(in srgb, var(--primary-color) 8%, var(--card-bg));
+}
+#dailyMenuCard {
+  background: color-mix(in srgb, var(--secondary-color) 8%, var(--card-bg));
+}
+#dailyLogCard {
+  background: color-mix(in srgb, var(--accent-color) 8%, var(--card-bg));
+}
+
+body.dark-theme #detailedAnalyticsAccordion,
+body.vivid-theme #detailedAnalyticsAccordion {
+  background: color-mix(in srgb, var(--primary-color) 8%, var(--card-bg));
+}
+body.dark-theme #dailyMenuCard,
+body.vivid-theme #dailyMenuCard {
+  background: color-mix(in srgb, var(--secondary-color) 8%, var(--card-bg));
+}
+body.dark-theme #dailyLogCard,
+body.vivid-theme #dailyLogCard {
+  background: color-mix(in srgb, var(--accent-color) 8%, var(--card-bg));
+}
+
 /* Box with extra info for each metric */
 .metric-info-container {
   background: var(--color-info-bg);


### PR DESCRIPTION
## Summary
- add margin rules for dashboard accordion and menu card
- give each main dashboard container a themed background color mix
- ensure dark/vivid themes keep same ratios

## Testing
- `npm run lint`
- `npm test` *(fails: apply built-in themes updates inputs)*

------
https://chatgpt.com/codex/tasks/task_e_688ae76b9b7c8326b561e7810be04f88