### PR TITLE
Интеграция на macro-analytics-card в таблото

### DIFF
--- a/code.html
+++ b/code.html
@@ -502,12 +502,7 @@
                   </div>
                 </div>
                 <div id="analyticsCardsContainer" class="analytics-cards-grid">
-                  <macro-analytics-card
-                    id="macroAnalyticsCard"
-                    target-data='{"calories":0,"protein_grams":0,"protein_percent":0,"carbs_grams":0,"carbs_percent":0,"fat_grams":0,"fat_percent":0}'
-                    current-data='{"calories":0,"protein_grams":0,"carbs_grams":0,"fat_grams":0}'
-                  ></macro-analytics-card>
-                  <p class="placeholder">Зареждане на детайлните показатели...</p>
+                  <macro-analytics-card id="macroAnalyticsCard"></macro-analytics-card>
                 </div>
               </div>
             </div>

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -138,9 +138,6 @@ body.vivid-theme .index-card .index-value {
   margin-bottom: var(--space-sm);
   font-size: 1.05rem;
 }
-#macroAnalyticsCard h5 {
-  justify-content: flex-start;
-}
 .analytics-card .mini-progress-bar {
   background: var(--surface-background);
   border-radius: var(--progress-bar-radius);
@@ -197,69 +194,6 @@ body.vivid-theme .index-card .index-value {
   margin-top: var(--space-sm);
 }
 
-/* Macros Analytics Card */
-#macroAnalyticsCard .macro-metrics-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-  gap: var(--space-sm);
-  margin-top: var(--space-sm);
-}
-#macroAnalyticsCard .macro-metric {
-  background: color-mix(in srgb, var(--surface-background) 90%, transparent);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-  border: 1px solid var(--border-color-soft);
-  border-radius: var(--radius-md);
-  padding: var(--space-sm);
-  text-align: center;
-  transition: transform 0.2s ease;
-}
-#macroAnalyticsCard .macro-metric:hover {
-  transform: scale(1.05);
-  border-color: var(--accent-color);
-}
-#macroAnalyticsCard .macro-metric.active {
-  transform: scale(1.05);
-  border-color: var(--accent-color);
-  box-shadow: 0 0 20px rgba(0,0,0,0.2);
-}
-#macroAnalyticsCard .macro-metric.protein.active { border-color: var(--macro-protein-color); }
-#macroAnalyticsCard .macro-metric.carbs.active { border-color: var(--macro-carbs-color); }
-#macroAnalyticsCard .macro-metric.fat.active { border-color: var(--macro-fat-color); }
-
-body.dark-theme #macroAnalyticsCard .macro-metric {
-  background: color-mix(in srgb, var(--surface-background) 60%, var(--primary-color) 10%);
-  border-color: color-mix(in srgb, var(--border-color) 70%, transparent);
-}
-#macroAnalyticsCard .macro-icon {
-  display: block;
-  font-size: 1.5rem;
-  margin: 0 auto var(--space-xs);
-  color: var(--text-color-secondary);
-}
-#macroAnalyticsCard .macro-label {
-  font-weight: 600;
-  color: var(--primary-color);
-}
-body.vivid-theme #macroAnalyticsCard .macro-label {
-  color: color-mix(in srgb, var(--primary-color) 75%, var(--text-color-primary));
-}
-#macroAnalyticsCard .macro-value {
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: var(--text-color-primary);
-}
-#macroAnalyticsCard .macro-subtitle {
-  color: var(--text-color-muted);
-  font-size: var(--fs-sm);
-}
-
-#macroAnalyticsCard .chart-container {
-  min-height: 180px;
-  position: relative;
-  padding: var(--space-sm);
-  text-align: center;
-}
 #macroMetricsPreview {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
@@ -275,7 +209,6 @@ body.vivid-theme #macroAnalyticsCard .macro-label {
 #macroMetricsPreview .macro-icon {
   font-size: 1rem;
 }
-#macroAnalyticsCard .macro-metric.calories .macro-icon,
 #macroMetricsPreview .macro-metric.calories .macro-icon {
   color: var(--text-color-primary);
 }

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -96,30 +96,42 @@ test('populates dashboard sections', () => {
   expect(document.querySelectorAll('#streakGrid .streak-day.logged').length).toBe(1);
 });
 
-test('sets macro card data attributes', async () => {
+test('обновява макро картата чрез setData', async () => {
   jest.resetModules();
   const fullData = {
     userName: 'Иван',
     analytics: { current: {}, streak: {} },
     planData: {
-      caloriesMacros: { calories: 1800, protein_grams: 120, protein_percent: 40, carbs_grams: 200, carbs_percent: 40, fat_grams: 50, fat_percent: 20 }
+      caloriesMacros: {
+        calories: 1800,
+        protein_grams: 120,
+        protein_percent: 40,
+        carbs_grams: 200,
+        carbs_percent: 40,
+        fat_grams: 50,
+        fat_percent: 20,
+      },
     },
     dailyLogs: [],
     currentStatus: {},
     initialData: {},
-    initialAnswers: {}
+    initialAnswers: {},
   };
   jest.unstable_mockModule('../app.js', () => ({
     fullDashboardData: fullData,
     todaysMealCompletionStatus: {},
     todaysExtraMeals: [],
     currentIntakeMacros: {},
-    planHasRecContent: false
+    planHasRecContent: false,
   }));
   ({ populateUI } = await import('../populateUI.js'));
-  populateUI();
   const card = document.getElementById('macroAnalyticsCard');
-  expect(card.getAttribute('target-data')).toContain('"calories":1800');
+  card.setData = jest.fn();
+  populateUI();
+  expect(card.setData).toHaveBeenCalledWith(
+    expect.objectContaining({ calories: 1800 }),
+    null,
+  );
 });
 
 test('hides modules when values are zero', async () => {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -290,15 +290,19 @@ function renderMacroPreviewGrid(macros) {
 }
 
 function populateDashboardMacros(macros) {
-    const card = document.getElementById('macroAnalyticsCard');
     renderMacroPreviewGrid(macros);
-    if (!card || !macros) return;
-    card.setAttribute('target-data', JSON.stringify(macros));
-    if (currentIntakeMacros && Object.keys(currentIntakeMacros).length > 0) {
-        card.setAttribute('current-data', JSON.stringify(currentIntakeMacros));
-    } else {
-        card.removeAttribute('current-data');
+    const container = selectors.analyticsCardsContainer;
+    let card = document.getElementById('macroAnalyticsCard');
+    if (!card && container) {
+        card = document.createElement('macro-analytics-card');
+        card.id = 'macroAnalyticsCard';
+        container.appendChild(card);
     }
+    if (!card || !macros) return;
+    const current = currentIntakeMacros && Object.keys(currentIntakeMacros).length > 0
+        ? currentIntakeMacros
+        : null;
+    card.setData(macros, current);
     renderPendingMacroChart();
 }
 


### PR DESCRIPTION
## Резюме
- заместен е статичният блок за макроси с `<macro-analytics-card>`
- попълването на данните става чрез `element.setData(target, current)`
- почистени са глобалните CSS стилове за картата и е обновен тестът за UI попълване

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d31de95c883269d067ec806d0fff6