### PR TITLE
Включване на utils в bundle-а на worker

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,18 @@
     "resolveJsonModule": true,
     "types": ["@cloudflare/workers-types"],
     "lib": ["es2020", "dom"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@utils/*": ["utils/*"]
+    }
   },
   "include": [
     "worker.js",
     "worker-backend.js",
     "mailer.js",
     "mailer.d.ts",
-    "js/**/*"
+    "js/**/*",
+    "utils/**/*"
   ]
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,6 +5,10 @@ compatibility_date = "2025-06-20"
 compatibility_flags = ["nodejs_compat"]
 main = "worker.js"
 
+[[rules]]
+globs = ["utils/**/*.js"]
+type = "ESModule"
+
 [[kv_namespaces]]
 binding = "RESOURCES_KV"
 id = "8ebf65a6ed0a44e7b7d1b4bc6f24465e"


### PR DESCRIPTION
## Обобщение
- добавен е `baseUrl` и alias `@utils/*` в tsconfig и включена папката `utils` в обхвата на компилатора
- добавено е правило в `wrangler.toml` за bundling на `utils` като ES модули

## Тестване
- `npm run lint`
- `npm test` (OOM при повторен опит с `CI=true`)


------
https://chatgpt.com/codex/tasks/task_e_688d45d521f0832693d078644d9b19ea