### PR TITLE
Запазване на макроси от анализ и план

### DIFF
--- a/js/__tests__/initialAnalysis.test.js
+++ b/js/__tests__/initialAnalysis.test.js
@@ -32,6 +32,7 @@ describe('initial analysis handlers', () => {
     }
     await worker.handleAnalyzeInitialAnswers('u1', env)
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis', '{"ok":true}')
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_macros', 'null')
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_status', 'ready')
     expect(global.fetch).toHaveBeenCalled()
   })

--- a/js/__tests__/planGenerationLogs.test.js
+++ b/js/__tests__/planGenerationLogs.test.js
@@ -61,5 +61,6 @@ describe('processSingleUserPlan log metrics', () => {
     expect(sentPrompt).toContain('-1.0');
     expect(sentPrompt).toContain('4.0');
     expect(sentPrompt).toContain('3.0');
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_caloriesMacros', '{}', { expirationTtl: 86400 });
   });
 });


### PR DESCRIPTION
## Обобщение
- Изчисляване и кеширане на дневни макроси след първоначален анализ на потребителя.
- Съхранение на финалните макронутриенти на плана с 24ч TTL за бърз достъп.
- Разширени тестове за потвърждаване на новите KV операции.

## Тестове
- `npm run lint`
- `npm test`
- `sh ./scripts/test.sh js/__tests__/initialAnalysis.test.js js/__tests__/planGenerationLogs.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688da05fc0b88326bad899abe87a216c