### PR TITLE
Поправка във функцията за прогрес при липсващо тегло

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -840,8 +840,10 @@ async function populateProgressHistory(dailyLogs, initialData) {
 
     const reversedLogs = [...(dailyLogs || [])].reverse();
     reversedLogs.forEach(log => {
-        if (log.date && log.data) {
-            const loggedWeight = safeParseFloat(log.data.weight);
+        if (log.date) {
+            const loggedWeight = safeParseFloat(
+                log.data?.weight ?? log.weight
+            );
             if (loggedWeight !== null) {
                 labels.push(new Date(log.date).toLocaleDateString('bg-BG', { day: 'numeric', month: 'short' }));
                 weightData.push(loggedWeight);


### PR DESCRIPTION
## Резюме
- добавен fallback при четене на тегло от дневници

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d7ff8f04c832688f3d4b09d5e0e10