### PR TITLE
Добавяне на миграция за caloriesMacros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,7 +1114,22 @@ The file `docs/mail_smtp.php` relies on **PHPMailer** for SMTP. Install it via C
 composer require phpmailer/phpmailer
 ```
 
+
 The script expects `vendor/autoload.php` to reside one directory above the PHP file (`require __DIR__ . '/../vendor/autoload.php';`). Ensure the `vendor` folder is placed accordingly to avoid "Failed opening required" errors.
+
+## KV migrations
+
+За еднократни актуализации на Cloudflare KV се използват помощни скриптове от директория `scripts/`.
+Миграцията за планове без макроси се стартира така:
+
+```bash
+node scripts/migrate-final-plan-macros.js
+```
+
+Скриптът обхожда всички ключове `<userId>_final_plan` в `USER_METADATA_KV`,
+изчислява липсващите `caloriesMacros` на база началните отговори и записва
+резултата обратно чрез `wrangler kv key put`. Преди и след изпълнение е добре да
+се проверяват стойностите с `wrangler kv key get`.
 
 ## Cron configuration
 

--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+class DummyMacroCard extends HTMLElement {
+  setData() {}
+}
+customElements.define('macro-analytics-card', DummyMacroCard);
+
+global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve([]) }));
+
+let populateDashboardMacros;
+let selectors;
+beforeAll(async () => {
+  ({ populateDashboardMacros } = await import('../populateUI.js'));
+  ({ selectors } = await import('../uiElements.js'));
+});
+
+function setupDom() {
+  document.body.innerHTML = '<div id="macroMetricsPreview"></div><div id="analyticsCardsContainer"></div>';
+  selectors.macroMetricsPreview = document.getElementById('macroMetricsPreview');
+  selectors.analyticsCardsContainer = document.getElementById('analyticsCardsContainer');
+}
+
+test('placeholder shown when macros missing and populates after migration', async () => {
+  setupDom();
+  await populateDashboardMacros(null);
+  expect(selectors.macroMetricsPreview.classList.contains('hidden')).toBe(true);
+
+  const macros = {
+    calories: 1800,
+    protein_percent: 30,
+    carbs_percent: 40,
+    fat_percent: 30,
+    protein_grams: 135,
+    carbs_grams: 180,
+    fat_grams: 60
+  };
+  await populateDashboardMacros(macros);
+  expect(selectors.macroMetricsPreview.classList.contains('hidden')).toBe(false);
+  expect(selectors.macroMetricsPreview.textContent).toContain('1800');
+});

--- a/scripts/migrate-final-plan-macros.js
+++ b/scripts/migrate-final-plan-macros.js
@@ -1,0 +1,71 @@
+import { spawnSync } from 'child_process';
+
+function calcMacroGrams(calories, percent, calsPerGram) {
+  const cal = Number(calories);
+  const pct = Number(percent);
+  if (!cal || !pct) return 0;
+  return Math.round((cal * pct) / 100 / calsPerGram);
+}
+
+function estimateMacros(initial = {}) {
+  const weight = Number(initial.weight);
+  const height = Number(initial.height);
+  const age = Number(initial.age);
+  if (!weight || !height || !age) return null;
+  const gender = (initial.gender || '').toLowerCase().startsWith('м') ? 'male' : 'female';
+  const activity = (initial.q1745878295708 || '').toLowerCase();
+  const activityFactors = {
+    'ниско': 1.2,
+    'sedentary': 1.2,
+    'седящ': 1.2,
+    'средно': 1.375,
+    'умерено': 1.375,
+    'високо': 1.55,
+    'активно': 1.55,
+    'много високо': 1.725
+  };
+  const factor = activityFactors[activity] || 1.375;
+  const bmr = 10 * weight + 6.25 * height - 5 * age + (gender === 'male' ? 5 : -161);
+  const calories = Math.round(bmr * factor);
+  const protein_percent = 30;
+  const carbs_percent = 40;
+  const fat_percent = 30;
+  const protein_grams = calcMacroGrams(calories, protein_percent, 4);
+  const carbs_grams = calcMacroGrams(calories, carbs_percent, 4);
+  const fat_grams = calcMacroGrams(calories, fat_percent, 9);
+  return { calories, protein_percent, carbs_percent, fat_percent, protein_grams, carbs_grams, fat_grams };
+}
+
+function runWrangler(args) {
+  const result = spawnSync('wrangler', args, { encoding: 'utf8', stdio: ['inherit', 'pipe', 'inherit'] });
+  if (result.status !== 0) {
+    throw new Error(`wrangler ${args.join(' ')} failed`);
+  }
+  return result.stdout.trim();
+}
+
+function migrate() {
+  const binding = 'USER_METADATA_KV';
+  const listJson = runWrangler(['kv', 'key', 'list', '--binding', binding]);
+  const keys = JSON.parse(listJson).map(k => k.name).filter(k => k.endsWith('_final_plan'));
+  keys.forEach(key => {
+    const userId = key.replace('_final_plan', '');
+    const planStr = runWrangler(['kv', 'key', 'get', key, '--binding', binding]);
+    let plan;
+    try { plan = JSON.parse(planStr || '{}'); } catch { plan = {}; }
+    if (plan.caloriesMacros && Object.keys(plan.caloriesMacros).length > 0) return;
+    const initStr = runWrangler(['kv', 'key', 'get', `${userId}_initial_answers`, '--binding', binding]);
+    let initial;
+    try { initial = JSON.parse(initStr || '{}'); } catch { initial = {}; }
+    const macros = estimateMacros(initial);
+    if (!macros) {
+      console.warn(`Skipping ${userId}: unable to compute macros`);
+      return;
+    }
+    plan.caloriesMacros = macros;
+    runWrangler(['kv', 'key', 'put', key, JSON.stringify(plan), '--binding', binding]);
+    console.log(`Updated ${key}`);
+  });
+}
+
+migrate();


### PR DESCRIPTION
## Обобщение
- нов скрипт за автоматично попълване на `caloriesMacros` в `USER_METADATA_KV`
- README допълнен със секция за KV миграции
- тест за `populateDashboardMacros` при липсващи макроси

## Тестове
- `npm run lint`
- `npm test` *(част от тестовете се провалят: workerEmail, passwordReset и др.)*
- `NODE_OPTIONS=--experimental-vm-modules npx jest js/__tests__/populateDashboardMacros.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688d773bd850832687f257f41c8c7a64