### PR TITLE
Fix domain links

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ means the Node dependencies haven't been installed. Run `npm install` and then
 try again. Recent versions of the worker rely on the `MAILER_ENDPOINT_URL`
 environment variable instead of dynamic imports. If this variable is missing, the
 worker uses the helper from `sendEmailWorker.js` and posts directly to
-`MAIL_PHP_URL` (defaults to `https://mybody.best/mailer/mail.php`). A **500** error from
+`MAIL_PHP_URL` (defaults to `https://radilovk.github.io/bodybest/mailer/mail.php`). A **500** error from
 `/api/sendTestEmail` usually indicates a problem with the PHP backend. Inspect
 the worker logs for details.
 
@@ -942,7 +942,7 @@ To send a test email задайте `WORKER_ADMIN_TOKEN`. Може да посо
 | Variable | Purpose |
 |----------|---------|
 | `MAILER_ENDPOINT_URL` | Endpoint called by `worker.js` when sending emails. If omitted, the worker posts to `sendEmailWorker.js`. The request payload includes both `message` and `body` fields for compatibility. |
-| `MAIL_PHP_URL` | Legacy PHP endpoint if you prefer your own backend. Defaults to `https://mybody.best/mailer/mail.php`. |
+| `MAIL_PHP_URL` | Legacy PHP endpoint if you prefer your own backend. Defaults to `https://radilovk.github.io/bodybest/mailer/mail.php`. |
 | `EMAIL_PASSWORD` | Password used by `mailer.js` when authenticating with the SMTP server. |
 | `FROM_EMAIL` | Sender address used by `mailer.js` and the PHP backend. |
 | `FROM_NAME` | Optional display name for the sender shown in outgoing emails. |

--- a/data/testEmailTemplate.html
+++ b/data/testEmailTemplate.html
@@ -12,7 +12,7 @@
         <h2 style="color:#2c3e50;margin-top:0;">Здравей, {{name}}</h2>
         <p style="color:#333;line-height:1.5;">Това е примерен HTML имейл. Целта е да демонстрира, че съдържанието може да бъде форматирано.</p>
         <p style="color:#333;line-height:1.5;">Ако виждаш този текст с правилните стилове, значи всичко работи.</p>
-        <a href="https://mybody.best" style="display:inline-block;margin-top:20px;padding:10px 25px;background:#4A90E2;color:#ffffff;text-decoration:none;border-radius:50px;">Посети MyBody</a>
+        <a href="https://radilovk.github.io/bodybest" style="display:inline-block;margin-top:20px;padding:10px 25px;background:#4A90E2;color:#ffffff;text-decoration:none;border-radius:50px;">Посети MyBody</a>
       </td>
     </tr>
   </table>

--- a/data/welcomeEmailTemplate.html
+++ b/data/welcomeEmailTemplate.html
@@ -73,7 +73,7 @@
                   <table border="0" cellspacing="0" cellpadding="0">
                     <tr>
                       <td align="center" style="border-radius: 50px; background: linear-gradient(135deg, #4A90E2 0%, #50E3C2 100%);">
-                        <a href="https://mybody.best/quest.html" target="_blank" class="email-font" style="font-size: 16px; font-weight: 700; color: #ffffff; text-decoration: none; border-radius: 50px; padding: 18px 40px; border: 1px solid #4A90E2; display: inline-block;">Попълнете въпросника</a>
+                        <a href="https://radilovk.github.io/bodybest/quest.html" target="_blank" class="email-font" style="font-size: 16px; font-weight: 700; color: #ffffff; text-decoration: none; border-radius: 50px; padding: 18px 40px; border: 1px solid #4A90E2; display: inline-block;">Попълнете въпросника</a>
                       </td>
                     </tr>
                   </table>

