### PR TITLE
feat: persist macro data with analysis and plan

### DIFF
--- a/js/__tests__/initialAnalysis.test.js
+++ b/js/__tests__/initialAnalysis.test.js
@@ -32,6 +32,7 @@ describe('initial analysis handlers', () => {
     }
     await worker.handleAnalyzeInitialAnswers('u1', env)
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis', '{"ok":true}')
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_macros', '{}')
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_status', 'ready')
     expect(global.fetch).toHaveBeenCalled()
   })

--- a/js/__tests__/planGenerationLogs.test.js
+++ b/js/__tests__/planGenerationLogs.test.js
@@ -61,5 +61,6 @@ describe('processSingleUserPlan log metrics', () => {
     expect(sentPrompt).toContain('-1.0');
     expect(sentPrompt).toContain('4.0');
     expect(sentPrompt).toContain('3.0');
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_caloriesMacros', '{}', { expirationTtl: 86400 });
   });
 });


### PR DESCRIPTION
## Summary
- store computed macros separately when saving initial analysis
- persist calories/macros from final plan in KV with 24h TTL
- adjust tests for new macros persistence

## Testing
- `npx eslint .`
- `sh scripts/test.sh js/__tests__/initialAnalysis.test.js js/__tests__/planGenerationLogs.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688d921ab58c8326b46ddb93806f6633