### PR TITLE
Добавяне на проверка за macro-analytics-card и тест

### DIFF
--- a/code.html
+++ b/code.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="css/dashboard_panel_styles.css">
     <script type="module">
       import { populateUI } from './js/populateUI.js';
-      populateUI();
+      await populateUI();
     </script>
   Прехвърлете CSS променливи: --space-lg, --space-sm, --space-xs,
     --text-color-secondary, --surface-background,

--- a/js/__tests__/populateDashboardMacros.missingComponent.test.js
+++ b/js/__tests__/populateDashboardMacros.missingComponent.test.js
@@ -1,0 +1,38 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+test('логва предупреждение при липсващ macro-analytics-card компонент', async () => {
+  jest.unstable_mockModule('../macroAnalyticsCardComponent.js', () => ({}));
+  document.body.innerHTML = `
+    <div id="macroMetricsPreview"></div>
+    <div id="analyticsCardsContainer"></div>
+  `;
+  const selectors = {
+    macroMetricsPreview: document.getElementById('macroMetricsPreview'),
+    analyticsCardsContainer: document.getElementById('analyticsCardsContainer'),
+  };
+  jest.unstable_mockModule('../uiElements.js', () => ({ selectors, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
+  jest.unstable_mockModule('../utils.js', () => ({
+    safeGet: () => {},
+    safeParseFloat: () => {},
+    capitalizeFirstLetter: () => {},
+    escapeHtml: () => {},
+    getProgressColor: () => {},
+    animateProgressFill: () => {},
+    getCssVar: () => ''
+  }));
+  jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id' }));
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: {},
+    todaysMealCompletionStatus: {},
+    todaysExtraMeals: [],
+    currentIntakeMacros: {},
+    planHasRecContent: false,
+  }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const { populateDashboardMacros } = await import('../populateUI.js');
+  await populateDashboardMacros({ calories: 1000, protein_percent: 30, carbs_percent: 40, fat_percent: 30 });
+  expect(warnSpy).toHaveBeenCalled();
+  expect(document.getElementById('macroAnalyticsCard')).toBeNull();
+});

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -90,8 +90,8 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-test('populates dashboard sections', () => {
-  populateUI();
+test('populates dashboard sections', async () => {
+  await populateUI();
   expect(document.getElementById('headerTitle').textContent).toBe('Табло: Иван');
   expect(document.getElementById('goalProgressText').textContent).toBe('50%');
   expect(document.getElementById('engagementProgressText').textContent).toBe('80%');
@@ -130,7 +130,7 @@ test('обновява макро картата чрез setData', async () => 
   ({ populateUI } = await import('../populateUI.js'));
   const card = document.getElementById('macroAnalyticsCard');
   card.setData = jest.fn();
-  populateUI();
+  await populateUI();
   expect(card.setData).toHaveBeenCalledWith(
     expect.objectContaining({ calories: 1800 }),
     null,
@@ -158,7 +158,7 @@ test('hides modules when values are zero', async () => {
     currentIntakeMacros: {}
   }));
   ({ populateUI } = await import('../populateUI.js'));
-  populateUI();
+  await populateUI();
   expect(document.getElementById('goalCard').classList.contains('hidden')).toBe(true);
   expect(document.getElementById('engagementCard').classList.contains('hidden')).toBe(true);
   expect(document.getElementById('healthCard').classList.contains('hidden')).toBe(true);
@@ -194,7 +194,7 @@ test('populates daily plan with color bars and meal types', async () => {
     planHasRecContent: false
   }));
   ({ populateUI } = await import('../populateUI.js'));
-  populateUI();
+  await populateUI();
   const cards = document.querySelectorAll('#dailyMealList .meal-card');
   expect(cards.length).toBe(3);
   cards.forEach(card => {
@@ -237,7 +237,7 @@ test('handles meal type variations', async () => {
     planHasRecContent: false
   }));
   ({ populateUI } = await import('../populateUI.js'));
-  populateUI();
+  await populateUI();
   const cards = document.querySelectorAll('#dailyMealList .meal-card');
   expect(cards[0].dataset.mealType).toBe('breakfast');
   expect(cards[1].dataset.mealType).toBe('lunch');
@@ -277,7 +277,7 @@ test('applies success color to completed meal bar', async () => {
   style.textContent = `#dailyMealList li.completed .meal-color-bar { background-color: rgb(46, 204, 113); }`;
   document.head.appendChild(style);
 
-  populateUI();
+  await populateUI();
   const li = document.querySelector('#dailyMealList li.completed');
   expect(li).not.toBeNull();
   const color = getComputedStyle(li.querySelector('.meal-color-bar')).backgroundColor;
@@ -321,7 +321,7 @@ test('clicking a meal card toggles completion status', async () => {
   ({ populateUI } = await import('../populateUI.js'));
   const { setupDynamicEventListeners } = await import('../eventListeners.js');
 
-  populateUI();
+  await populateUI();
   setupDynamicEventListeners();
 
   const card = document.querySelector('#dailyMealList .meal-card');
@@ -355,7 +355,7 @@ describe('progress bar width handling', () => {
       planHasRecContent: false
     }));
     ({ populateUI } = await import('../populateUI.js'));
-    populateUI();
+    await populateUI();
   };
 
   test.each([

--- a/js/app.js
+++ b/js/app.js
@@ -359,7 +359,7 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
             if(selectors.planPendingState) selectors.planPendingState.classList.add('hidden');
             if(selectors.appWrapper) selectors.appWrapper.style.display = 'block';
 
-            populateUI();
+            await populateUI();
             initializeAchievements(currentUserId);
             setupDynamicEventListeners();
             await checkAdminQueries(currentUserId);
@@ -447,7 +447,7 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
             triggerAssistantWiggle();
         }
 
-        populateUI();
+        await populateUI();
 
         const plan = fullDashboardData.planData;
         const hasRecs = planHasRecContent(plan);
@@ -647,7 +647,7 @@ export async function handleSaveLog() { // Exported for eventListeners.js
                 }
             }
         }
-        populateUI();
+        await populateUI();
         initializeAchievements(currentUserId);
         showToast(result.message || "Логът е запазен!", false);
     } catch (error) {


### PR DESCRIPTION
## Резюме
- Превключване на populateDashboardMacros към асинхронна логика с ensureMacroCard и предупреждение при липсващ компонент
- Актуализиране на populateUI и app.js да изчакват зареждането на картата
- Добавяне на unit тест за липсващия web компонент и обновяване на съществуващите тестове

## Тестване
- `npm run lint`
- `NODE_OPTIONS=--experimental-vm-modules npx jest js/__tests__/populateDashboardMacros.missingComponent.test.js --runInBand`
- `NODE_OPTIONS=--experimental-vm-modules npx jest js/__tests__/populateUI.test.js --runInBand --testNamePattern='populates dashboard sections'`
- Опит за `npm test` на пълния пакет (изчерпа паметта)


------
https://chatgpt.com/codex/tasks/task_e_688d4c5a495c8326b611db10ef0d4dfb