### PR TITLE
Adapt progress chart to theme colors

### DIFF
--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -89,6 +89,7 @@ export function applyTheme(theme) {
     document.body.classList.remove('light-theme', 'dark-theme', 'vivid-theme');
     const cls = theme === 'dark' ? 'dark-theme' : theme === 'vivid' ? 'vivid-theme' : 'light-theme';
     document.body.classList.add(cls);
+    document.dispatchEvent(new Event('themechange'));
 }
 
 export function toggleTheme() {


### PR DESCRIPTION
## Summary
- draw progress chart using CSS variables for primary and text colors
- refresh chart colors on theme switch via custom `themechange` event

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688eb0ddf2088326896c775dbd7194fb