### PR TITLE
Use discrete CSS variables for progress bar colors

### DIFF
--- a/js/__tests__/getProgressColor.test.js
+++ b/js/__tests__/getProgressColor.test.js
@@ -2,11 +2,11 @@ import { getProgressColor } from '../utils.js';
 
 describe('getProgressColor', () => {
   test.each([
-    [0, 'rgb(231, 76, 60)'],
-    [50, 'rgb(243, 156, 18)'],
-    [75, 'rgb(255, 203, 0)'],
-    [100, 'rgb(46, 204, 113)'],
-    [25, 'rgb(237, 116, 39)']
+    [0, 'var(--rating-1)'],
+    [25, 'var(--rating-2)'],
+    [50, 'var(--rating-3)'],
+    [75, 'var(--rating-4)'],
+    [100, 'var(--rating-5)']
   ])('returns color for %i%%', (pct, expected) => {
     expect(getProgressColor(pct)).toBe(expected);
   });

--- a/js/utils.js
+++ b/js/utils.js
@@ -104,40 +104,27 @@ export function fileToText(file) {
 }
 
 /**
- * Изчислява крайния цвят на прогрес бар спрямо процента.
- * @param {number} percent Стойността в диапазона 0-100.
- * @returns {string} CSS rgb() низ за крайния цвят.
+ * Нива на прогрес и свързани цветове.
+ * limit - горна граница (включително) на процента.
+ * color - CSS променлива за съответния цвят.
  */
-export let progressColorStops = [
-    { pct: 0, color: [231, 76, 60] },       // червено
-    { pct: 50, color: [243, 156, 18] },     // оранжево
-    { pct: 75, color: [255, 203, 0] },      // жълто
-    { pct: 100, color: [46, 204, 113] }     // зелено
+export const progressLevels = [
+    { limit: 20, color: 'var(--rating-1)' },
+    { limit: 40, color: 'var(--rating-2)' },
+    { limit: 60, color: 'var(--rating-3)' },
+    { limit: 80, color: 'var(--rating-4)' },
+    { limit: 100, color: 'var(--rating-5)' }
 ];
 
-export function setProgressColorStops(stops) {
-    if (Array.isArray(stops) && stops.length > 0) {
-        progressColorStops = stops;
-    }
-}
-
+/**
+ * Връща цвета за най-близкия праг ≥ подадения процент.
+ * @param {number} percent Стойност в диапазона 0-100.
+ * @returns {string} CSS променлива за цвета.
+ */
 export function getProgressColor(percent) {
-    const stops = progressColorStops;
     const p = Math.max(0, Math.min(100, percent));
-    for (let i = 1; i < stops.length; i++) {
-        if (p <= stops[i].pct) {
-            const lower = stops[i - 1];
-            const upper = stops[i];
-            const range = upper.pct - lower.pct;
-            const t = range === 0 ? 0 : (p - lower.pct) / range;
-            const r = Math.round(lower.color[0] + (upper.color[0] - lower.color[0]) * t);
-            const g = Math.round(lower.color[1] + (upper.color[1] - lower.color[1]) * t);
-            const b = Math.round(lower.color[2] + (upper.color[2] - lower.color[2]) * t);
-            return `rgb(${r}, ${g}, ${b})`;
-        }
-    }
-    const c = stops[stops.length - 1].color;
-    return `rgb(${c[0]}, ${c[1]}, ${c[2]})`;
+    const level = progressLevels.find((l) => p <= l.limit) || progressLevels[progressLevels.length - 1];
+    return level.color;
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace color interpolation with fixed progressLevels using `--rating-*` CSS vars
- simplify `getProgressColor` to return first matching level
- adjust tests for the new discrete color mapping

## Testing
- `npm run lint`
- `npm test js/__tests__/getProgressColor.test.js`
- `npm test` *(fails: sendAnalysisLinkEmail and sendContactEmail tests; handlePerformPasswordReset updates password and deletes token; extraMealFormSubmit, extraMealNutrientLookup, populateDashboardMacros, extraMealAutofill, registerEmail, populateDashboardMacros.missingComponent)*

------
https://chatgpt.com/codex/tasks/task_e_688eb20380e483269a4b45811c3875aa