### PR TITLE
Handle questionnaire auto submission

### DIFF
--- a/css/quest_styles.css
+++ b/css/quest_styles.css
@@ -301,12 +301,12 @@ button[id^="nextBtn"]:hover, button[id="regSubmitBtn"]:hover, button[id="submitB
 }
 
 /* Второстепенен бутон (Назад) */
-button[id^="prevBtn"], button[id="regBackBtn"], button[id="restartBtn"] {
+button[id^="prevBtn"], button[id="regBackBtn"], button[id="restartBtn"], button[id="finalBackBtn"] {
   background-color: transparent;
   color: var(--accent-primary);
   border: 2px solid var(--accent-primary);
 }
-button[id^="prevBtn"]:hover, button[id="regBackBtn"]:hover, button[id="restartBtn"]:hover {
+button[id^="prevBtn"]:hover, button[id="regBackBtn"]:hover, button[id="restartBtn"]:hover, button[id="finalBackBtn"]:hover {
   background-color: var(--accent-primary);
   color: var(--text-on-accent);
 }


### PR DESCRIPTION
## Summary
- auto-submit answers when showing final questionnaire page
- remove the manual submit and restart buttons
- expose `finalBackBtn` and style it like other back buttons

## Testing
- `npm run lint`
- `npm test` *(fails: handlePerformPasswordReset and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_688bb4c754408326a636ab60e40be2ea