### PR TITLE
Документиране на изчисленията за макроси

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,6 +875,35 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
 
 За новата логика има тестове `macroUtils.test.js`, `macroCalc.test.js`, `extraMealForm.test.js` и `extraMealFormSubmit.test.js`. При локална разработка стартирайте `npm test` след `npm install`, за да се изпълнят всички проверки.
 
+### Изчисления на макросите
+
+Макросите се съхраняват в речник `caloriesMacros` с калории и грамове:
+
+```json
+{
+  "calories": 1800,
+  "protein_grams": 135,
+  "carbs_grams": 180,
+  "fat_grams": 60
+}
+```
+
+Този обект се изпраща към AI модела за оценка на съотношението:
+
+```bash
+curl -X POST /api/aiHelper \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt":"macro check","macros":{"calories":1800,"protein_grams":135,"carbs_grams":180,"fat_grams":60}}'
+```
+
+Отговорът позволява сравнение **План vs Препоръка**:
+
+| План | Препоръка |
+|------|-----------|
+| 1800 kcal / 135 г P / 180 г C / 60 г F | 1900 kcal / 140 г P / 200 г C / 65 г F |
+
+Разликата се визуализира в `macroAnalyticsCard` и се записва в ключ `<userId>_analysis_macros`.
+
 Ендпойнтът `/api/peekAdminQueries` връща списък с неприключени запитвания, без да ги маркира като прочетени. Използва се основно за показване на индикатора, докато `/api/getAdminQueries` обновява флага `read` при зареждане на данните.
 
 ### Нови API ендпойнти

--- a/docs/final_plan_kv_example.md
+++ b/docs/final_plan_kv_example.md
@@ -15,3 +15,33 @@
 - `generationMetadata` – технически данни за генерирането (timestamp, използван модел и др.).
 
 Пълният примерен запис може да се види във файла [`final_plan_template.json`](final_plan_template.json). Структурата следва camelCase именуване и съдържа текст на български език.
+
+## Макро записи
+
+За проследяване на промените се използват два помощни ключа:
+
+- `<userId>_final_analysis_macros` – сравнение „План vs Препоръка“.
+- `<userId>_final_caloriesMacros` – копие на макронутриентите за бърз достъп.
+
+```json
+// <userId>_final_analysis_macros
+{
+  "plan": { "calories": 1800, "protein_grams": 135, "carbs_grams": 180, "fat_grams": 60 },
+  "recommendation": { "calories": 1900, "protein_grams": 140, "carbs_grams": 190, "fat_grams": 65 }
+}
+```
+
+```json
+// <userId>_final_caloriesMacros
+{
+  "calories": 1800,
+  "protein_percent": 30,
+  "carbs_percent": 40,
+  "fat_percent": 30,
+  "protein_grams": 135,
+  "carbs_grams": 180,
+  "fat_grams": 60
+}
+```
+
+Всички стойности са в **kcal** и **грамове**.

--- a/docs/questionnaire_kv_example.md
+++ b/docs/questionnaire_kv_example.md
@@ -44,9 +44,39 @@
   "mainChallenge": "Липса на време за готвене",
   "medicalConditions": ["Нямам"],
   "medications": "Не",
-  "submissionDate": "2024-07-17T09:32:05.123Z"
+"submissionDate": "2024-07-17T09:32:05.123Z"
 }
 ```
+
+## Макроси и калории
+
+След обработка се създават два KV записа:
+
+- `<userId>_analysis_macros` – резултат от AI оценка „План vs Препоръка“.
+- `<userId>_caloriesMacros` – базов дневен прием и макроси.
+
+```json
+// <userId>_analysis_macros
+{
+  "plan": { "calories": 1700, "protein_grams": 120, "carbs_grams": 150, "fat_grams": 55 },
+  "recommendation": { "calories": 1800, "protein_grams": 130, "carbs_grams": 160, "fat_grams": 60 }
+}
+```
+
+```json
+// <userId>_caloriesMacros
+{
+  "calories": 1800,
+  "protein_percent": 30,
+  "carbs_percent": 40,
+  "fat_percent": 30,
+  "protein_grams": 135,
+  "carbs_grams": 180,
+  "fat_grams": 60
+}
+```
+
+Всички стойности са в **kcal** и **грамове**.
 
 В полетата, където изборът позволява повече от една стойност (тип `checkbox`), отговорът е масив от низове. Числовите въпроси (`number`) се съхраняват като числа, а текстовите като низове. Полето `submissionDate` се добавя при изпращане и отбелязва момента на попълване.
 


### PR DESCRIPTION
## Summary
- описано е как се изчисляват макросите и сравняват план и препоръка
- добавени са примери за `*_analysis_macros` и `*_caloriesMacros` в KV документацията
- всички примери са унифицирани в kcal и грамове

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688da06dc2348326aae82eba0b513f89