### PR TITLE
chore: remove unused progress start color variable

### DIFF
--- a/code.html
+++ b/code.html
@@ -14,7 +14,7 @@
     </script>
   Прехвърлете CSS променливи: --space-lg, --space-sm, --space-xs,
     --text-color-secondary, --surface-background,
-    --progress-start-color, --progress-end-color.
+    --progress-end-color.
 -->
 <html lang="bg">
   <head>

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -88,7 +88,6 @@
   --progress-color-50: 243, 156, 18;
   --progress-color-75: 255, 203, 0;
   --progress-color-100: 46, 204, 113;
-  --progress-start-color: var(--color-danger);
 
   --progress-bar-bg-empty: #e9ecef;
   --progress-gradient: linear-gradient(to right, var(--color-danger), var(--color-warning), var(--color-success));

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -136,9 +136,6 @@ function populateDashboardDetailedAnalytics(analyticsData) {
             progress.setAttribute('aria-valuemax', '100');
             const fill = document.createElement('div');
             fill.className = 'mini-progress-fill';
-            if (metric.colorKey) {
-                fill.style.setProperty('--progress-start-color', `var(--color-${metric.colorKey})`);
-            }
             progress.appendChild(fill);
             card.appendChild(progress);
 


### PR DESCRIPTION
## Summary
- drop `--progress-start-color` from base styles
- stop assigning `--progress-start-color` in populateUI
- remove obsolete reference in code.html

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688eb1e0caa88326b620cd2ae7c6d382