### PR TITLE
fix: load Chart.js constructor from CDN

### DIFF
--- a/js/chartLoader.js
+++ b/js/chartLoader.js
@@ -5,7 +5,9 @@ export async function ensureChart() {
         || (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test')) {
       ChartLib = () => ({ destroy() {} });
     } else {
-      ChartLib = (await import('https://cdn.jsdelivr.net/npm/chart.js')).default;
+      const module = await import('https://cdn.jsdelivr.net/npm/chart.js/auto');
+      ChartLib = module.default || module.Chart;
+      if (!ChartLib) throw new Error('Chart.js failed to load');
       console.debug('Chart.js loaded');
     }
   }


### PR DESCRIPTION
## Summary
- load Chart.js from `chart.js/auto` CDN and verify constructor

## Testing
- `npm run lint`
- `npm test` *(fails: sendAnalysisLinkEmail loads subject/body from KV; sendContactEmail uses contact_form_label from KV)*

------
https://chatgpt.com/codex/tasks/task_e_688d6b04fbf08326b4aac98a753ecb25