### PR TITLE
refactor: inline email utils for worker

### DIFF
--- a/js/__tests__/workerEmail.test.js
+++ b/js/__tests__/workerEmail.test.js
@@ -250,13 +250,12 @@ describe('sendAnalysisLinkEmail and sendContactEmail', () => {
   let sendAnalysisLinkEmail, sendContactEmail, sendEmailUniversal;
   beforeEach(async () => {
     jest.resetModules();
-    jest.unstable_mockModule('../../utils/emailSender.js', () => ({
-      sendEmailUniversal: jest.fn().mockResolvedValue(true)
-    }));
-    ({ sendAnalysisLinkEmail, sendContactEmail } = await import('../../worker.js'));
-    ({ sendEmailUniversal } = await import('../../utils/emailSender.js'));
+    const mod = await import('../../worker.js');
+    jest.spyOn(mod, 'sendEmailUniversal').mockResolvedValue(true);
+    ({ sendAnalysisLinkEmail, sendContactEmail, sendEmailUniversal } = mod);
   });
   afterEach(() => {
+    if (sendEmailUniversal?.mockRestore) sendEmailUniversal.mockRestore();
     jest.resetModules();
   });
 


### PR DESCRIPTION
## Summary
- embed email sending, template rendering, and JSON parsing helpers directly inside `worker.js`
- use Web Crypto API for password hashing and export `sendEmailUniversal`
- update worker email tests for new structure

## Testing
- `npm run lint`
- `npm test` *(fails: ReferenceError fetch is not defined and expectation mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_688d4f42fd4c8326b91bc5bf8f557481