### PR TITLE
fix: load Chart.js correctly

### DIFF
--- a/js/chartLoader.js
+++ b/js/chartLoader.js
@@ -1,11 +1,15 @@
 let ChartLib;
 export async function ensureChart() {
   if (!ChartLib) {
-    if (typeof window === 'undefined'
-        || (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test')) {
-      ChartLib = () => ({ destroy() {} });
+    if (
+      typeof window === 'undefined' ||
+      (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test')
+    ) {
+      class DummyChart { destroy() {} }
+      ChartLib = DummyChart;
     } else {
-      ChartLib = (await import('https://cdn.jsdelivr.net/npm/chart.js')).default;
+      const mod = await import('https://cdn.jsdelivr.net/npm/chart.js/auto');
+      ChartLib = mod.default || mod.Chart;
       console.debug('Chart.js loaded');
     }
   }


### PR DESCRIPTION
## Summary
- load Chart.js via `chart.js/auto` CDN
- add dummy Chart class for non-browser environments

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d5dc6f4ac832684ea76555792982d