### PR TITLE
Add macro tracking for extra meal form

### DIFF
--- a/extra-meal-entry-form.html
+++ b/extra-meal-entry-form.html
@@ -86,6 +86,28 @@
             </select>
             <input type="datetime-local" id="mealTimeSpecific" name="mealTimeSpecific" class="hidden input-focus-animate" style="margin-top: var(--space-sm);" aria-label="Конкретно време на консумация">
         </div>
+
+        <div class="form-group" style="margin-top: var(--space-md);">
+            <label style="display:block;margin-bottom:var(--space-xs);">Приблизителни макроси (по избор)</label>
+            <div class="macro-inputs-grid" style="display:flex;flex-wrap:wrap;gap:var(--space-sm);">
+                <label style="display:flex;flex-direction:column;">
+                    Калории
+                    <input type="number" name="calories" min="0" step="1" class="input-focus-animate" style="max-width:6rem;">
+                </label>
+                <label style="display:flex;flex-direction:column;">
+                    Протеин (g)
+                    <input type="number" name="protein" min="0" step="1" class="input-focus-animate" style="max-width:6rem;">
+                </label>
+                <label style="display:flex;flex-direction:column;">
+                    Въглехидрати (g)
+                    <input type="number" name="carbs" min="0" step="1" class="input-focus-animate" style="max-width:6rem;">
+                </label>
+                <label style="display:flex;flex-direction:column;">
+                    Мазнини (g)
+                    <input type="number" name="fat" min="0" step="1" class="input-focus-animate" style="max-width:6rem;">
+                </label>
+            </div>
+        </div>
     </div>
 
     <!-- Стъпка 3: Причина -->
@@ -157,6 +179,10 @@
             <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Храна:</strong> <span data-summary="foodDescription"></span></div>
             <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Количество:</strong> <span data-summary="quantityEstimate"></span></div>
             <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Време:</strong> <span data-summary="mealTimeSelect"></span></div>
+            <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Калории:</strong> <span data-summary="calories"></span></div>
+            <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Протеин:</strong> <span data-summary="protein"></span></div>
+            <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Въглехидрати:</strong> <span data-summary="carbs"></span></div>
+            <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Мазнини:</strong> <span data-summary="fat"></span></div>
             <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Причина:</strong> <span data-summary="reasonPrimary"></span></div>
             <div style="margin-bottom: var(--space-xs); padding: var(--space-xs) 0; border-bottom: 1px dotted var(--border-color-soft);"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Усещане:</strong> <span data-summary="feelingAfter"></span></div>
             <div style="padding: var(--space-xs) 0;"><strong style="color: var(--text-color-primary); margin-right: var(--space-xs); min-width: 130px; display: inline-block;">Замести планирано:</strong> <span data-summary="replacedPlanned"></span></div>

--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -31,3 +31,21 @@ test('показва съобщение при липса на количест�
   expect(showToastMock).toHaveBeenCalled();
   expect(fetch).not.toHaveBeenCalled();
 });
+
+test('изпраща макро стойности при попълнени полета', async () => {
+  document.body.innerHTML = `<form id="f">
+    <input type="radio" name="quantityEstimateVisual" value="малко" checked>
+    <input name="calories" value="120">
+    <input name="protein" value="10">
+    <input name="carbs" value="15">
+    <input name="fat" value="5">
+  </form>`;
+  const form = document.getElementById('f');
+  const e = { preventDefault: jest.fn(), target: form };
+  await handleExtraMealFormSubmit(e);
+  const body = JSON.parse(fetch.mock.calls[0][1].body);
+  expect(body.calories).toBe(120);
+  expect(body.protein).toBe(10);
+  expect(body.carbs).toBe(15);
+  expect(body.fat).toBe(5);
+});

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -106,6 +106,14 @@ export function initializeExtraMealFormLogic(formContainerElement) {
             replacedDisplay += ` (Засегнато: ${skippedMealVal})`;
         }
         summaryContainer.querySelector('[data-summary="replacedPlanned"]').textContent = replacedDisplay;
+
+        ['calories','protein','carbs','fat'].forEach(field => {
+            const el = summaryContainer.querySelector(`[data-summary="${field}"]`);
+            if (el) {
+                const val = getElValue(field);
+                el.textContent = val ? val : '-';
+            }
+        });
     }
 
     function showCurrentStep() {
@@ -312,9 +320,13 @@ export async function handleExtraMealFormSubmit(event) {
 
     const dataToSend = { userId: currentUserId, timestamp: new Date().toISOString() };
 
+    const numericFields = ['calories','protein','carbs','fat'];
     for (let [key, value] of formData.entries()) {
         if (key === 'quantityEstimateVisual') {
             dataToSend['quantityEstimate'] = value;
+        } else if (numericFields.includes(key)) {
+            const num = parseFloat(value);
+            if (!isNaN(num)) dataToSend[key] = num;
         } else {
             dataToSend[key] = value;
         }

--- a/worker.js
+++ b/worker.js
@@ -1371,6 +1371,10 @@ async function handleLogExtraMealRequest(request, env) {
             feelingAfter: inputData.feelingAfter || "не е посочено", // e.g., "добре", "виновен", "подут"
             replacedPlanned: inputData.replacedPlanned || "не", // "да_напълно", "да_частично", "не"
             skippedMeal: inputData.skippedMeal || null, // Кое планирано хранене е пропуснато, ако има такова
+            calories: (inputData.calories !== undefined && !isNaN(parseFloat(inputData.calories))) ? parseFloat(inputData.calories) : null,
+            protein: (inputData.protein !== undefined && !isNaN(parseFloat(inputData.protein))) ? parseFloat(inputData.protein) : null,
+            carbs: (inputData.carbs !== undefined && !isNaN(parseFloat(inputData.carbs))) ? parseFloat(inputData.carbs) : null,
+            fat: (inputData.fat !== undefined && !isNaN(parseFloat(inputData.fat))) ? parseFloat(inputData.fat) : null,
             type: "extra_meal" // Маркер за типа запис
         };
 


### PR DESCRIPTION
## Summary
- allow entering calories, protein, carbs and fat in the extra meal form
- capture those macros in the summary and send them in the payload
- store optional macro values in the worker
- extend test to verify macro fields are submitted

## Testing
- `npm run lint`
- `npm test` *(fails: Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688be231c8648326b0fc22bdb8eff56a