### PR TITLE
feat: centralize email template rendering

### DIFF
--- a/js/__tests__/adminEmailPreview.test.js
+++ b/js/__tests__/adminEmailPreview.test.js
@@ -1,15 +1,17 @@
 /** @jest-environment jsdom */
 import { jest } from '@jest/globals';
 
-let attachEmailPreview;
+let attachEmailPreview, attachSubjectPreview;
 
 beforeEach(async () => {
   jest.resetModules();
   document.body.innerHTML = `
     <textarea id="t"></textarea>
     <div id="p"></div>
+    <input id="s">
+    <div id="sp"></div>
     <button id="showStats"></button>`;
-  ({ attachEmailPreview } = await import('../admin.js'));
+  ({ attachEmailPreview, attachSubjectPreview } = await import('../admin.js'));
 });
 
 test('updates preview with sanitized HTML', () => {
@@ -22,4 +24,15 @@ test('updates preview with sanitized HTML', () => {
   textarea.value = '<img src="x" onerror="alert(1)">';
   textarea.dispatchEvent(new Event('input'));
   expect(preview.innerHTML).toBe('<img src="x">');
+});
+
+test('subject preview replaces placeholders', () => {
+  const input = document.getElementById('s');
+  const preview = document.getElementById('sp');
+  input.value = 'Hi {{name}}';
+  attachSubjectPreview(input, preview, { name: 'Иван' });
+  expect(preview.textContent).toBe('Hi Иван');
+  input.value = 'Bye {{name}}';
+  input.dispatchEvent(new Event('input'));
+  expect(preview.textContent).toBe('Bye Иван');
 });

--- a/js/__tests__/mailer.test.js
+++ b/js/__tests__/mailer.test.js
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals'
 import { readFileSync } from 'fs'
+import { renderTemplate } from '../../utils/templateRenderer.js'
 
 let sendWelcomeEmail
 
@@ -16,7 +17,10 @@ afterEach(() => {
 })
 
 test('sends welcome email with correct options', async () => {
-    const expected = readFileSync('data/welcomeEmailTemplate.html', 'utf8').replace(/{{\s*name\s*}}/g, 'Иван')
+    const expected = renderTemplate(
+        readFileSync('data/welcomeEmailTemplate.html', 'utf8'),
+        { name: 'Иван', current_year: new Date().getFullYear() }
+    )
     await sendWelcomeEmail('client@example.com', 'Иван')
     expect(global.fetch).toHaveBeenCalledWith('https://mail', expect.objectContaining({
         method: 'POST',
@@ -25,7 +29,8 @@ test('sends welcome email with correct options', async () => {
             to: 'client@example.com',
             subject: 'Добре дошъл в MyBody!',
             message: expected,
-            body: expected
+            body: expected,
+            fromName: ''
         })
     }))
 })

--- a/js/__tests__/submitQuestionnaireAnalysis.test.js
+++ b/js/__tests__/submitQuestionnaireAnalysis.test.js
@@ -27,7 +27,18 @@ describe('submit questionnaire workflow', () => {
       AI: { run: jest.fn().mockResolvedValue({ response: '{"score":1}' }) }
     }
     kvStore['email_to_uuid_user@example.com'] = 'u1'
-    const req = { json: async () => ({ email: 'user@example.com', name: 'Иван' }) }
+    const req = {
+      json: async () => ({
+        email: 'user@example.com',
+        name: 'Иван',
+        gender: 'm',
+        age: 30,
+        height: 180,
+        weight: 80,
+        goal: 'fit',
+        medicalConditions: 'none'
+      })
+    }
     const res = await worker.handleSubmitQuestionnaire(req, env)
     expect(res.success).toBe(true)
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_initial_answers', expect.any(String))

--- a/js/__tests__/templateRenderer.test.js
+++ b/js/__tests__/templateRenderer.test.js
@@ -1,4 +1,4 @@
-import { renderTemplate } from '../../utils/template.js';
+import { renderTemplate } from '../../utils/templateRenderer.js';
 
 describe('renderTemplate', () => {
   test('замества всички плейсхолдери', () => {

--- a/js/admin.js
+++ b/js/admin.js
@@ -5,7 +5,7 @@ import { fileToDataURL, fileToText, getProgressColor, animateProgressFill } from
 import { loadTemplateInto } from './templateLoader.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 import { loadMaintenanceFlag, setMaintenanceFlag } from './maintenanceMode.js';
-import { renderTemplate } from '../utils/template.js';
+import { renderTemplate } from '../utils/templateRenderer.js';
 
 async function ensureLoggedIn() {
     if (localStorage.getItem('adminSession') === 'true') {

--- a/mailer.js
+++ b/mailer.js
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv'
 import fs from 'fs/promises'
 import { sendEmailUniversal } from './utils/emailSender.js'
+import { renderTemplate } from './utils/templateRenderer.js'
 
 dotenv.config()
 
@@ -66,7 +67,10 @@ export async function sendEmail(toEmail, subject, html) {
 
 export async function sendWelcomeEmail(toEmail, userName) {
     const tpl = await getEmailTemplate()
-    const html = tpl.body.replace(/{{\s*name\s*}}/g, userName)
+    const html = renderTemplate(tpl.body, {
+        name: userName,
+        current_year: new Date().getFullYear()
+    })
     try {
         await sendEmail(toEmail, tpl.subject, html)
     } catch (error) {

--- a/utils/template.js
+++ b/utils/template.js
@@ -1,7 +1,0 @@
-export function renderTemplate(tpl, vars = {}) {
-  return tpl.replace(/{{\s*(\w+)\s*}}/g, (_, key) =>
-    Object.prototype.hasOwnProperty.call(vars, key) ? String(vars[key]) : ''
-  );
-}
-
-export default { renderTemplate };

--- a/utils/templateRenderer.js
+++ b/utils/templateRenderer.js
@@ -1,0 +1,14 @@
+/**
+ * Renders a template string by replacing {{key}} placeholders with values from data.
+ * Missing keys are replaced with an empty string.
+ * @param {string} str template text
+ * @param {Record<string, unknown>} data values map
+ * @returns {string} rendered string
+ */
+export function renderTemplate(str, data = {}) {
+  return String(str).replace(/{{\s*(\w+)\s*}}/g, (_, key) =>
+    Object.prototype.hasOwnProperty.call(data, key) ? String(data[key]) : ''
+  );
+}
+
+export default { renderTemplate };

--- a/worker.js
+++ b/worker.js
@@ -14,7 +14,7 @@
 // Използва се унифициран модул за изпращане на имейли
 import { sendEmailUniversal } from './utils/emailSender.js';
 import { parseJsonSafe } from './utils/parseJsonSafe.js';
-import { renderTemplate } from './utils/template.js';
+import { renderTemplate } from './utils/templateRenderer.js';
 
 const WELCOME_SUBJECT = 'Добре дошъл в MyBody!';
 const WELCOME_BODY_TEMPLATE = `<!DOCTYPE html>
@@ -166,7 +166,10 @@ async function getEmailConfig(kind, env, defaults = {}) {
 }
 
 async function sendWelcomeEmail(to, name, env) {
-    const html = WELCOME_BODY_TEMPLATE.replace(/{{\s*name\s*}}/g, name);
+    const html = renderTemplate(WELCOME_BODY_TEMPLATE, {
+        name,
+        current_year: new Date().getFullYear()
+    });
     try {
         await sendEmailUniversal(to, WELCOME_SUBJECT, html, env);
     } catch (err) {
@@ -220,7 +223,7 @@ async function sendPasswordResetEmail(to, token, env) {
     const base = env?.[PASSWORD_RESET_PAGE_URL_VAR_NAME] || 'https://radilovk.github.io/bodybest/reset-password.html';
     const url = new URL(base);
     url.searchParams.set('token', token);
-    const html = tpl.replace(/{{\s*link\s*}}/g, url.toString());
+    const html = renderTemplate(tpl, { link: url.toString() });
     try {
         await sendEmailUniversal(to, subject, html, env);
     } catch (err) {


### PR DESCRIPTION
## Summary
- add reusable templateRenderer utility and tests
- use renderTemplate in worker and mailer to populate all placeholders
- preview email bodies and subjects via template renderer

## Testing
- `npm run lint`
- `npm test js/__tests__/mailer.test.js`
- `npm test js/__tests__/submitQuestionnaireAnalysis.test.js`
- `npm test` *(fails: ReferenceError: fetch is not defined in several suites)*

------
https://chatgpt.com/codex/tasks/task_e_688d37a054888326b94562e0f9dcb35f