### PR TITLE
feat: add auto refresh and localization to macro card

### DIFF
--- a/docs/macroAnalyticsCard.html
+++ b/docs/macroAnalyticsCard.html
@@ -2,133 +2,26 @@
 <html lang="bg">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Шаблон MacroAnalyticsCard</title>
-  <link rel="stylesheet" href="../css/base_styles.css">
-  <link rel="stylesheet" href="../css/components_styles.css">
-  <link rel="stylesheet" href="../css/dashboard_panel_styles.css">
-  <link rel="stylesheet" href="../css/responsive_styles.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <title>MacroAnalyticsCard – автономен пример</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 1rem; }
+    iframe { width: 100%; max-width: 500px; height: 560px; border: 1px solid #ccc; border-radius: 8px; }
+  </style>
 </head>
 <body>
-  <div class="card" style="max-width:600px;margin:2rem auto;">
-    <div id="macroAnalyticsCard" class="analytics-card">
-      <h5>Калории и Макронутриенти</h5>
-      <div class="chart-container">
-        <canvas id="macroChart"></canvas>
-      </div>
-      <div id="macroMetricsGrid" class="macro-metrics-grid"></div>
-    </div>
-  </div>
-
+  <h1>Standalone MacroAnalyticsCard</h1>
+  <p>
+    Файлът <code>macroAnalyticsCardStandalone.html</code> съдържа всички нужни стилове и логика.
+    Може да бъде вграден чрез &lt;iframe&gt; или чрез копиране на Web Component кода.
+  </p>
+  <iframe src="../macroAnalyticsCardStandalone.html" title="Macro Analytics Card"></iframe>
   <details>
-    <summary>Описание и логика</summary>
-    <p>Модулът визуализира препоръчан дневен прием на макронутриенти.</p>
-    <ul>
-      <li><code>renderMacroAnalyticsCard(macros)</code> – създава HTML структурата и попълва стойностите.</li>
-      <li><code>renderPendingMacroChart()</code> – инициализира кръговата диаграма с помощта на <code>Chart.js</code>.</li>
-      <li><code>highlightMacro(el)</code> – маркира избрания елемент в решетката.</li>
-    </ul>
-    <p>Функциите се намират в <code>js/populateUI.js</code> и се изпълняват при зареждане на таблото. Диаграмата се рисува при отваряне на секцията за детайлни показатели.</p>
+    <summary>Интеграция</summary>
+    <ol>
+      <li>Копирайте файла или го вградете с <code>&lt;iframe&gt;</code>.</li>
+      <li>Подайте данни чрез атрибутите <code>target-data</code> и <code>current-data</code> (JSON) или използвайте <code>data-endpoint</code> с <code>refresh-interval</code>.</li>
+      <li>Променете цветовете чрез CSS променливите в <code>:root</code>.</li>
+    </ol>
   </details>
-
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script type="module">
-    const demoData = {
-      calories: 2200,
-      protein_grams: 140,
-      protein_percent: 25,
-      carbs_grams: 230,
-      carbs_percent: 45,
-      fat_grams: 70,
-      fat_percent: 30
-    };
-
-    let macroChartInstance = null;
-    let pendingMacroData = null;
-
-    const getCssVar = (name, fallback = '') =>
-      getComputedStyle(document.documentElement).getPropertyValue(name) || fallback;
-
-    function highlightMacro(el) {
-      const grid = document.getElementById('macroMetricsGrid');
-      if (!grid || !el) return;
-      grid.querySelectorAll('.macro-metric').forEach(div => div.classList.remove('active'));
-      el.classList.add('active');
-    }
-
-    function renderMacroAnalyticsCard(macros) {
-      const grid = document.getElementById('macroMetricsGrid');
-      grid.innerHTML = '';
-      const list = [
-        { l: 'Калории', v: macros.calories, s: 'kcal дневно' },
-        { l: 'Белтъчини', v: macros.protein_grams, s: `${macros.protein_percent}%`, c: '--macro-protein-color' },
-        { l: 'Въглехидрати', v: macros.carbs_grams, s: `${macros.carbs_percent}%`, c: '--macro-carbs-color' },
-        { l: 'Мазнини', v: macros.fat_grams, s: `${macros.fat_percent}%`, c: '--macro-fat-color' }
-      ];
-      const iconMap = {
-        'Калории': 'bi-fire',
-        'Белтъчини': 'bi-egg-fried',
-        'Въглехидрати': 'bi-basket',
-        'Мазнини': 'bi-droplet'
-      };
-      list.forEach(item => {
-        const div = document.createElement('div');
-        div.className = 'macro-metric';
-
-        div.innerHTML = `
-          <span class="macro-icon"><i class="bi ${iconMap[item.l] || 'bi-circle'}"></i></span>
-          <div class="macro-label" style="color:${item.c ? getCssVar(item.c) : ''}">${item.l}</div>
-          <div class="macro-value">${item.v}</div>
-          <div class="macro-subtitle">${item.s}</div>`;
-        div.addEventListener('click', () => highlightMacro(div));
-        grid.appendChild(div);
-      });
-      pendingMacroData = macros;
-    }
-
-    function renderPendingMacroChart() {
-      if (!pendingMacroData) return;
-      const canvas = document.getElementById('macroChart');
-      if (!canvas || typeof Chart === 'undefined') return;
-      if (macroChartInstance) {
-        macroChartInstance.destroy();
-        macroChartInstance = null;
-      }
-      const m = pendingMacroData;
-      const ctx = canvas.getContext('2d');
-      macroChartInstance = new Chart(ctx, {
-        type: 'doughnut',
-        data: {
-          labels: [
-            `Белтъчини (${m.protein_percent}%)`,
-            `Въглехидрати (${m.carbs_percent}%)`,
-            `Мазнини (${m.fat_percent}%)`
-          ],
-          datasets: [{
-            label: 'Разпределение на макроси',
-            data: [m.protein_grams, m.carbs_grams, m.fat_grams],
-            backgroundColor: [
-              getCssVar('--macro-protein-color', 'rgb(54,162,235)'),
-              getCssVar('--macro-carbs-color', 'rgb(255,205,86)'),
-              getCssVar('--macro-fat-color', 'rgb(255,99,132)')
-            ],
-            hoverOffset: 4
-          }]
-        },
-        options: {
-          responsive: true,
-          plugins: {
-            legend: { display: false },
-            title: { display: true, text: `Дневен прием (${m.calories} kcal)` }
-          }
-        }
-      });
-    }
-
-    // Инициализация на примера
-    renderMacroAnalyticsCard(demoData);
-    renderPendingMacroChart();
-  </script>
 </body>
 </html>

--- a/macroAnalyticsCardStandalone.html
+++ b/macroAnalyticsCardStandalone.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<!--
+  Самостоятелен модул за визуализация на макронутриенти.
+  Няма вътрешни зависимости; използва единствено CDN за Bootstrap Icons и Chart.js.
+  Интеграция:
+  - копирайте файла или го вградете с <iframe>;
+  - подайте данни чрез атрибутите "current-data" и "target-data" (JSON) или
+    използвайте "data-endpoint" и "refresh-interval" за автоматично опресняване;
+  - цветовете се настройват чрез CSS променливите в :root.
+-->
+<html lang="bg">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Standalone Macro Analytics Card</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+  <style>
+  :root {
+    --main-bg: #1A1D2D;
+    --card-bg: #2C314A;
+    --text-color: #E0E0E0;
+    --text-secondary-color: #A0A5C0;
+    --macro-protein-color: #5BC0BE;
+    --macro-carbs-color: #FFD166;
+    --macro-fat-color: #FF6B6B;
+  }
+  body {
+    background: var(--main-bg);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    color: var(--text-color);
+    padding: 1rem;
+  }
+  @media (max-width: 480px) {
+    body { padding: 0.5rem; }
+  }
+  </style>
+</head>
+<body>
+  <macro-analytics-card
+    locale="bg"
+    target-data='{"calories":2200,"protein_grams":140,"protein_percent":25,"carbs_grams":248,"carbs_percent":45,"fat_grams":73,"fat_percent":30}'
+    current-data='{"calories":950,"protein_grams":70,"carbs_grams":90,"fat_grams":40}'
+  ></macro-analytics-card>
+
+  <script type="module">
+    const macroCardLocales = {
+      bg: {
+        title: 'Калории и Макронутриенти',
+        caloriesLabel: 'Приети Калории',
+        macros: {
+          protein: 'Белтъчини',
+          carbs: 'Въглехидрати',
+          fat: 'Мазнини'
+        },
+        fromGoal: 'от целта',
+        totalCaloriesLabel: (calories) => `от ${calories} kcal`
+      },
+      en: {
+        title: 'Calories & Macros',
+        caloriesLabel: 'Calories Consumed',
+        macros: {
+          protein: 'Protein',
+          carbs: 'Carbohydrates',
+          fat: 'Fat'
+        },
+        fromGoal: 'of goal',
+        totalCaloriesLabel: (calories) => `of ${calories} kcal`
+      }
+    };
+
+    const template = document.createElement('template');
+    template.innerHTML = `
+      <style>
+        :host { display: block; }
+        .card {
+          background: var(--card-bg);
+          border-radius: 20px;
+          padding: 1.5rem;
+          border: 1px solid rgba(255, 255, 255, 0.05);
+          box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+          max-width: 450px;
+          margin: 2rem auto;
+          opacity: 0;
+          transform: scale(0.95);
+        }
+        :host(.loaded) .card { animation: fade-in 0.6s ease forwards; }
+        @keyframes fade-in { to { opacity: 1; transform: scale(1); } }
+        .analytics-card h5 {
+          text-align: center;
+          font-size: 1.25rem;
+          font-weight: 600;
+          margin-bottom: 1.5rem;
+          color: var(--text-color);
+        }
+        .chart-container {
+          position: relative;
+          margin: 0 auto;
+          max-width: 250px;
+          height: 250px;
+        }
+        .chart-center-text {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          text-align: center;
+          pointer-events: none;
+        }
+        .chart-center-text .consumed-calories {
+          font-size: 2.5rem;
+          font-weight: 700;
+          line-height: 1.1;
+          color: var(--text-color);
+        }
+        .chart-center-text .total-calories-label {
+          font-size: 0.8rem;
+          color: var(--text-secondary-color);
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
+        }
+        .macro-metrics-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+          gap: 0.75rem;
+          margin-top: 1rem;
+        }
+        .macro-metric {
+          text-align: center;
+          padding: 0.5rem;
+          border: 1px solid rgba(255, 255, 255, 0.05);
+          border-radius: 12px;
+          cursor: pointer;
+          transition: border-color 0.3s ease, transform 0.3s ease;
+        }
+        .macro-metric:hover { transform: scale(1.05); }
+        .macro-metric.active { border-width: 2px; }
+        .macro-metric.protein.active { border-color: var(--macro-protein-color); }
+        .macro-metric.carbs.active { border-color: var(--macro-carbs-color); }
+        .macro-metric.fat.active { border-color: var(--macro-fat-color); }
+        .macro-icon { font-size: 1.2rem; }
+        .macro-label { font-size: 0.85rem; margin-top: 0.25rem; }
+        .macro-value { font-size: 1.1rem; font-weight: 600; }
+        .macro-subtitle { font-size: 0.75rem; color: var(--text-secondary-color); }
+
+        /* Skeleton loading */
+        .skeleton {
+          position: relative;
+          overflow: hidden;
+          background-color: rgba(255, 255, 255, 0.1);
+        }
+        .skeleton::after {
+          content: '';
+          position: absolute;
+          inset: 0;
+          transform: translateX(-100%);
+          background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
+          animation: shimmer 1.2s infinite;
+        }
+        @keyframes shimmer {
+          100% { transform: translateX(100%); }
+        }
+        .chart-skeleton { width: 100%; height: 100%; border-radius: 50%; }
+        .metric-skeleton { height: 60px; border-radius: 12px; }
+
+        @media (max-width: 480px) {
+          .card { padding: 1rem; }
+          .chart-container { max-width: 200px; height: 200px; }
+          .macro-metrics-grid { grid-template-columns: repeat(2, 1fr); }
+        }
+      </style>
+      <div class="card analytics-card">
+        <h5></h5>
+        <div class="chart-container">
+          <div class="chart-skeleton skeleton"></div>
+          <canvas hidden aria-label="Диаграма на макронутриенти" role="img"></canvas>
+          <div class="chart-center-text"></div>
+        </div>
+        <div class="macro-metrics-grid" role="list">
+          <div class="macro-metric metric-skeleton skeleton"></div>
+          <div class="macro-metric metric-skeleton skeleton"></div>
+          <div class="macro-metric metric-skeleton skeleton"></div>
+          <div class="macro-metric metric-skeleton skeleton"></div>
+        </div>
+      </div>
+    `;
+
+    class MacroAnalyticsCard extends HTMLElement {
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.appendChild(template.content.cloneNode(true));
+        this.grid = this.shadowRoot.querySelector('.macro-metrics-grid');
+        this.centerText = this.shadowRoot.querySelector('.chart-center-text');
+        this.canvas = this.shadowRoot.querySelector('canvas');
+        this.titleEl = this.shadowRoot.querySelector('h5');
+        this.chart = null;
+        this.activeMacroIndex = null;
+        this.targetData = null;
+        this.currentData = null;
+        this.observer = null;
+        this.refreshTimer = null;
+        this.locale = this.getAttribute('locale') || 'bg';
+        this.labels = macroCardLocales[this.locale] || macroCardLocales.bg;
+      }
+
+      static get observedAttributes() {
+        return ['target-data', 'current-data', 'locale', 'data-endpoint', 'refresh-interval'];
+      }
+
+      connectedCallback() {
+        this.classList.add('loaded');
+        this.titleEl.textContent = this.labels.title;
+        this.lazyLoadChart();
+        this.setupAutoRefresh();
+      }
+
+      attributeChangedCallback(name, _oldVal, newVal) {
+        if (name === 'locale') {
+          this.locale = newVal;
+          this.labels = macroCardLocales[this.locale] || macroCardLocales.bg;
+          if (this.titleEl) this.titleEl.textContent = this.labels.title;
+          this.renderMetrics();
+          return;
+        }
+        if (name === 'data-endpoint' || name === 'refresh-interval') {
+          this.setupAutoRefresh();
+          return;
+        }
+        try {
+          const parsed = JSON.parse(newVal);
+          if (name === 'target-data') this.targetData = parsed;
+          if (name === 'current-data') this.currentData = parsed;
+          this.renderMetrics();
+          this.renderChart();
+        } catch (e) {
+          console.error(`Invalid JSON for ${name}`, e);
+        }
+      }
+
+      disconnectedCallback() {
+        if (this.refreshTimer) clearInterval(this.refreshTimer);
+      }
+
+      async ensureChartJs() {
+        if (window.Chart) return;
+        await new Promise((resolve, reject) => {
+          const script = document.createElement('script');
+          script.src = 'https://cdn.jsdelivr.net/npm/chart.js';
+          script.onload = resolve;
+          script.onerror = reject;
+          document.head.appendChild(script);
+        });
+      }
+
+      lazyLoadChart() {
+        if (this.observer) return;
+        if (!('IntersectionObserver' in window)) {
+          this.ensureChartJs().then(() => this.renderChart());
+          return;
+        }
+        this.observer = new IntersectionObserver(async (entries) => {
+          entries.forEach(async (entry) => {
+            if (entry.isIntersecting) {
+              this.observer.disconnect();
+              await this.ensureChartJs();
+              this.renderChart();
+            }
+          });
+        }, { threshold: 0.1 });
+        this.observer.observe(this);
+      }
+
+      setupAutoRefresh() {
+        if (this.refreshTimer) {
+          clearInterval(this.refreshTimer);
+          this.refreshTimer = null;
+        }
+        const endpoint = this.getAttribute('data-endpoint');
+        if (!endpoint) return;
+        const interval = parseInt(this.getAttribute('refresh-interval') || '60000', 10);
+        const fetchData = async () => {
+          try {
+            const res = await fetch(endpoint);
+            const data = await res.json();
+            if (data.target && data.current) {
+              this.setData(data.target, data.current);
+            }
+          } catch (e) {
+            console.error('Failed to fetch macro data', e);
+          }
+        };
+        fetchData();
+        this.refreshTimer = setInterval(fetchData, interval);
+      }
+
+      setData(target, current) {
+        this.setAttribute('target-data', JSON.stringify(target));
+        this.setAttribute('current-data', JSON.stringify(current));
+      }
+
+      getCssVar(name) {
+        return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+      }
+
+      highlightMacro(el, index) {
+        this.grid.querySelectorAll('.macro-metric').forEach((div) => {
+          div.classList.remove('active');
+          div.setAttribute('aria-pressed', 'false');
+        });
+        if (this.chart) this.chart.setActiveElements([]);
+        if (this.activeMacroIndex === index) {
+          this.activeMacroIndex = null;
+          if (this.chart) this.chart.update();
+          return;
+        }
+        this.activeMacroIndex = index;
+        if (el) {
+          el.classList.add('active');
+          el.setAttribute('aria-pressed', 'true');
+        }
+        if (this.chart && index !== null && index > -1) {
+          this.chart.setActiveElements([{ datasetIndex: 1, index }]);
+          this.chart.update();
+        }
+      }
+
+      renderMetrics() {
+        const target = this.targetData;
+        const current = this.currentData;
+        if (!target || !current) return;
+        this.grid.innerHTML = '';
+        this.centerText.innerHTML = `
+          <div class="consumed-calories">${current.calories}</div>
+          <div class="total-calories-label">${this.labels.totalCaloriesLabel(target.calories)}</div>`;
+        const calDiv = document.createElement('div');
+        calDiv.className = 'macro-metric calories';
+        calDiv.setAttribute('role', 'listitem');
+        calDiv.setAttribute('aria-label', `${this.labels.caloriesLabel}: ${current.calories} от ${target.calories} килокалории`);
+        calDiv.innerHTML = `
+          <span class="macro-icon"><i class="bi bi-fire"></i></span>
+          <div class="macro-label">${this.labels.caloriesLabel}</div>
+          <div class="macro-value">${current.calories} / ${target.calories} kcal</div>`;
+        this.grid.appendChild(calDiv);
+        const macros = [
+          { key: 'protein', icon: 'bi-egg-fried' },
+          { key: 'carbs', icon: 'bi-basket' },
+          { key: 'fat', icon: 'bi-droplet-half' }
+        ];
+        macros.forEach((item, idx) => {
+          const label = this.labels.macros[item.key];
+          const currentVal = current[`${item.key}_grams`];
+          const targetVal = target[`${item.key}_grams`];
+          const percent = target[`${item.key}_percent`];
+          const div = document.createElement('div');
+          div.className = `macro-metric ${item.key}`;
+          div.setAttribute('role', 'button');
+          div.setAttribute('tabindex', '0');
+          div.setAttribute('aria-label', `${label}: ${currentVal} от ${targetVal} грама (${percent}% ${this.labels.fromGoal})`);
+          div.setAttribute('aria-pressed', 'false');
+          div.innerHTML = `
+            <span class="macro-icon"><i class="bi ${item.icon}"></i></span>
+            <div class="macro-label">${label}</div>
+            <div class="macro-value">${currentVal} / ${targetVal}г</div>
+            <div class="macro-subtitle">${percent}% ${this.labels.fromGoal}</div>`;
+          div.addEventListener('click', () => this.highlightMacro(div, idx));
+          div.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              this.highlightMacro(div, idx);
+            }
+          });
+          this.grid.appendChild(div);
+        });
+      }
+
+      renderChart() {
+        const target = this.targetData;
+        const current = this.currentData;
+        if (!target || !current || !this.canvas || typeof Chart === 'undefined') return;
+        const skeleton = this.shadowRoot.querySelector('.chart-skeleton');
+        if (skeleton) skeleton.remove();
+        if (this.canvas.hasAttribute('hidden')) this.canvas.removeAttribute('hidden');
+        if (this.chart) this.chart.destroy();
+        const ctx = this.canvas.getContext('2d');
+        const macroColors = [
+          this.getCssVar('--macro-protein-color'),
+          this.getCssVar('--macro-carbs-color'),
+          this.getCssVar('--macro-fat-color')
+        ];
+        this.chart = new Chart(ctx, {
+          type: 'doughnut',
+          data: {
+            labels: [
+              `${this.labels.macros.protein} (${target.protein_percent}%)`,
+              `${this.labels.macros.carbs} (${target.carbs_percent}%)`,
+              `${this.labels.macros.fat} (${target.fat_percent}%)`
+            ],
+            datasets: [
+              {
+                label: this.locale === 'en' ? 'Target (g)' : 'Цел (гр)',
+                data: [target.protein_grams, target.carbs_grams, target.fat_grams],
+                backgroundColor: macroColors.map((c) => `${c}40`),
+                borderWidth: 0,
+                cutout: '80%'
+              },
+              {
+                label: this.locale === 'en' ? 'Intake (g)' : 'Прием (гр)',
+                data: [current.protein_grams, current.carbs_grams, current.fat_grams],
+                backgroundColor: macroColors,
+                borderColor: this.getCssVar('--card-bg'),
+                borderWidth: 4,
+                borderRadius: 8,
+                cutout: '65%',
+                hoverOffset: 12
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            animation: { duration: 800, easing: 'easeOutQuart' },
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                callbacks: {
+                  label: (context) => {
+                    const label = context.dataset.label || '';
+                    return `${label}: ${context.parsed}g`;
+                  }
+                }
+              }
+            },
+            onClick: (evt, elements) => {
+              if (elements.length > 0) {
+                const idx = elements[0].index;
+                const macroCard = this.grid.querySelectorAll('.macro-metric')[idx + 1];
+                this.highlightMacro(macroCard, idx);
+              } else {
+                this.highlightMacro(null, this.activeMacroIndex);
+              }
+            }
+          }
+        });
+      }
+    }
+
+    customElements.define('macro-analytics-card', MacroAnalyticsCard);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document standalone `macroAnalyticsCardStandalone.html` with developer notes and integration instructions
- embed the standalone card via `docs/macroAnalyticsCard.html` to keep usage self-contained

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(failing: passwordReset updates)*

------
https://chatgpt.com/codex/tasks/task_e_688c294236548326bc540149cab65ca3