### PR TITLE
refactor progress bar colors

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -228,7 +228,7 @@ details[open] summary::after {
 }
 #analyticsSummary .progress-fill {
   position: relative;
-  background: linear-gradient(to right, var(--color-danger), var(--progress-end-color));
+  background: var(--progress-color);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -94,6 +94,7 @@
   --progress-gradient: linear-gradient(to right, var(--color-danger), var(--color-warning), var(--color-success));
   --progress-end-color: var(--color-success);
   --progress-bar-glow-color: color-mix(in srgb, var(--progress-end-color) 60%, transparent);
+  --progress-color: var(--progress-end-color);
   --progress-bar-height: 1rem;
   --progress-bar-radius: var(--radius-sm);
 
@@ -187,6 +188,7 @@ body.dark-theme {
   --shadow-soft: 0px 6px 18px rgba(var(--surface-background-rgb), 0.5), 0px 2px 7px rgba(var(--surface-background-rgb), 0.3);
 
   --progress-bar-bg-empty: #393E57;
+  --progress-color: var(--progress-end-color);
 
   /* Макро диаграма - тъмна тема */
   --macro-protein-color: #5BC0BE;
@@ -273,6 +275,7 @@ body.vivid-theme {
 
   --progress-bar-bg-empty: #393E57;
   --progress-end-color: #80FF80;
+  --progress-color: var(--progress-end-color);
 
   /* Макро диаграма - ярка тема */
   --macro-protein-color: #5BC0BE;

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -36,11 +36,7 @@
 }
 .progress-fill {
   position: relative;
-  background: linear-gradient(
-    to right,
-    color-mix(in srgb, var(--progress-start-color) 90%, transparent),
-    var(--progress-end-color)
-  );
+  background: var(--progress-color);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;
@@ -149,11 +145,7 @@ body.vivid-theme .index-card .index-value {
 }
 .analytics-card .mini-progress-fill {
   position: relative;
-  background: linear-gradient(
-    to right,
-    color-mix(in srgb, var(--progress-start-color) 90%, transparent),
-    var(--progress-end-color)
-  );
+  background: var(--progress-color);
   height: 100%;
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   width: 0;


### PR DESCRIPTION
## Summary
- simplify progress bar styling by using `--progress-color`
- add `--progress-color` variable across themes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ea9af5b888326b2fecfa20bdb75df