### PR TITLE
Use shared Chart.js loader

### DIFF
--- a/macroAnalyticsCardStandalone.html
+++ b/macroAnalyticsCardStandalone.html
@@ -250,13 +250,17 @@
 
       async ensureChartJs() {
         if (window.Chart) return;
-        await new Promise((resolve, reject) => {
-          const script = document.createElement('script');
-          script.src = 'https://cdn.jsdelivr.net/npm/chart.js';
-          script.onload = resolve;
-          script.onerror = reject;
-          document.head.appendChild(script);
-        });
+        // Prevent duplicate script tags by sharing a global loading promise
+        if (!window._chartPromise) {
+          window._chartPromise = new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = 'https://cdn.jsdelivr.net/npm/chart.js';
+            script.onload = resolve;
+            script.onerror = reject;
+            document.head.appendChild(script);
+          });
+        }
+        await window._chartPromise;
       }
 
       lazyLoadChart() {


### PR DESCRIPTION
## Summary
- prevent duplicate Chart.js loads in standalone macro card via global promise

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d3a9f4ef883268a2186d54fec1751