### PR TITLE
fix: load Chart.js constructor from CDN

### DIFF
--- a/js/chartLoader.js
+++ b/js/chartLoader.js
@@ -5,7 +5,9 @@ export async function ensureChart() {
         || (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test')) {
       ChartLib = () => ({ destroy() {} });
     } else {
-      ChartLib = (await import('https://cdn.jsdelivr.net/npm/chart.js')).default;
+      const module = await import('https://cdn.jsdelivr.net/npm/chart.js/auto');
+      ChartLib = module.default || module.Chart;
+      if (!ChartLib) throw new Error('Chart.js failed to load');
       console.debug('Chart.js loaded');
     }
   }


### PR DESCRIPTION
## Summary
- fetch Chart.js from the `auto` bundle and pick the real constructor

## Testing
- `npm run lint`
- `npm test` *(fails: workerEmail.test.js, passwordReset.test.js, registerEmail.test.js, submitQuestionnaireEmailFlag.test.js, submitQuizErrorReset.test.js, planContent.test.js, login.test.js, stripPlanModSignature.test.js)*
- `npm test js/__tests__/macroAnalyticsCardComponent.test.js js/__tests__/clientProfileChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688d6afce46883268695f8a1c11af11c