### PR TITLE
Поправка: зареждане на Chart.js през CDN модул

### DIFF
--- a/js/chartLoader.js
+++ b/js/chartLoader.js
@@ -6,7 +6,7 @@ export async function ensureChart() {
       ChartLib = () => ({ destroy() {} });
     } else {
       try {
-        const module = await import('https://cdn.jsdelivr.net/npm/chart.js/auto/auto.js');
+        const module = await import('https://cdn.jsdelivr.net/npm/chart.js?module');
         ChartLib = module.default || module.Chart;
         if (!ChartLib) throw new Error('Chart.js failed to load');
         console.debug('Chart.js loaded');


### PR DESCRIPTION
## Обобщение
- Зареждането на Chart.js вече използва `https://cdn.jsdelivr.net/npm/chart.js?module`, което коректно резолвира зависимостта `@kurkle/color` и връща валиден конструктор.

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d8ed608e88326b350fcf6c4a06584