### PR TITLE
Use import.meta.url and cache for macro card locales

### DIFF
--- a/js/macroCardLocales.js
+++ b/js/macroCardLocales.js
@@ -1,7 +1,32 @@
 const cache = {};
+
 export async function loadLocale(lng) {
   if (cache[lng]) return cache[lng];
-  const res = await fetch(`./locales/macroCard.${lng}.json`);
-  cache[lng] = res.ok ? await res.json() : await loadLocale('bg');
-  return cache[lng];
+  try {
+    const url = new URL(`../locales/macroCard.${lng}.json`, import.meta.url);
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    cache[lng] = await res.json();
+    return cache[lng];
+  } catch {
+    if (lng !== 'bg') {
+      if (!cache.bg) {
+        try {
+          const url = new URL(`../locales/macroCard.bg.json`, import.meta.url);
+          const res = await fetch(url);
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          cache.bg = await res.json();
+        } catch {
+          cache.bg = {};
+        }
+      }
+      if (Object.keys(cache.bg).length) {
+        cache[lng] = cache.bg;
+        return cache.bg;
+      }
+    }
+    console.warn(`Failed to load locale "${lng}"`);
+    cache[lng] = {};
+    return cache[lng];
+  }
 }


### PR DESCRIPTION
## Summary
- refactor macroCard locale loader to use import.meta.url
- cache locales and fall back to `bg` once

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d9f6b96e083268827dd5ed8835983