--- a/js/__tests__/adminSendTests.test.js
+++ b/js/__tests__/adminSendTests.test.js
@@ -234,7 +234,7 @@ describe('sendTestQuestionnaire', () => {
     expect(text.startsWith(JSON.stringify(responseData, null, 2))).toBe(true);
     const link = document.getElementById('openTestQAnalysis');
     expect(link.classList.contains('hidden')).toBe(false);
-    expect(link.getAttribute('href')).toBe('https://mybody.best/reganalize/analyze.html?userId=u5');
+    expect(link.getAttribute('href')).toBe('https://radilovk.github.io/bodybest/reganalize/analyze.html?userId=u5');
   });
 
   test('calls reAnalyzeQuestionnaire when no JSON is provided', async () => {
@@ -245,6 +245,6 @@ describe('sendTestQuestionnaire', () => {
     expect(global.fetch).toHaveBeenCalledWith('/api/reAnalyzeQuestionnaire', expect.any(Object));
     const link = document.getElementById('openTestQAnalysis');
     expect(link.classList.contains('hidden')).toBe(false);
-    expect(link.getAttribute('href')).toBe('https://mybody.best/reganalize/analyze.html?userId=u1');
+    expect(link.getAttribute('href')).toBe('https://radilovk.github.io/bodybest/reganalize/analyze.html?userId=u1');
   });
 });

