### PR TITLE
feat: better chart.js import error handling

### DIFF
--- a/code.html
+++ b/code.html
@@ -1387,6 +1387,7 @@
     <!-- End #appWrapper -->
 
     <!-- Коригирана JavaScript Връзка -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="module" src="js/macroAnalyticsCardComponent.js"></script>
     <script type="module" src="js/app.js" defer></script>
     <script type="module" src="js/planModChat.js" defer></script>

--- a/js/__tests__/chartLoader.test.js
+++ b/js/__tests__/chartLoader.test.js
@@ -1,0 +1,8 @@
+/** @jest-environment node */
+import { jest } from '@jest/globals';
+
+test('ensureChart throws clear error in test environment', async () => {
+  jest.resetModules();
+  const { ensureChart } = await import('../chartLoader.js');
+  await expect(ensureChart()).rejects.toThrow('Chart.js');
+});

--- a/js/__tests__/progressHistoryChartError.test.js
+++ b/js/__tests__/progressHistoryChartError.test.js
@@ -1,0 +1,36 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+test('показва toast при грешка в Chart.js', async () => {
+  jest.resetModules();
+  document.body.innerHTML = '<div id="progressHistoryCard"></div>';
+  const showToast = jest.fn();
+  jest.unstable_mockModule('../uiElements.js', () => ({
+    selectors: { progressHistoryCard: document.getElementById('progressHistoryCard') },
+    trackerInfoTexts: {},
+    detailedMetricInfoTexts: {}
+  }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast }));
+  jest.unstable_mockModule('../chartLoader.js', () => ({
+    ensureChart: jest.fn(async () => { throw new Error('fail'); })
+  }));
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: {
+      userName: '',
+      analytics: { current: {}, streak: {} },
+      planData: {},
+      dailyLogs: [{ date: '2024-01-02', data: { weight: 80 } }],
+      currentStatus: {},
+      initialData: { weight: 81 },
+      initialAnswers: {}
+    },
+    todaysMealCompletionStatus: {},
+    todaysExtraMeals: [],
+    currentIntakeMacros: {},
+    planHasRecContent: false
+  }));
+  const { populateUI } = await import('../populateUI.js');
+  await populateUI();
+  expect(showToast).toHaveBeenCalledWith('Графиката не може да се зареди.', true, 4000);
+  expect(document.getElementById('progressHistoryCard').innerHTML).toContain('Графиката не може да се зареди.');
+});

--- a/js/chartLoader.js
+++ b/js/chartLoader.js
@@ -1,13 +1,22 @@
 let ChartLib;
+
 export async function ensureChart() {
-  if (!ChartLib) {
-    if (typeof window === 'undefined'
-        || (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test')) {
-      ChartLib = () => ({ destroy() {} });
-    } else {
-      ChartLib = (await import('https://cdn.jsdelivr.net/npm/chart.js')).default;
-      console.debug('Chart.js loaded');
-    }
+  if (ChartLib) return ChartLib;
+
+  if (
+    typeof window === 'undefined' ||
+    (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test')
+  ) {
+    throw new Error('Chart.js не е наличен в текущата среда');
   }
-  return ChartLib;
+
+  try {
+    ChartLib = (await import('https://cdn.jsdelivr.net/npm/chart.js')).default;
+    console.debug('Chart.js loaded');
+    return ChartLib;
+  } catch (err) {
+    console.error('Неуспешно зареждане на Chart.js', err);
+    throw new Error('Неуспешно зареждане на Chart.js');
+  }
 }
+

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -862,6 +862,7 @@ async function populateProgressHistory(dailyLogs, initialData) {
         Chart = await ensureChart();
     } catch (e) {
         console.warn('Chart.js is not loaded.', e);
+        showToast('Графиката не може да се зареди.', true, 4000);
         card.innerHTML = '<div class="alert alert-warning" role="alert">Графиката не може да се зареди.</div>';
         return;
     }


### PR DESCRIPTION
## Summary
- provide clear error when Chart.js fails to load and rely on CDN script tag
- surface Chart.js errors to users with visible toast
- add tests for chart loading failures

## Testing
- `npm run lint`
- `npm test`
- `sh ./scripts/test.sh js/__tests__/chartLoader.test.js js/__tests__/progressHistoryChartError.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688d64027f548326893c2878fd2a1d65