### PR TITLE
feat: добавяне на универсален формат за кратки дати

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,6 +1,6 @@
 // populateUI.js - Попълване на UI с данни
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
-import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, getProgressColor, animateProgressFill, getCssVar } from './utils.js';
+import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, getProgressColor, animateProgressFill, getCssVar, formatDateBgShort } from './utils.js';
 import { generateId } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
@@ -833,7 +833,7 @@ export async function populateProgressHistory(dailyLogs, initialData) {
     const initialWeight = safeParseFloat(initialData?.weight);
     if (initialWeight !== null) {
         const submissionDate = safeGet(fullDashboardData.initialAnswers, 'submissionDate', new Date().toISOString());
-        labels.push(new Date(submissionDate).toLocaleDateString('bg-BG', { day: 'numeric', month: 'short' }));
+        labels.push(formatDateBgShort(submissionDate));
         weightData.push(initialWeight);
     }
 
@@ -844,14 +844,14 @@ export async function populateProgressHistory(dailyLogs, initialData) {
                 log.data?.weight ?? log.weight
             );
             if (loggedWeight !== null) {
-                labels.push(new Date(log.date).toLocaleDateString('bg-BG', { day: 'numeric', month: 'short' }));
+                labels.push(formatDateBgShort(log.date));
                 weightData.push(loggedWeight);
             }
         }
     });
 
     if (weightData.length === 1) {
-        labels.push(new Date().toLocaleDateString('bg-BG', { day: 'numeric', month: 'short' }));
+        labels.push(formatDateBgShort(new Date()));
         weightData.push(weightData[0]); // права линия
     }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -49,6 +49,16 @@ export const escapeHtml = (text) => {
 };
 
 /**
+ * Форматира дата в кратък български формат (напр. "1 ян").
+ * @param {string|number|Date} date - Датата за форматиране.
+ * @returns {string} Форматираната дата.
+ */
+export function formatDateBgShort(date) {
+    return new Date(date)
+        .toLocaleDateString('bg-BG', { day: 'numeric', month: 'short' });
+}
+
+/**
  * Преобразува File обект към base64 низ без data префикс.
  * @param {File} file - Изображението за конвертиране.
  * @returns {Promise<string>} Обещание с base64 съдържанието.


### PR DESCRIPTION
## Обобщение
- добавена `formatDateBgShort` в `utils.js` за централизирано форматиране на дати
- използване на новата функция в `populateUI.js` вместо директно `toLocaleDateString`

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d895c90c48326b9cbf68e1d9a3ac3