### PR TITLE
feat: nutrient lookup cache

### DIFF
--- a/js/__tests__/extraMealNutrientLookup.test.js
+++ b/js/__tests__/extraMealNutrientLookup.test.js
@@ -1,0 +1,62 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let initializeExtraMealFormLogic;
+
+beforeEach(async () => {
+  jest.resetModules();
+  global.fetch = jest.fn((url, opts) => {
+    if (typeof url === 'string' && url === '/nutrient-lookup') {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ calories: 100, protein: 20, carbs: 10, fat: 5 })
+      });
+    }
+    return Promise.resolve({ json: async () => [] });
+  });
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    showLoading: jest.fn(),
+    showToast: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+  jest.unstable_mockModule('../app.js', () => ({
+    currentUserId: 'u1',
+    todaysExtraMeals: [],
+    todaysMealCompletionStatus: {},
+    currentIntakeMacros: {},
+    fullDashboardData: { planData: { week1Menu: {} } }
+  }));
+  ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));
+});
+
+test('извиква nutrient lookup при непозната храна', async () => {
+  document.body.innerHTML = `<div id="c">
+    <form id="extraMealEntryFormActual">
+      <div class="form-step"></div>
+      <div class="form-wizard-navigation">
+        <button id="emPrevStepBtn"></button>
+        <button id="emNextStepBtn"></button>
+        <button id="emSubmitBtn"></button>
+        <button id="emCancelBtn"></button>
+      </div>
+      <textarea id="foodDescription"></textarea>
+      <div id="foodSuggestionsDropdown"></div>
+      <input type="radio" name="quantityEstimateVisual" value="x" checked>
+      <input name="calories">
+      <input name="protein">
+      <input name="carbs">
+      <input name="fat">
+      <div class="form-step"></div>
+    </form>
+  </div>`;
+  const container = document.getElementById('c');
+  initializeExtraMealFormLogic(container);
+  const input = container.querySelector('#foodDescription');
+  input.value = 'непозната храна';
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  await new Promise(r => setTimeout(r, 0));
+  expect(global.fetch).toHaveBeenCalledWith('/nutrient-lookup', expect.objectContaining({ method: 'POST' }));
+  expect(container.querySelector('input[name="calories"]').value).toBe('100');
+});


### PR DESCRIPTION
## Summary
- добавен `/nutrient-lookup` endpoint с кеш в USER_METADATA_KV
- автоматично извличане на макроси при попълване на извънредно хранене
- unit тест за заявката към `/nutrient-lookup`

## Testing
- `npm run lint`
- `npm test` *(failing: registerEmail.test.js, passwordReset.test.js, workerEmail.test.js, submitQuestionnaireEmailFlag.test.js, login.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688d8aeea5508326861f560a7440fa8c