### PR TITLE
Fix client macros loading via fetch

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -1,7 +1,22 @@
 /** @jest-environment jsdom */
-import { calculateCurrentMacros } from '../macroUtils.js';
+import { readFileSync } from 'fs';
+import { calculateCurrentMacros, loadDietModel } from '../macroUtils.js';
 
-test('calculateCurrentMacros sums macros from completed meals and extras', () => {
+const dietModel = JSON.parse(
+  readFileSync(new URL('../../kv/DIET_RESOURCES/base_diet_model.json', import.meta.url))
+);
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(dietModel) })
+  );
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('calculateCurrentMacros sums macros from completed meals and extras', async () => {
   const planMenu = {
     monday: [
       { id: 'z-01', meal_name: 'Протеинов шейк' },
@@ -22,6 +37,7 @@ test('calculateCurrentMacros sums macros from completed meals and extras', () =>
     { calories: 100, protein: 5, carbs: 10, fat: 2 }
   ];
 
-  const result = calculateCurrentMacros(planMenu, completionStatus, extraMeals);
+  await loadDietModel();
+  const result = await calculateCurrentMacros(planMenu, completionStatus, extraMeals);
   expect(result).toEqual({ calories: 880, protein: 67, carbs: 48, fat: 42 });
 });

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -20,7 +20,7 @@ import {
     fullDashboardData, activeTooltip, currentUserId,
     setChatModelOverride, setChatPromptOverride
 } from './app.js';
-import { calculateCurrentMacros } from './macroUtils.js';
+import { calculateCurrentMacros, loadDietModel } from './macroUtils.js';
 import {
     openPlanModificationChat,
     clearPlanModChat,
@@ -287,7 +287,7 @@ export function setupDynamicEventListeners() {
     }
 }
 
-function handleDelegatedClicks(event) {
+async function handleDelegatedClicks(event) {
     const target = event.target;
     if (target.closest('.modal-content') && !target.closest('[data-modal-close]')) return;
 
@@ -339,9 +339,10 @@ function handleDelegatedClicks(event) {
         if (day && index !== undefined) {
             const isCompleted = mealCard.classList.toggle('completed');
             todaysMealCompletionStatus[`${day}_${index}`] = isCompleted;
+            await loadDietModel();
             Object.assign(
                 currentIntakeMacros,
-                calculateCurrentMacros(
+                await calculateCurrentMacros(
                     fullDashboardData.planData?.week1Menu,
                     todaysMealCompletionStatus,
                     todaysExtraMeals

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -3,7 +3,7 @@ import { selectors } from './uiElements.js';
 import { showLoading, showToast, openModal as genericOpenModal, closeModal as genericCloseModal } from './uiHandlers.js';
 import { apiEndpoints } from './config.js';
 import { currentUserId, todaysExtraMeals, todaysMealCompletionStatus, currentIntakeMacros, fullDashboardData } from './app.js';
-import { calculateCurrentMacros } from './macroUtils.js';
+import { calculateCurrentMacros, loadDietModel } from './macroUtils.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 
 let extraMealFormLoaded = false;
@@ -369,9 +369,10 @@ export async function handleExtraMealFormSubmit(event) {
             carbs: dataToSend.carbs || 0,
             fat: dataToSend.fat || 0
         });
+        await loadDietModel();
         Object.assign(
             currentIntakeMacros,
-            calculateCurrentMacros(
+            await calculateCurrentMacros(
                 fullDashboardData.planData?.week1Menu,
                 todaysMealCompletionStatus,
                 todaysExtraMeals


### PR DESCRIPTION
## Summary
- load diet model via fetch in `macroUtils`
- await macro data in event handlers and extra meal form
- adjust tests to mock `fetch`

## Testing
- `npm run lint`
- `npm test` *(fails: some suites like passwordReset.test.js, registerEmail.test.js, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688bec3f044483269d5414a9cfcf767d