### PR TITLE
Нормализиране на дневните логове и актуализиране на прогреса

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -10,7 +10,7 @@ import {
     openModal, closeModal,
     showLoading, showToast, updateTabsOverflowIndicator
 } from './uiHandlers.js';
-import { populateUI } from './populateUI.js';
+import { populateUI, populateProgressHistory } from './populateUI.js';
 // КОРЕКЦИЯ: Премахваме handleDelegatedClicks от импорта тук
 import { setupStaticEventListeners, setupDynamicEventListeners, initializeCollapsibleCards } from './eventListeners.js';
 import {
@@ -414,6 +414,11 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
             showPlanPendingState(`Възникна грешка при генерирането на вашия план: ${data.message || 'Свържете се с поддръжка.'}`); return;
         }
 
+        fullDashboardData.dailyLogs = (fullDashboardData.dailyLogs || []).map(log => ({
+            date: log.date,
+            data: { ...log.data, weight: log.data?.weight ?? log.weight }
+        }));
+
         if(selectors.planPendingState) selectors.planPendingState.classList.add('hidden');
         if(selectors.appWrapper) selectors.appWrapper.style.display = 'block';
 
@@ -448,6 +453,7 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
         }
 
         await populateUI();
+        await populateProgressHistory(fullDashboardData.dailyLogs, fullDashboardData.initialData);
 
         const plan = fullDashboardData.planData;
         const hasRecs = planHasRecContent(plan);

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -28,7 +28,6 @@ export async function populateUI() {
         data.planData?.additionalGuidelines ||
         data.additionalGuidelines;
     try { populateRecsTab(data.planData, data.initialAnswers, guidelinesData); } catch(e) { console.error("Error in populateRecsTab:", e); }
-    try { await populateProgressHistory(data.dailyLogs, data.initialData); } catch(e) { console.error("Error in populateProgressHistory:", e); }
 }
 
 function populateUserInfo(userName) {
@@ -824,7 +823,7 @@ export function handleAccordionToggle(event) {
     }
 }
 
-async function populateProgressHistory(dailyLogs, initialData) {
+export async function populateProgressHistory(dailyLogs, initialData) {
     const card = selectors.progressHistoryCard;
     if (!card) return;
 


### PR DESCRIPTION
## Резюме
- Нормализиране на `dailyLogs` и подаване към `populateProgressHistory`.
- Експорт и директно извикване на `populateProgressHistory` извън `populateUI`.

## Тестване
- `npm run lint`
- `npm test` *(част от тестовете се провалиха: workerEmail.test.js, passwordReset.test.js, registerEmail.test.js, submitQuestionnaireEmailFlag.test.js, planContent.test.js, login.test.js, stripPlanModSignature.test.js, submitQuizErrorReset.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688d871e1a808326a576c9cb2ee14350