### PR TITLE
Добавяне на въвеждане на грамаж и скалиране на макроси

### DIFF
--- a/docs/scaleMacrosExample.md
+++ b/docs/scaleMacrosExample.md
@@ -1,0 +1,13 @@
+# Пример: скалиране на макроси
+
+Следният код показва как 150 г пилешко месо се превръщат в макроси.
+
+```js
+import { scaleMacros } from '../js/macroUtils.js';
+
+const chicken100g = { calories: 110, protein: 21, carbs: 0, fat: 2.4 };
+const result = scaleMacros(chicken100g, 150);
+// result: { calories: 165, protein: 31.5, carbs: 0, fat: 3.6 }
+```
+
+Получаваме **165 ккал, 31.5 г протеин, 3.6 г мазнини**.

--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -1,5 +1,6 @@
 import { loadLocale } from './macroCardLocales.js';
 import { ensureChart } from './chartLoader.js';
+import { scaleMacros } from './macroUtils.js';
 
 let Chart;
 
@@ -196,7 +197,26 @@ export class MacroAnalyticsCard extends HTMLElement {
       return;
     }
     try {
-      const parsed = JSON.parse(newVal);
+      let parsed = JSON.parse(newVal);
+      if (name === 'current-data' && parsed && typeof parsed.grams === 'number') {
+        if (parsed.macros) {
+          const scaled = scaleMacros(parsed.macros, parsed.grams);
+          parsed = {
+            calories: scaled.calories,
+            protein_grams: scaled.protein,
+            carbs_grams: scaled.carbs,
+            fat_grams: scaled.fat
+          };
+        } else {
+          const scaled = scaleMacros(parsed, parsed.grams);
+          parsed = {
+            calories: scaled.calories,
+            protein_grams: scaled.protein,
+            carbs_grams: scaled.carbs,
+            fat_grams: scaled.fat
+          };
+        }
+      }
       if (name === 'target-data') this.targetData = parsed;
       if (name === 'plan-data') this.planData = parsed;
       if (name === 'current-data') this.currentData = parsed;


### PR DESCRIPTION
## Обобщение
- позволено е въвеждане на грамаж при добавяне на продукт и скалиране на макросите
- MacroAnalyticsCard използва `scaleMacros` за визуализация спрямо грамове
- добавен е документационен пример за преобразуване на 150 г пилешко в макроси

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e5b37d7e483268e8bd74586b86d54