### PR TITLE
Handle missing Chart.js gracefully in dashboard charts

### DIFF
--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -217,6 +217,13 @@ export class MacroAnalyticsCard extends HTMLElement {
       this.showLoading();
       try {
         Chart = await ensureChart();
+        if (typeof Chart !== 'function') {
+          const container = this.shadowRoot.querySelector('.chart-container');
+          if (container) {
+            container.innerHTML = '<div class="alert alert-warning" role="alert">Диаграмата не може да се зареди.</div>';
+          }
+          return;
+        }
         this.renderChart();
       } catch (e) {
         console.error('Failed to load Chart.js', e);

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -866,6 +866,11 @@ async function populateProgressHistory(dailyLogs, initialData) {
         return;
     }
 
+    if (typeof Chart !== 'function') {
+        card.innerHTML = '<div class="alert alert-warning" role="alert">Графиката не може да се зареди.</div>';
+        return;
+    }
+
     if (progressChartInstance) {
         progressChartInstance.destroy();
         progressChartInstance = null;


### PR DESCRIPTION
## Summary
- warn users when progress chart can't load because Chart.js missing
- warn users if macro analytics chart can't render without Chart.js

## Testing
- `npm run lint`
- `npm test`
- `node --input-type=module - <<'NODE'
import { JSDOM } from 'jsdom';
const dom = new JSDOM('<div id="card"></div>');
const card = dom.window.document.getElementById('card');
const Chart = undefined;
if (typeof Chart !== 'function') {
  card.innerHTML = '<div class="alert alert-warning" role="alert">Графиката не може да се зареди.</div>';
}
console.log(card.innerHTML);
NODE`
- `node --input-type=module - <<'NODE'
import { JSDOM } from 'jsdom';
const dom = new JSDOM('<div id="card"></div>');
const card = dom.window.document.getElementById('card');
const Chart = function(){};
if (typeof Chart !== 'function') {
  card.innerHTML = '<div class="alert alert-warning" role="alert">Графиката не може да се зареди.</div>';
} else {
  card.innerHTML = '<canvas></canvas>';
}
console.log(card.innerHTML);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_688d64ba41c48326992e8cbf1413f6da