### PR TITLE
Fix mobile menu background color

### DIFF
--- a/js/basicNav.js
+++ b/js/basicNav.js
@@ -4,8 +4,9 @@ export function initBasicNav() {
   const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
   if (mobileMenuBtn && nav) {
     const applyHeaderColor = () => {
-      const header = document.getElementById('header');
-      const bg = header ? getComputedStyle(header).backgroundColor : '';
+      const bg = getComputedStyle(document.documentElement)
+        .getPropertyValue('--header-bg-solid')
+        .trim();
       if (bg) nav.style.background = bg;
     };
     const close = () => {

--- a/script.js
+++ b/script.js
@@ -185,7 +185,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // 2. Мобилно меню
     if (mobileMenuBtn && nav) {
         const applyHeaderColor = () => {
-            const bg = header ? getComputedStyle(header).backgroundColor : '';
+            const bg = getComputedStyle(document.documentElement)
+                .getPropertyValue('--header-bg-solid')
+                .trim();
             if (bg) nav.style.background = bg;
         };
         const closeNav = () => {


### PR DESCRIPTION
## Summary
- fetch solid header color via CSS variable in navigation scripts
- keep nav background solid when mobile menu opens

## Testing
- `npm run lint`
- `npm test` *(fails: registers email tests and others)*

------
https://chatgpt.com/codex/tasks/task_e_688af41ed59c8326879b919527a48e02