### PR TITLE
Handle contact form submission via fetch API

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -49,6 +49,7 @@
         </div>
         <button type="submit" class="btn">Изпрати</button>
       </form>
+      <div id="contact-msg" class="message"></div>
     </section>
   </main>
 
@@ -100,5 +101,6 @@
     </div>
   </footer>
   <script src="js/basicNav.js" type="module"></script>
+  <script src="js/contactForm.js" type="module"></script>
 </body>
 </html>

--- a/js/__tests__/contactForm.test.js
+++ b/js/__tests__/contactForm.test.js
@@ -1,0 +1,54 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let setupContactForm;
+let showMessage;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <form id="contact-form">
+      <input type="text" id="name">
+      <input type="email" id="email">
+      <textarea id="message"></textarea>
+      <button type="submit">Send</button>
+    </form>
+    <div id="contact-msg"></div>`;
+  jest.unstable_mockModule('../messageUtils.js', () => ({
+    showMessage: jest.fn(),
+    hideMessage: jest.fn()
+  }));
+  ({ setupContactForm } = await import('../contactForm.js'));
+  ({ showMessage } = await import('../messageUtils.js'));
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+});
+
+test('sends request and clears fields on success', async () => {
+  const form = document.getElementById('contact-form');
+  form.querySelector('#name').value = 'User';
+  form.querySelector('#email').value = 'user@test.com';
+  form.querySelector('#message').value = 'Hi';
+  setupContactForm('#contact-form', '#contact-msg');
+  form.dispatchEvent(new Event('submit', { bubbles: true }));
+  await Promise.resolve();
+  expect(fetch).toHaveBeenCalledWith('/api/contact', expect.any(Object));
+  expect(form.querySelector('#name').value).toBe('');
+  expect(form.querySelector('#email').value).toBe('');
+  expect(form.querySelector('#message').value).toBe('');
+});
+
+test('shows message on invalid email', async () => {
+  const form = document.getElementById('contact-form');
+  form.querySelector('#name').value = 'User';
+  form.querySelector('#email').value = 'bad';
+  form.querySelector('#message').value = 'Hi';
+  setupContactForm('#contact-form', '#contact-msg');
+  form.dispatchEvent(new Event('submit', { bubbles: true }));
+  await Promise.resolve();
+  expect(fetch).not.toHaveBeenCalled();
+  expect(showMessage).toHaveBeenCalledWith(
+    document.getElementById('contact-msg'),
+    'Невалиден e-mail адрес.',
+    true
+  );
+});

--- a/js/contactForm.js
+++ b/js/contactForm.js
@@ -1,0 +1,57 @@
+import { showMessage, hideMessage } from './messageUtils.js';
+
+/**
+ * Инициализира обработката на контактната форма.
+ * @param {string} formSelector - Селектор за формата.
+ * @param {string} messageSelector - Селектор за елемента за съобщения.
+ */
+export function setupContactForm(formSelector, messageSelector) {
+  const form = document.querySelector(formSelector);
+  const messageEl = document.querySelector(messageSelector);
+  if (!form || !messageEl) {
+    console.error('setupContactForm: elements not found');
+    return;
+  }
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    hideMessage(messageEl);
+
+    const nameInput = form.querySelector('#name');
+    const emailInput = form.querySelector('#email');
+    const messageInput = form.querySelector('#message');
+    if (!nameInput || !emailInput || !messageInput) {
+      console.error('setupContactForm: missing input fields');
+      return;
+    }
+
+    const name = nameInput.value.trim();
+    const email = emailInput.value.trim();
+    const message = messageInput.value.trim();
+
+    if (!name || !email || !message)
+      return showMessage(messageEl, 'Моля, попълнете всички полета.', true);
+    if (!emailInput.validity.valid)
+      return showMessage(messageEl, 'Невалиден e-mail адрес.', true);
+
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, message })
+      });
+      if (!res.ok) throw new Error('Грешка при изпращането. Моля, опитайте отново.');
+      showMessage(messageEl, 'Съобщението е изпратено успешно!', false);
+      form.reset();
+    } catch (err) {
+      console.error('Contact form error:', err);
+      showMessage(messageEl, err.message || 'Нещо се обърка. Опитайте пак.', true);
+    }
+  });
+}
+
+// TODO: Добави reCAPTCHA или друга защита от спам при публичен достъп до API.
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupContactForm('#contact-form', '#contact-msg');
+});

--- a/js/maintenanceMode.js
+++ b/js/maintenanceMode.js
@@ -8,7 +8,7 @@ export async function loadMaintenanceFlag() {
     const resp = await fetch(apiEndpoints.getMaintenanceMode);
     const data = await resp.json();
     if (!resp.ok || !data.success) throw new Error(data.message || 'Error');
-    return data.enabled === true || data.enabled === '1';
+    return data.enabled === true || data.enabled === 1 || data.enabled === '1';
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -389,6 +389,15 @@ footer { background: var(--dark-bg); color: var(--light-text); padding: 80px 0 3
 .modal-content #forgot-password-link { margin-top: 0.5rem; width: 100%; justify-content: flex-end; }
 
 
+/* Общи съобщения за статус */
+.message {
+    padding: 0.8rem; border-radius: 0.5rem; margin-top: 1rem;
+    font-size: 0.9rem; display: none; border: 1px solid transparent;
+    text-align: left; word-wrap: break-word;
+}
+.message.error { color: var(--color-danger); background-color: rgba(231, 76, 60, 0.1); border-color: var(--color-danger); }
+.message.success { color: var(--color-success); background-color: rgba(46, 204, 113, 0.1); border-color: var(--color-success); }
+
 /* Съобщения за грешки/успех */
 .modal-content .message {
     padding: 0.8rem; border-radius: 0.5rem; margin-top: 1rem;


### PR DESCRIPTION
## Summary
- implement `contactForm.js` module to send form data to `/api/contact`, show user feedback and reset fields
- add message placeholder, module import and global message styles
- allow numeric maintenance flag values

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d3de147e88326bba9d8190626123a