### PR TITLE
Зареждане на Chart.js чрез споделен промис

### DIFF
--- a/js/chartLoader.js
+++ b/js/chartLoader.js
@@ -10,22 +10,33 @@ export async function ensureChart() {
         || (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test')) {
       ChartLib = () => ({ destroy() {} });
     } else {
-      try {
-        const url = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.js';
-        const module = await import(url);
-        ChartLib = module.Chart || module.default || globalThis.Chart;
-        if (!ChartLib) throw new Error('Chart.js failed to load');
-        console.debug('Chart.js loaded');
-      } catch (e) {
-        console.warn('Failed to load Chart.js', e);
-        if (typeof document !== 'undefined') {
-          const warning = document.createElement('div');
-          warning.className = 'alert alert-warning';
-          warning.setAttribute('role', 'alert');
-          warning.textContent = 'Chart.js не може да се зареди.';
-          document.body.prepend(warning);
+      if (window.Chart) {
+        ChartLib = window.Chart;
+      } else {
+        if (!window._chartPromise) {
+          window._chartPromise = new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.js';
+            script.onload = () => resolve(window.Chart);
+            script.onerror = reject;
+            document.head.appendChild(script);
+          });
         }
-        ChartLib = () => ({ destroy() {} });
+        try {
+          ChartLib = await window._chartPromise;
+          if (!ChartLib) throw new Error('Chart.js failed to load');
+          console.debug('Chart.js loaded');
+        } catch (e) {
+          console.warn('Failed to load Chart.js', e);
+          if (typeof document !== 'undefined') {
+            const warning = document.createElement('div');
+            warning.className = 'alert alert-warning';
+            warning.setAttribute('role', 'alert');
+            warning.textContent = 'Chart.js не може да се зареди.';
+            document.body.prepend(warning);
+          }
+          ChartLib = () => ({ destroy() {} });
+        }
       }
     }
   }


### PR DESCRIPTION
## Обобщение
- Зареждане на Chart.js чрез `<script>` с глобален `window._chartPromise`, за да се избегнат дублиращи заявки.
- Връщане на `window.Chart` при успешен load и Stand‑in функция при грешка.

## Тестове
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688da0f44ca88326879cf845db8200c9