### PR TITLE
fix: replace mini progress classes with standard ones

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -130,12 +130,12 @@ function populateDashboardDetailedAnalytics(analyticsData) {
             card.appendChild(header);
 
             const progress = document.createElement('div');
-            progress.className = 'mini-progress-bar';
+            progress.className = 'progress-bar';
             progress.setAttribute('role', 'progressbar');
             progress.setAttribute('aria-valuemin', '0');
             progress.setAttribute('aria-valuemax', '100');
             const fill = document.createElement('div');
-            fill.className = 'mini-progress-fill';
+            fill.className = 'progress-fill';
             if (metric.colorKey) {
                 fill.style.setProperty('--progress-start-color', `var(--color-${metric.colorKey})`);
             }


### PR DESCRIPTION
## Summary
- refactor mini progress bar elements to use standard `progress-bar` and `progress-fill` classes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ea4863878832688679ac224ba800c