### PR TITLE
Зареждане на продуктови макроси при стартиране

### DIFF
--- a/js/__tests__/loadProductMacrosInit.test.js
+++ b/js/__tests__/loadProductMacrosInit.test.js
@@ -1,0 +1,69 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+test('initializeApp продължава при грешка в loadProductMacros', async () => {
+  const loadProductMacros = jest.fn().mockRejectedValue(new Error('missing'));
+
+  jest.unstable_mockModule('../macroUtils.js', () => ({ loadProductMacros }));
+  jest.unstable_mockModule('../config.js', () => ({ isLocalDevelopment: false, apiEndpoints: {} }));
+  jest.unstable_mockModule('../logger.js', () => ({ debugLog: jest.fn(), enableDebug: jest.fn() }));
+  jest.unstable_mockModule('../utils.js', () => ({
+    safeParseFloat: jest.fn(),
+    escapeHtml: jest.fn(),
+    fileToDataURL: jest.fn(),
+    normalizeDailyLogs: jest.fn()
+  }));
+  const initializeSelectors = jest.fn();
+  jest.unstable_mockModule('../uiElements.js', () => ({
+    selectors: { tabButtons: [] },
+    initializeSelectors,
+    loadInfoTexts: jest.fn()
+  }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    initializeTheme: jest.fn(),
+    loadAndApplyColors: jest.fn(),
+    activateTab: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: jest.fn(),
+    showLoading: jest.fn(),
+    showToast: jest.fn(),
+    updateTabsOverflowIndicator: jest.fn()
+  }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ populateUI: jest.fn(), populateProgressHistory: jest.fn() }));
+  jest.unstable_mockModule('../eventListeners.js', () => ({
+    setupStaticEventListeners: jest.fn(),
+    setupDynamicEventListeners: jest.fn(),
+    initializeCollapsibleCards: jest.fn()
+  }));
+  jest.unstable_mockModule('../chat.js', () => ({
+    displayMessage: jest.fn(),
+    displayTypingIndicator: jest.fn(),
+    scrollToChatBottom: jest.fn(),
+    setAutomatedChatPending: jest.fn()
+  }));
+  jest.unstable_mockModule('../achievements.js', () => ({ initializeAchievements: jest.fn() }));
+  jest.unstable_mockModule('../adaptiveQuiz.js', () => ({
+    openAdaptiveQuizModal: jest.fn(),
+    renderCurrentQuizQuestion: jest.fn(),
+    showQuizValidationMessage: jest.fn(),
+    hideQuizValidationMessage: jest.fn()
+  }));
+  jest.unstable_mockModule('../planModChat.js', () => ({ openPlanModificationChat: jest.fn() }));
+
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  await import('../app.js');
+
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true, planStatus: 'ready', planData: {}, dashboardData: {}, dailyLogs: [], planMenu: {}, progressHistory: [] })
+  });
+
+  sessionStorage.setItem('userId', '123');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  await new Promise((r) => setTimeout(r, 0));
+
+  expect(loadProductMacros).toHaveBeenCalled();
+  expect(warnSpy).toHaveBeenCalled();
+  expect(initializeSelectors).toHaveBeenCalled();
+});

--- a/js/app.js
+++ b/js/app.js
@@ -13,6 +13,7 @@ import {
 import { populateUI, populateProgressHistory } from './populateUI.js';
 // КОРЕКЦИЯ: Премахваме handleDelegatedClicks от импорта тук
 import { setupStaticEventListeners, setupDynamicEventListeners, initializeCollapsibleCards } from './eventListeners.js';
+import { loadProductMacros } from './macroUtils.js';
 import {
     displayMessage as displayChatMessage,
     displayTypingIndicator as displayChatTypingIndicator, scrollToChatBottom,
@@ -284,6 +285,11 @@ export { planHasRecContent };
 async function initializeApp() {
     try {
         debugLog("initializeApp starting from app.js...");
+        try {
+            await loadProductMacros();
+        } catch (err) {
+            console.warn("Неуспешно зареждане на продуктови макроси:", err);
+        }
         initializeSelectors();
         triggerAssistantWiggle();
         await loadInfoTexts();


### PR DESCRIPTION
## Резюме
- Зареждане на продуктови макроси още при стартиране на приложението с предпазване при грешка
- Добавен тест, който гарантира, че приложението логва предупреждение и продължава работа

## Тестване
- `npm run lint`
- `npm test` *(неуспешно: js/__tests__/workerEmail.test.js, js/__tests__/passwordReset.test.js)*
- `npm test js/__tests__/loadProductMacrosInit.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688e919827c88326a02c010aba1d21d5