### PR TITLE
Добавени overrides за макроси и автопопълване

### DIFF
--- a/js/__tests__/extraMealAutofill.test.js
+++ b/js/__tests__/extraMealAutofill.test.js
@@ -1,0 +1,53 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let initializeExtraMealFormLogic;
+
+beforeEach(async () => {
+  jest.resetModules();
+  global.fetch = jest.fn().mockResolvedValue({ json: async () => [] });
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    showLoading: jest.fn(),
+    showToast: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+  jest.unstable_mockModule('../app.js', () => ({
+    currentUserId: 'u1',
+    todaysExtraMeals: [],
+    todaysMealCompletionStatus: {},
+    currentIntakeMacros: {},
+    fullDashboardData: { planData: { week1Menu: {} } }
+  }));
+  ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));
+});
+
+test('автопопълва макросите при разпозната храна', () => {
+  document.body.innerHTML = `<div id="c">
+    <form id="extraMealEntryFormActual">
+      <div class="form-step"></div>
+      <div class="form-wizard-navigation">
+        <button id="emPrevStepBtn"></button>
+        <button id="emNextStepBtn"></button>
+        <button id="emSubmitBtn"></button>
+        <button id="emCancelBtn"></button>
+      </div>
+      <textarea id="foodDescription"></textarea>
+      <div id="foodSuggestionsDropdown"></div>
+      <input type="radio" name="quantityEstimateVisual" value="x" checked>
+      <input name="calories">
+      <input name="protein">
+      <input name="carbs">
+      <input name="fat">
+      <div class="form-step"></div>
+    </form>
+  </div>`;
+  const container = document.getElementById('c');
+  initializeExtraMealFormLogic(container);
+  const input = container.querySelector('#foodDescription');
+  input.value = 'ябълка';
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  expect(container.querySelector('input[name="calories"]').value).toBe('52');
+  expect(container.querySelector('input[name="protein"]').value).toBe('0.3');
+});

--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -22,7 +22,9 @@ beforeEach(async () => {
   }));
   jest.unstable_mockModule('../macroUtils.js', () => ({
     addMealMacros: addMealMacrosMock,
-    removeMealMacros: jest.fn()
+    removeMealMacros: jest.fn(),
+    registerNutrientOverrides: jest.fn(),
+    getNutrientOverride: jest.fn(() => null)
   }));
   jest.unstable_mockModule('../app.js', () => {
     currentIntakeMacrosRef = {};

--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import { calculateCurrentMacros, addMealMacros, removeMealMacros } from '../macroUtils.js';
+import { calculateCurrentMacros, addMealMacros, removeMealMacros, registerNutrientOverrides, getNutrientOverride, __testExports } from '../macroUtils.js';
 
 test('calculateCurrentMacros sums macros from completed meals and extras', () => {
   const planMenu = {
@@ -33,4 +33,14 @@ test('addMealMacros и removeMealMacros актуализират акумула�
   expect(acc).toEqual({ calories: 200, protein: 20, carbs: 30, fat: 10 });
   removeMealMacros(meal, acc);
   expect(acc).toEqual({ calories: 0, protein: 0, carbs: 0, fat: 0 });
+});
+
+test('getNutrientOverride кешира резултатите', () => {
+  registerNutrientOverrides({ 'ябълка': { calories: 52, protein: 0.3, carbs: 14, fat: 0.2 } });
+  expect(__testExports.nutrientCache.size).toBe(0);
+  const first = getNutrientOverride('ЯБЪЛКА');
+  expect(first).toEqual({ calories: 52, protein: 0.3, carbs: 14, fat: 0.2 });
+  expect(__testExports.nutrientCache.size).toBe(1);
+  getNutrientOverride('ябълка');
+  expect(__testExports.nutrientCache.size).toBe(1);
 });

--- a/kv/DIET_RESOURCES/nutrient_overrides.json
+++ b/kv/DIET_RESOURCES/nutrient_overrides.json
@@ -1,0 +1,4 @@
+{
+  "ябълка": { "calories": 52, "protein": 0.3, "carbs": 14, "fat": 0.2 },
+  "банан": { "calories": 96, "protein": 1.3, "carbs": 27, "fat": 0.3 }
+}


### PR DESCRIPTION
## Резюме
- добавен `nutrient_overrides.json` с примерни храни
- кеширане и API за override стойности в `macroUtils`
- автопопълване на макроси в формата за извънредно хранене

## Тестове
- `npm run lint`
- `npm test` *(част от тестовете се провалиха: workerEmail, registerEmail, passwordReset, login, submitQuestionnaireEmailFlag)*

------
https://chatgpt.com/codex/tasks/task_e_688d878964e48326b60c7ba0e7ddc0ab