### PR TITLE
feat: add plan macros comparison

### DIFF
--- a/js/__tests__/macroAnalyticsCardComponent.test.js
+++ b/js/__tests__/macroAnalyticsCardComponent.test.js
@@ -44,13 +44,14 @@ test('рендерира метриките и реагира на highlightMacr
     fat_grams: 70,
     fat_percent: 35
   };
+  const plan = { calories: 1900 };
   const current = {
     calories: 1200,
     protein_grams: 60,
     carbs_grams: 100,
     fat_grams: 40
   };
-  card.setData(target, current);
+  card.setData({ target, plan, current });
   const utils = within(card.shadowRoot);
   await waitFor(() => utils.getByText('Белтъчини'));
   expect(utils.getByText('60 / 150г')).toBeTruthy();
@@ -90,6 +91,7 @@ test('data-endpoint и refresh-interval извикват fetch периодич�
           fat_grams: 70,
           fat_percent: 35
         },
+        plan: { calories: 1900 },
         current: {
           calories: 1200,
           protein_grams: 60,

--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import { calculateCurrentMacros, addMealMacros, removeMealMacros, registerNutrientOverrides, getNutrientOverride, __testExports } from '../macroUtils.js';
+import { calculateCurrentMacros, addMealMacros, removeMealMacros, registerNutrientOverrides, getNutrientOverride, calculatePlanMacros, __testExports } from '../macroUtils.js';
 
 test('calculateCurrentMacros sums macros from completed meals and extras', () => {
   const planMenu = {
@@ -24,6 +24,15 @@ test('calculateCurrentMacros sums macros from completed meals and extras', () =>
 
   const result = calculateCurrentMacros(planMenu, completionStatus, extraMeals);
   expect(result).toEqual({ calories: 880, protein: 67, carbs: 48, fat: 42 });
+});
+
+test('calculatePlanMacros sums macros for day menu', () => {
+  const dayMenu = [
+    { id: 'z-01', meal_name: 'Протеинов шейк' },
+    { id: 'o-01', meal_name: 'Печено пилешко с ориз/картофи и салата' }
+  ];
+  const result = calculatePlanMacros(dayMenu);
+  expect(result).toEqual({ calories: 850, protein: 72, carbs: 70, fat: 28 });
 });
 
 test('addMealMacros и removeMealMacros актуализират акумулатора', () => {

--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -2,7 +2,10 @@
 import { jest } from '@jest/globals';
 
 class DummyMacroCard extends HTMLElement {
-  setData() {}
+  constructor() {
+    super();
+    this.setData = jest.fn();
+  }
 }
 customElements.define('macro-analytics-card', DummyMacroCard);
 
@@ -10,7 +13,9 @@ global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve([]) }
 
 let populateDashboardMacros;
 let selectors;
+let appState;
 beforeAll(async () => {
+  appState = await import('../app.js');
   ({ populateDashboardMacros } = await import('../populateUI.js'));
   ({ selectors } = await import('../uiElements.js'));
 });
@@ -35,7 +40,20 @@ test('placeholder shown when macros missing and populates after migration', asyn
     carbs_grams: 180,
     fat_grams: 60
   };
+  const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
+  const currentDayKey = dayNames[new Date().getDay()];
+  const dayMenu = [
+    { id: 'z-01', meal_name: 'Протеинов шейк' },
+    { id: 'o-01', meal_name: 'Печено пилешко с ориз/картофи и салата' }
+  ];
+  appState.fullDashboardData.planData = { week1Menu: { [currentDayKey]: dayMenu } };
   await populateDashboardMacros(macros);
   expect(selectors.macroMetricsPreview.classList.contains('hidden')).toBe(false);
   expect(selectors.macroMetricsPreview.textContent).toContain('1800');
+  const card = document.getElementById('macroAnalyticsCard');
+  expect(card.setData).toHaveBeenCalledWith({
+    target: macros,
+    plan: { calories: 850, protein: 72, carbs: 70, fat: 28 },
+    current: null
+  });
 });

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -87,6 +87,18 @@ export function removeMealMacros(meal, acc) {
 }
 
 /**
+ * Сумира макросите на всички хранения за деня.
+ * @param {Array} dayMenu - Масив от хранения за текущия ден.
+ * @returns {{ calories:number, protein:number, carbs:number, fat:number }}
+ */
+export function calculatePlanMacros(dayMenu = []) {
+  const acc = { calories: 0, protein: 0, carbs: 0, fat: 0 };
+  if (!Array.isArray(dayMenu)) return acc;
+  dayMenu.forEach((meal) => addMealMacros(meal, acc));
+  return acc;
+}
+
+/**
  * Изчислява общите макроси за изпълнените хранения и извънредни хранения.
  * @param {Object} planMenu - Менюто по дни със списъци от хранения.
  * @param {Object} completionStatus - Обект със статуси дали храненето е изпълнено (day_index ключове).

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -5,6 +5,7 @@ import { generateId } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
 import { ensureChart } from './chartLoader.js';
+import { calculatePlanMacros } from './macroUtils.js';
 
 export let macroChartInstance = null;
 export let progressChartInstance = null;
@@ -313,7 +314,12 @@ export async function populateDashboardMacros(macros) {
     const current = currentIntakeMacros && Object.keys(currentIntakeMacros).length > 0
         ? currentIntakeMacros
         : null;
-    card.setData(macros, current);
+    const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+    const today = new Date();
+    const currentDayKey = dayNames[today.getDay()];
+    const dayMenu = fullDashboardData?.planData?.week1Menu?.[currentDayKey] || [];
+    const planMacros = calculatePlanMacros(dayMenu);
+    card.setData({ target: macros, plan: planMacros, current });
     renderPendingMacroChart();
 }
 

--- a/macroAnalyticsCardStandalone.html
+++ b/macroAnalyticsCardStandalone.html
@@ -294,7 +294,7 @@
             const res = await fetch(endpoint);
             const data = await res.json();
             if (data.target && data.current) {
-              this.setData(data.target, data.current);
+              this.setData(data);
             }
           } catch (e) {
             console.error('Failed to fetch macro data', e);
@@ -304,9 +304,10 @@
         this.refreshTimer = setInterval(fetchData, interval);
       }
 
-      setData(target, current) {
-        this.setAttribute('target-data', JSON.stringify(target));
-        this.setAttribute('current-data', JSON.stringify(current));
+      setData({ target, plan, current }) {
+        if (target) this.setAttribute('target-data', JSON.stringify(target));
+        if (plan) this.setAttribute('plan-data', JSON.stringify(plan));
+        if (current) this.setAttribute('current-data', JSON.stringify(current));
       }
 
       getCssVar(name) {


### PR DESCRIPTION
## Summary
- add `calculatePlanMacros` helper and tests
- compare daily plan vs recommendation in dashboard macros and macro card
- update macro analytics card to accept plan data

## Testing
- `npm run lint`
- `npm test js/__tests__/macroUtils.test.js js/__tests__/macroAnalyticsCardComponent.test.js js/__tests__/populateDashboardMacros.test.js`
- `npm test` *(fails: sendAnalysisLinkEmail loads subject/body from KV)*

------
https://chatgpt.com/codex/tasks/task_e_688d8dd3dcd083269baa77d6fa705748