### PR TITLE
refactor: extract macro card locale loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,33 @@ import 'bootstrap-icons/font/bootstrap-icons.css';
 }
 ```
 
+**Локализация**
+
+```js
+import { loadLocale } from './js/macroCardLocales.js';
+const labels = await loadLocale(document.documentElement.lang);
+```
+
+Модулът кешира преводите и ако файлът липсва, връща българската версия. Файловете са в `locales/`:
+
+```
+locales/
+  macroCard.bg.json
+  macroCard.en.json
+```
+
+Структура на всеки JSON:
+
+```json
+{
+  "title": "Калории и Макронутриенти",
+  "caloriesLabel": "Приети Калории",
+  "macros": { "protein": "", "carbs": "", "fat": "" },
+  "fromGoal": "от целта",
+  "totalCaloriesLabel": "от {calories} kcal"
+}
+```
+
 **Динамични данни**
 
 ```js

--- a/js/__tests__/macroCardLocales.test.js
+++ b/js/__tests__/macroCardLocales.test.js
@@ -1,0 +1,24 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+describe('loadLocale', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('falls back to bg and caches result', async () => {
+    const fetchMock = jest.fn((url) => {
+      if (url.includes('macroCard.de.json')) return Promise.resolve({ ok: false });
+      if (url.includes('macroCard.bg.json')) return Promise.resolve({ ok: true, json: async () => ({ title: 'bg' }) });
+      return Promise.resolve({ ok: true, json: async () => ({ title: 'en' }) });
+    });
+    global.fetch = fetchMock;
+    const { loadLocale } = await import('../macroCardLocales.js');
+    const first = await loadLocale('de');
+    expect(first).toEqual({ title: 'bg' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const second = await loadLocale('de');
+    expect(second).toBe(first);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/js/macroCardLocales.js
+++ b/js/macroCardLocales.js
@@ -1,0 +1,7 @@
+const cache = {};
+export async function loadLocale(lng) {
+  if (cache[lng]) return cache[lng];
+  const res = await fetch(`./locales/macroCard.${lng}.json`);
+  cache[lng] = res.ok ? await res.json() : await loadLocale('bg');
+  return cache[lng];
+}


### PR DESCRIPTION
## Summary
- extract locale loader into `js/macroCardLocales.js` with caching and bg fallback
- load locales based on `<html lang>` in `macroAnalyticsCardComponent`
- document localization module and file structure

## Testing
- `npm run lint`
- `npm test` *(fails: submitQuestionnaireEmailFlag.test.js, planContent.test.js, login.test.js, stripPlanModSignature.test.js, submitQuizErrorReset.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688d48fad3308326ab3c33c33c052eca