### PR TITLE
Добавен renderTemplate и използване в имейл логиката

### DIFF
--- a/js/__tests__/template.test.js
+++ b/js/__tests__/template.test.js
@@ -1,0 +1,13 @@
+import { renderTemplate } from '../../utils/template.js';
+
+describe('renderTemplate', () => {
+  test('замества всички плейсхолдери', () => {
+    const tpl = 'Здравей, {{ name }}! Вашият линк: {{ link }}';
+    const vars = { name: 'Иван', link: 'http://example.com' };
+    expect(renderTemplate(tpl, vars)).toBe('Здравей, Иван! Вашият линк: http://example.com');
+  });
+
+  test('липсващи ключове дават празен низ', () => {
+    expect(renderTemplate('Hello {{missing}}', {})).toBe('Hello ');
+  });
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -5,6 +5,7 @@ import { fileToDataURL, fileToText, getProgressColor, animateProgressFill } from
 import { loadTemplateInto } from './templateLoader.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 import { loadMaintenanceFlag, setMaintenanceFlag } from './maintenanceMode.js';
+import { renderTemplate } from '../utils/template.js';
 
 async function ensureLoggedIn() {
     if (localStorage.getItem('adminSession') === 'true') {
@@ -235,11 +236,7 @@ function updateHints(modelInput, descElem) {
 export function attachEmailPreview(textarea, previewElem, sample = {}) {
     if (!textarea || !previewElem) return;
     const update = () => {
-        let html = textarea.value;
-        for (const [key, val] of Object.entries(sample)) {
-            const re = new RegExp(`{{\\s*${key}\\s*}}`, 'g');
-            html = html.replace(re, val);
-        }
+        const html = renderTemplate(textarea.value, sample);
         previewElem.innerHTML = sanitizeHTML(html);
     };
     textarea.addEventListener('input', update);

--- a/utils/template.js
+++ b/utils/template.js
@@ -1,0 +1,7 @@
+export function renderTemplate(tpl, vars = {}) {
+  return tpl.replace(/{{\s*(\w+)\s*}}/g, (_, key) =>
+    Object.prototype.hasOwnProperty.call(vars, key) ? String(vars[key]) : ''
+  );
+}
+
+export default { renderTemplate };

--- a/worker.js
+++ b/worker.js
@@ -14,6 +14,7 @@
 // Използва се унифициран модул за изпращане на имейли
 import { sendEmailUniversal } from './utils/emailSender.js';
 import { parseJsonSafe } from './utils/parseJsonSafe.js';
+import { renderTemplate } from './utils/template.js';
 
 const WELCOME_SUBJECT = 'Добре дошъл в MyBody!';
 const WELCOME_BODY_TEMPLATE = `<!DOCTYPE html>
@@ -186,7 +187,7 @@ async function sendAnalysisLinkEmail(to, name, link, env) {
     if (!tpl.includes('{{link}}')) {
         console.warn('ANALYSIS_EMAIL_BODY missing {{link}} placeholder');
     }
-    const html = tpl.replace(/{{\s*name\s*}}/g, name).replace(/{{\s*link\s*}}/g, link);
+    const html = renderTemplate(tpl, { name, link });
     try {
         await sendEmailUniversal(to, subject, html, env);
         return true;
@@ -205,9 +206,7 @@ async function sendContactEmail(to, name, env) {
     });
     if (send === '0' || send === 'false') return;
     const formLabel = extras.contact_form_label;
-    const html = tpl
-        .replace(/{{\s*name\s*}}/g, name)
-        .replace(/{{\s*form_label\s*}}/g, formLabel);
+    const html = renderTemplate(tpl, { name, form_label: formLabel });
     try {
         await sendEmailUniversal(to, subject, html, env);
     } catch (err) {


### PR DESCRIPTION
## Summary
- добавен универсален `renderTemplate` помощник
- използван `renderTemplate` за визуализация и изпращане на имейли
- покрит шаблонният механизъм с unit тестове

## Testing
- `npm run lint`
- `npm test` *(неуспешно: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688d2f460a1483269cc1757a76adac02