### PR TITLE
Обновяване на цветовете на прогрес графиката при смяна на тема

### DIFF
--- a/js/__tests__/progressChartTheme.test.js
+++ b/js/__tests__/progressChartTheme.test.js
@@ -1,0 +1,39 @@
+import { jest } from '@jest/globals';
+import * as ui from '../populateUI.js';
+
+// Mock getComputedStyle to provide CSS variables
+function mockStyles(primary, text) {
+  global.getComputedStyle = () => ({
+    getPropertyValue: (prop) => {
+      if (prop === '--primary-color') return primary;
+      if (prop === '--text-color-primary') return text;
+      return '';
+    }
+  });
+}
+
+describe('updateProgressChartColors', () => {
+  beforeEach(() => {
+    mockStyles('#123456', '#654321');
+    ui.__setProgressChartInstance({
+      data: { datasets: [{ borderColor: '', backgroundColor: '' }] },
+      options: {
+        scales: { x: { ticks: {} }, y: { ticks: {}, title: {}, grid: {} } },
+        plugins: { legend: { labels: {} } }
+      },
+      update: jest.fn()
+    });
+  });
+
+  test('applies colors based on CSS variables', () => {
+    ui.updateProgressChartColors();
+    expect(ui.progressChartInstance.data.datasets[0].borderColor).toBe('#123456');
+    expect(ui.progressChartInstance.options.scales.y.ticks.color).toBe('#654321');
+    expect(ui.progressChartInstance.update).toHaveBeenCalled();
+  });
+
+  test('event triggers color update', () => {
+    document.dispatchEvent(new Event('progressChartThemeChange'));
+    expect(ui.progressChartInstance.update).toHaveBeenCalled();
+  });
+});

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -10,6 +10,11 @@ import { calculatePlanMacros, getNutrientOverride, addMealMacros, scaleMacros } 
 export let macroChartInstance = null;
 export let progressChartInstance = null;
 
+// Helper for tests to inject chart instance
+export function __setProgressChartInstance(instance) {
+    progressChartInstance = instance;
+}
+
 function addAlpha(color, alpha) {
     const c = color.trim();
     if (c.startsWith('#')) {
@@ -41,7 +46,7 @@ function getProgressChartColors() {
     };
 }
 
-function applyProgressChartTheme() {
+export function updateProgressChartColors() {
     if (!progressChartInstance) return;
     const { border, fill, grid, tick } = getProgressChartColors();
     const ds = progressChartInstance.data.datasets[0];
@@ -57,7 +62,7 @@ function applyProgressChartTheme() {
     progressChartInstance.update();
 }
 
-document.addEventListener('themechange', applyProgressChartTheme);
+document.addEventListener('progressChartThemeChange', updateProgressChartColors);
 
 export async function populateUI() {
     const data = fullDashboardData; // Access global state
@@ -1003,5 +1008,5 @@ export async function populateProgressHistory(dailyLogs, initialData) {
             }
         }
     });
-    applyProgressChartTheme();
+    updateProgressChartColors();
 }

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -90,6 +90,7 @@ export function applyTheme(theme) {
     const cls = theme === 'dark' ? 'dark-theme' : theme === 'vivid' ? 'vivid-theme' : 'light-theme';
     document.body.classList.add(cls);
     document.dispatchEvent(new Event('themechange'));
+    document.dispatchEvent(new Event('progressChartThemeChange'));
 }
 
 export function toggleTheme() {


### PR DESCRIPTION
## Обобщение
- уведомяване на UI за промяна на тема чрез събитие `progressChartThemeChange`
- актуализиране на цветовете на графиката без повторно създаване
- тест за обновяване на цветовете при смяна на тема

## Тестове
- `npm run lint`
- `npm test js/__tests__/progressChartTheme.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688eb25c0b388326b718490d9217120a