### PR TITLE
Поправка на графиката за прогрес при единични записи

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -851,7 +851,12 @@ async function populateProgressHistory(dailyLogs, initialData) {
         }
     });
 
-    if (labels.length < 2 || weightData.length < 2) {
+    if (weightData.length === 1) {
+        labels.push(new Date().toLocaleDateString('bg-BG', { day: 'numeric', month: 'short' }));
+        weightData.push(weightData[0]); // права линия
+    }
+
+    if (weightData.length === 0) {
         card.classList.add('hidden');
         return;
     }


### PR DESCRIPTION
## Обобщение
- Добавена е обработка на случай с единична стойност за тегло, като се допълва втора точка за права линия.
- Картичката с прогрес се скрива при липса на данни и се показва в противен случай.

## Тестване
- `npm run lint`
- `npm test` *(част от тестовете се провалиха: workerEmail.test.js, planContent.test.js, login.test.js и др.)*


------
https://chatgpt.com/codex/tasks/task_e_688d835808b88326acc7045ab36fd66e