--- a/js/__tests__/workerEmail.test.js
+++ b/js/__tests__/workerEmail.test.js
@@ -47,7 +47,7 @@ describe('handleSendEmailRequest and sendEmailUniversal', () => {
     const env = { WORKER_ADMIN_TOKEN: 'secret' };
     const res = await handleSendEmailRequest(req, env);
     expect(fetch).toHaveBeenCalledWith(
-      'https://mybody.best/mailer/mail.php',
+      'https://radilovk.github.io/bodybest/mailer/mail.php',
       expect.objectContaining({
         body: JSON.stringify({ to: 'a@b.bg', subject: 'S', message: 'B', body: 'B', fromName: '' }),
         headers: { 'Content-Type': 'application/json' }
@@ -66,7 +66,7 @@ describe('handleSendEmailRequest and sendEmailUniversal', () => {
     });
     await sendEmailUniversal('t@e.com', 'Hi', 'Body', {});
     expect(fetch).toHaveBeenCalledWith(
-      'https://mybody.best/mailer/mail.php',
+      'https://radilovk.github.io/bodybest/mailer/mail.php',
       expect.objectContaining({
         body: JSON.stringify({ to: 't@e.com', subject: 'Hi', message: 'Body', body: 'Body', fromName: '' }),
         headers: { 'Content-Type': 'application/json' }
@@ -176,7 +176,7 @@ describe('handleSendTestEmailRequest', () => {
     const env = { WORKER_ADMIN_TOKEN: 'secret' };
     const res = await handleSendTestEmailRequest(request, env);
     expect(res.success).toBe(true);
-    expect(fetch).toHaveBeenCalledWith('https://mybody.best/mailer/mail.php', expect.any(Object));
+    expect(fetch).toHaveBeenCalledWith('https://radilovk.github.io/bodybest/mailer/mail.php', expect.any(Object));
   });
 
   test('forwards fromName to mailer', async () => {
@@ -222,7 +222,7 @@ describe('handleSendTestEmailRequest', () => {
       expect.any(String)
     );
     expect(fetch).toHaveBeenCalledWith(
-      'https://mybody.best/mailer/mail.php',
+      'https://radilovk.github.io/bodybest/mailer/mail.php',
       expect.any(Object)
     );
   });

--- a/reganalize/etemplate
+++ b/reganalize/etemplate
@@ -73,7 +73,7 @@
                   <table border="0" cellspacing="0" cellpadding="0">
                     <tr>
                       <td align="center" style="border-radius: 50px; background: linear-gradient(135deg, #4A90E2 0%, #50E3C2 100%);">
-                        <a href="https://mybody.best/quest.html" target="_blank" class="email-font" style="font-size: 16px; font-weight: 700; color: #ffffff; text-decoration: none; border-radius: 50px; padding: 18px 40px; border: 1px solid #4A90E2; display: inline-block;">Попълнете въпросника</a>
+                        <a href="https://radilovk.github.io/bodybest/quest.html" target="_blank" class="email-font" style="font-size: 16px; font-weight: 700; color: #ffffff; text-decoration: none; border-radius: 50px; padding: 18px 40px; border: 1px solid #4A90E2; display: inline-block;">Попълнете въпросника</a>
                       </td>
                     </tr>
                   </table>

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -53,7 +53,7 @@ async function checkRateLimit(env, identifier, limit = 3, windowMs = 60000) {
 }
 
 async function sendViaPhp(to, subject, message, env = {}) {
-  const url = env[MAIL_PHP_URL_VAR_NAME] || 'https://mybody.best/mailer/mail.php';
+  const url = env[MAIL_PHP_URL_VAR_NAME] || 'https://radilovk.github.io/bodybest/mailer/mail.php';
   const fromName = env.FROM_NAME || '';
   const resp = await fetch(url, {
     method: 'POST',

--- a/worker.js
+++ b/worker.js
@@ -116,7 +116,7 @@ const WELCOME_BODY_TEMPLATE = `<!DOCTYPE html>
                   <table border="0" cellspacing="0" cellpadding="0">
                     <tr>
                       <td align="center" style="border-radius: 50px; background: linear-gradient(135deg, #4A90E2 0%, #50E3C2 100%);">
-                        <a href="https://mybody.best/quest.html" target="_blank" class="email-font" style="font-size: 16px; font-weight: 700; color: #ffffff; text-decoration: none; border-radius: 50px; padding: 18px 40px; border: 1px solid #4A90E2; display: inline-block;">Попълнете въпросника</a>
+                        <a href="https://radilovk.github.io/bodybest/quest.html" target="_blank" class="email-font" style="font-size: 16px; font-weight: 700; color: #ffffff; text-decoration: none; border-radius: 50px; padding: 18px 40px; border: 1px solid #4A90E2; display: inline-block;">Попълнете въпросника</a>
                       </td>
                     </tr>
                   </table>
@@ -213,7 +213,7 @@ async function sendAnalysisLinkEmail(to, name, link, env) {
 async function sendPasswordResetEmail(to, token, env) {
     const subject = env?.[PASSWORD_RESET_EMAIL_SUBJECT_VAR_NAME] || PASSWORD_RESET_SUBJECT;
     const tpl = env?.[PASSWORD_RESET_EMAIL_BODY_VAR_NAME] || PASSWORD_RESET_BODY_TEMPLATE;
-    const base = env?.[PASSWORD_RESET_PAGE_URL_VAR_NAME] || 'https://mybody.best/reset-password.html';
+    const base = env?.[PASSWORD_RESET_PAGE_URL_VAR_NAME] || 'https://radilovk.github.io/bodybest/reset-password.html';
     const url = new URL(base);
     url.searchParams.set('token', token);
     const html = tpl.replace(/{{\s*link\s*}}/g, url.toString());
@@ -846,7 +846,7 @@ async function handleSubmitQuestionnaire(request, env, ctx) {
         console.log(`SUBMIT_QUESTIONNAIRE (${userId}): Saved initial answers, status set to pending.`);
 
         const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] ||
-            'https://mybody.best/reganalize/analyze.html';
+            'https://radilovk.github.io/bodybest/reganalize/analyze.html';
         const url = new URL(baseUrl);
         url.searchParams.set('userId', userId);
         const link = url.toString();
@@ -902,7 +902,7 @@ async function handleSubmitDemoQuestionnaire(request, env, ctx) {
         console.log(`SUBMIT_DEMO_QUESTIONNAIRE (${userId}): Saved initial answers.`);
 
         const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] ||
-            'https://mybody.best/reganalize/analyze.html';
+            'https://radilovk.github.io/bodybest/reganalize/analyze.html';
         const url = new URL(baseUrl);
         url.searchParams.set('userId', userId);
         const link = url.toString();
@@ -1904,7 +1904,7 @@ async function handleReAnalyzeQuestionnaireRequest(request, env, ctx) {
             await handleAnalyzeInitialAnswers(userId, env);
             await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'pending');
         }
-        const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] || 'https://mybody.best/reganalize/analyze.html';
+        const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] || 'https://radilovk.github.io/bodybest/reganalize/analyze.html';
         const url = new URL(baseUrl);
         url.searchParams.set('userId', userId);
         return { success: true, userId, link: url.toString() };


### PR DESCRIPTION
## Summary
- update HTML templates to use radilovk.github.io links
- adjust worker default URLs accordingly
- align tests with new domain
- document new default `MAIL_PHP_URL`

## Testing
- `npm run lint`
- `npm test` *(fails: handlePerformPasswordReset updates password and deletes token)*

------
https://chatgpt.com/codex/tasks/task_e_688bb2865200832683eadeaaf2c6caed