### PR TITLE
Add macro summation utility

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -1,0 +1,27 @@
+/** @jest-environment jsdom */
+import { calculateCurrentMacros } from '../macroUtils.js';
+
+test('calculateCurrentMacros sums macros from completed meals and extras', () => {
+  const planMenu = {
+    monday: [
+      { id: 'z-01', meal_name: 'Протеинов шейк' },
+      { id: 'o-01', meal_name: 'Печено пилешко с ориз/картофи и салата' }
+    ],
+    tuesday: [
+      { id: 'o-02', meal_name: 'Телешки кюфтета със салата' }
+    ]
+  };
+
+  const completionStatus = {
+    monday_0: true,
+    monday_1: false,
+    tuesday_0: true
+  };
+
+  const extraMeals = [
+    { calories: 100, protein: 5, carbs: 10, fat: 2 }
+  ];
+
+  const result = calculateCurrentMacros(planMenu, completionStatus, extraMeals);
+  expect(result).toEqual({ calories: 880, protein: 67, carbs: 48, fat: 42 });
+});

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -1,0 +1,56 @@
+import { readFileSync } from 'fs';
+
+const dietModelPath = new URL('../kv/DIET_RESOURCES/base_diet_model.json', import.meta.url);
+const dietModel = JSON.parse(readFileSync(dietModelPath, 'utf8'));
+
+// Създаваме речник за бързо търсене на макроси по id или име
+const macrosByIdOrName = new Map();
+(dietModel['ястия'] || []).forEach((meal) => {
+  const macros = meal['хранителни_стойности'];
+  if (macros) {
+    macrosByIdOrName.set(meal.id, macros);
+    macrosByIdOrName.set((meal.име || '').toLowerCase(), macros);
+  }
+});
+
+/**
+ * Изчислява общите макроси за изпълнените хранения и извънредни хранения.
+ * @param {Object} planMenu - Менюто по дни със списъци от хранения.
+ * @param {Object} completionStatus - Обект със статуси дали храненето е изпълнено (day_index ключове).
+ * @param {Array} extraMeals - Допълнителни хранения с макроси { calories, protein, carbs, fat }.
+ * @returns {{ calories:number, protein:number, carbs:number, fat:number }}
+ */
+export function calculateCurrentMacros(planMenu = {}, completionStatus = {}, extraMeals = []) {
+  let calories = 0;
+  let protein = 0;
+  let carbs = 0;
+  let fat = 0;
+
+  Object.entries(planMenu).forEach(([day, meals]) => {
+    (meals || []).forEach((meal, idx) => {
+      const key = `${day}_${idx}`;
+      if (completionStatus[key]) {
+        const macros = macrosByIdOrName.get(meal.id) || macrosByIdOrName.get((meal.meal_name || '').toLowerCase());
+        if (macros) {
+          calories += Number(macros['калории']) || 0;
+          protein += Number(macros['белтъчини']) || 0;
+          carbs += Number(macros['въглехидрати']) || 0;
+          fat += Number(macros['мазнини']) || 0;
+        }
+      }
+    });
+  });
+
+  if (Array.isArray(extraMeals)) {
+    extraMeals.forEach((m) => {
+      calories += Number(m.calories) || 0;
+      protein += Number(m.protein) || 0;
+      carbs += Number(m.carbs) || 0;
+      fat += Number(m.fat) || 0;
+    });
+  }
+
+  return { calories, protein, carbs, fat };
+}
+
+export const __testExports = { macrosByIdOrName };


### PR DESCRIPTION
## Summary
- add `calculateCurrentMacros` helper for tallying finished meals and extras
- provide Jest test verifying macro totals

## Testing
- `npm run lint`
- `npm test` *(fails: maintenanceMode.test.js, registerEmail.test.js, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688bdf3d0a488326b86dcdac73aed993