### PR TITLE
Обновен loader за Chart.js с предупреждение при грешка

### DIFF
--- a/js/chartLoader.js
+++ b/js/chartLoader.js
@@ -5,10 +5,22 @@ export async function ensureChart() {
         || (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test')) {
       ChartLib = () => ({ destroy() {} });
     } else {
-      const module = await import('https://cdn.jsdelivr.net/npm/chart.js/auto');
-      ChartLib = module.default || module.Chart;
-      if (!ChartLib) throw new Error('Chart.js failed to load');
-      console.debug('Chart.js loaded');
+      try {
+        const module = await import('https://cdn.jsdelivr.net/npm/chart.js/auto/auto.js');
+        ChartLib = module.default || module.Chart;
+        if (!ChartLib) throw new Error('Chart.js failed to load');
+        console.debug('Chart.js loaded');
+      } catch (e) {
+        console.warn('Failed to load Chart.js', e);
+        if (typeof document !== 'undefined') {
+          const warning = document.createElement('div');
+          warning.className = 'alert alert-warning';
+          warning.setAttribute('role', 'alert');
+          warning.textContent = 'Chart.js не може да се зареди.';
+          document.body.prepend(warning);
+        }
+        ChartLib = () => ({ destroy() {} });
+      }
     }
   }
   return ChartLib;


### PR DESCRIPTION
## Резюме
- обновен CDN адрес за Chart.js към `auto/auto.js`
- добавена обработка на грешки с визуално предупреждение

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d8a19918c8326bb1f9e742ebcf09b