### PR TITLE
warn when macros or container missing

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -304,13 +304,22 @@ export async function populateDashboardMacros(macros) {
         return;
     }
     const container = selectors.analyticsCardsContainer;
+    if (!container) {
+        console.warn('Analytics cards container not found.');
+        return;
+    }
+
     let card = document.getElementById('macroAnalyticsCard');
-    if (!card && container) {
+    if (!card) {
         card = document.createElement('macro-analytics-card');
         card.id = 'macroAnalyticsCard';
         container.appendChild(card);
     }
-    if (!card || !macros) return;
+
+    if (!macros) {
+        console.warn('Macros data is missing.');
+        return;
+    }
     const current = currentIntakeMacros && Object.keys(currentIntakeMacros).length > 0
         ? currentIntakeMacros
         : null;


### PR DESCRIPTION
## Summary
- warn when analytics container missing before rendering dashboard macros
- log when macros data is absent

## Testing
- `npm run lint`
- `npm test` *(fails: process did not exit cleanly, FATAL OOM)*

------
https://chatgpt.com/codex/tasks/task_e_688dacaab7a483268973b0550f29a676