### PR TITLE
Централизиране на цветове за макрокартата

### DIFF
--- a/code.html
+++ b/code.html
@@ -27,6 +27,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 
     <!-- Коригирани CSS Връзки -->
+    <link href="css/macro-card-vars.css" rel="stylesheet" />
     <link href="css/base_styles.css" rel="stylesheet" />
     <link href="css/layout_styles.css" rel="stylesheet" />
     <link href="css/components_styles.css" rel="stylesheet" />

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -3,6 +3,7 @@
    Версия: 2.11.0 (Корекции по UI/UX от скрийншоти v3, стилове за адаптивен въпросник)
    ========================================================================== */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Nunito+Sans:wght@400;700&display=swap');
+@import './macro-card-vars.css';
 
 /* ==========================================================================
    0. ОСНОВНИ ПРОМЕНЛИВИ И ГЛОБАЛНИ СТИЛОВЕ
@@ -46,9 +47,6 @@
   --input-focus-shadow: rgba(58, 80, 107, 0.25);
 
   /* Цветове за макро диаграмата */
-  --macro-protein-color: #5BC0BE; /* Протеини */
-  --macro-fat-color: #FFD166;     /* Мазнини */
-  --macro-carbs-color: #FF6B6B;   /* Въглехидрати */
   --macro-fiber-color: #6FCF97;   /* Фибри */
   --macro-ring-highlight: #ffffff; /* Подчертаване на кръга */
   --macro-stroke-color: #e0e0e0;   /* Рамка на диаграмата */
@@ -189,9 +187,6 @@ body.dark-theme {
   --progress-bar-bg-empty: #393E57;
 
   /* Макро диаграма - тъмна тема */
-  --macro-protein-color: #5BC0BE;
-  --macro-fat-color: #FFD166;
-  --macro-carbs-color: #FF6B6B;
   --macro-ring-highlight: #1C1F2E;
   --macro-stroke-color: #444444;
 
@@ -275,9 +270,6 @@ body.vivid-theme {
   --progress-end-color: #80FF80;
 
   /* Макро диаграма - ярка тема */
-  --macro-protein-color: #5BC0BE;
-  --macro-fat-color: #FFD166;
-  --macro-carbs-color: #FF6B6B;
   --macro-ring-highlight: #1C1F2E;
   --macro-stroke-color: #444444;
 

--- a/css/macro-card-vars.css
+++ b/css/macro-card-vars.css
@@ -1,0 +1,5 @@
+:root {
+  --macro-protein-color: #5BC0BE;
+  --macro-carbs-color:   #FFD166;
+  --macro-fat-color:     #FF6B6B;
+}

--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -7,6 +7,7 @@ let Chart;
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    @import "../css/macro-card-vars.css";
     :host { display: block; }
     .card {
       background: var(--card-bg);

--- a/macroAnalyticsCardStandalone.html
+++ b/macroAnalyticsCardStandalone.html
@@ -17,15 +17,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Standalone Macro Analytics Card</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+  <link rel="stylesheet" href="./css/macro-card-vars.css" />
   <style>
   :root {
     --main-bg: #1A1D2D;
     --card-bg: #2C314A;
     --text-color: #E0E0E0;
     --text-secondary-color: #A0A5C0;
-    --macro-protein-color: #5BC0BE;
-    --macro-carbs-color: #FFD166;
-    --macro-fat-color: #FF6B6B;
     --macro-fiber-color: #6FCF97;
   }
   body {

--- a/macroChart.html
+++ b/macroChart.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Шаблон MacroAnalyticsCard</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+  <link rel="stylesheet" href="./css/macro-card-vars.css" />
   <script type="module" src="./js/macroAnalyticsCardComponent.js"></script>
   <style>
     :root {
@@ -12,9 +13,6 @@
       --card-bg: #2C314A;
       --text-color: #E0E0E0;
       --text-secondary-color: #A0A5C0;
-      --macro-protein-color: #5BC0BE;
-      --macro-carbs-color: #FFD166;
-      --macro-fat-color: #FF6B6B;
     }
     body {
       background-color: var(--main-bg);


### PR DESCRIPTION
## Резюме
- добавен `css/macro-card-vars.css` с общи цветови променливи за макронутриенти
- HTML страниците и компонентът на макрокартата вече използват споделения файл
- премахнати дублирани дефиниции от базовите стилове

## Тестване
- `npm run lint`
- `npm test` *(част от тестовете се провалиха – виж регистрите)*

------
https://chatgpt.com/codex/tasks/task_e_688e9e74129883269f7e4ce4d5a24ec6