### PR TITLE
refactor: reuse today's date in progress chart

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -829,6 +829,7 @@ export async function populateProgressHistory(dailyLogs, initialData) {
 
     const weightData = [];
     const labels = [];
+    const todayStr = formatDateBgShort(new Date());
 
     const initialWeight = safeParseFloat(initialData?.weight);
     if (initialWeight !== null) {
@@ -851,7 +852,7 @@ export async function populateProgressHistory(dailyLogs, initialData) {
     });
 
     if (weightData.length === 1) {
-        labels.push(formatDateBgShort(new Date()));
+        labels.push(todayStr);
         weightData.push(weightData[0]); // права линия
     }
 


### PR DESCRIPTION
## Summary
- reuse already-formatted current date in `populateProgressHistory`

## Testing
- `npm run lint`
- `npm test` *(fails: workerEmail, passwordReset, registerEmail, populateDashboardMacros.missingComponent, submitQuestionnaireEmailFlag, login)*

------
https://chatgpt.com/codex/tasks/task_e_688d8b51d7ec832691f3474a349c6fec