### PR TITLE
feat: normalize daily log structure

### DIFF
--- a/js/__tests__/normalizeDailyLogs.test.js
+++ b/js/__tests__/normalizeDailyLogs.test.js
@@ -1,0 +1,37 @@
+/** @jest-environment node */
+import { normalizeDailyLogs } from '../utils.js';
+
+describe('normalizeDailyLogs', () => {
+  test('премества weight и completedMealsStatus в data', () => {
+    const input = [{
+      date: '2024-01-01',
+      weight: 80,
+      completedMealsStatus: { breakfast: true },
+      data: { note: 'hi' }
+    }];
+    const result = normalizeDailyLogs(input);
+    expect(result).toEqual([
+      {
+        date: '2024-01-01',
+        data: {
+          note: 'hi',
+          weight: 80,
+          completedMealsStatus: { breakfast: true }
+        }
+      }
+    ]);
+  });
+
+  test('запазва вече нормализирани записи', () => {
+    const input = [{
+      date: '2024-01-02',
+      data: {
+        note: 'ok',
+        weight: 70,
+        completedMealsStatus: { lunch: false }
+      }
+    }];
+    expect(normalizeDailyLogs(input)).toEqual(input);
+  });
+});
+

--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,7 @@
 // app.js - Основен Файл на Приложението
 import { isLocalDevelopment, apiEndpoints } from './config.js';
 import { debugLog, enableDebug } from './logger.js';
-import { safeParseFloat, escapeHtml, fileToDataURL } from './utils.js';
+import { safeParseFloat, escapeHtml, fileToDataURL, normalizeDailyLogs } from './utils.js';
 import { selectors, initializeSelectors, loadInfoTexts } from './uiElements.js';
 import {
     initializeTheme,
@@ -354,6 +354,7 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
             const data = createTestData();
             debugLog("Using test data for development:", data);
             fullDashboardData = data;
+            fullDashboardData.dailyLogs = normalizeDailyLogs(fullDashboardData.dailyLogs);
             chatHistory = []; // Reset chat history for test user on reload
 
             if(selectors.planPendingState) selectors.planPendingState.classList.add('hidden');
@@ -414,10 +415,7 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
             showPlanPendingState(`Възникна грешка при генерирането на вашия план: ${data.message || 'Свържете се с поддръжка.'}`); return;
         }
 
-        fullDashboardData.dailyLogs = (fullDashboardData.dailyLogs || []).map(log => ({
-            date: log.date,
-            data: { ...log.data, weight: log.data?.weight ?? log.weight }
-        }));
+        fullDashboardData.dailyLogs = normalizeDailyLogs(fullDashboardData.dailyLogs);
 
         if(selectors.planPendingState) selectors.planPendingState.classList.add('hidden');
         if(selectors.appWrapper) selectors.appWrapper.style.display = 'block';
@@ -638,6 +636,7 @@ export async function handleSaveLog() { // Exported for eventListeners.js
             if(!fullDashboardData.dailyLogs) fullDashboardData.dailyLogs = [];
             fullDashboardData.dailyLogs.push({date: result.savedDate, data: result.savedData || logPayload.data});
         }
+        fullDashboardData.dailyLogs = normalizeDailyLogs(fullDashboardData.dailyLogs);
         if (fullDashboardData.dailyLogs) {
             fullDashboardData.dailyLogs.sort((a,b) => new Date(b.date).getTime() - new Date(a.date).getTime());
         }

--- a/js/utils.js
+++ b/js/utils.js
@@ -251,3 +251,20 @@ export function contrastRatio(c1, c2) {
     const darker = Math.min(L1, L2);
     return (lighter + 0.05) / (darker + 0.05);
 }
+
+/**
+ * Нормализира масив от дневни логове, като гарантира наличието на weight и completedMealsStatus в data.
+ * @param {Array<Object>} logs Масив с дневни логове.
+ * @returns {Array<Object>} Нов масив с унифицирани записи.
+ */
+export function normalizeDailyLogs(logs = []) {
+    return logs.map(log => ({
+        date: log.date,
+        data: {
+            ...log.data,
+            weight: log.data?.weight ?? log.weight,
+            completedMealsStatus: log.data?.completedMealsStatus ?? log.completedMealsStatus
+        }
+    }));
+}
+


### PR DESCRIPTION
## Summary
- ensure daily logs keep weight and meal status in a unified data block
- reuse normalization when loading dashboard data and saving logs
- cover daily log normalization with focused unit tests

## Testing
- `npm run lint`
- `npm test` *(fails: workerEmail.test.js, passwordReset.test.js)*
- `sh ./scripts/test.sh js/__tests__/normalizeDailyLogs.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688d8b5a49748326ae25fc6a96e67e04