### PR TITLE
Динамично зареждане на Chart.js за макро диаграмата

### DIFF
--- a/code.html
+++ b/code.html
@@ -1382,7 +1382,6 @@
     <!-- End #appWrapper -->
 
     <!-- Коригирана JavaScript Връзка -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
     <script type="module" src="js/macroAnalyticsCardComponent.js"></script>
     <script type="module" src="js/app.js" defer></script>
     <script type="module" src="js/planModChat.js" defer></script>


### PR DESCRIPTION
## Резюме
- махнат е статичният `<script>` за Chart.js от code.html
- MacroAnalyticsCard зарежда Chart.js динамично и визуализира спинър до готовност

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d4f9732f48326a7517178c68482b2