### PR TITLE
feat: validate macro calories

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -1,4 +1,5 @@
 /** @jest-environment jsdom */
+import { jest } from '@jest/globals';
 import { calculateCurrentMacros, addMealMacros, removeMealMacros, registerNutrientOverrides, getNutrientOverride, calculatePlanMacros, loadProductMacros, scaleMacros, __testExports } from '../macroUtils.js';
 
 test('calculateCurrentMacros sums macros from completed meals and extras', () => {
@@ -37,25 +38,33 @@ test('calculatePlanMacros sums macros for day menu', () => {
 
 test('addMealMacros и removeMealMacros актуализират акумулатора', () => {
   const acc = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
-  const meal = { calories: 200, protein: 20, carbs: 30, fat: 10, fiber: 5 };
+  const meal = { calories: 290, protein: 20, carbs: 30, fat: 10, fiber: 5 };
   addMealMacros(meal, acc);
-  expect(acc).toEqual({ calories: 200, protein: 20, carbs: 30, fat: 10, fiber: 5 });
+  expect(acc).toEqual({ calories: 290, protein: 20, carbs: 30, fat: 10, fiber: 5 });
   removeMealMacros(meal, acc);
   expect(acc).toEqual({ calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 });
 });
 
 test('scaleMacros скалира макросите спрямо грамовете', () => {
-  const base = { calories: 200, protein: 20, carbs: 30, fat: 10, fiber: 5 };
-  expect(scaleMacros(base, 150)).toEqual({ calories: 300, protein: 30, carbs: 45, fat: 15, fiber: 7.5 });
-  expect(scaleMacros(base, 75)).toEqual({ calories: 150, protein: 15, carbs: 22.5, fat: 7.5, fiber: 3.75 });
+  const base = { calories: 290, protein: 20, carbs: 30, fat: 10, fiber: 5 };
+  expect(scaleMacros(base, 150)).toEqual({ calories: 435, protein: 30, carbs: 45, fat: 15, fiber: 7.5 });
+  expect(scaleMacros(base, 75)).toEqual({ calories: 217.5, protein: 15, carbs: 22.5, fat: 7.5, fiber: 3.75 });
 });
 
 test('resolveMacros при grams използва scaleMacros', () => {
-  const meal = { calories: 200, protein: 20, carbs: 30, fat: 10, fiber: 5 };
+  const meal = { calories: 290, protein: 20, carbs: 30, fat: 10, fiber: 5 };
   const result150 = __testExports.resolveMacros(meal, 150);
   const result75 = __testExports.resolveMacros(meal, 75);
-  expect(result150).toEqual({ calories: 300, protein: 30, carbs: 45, fat: 15, fiber: 7.5 });
-  expect(result75).toEqual({ calories: 150, protein: 15, carbs: 22.5, fat: 7.5, fiber: 3.75 });
+  expect(result150).toEqual({ calories: 435, protein: 30, carbs: 45, fat: 15, fiber: 7.5 });
+  expect(result75).toEqual({ calories: 217.5, protein: 15, carbs: 22.5, fat: 7.5, fiber: 3.75 });
+});
+
+test('validateMacroCalories предупреждава при голямо отклонение', () => {
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const acc = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
+  addMealMacros({ calories: 500, protein: 30, carbs: 30, fat: 10, fiber: 0 }, acc);
+  expect(warnSpy).toHaveBeenCalled();
+  warnSpy.mockRestore();
 });
 
 test('getNutrientOverride кешира резултатите', () => {

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -118,8 +118,21 @@ function resolveMacros(meal, grams) {
   return typeof grams === 'number' ? scaleMacros(macros, grams) : macros;
 }
 
+function validateMacroCalories(macros = {}, threshold = 0.05) {
+  const { calories = 0, protein = 0, carbs = 0, fat = 0 } = macros;
+  const calc = protein * 4 + carbs * 4 + fat * 9;
+  if (!calc) return;
+  const diff = Math.abs(calc - calories);
+  if (diff / calc > threshold) {
+    console.warn(
+      `[macroUtils] Calorie mismatch: expected ${calc.toFixed(2)}, received ${calories}`
+    );
+  }
+}
+
 export function addMealMacros(meal, acc) {
   const m = resolveMacros(meal, meal?.grams);
+  validateMacroCalories(m);
   acc.calories = (acc.calories || 0) + m.calories;
   acc.protein = (acc.protein || 0) + m.protein;
   acc.carbs = (acc.carbs || 0) + m.carbs;
@@ -130,6 +143,7 @@ export function addMealMacros(meal, acc) {
 
 export function removeMealMacros(meal, acc) {
   const m = resolveMacros(meal, meal?.grams);
+  validateMacroCalories(m);
   acc.calories = (acc.calories || 0) - m.calories;
   acc.protein = (acc.protein || 0) - m.protein;
   acc.carbs = (acc.carbs || 0) - m.carbs;


### PR DESCRIPTION
## Summary
- add helper to validate macro calories vs nutrient breakdown
- warn devs when calorie mismatch exceeds 5%
- cover macro calorie deviation with new unit test

## Testing
- `npm run lint`
- `sh ./scripts/test.sh js/__tests__/macroUtils.test.js`
- `sh ./scripts/test.sh` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688e9eb386e08326b4dc6409e2b144ba