### PR TITLE
refactor progress color variable

### DIFF
--- a/code.html
+++ b/code.html
@@ -14,7 +14,7 @@
     </script>
   Прехвърлете CSS променливи: --space-lg, --space-sm, --space-xs,
     --text-color-secondary, --surface-background,
-    --progress-end-color.
+    --progress-color.
 -->
 <html lang="bg">
   <head>

--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -91,9 +91,8 @@
 
   --progress-bar-bg-empty: #e9ecef;
   --progress-gradient: linear-gradient(to right, var(--color-danger), var(--color-warning), var(--color-success));
-  --progress-end-color: var(--color-success);
-  --progress-bar-glow-color: color-mix(in srgb, var(--progress-end-color) 60%, transparent);
-  --progress-color: var(--progress-end-color);
+  --progress-color: var(--color-success);
+  --progress-bar-glow-color: color-mix(in srgb, var(--progress-color) 60%, transparent);
   --progress-bar-height: 1rem;
   --progress-bar-radius: var(--radius-sm);
 
@@ -187,7 +186,7 @@ body.dark-theme {
   --shadow-soft: 0px 6px 18px rgba(var(--surface-background-rgb), 0.5), 0px 2px 7px rgba(var(--surface-background-rgb), 0.3);
 
   --progress-bar-bg-empty: #393E57;
-  --progress-color: var(--progress-end-color);
+  --progress-color: var(--color-success);
 
   /* Макро диаграма - тъмна тема */
   --macro-protein-color: #5BC0BE;
@@ -273,8 +272,7 @@ body.vivid-theme {
   --shadow-soft: 0px 6px 18px rgba(var(--surface-background-rgb), 0.5), 0px 2px 7px rgba(var(--surface-background-rgb), 0.3);
 
   --progress-bar-bg-empty: #393E57;
-  --progress-end-color: #80FF80;
-  --progress-color: var(--progress-end-color);
+  --progress-color: #80FF80;
 
   /* Макро диаграма - ярка тема */
   --macro-protein-color: #5BC0BE;

--- a/js/__tests__/personalizationTemplates.test.js
+++ b/js/__tests__/personalizationTemplates.test.js
@@ -17,14 +17,14 @@ beforeEach(async () => {
     colorGroups: [
       { name: 'Dashboard', items: [
         { var: 'primary-color', label: '' },
-        { var: 'progress-end-color', label: '' }
+        { var: 'progress-color', label: '' }
       ] },
       { name: 'Code', items: [{ var: 'code-bg', label: '' }] }
     ],
     sampleThemes: {
       dashboard: { Light: {
         'primary-color': '#010101',
-        'progress-end-color': '#030303'
+        'progress-color': '#030303'
       } },
       code: { Light: { 'code-bg': '#020202' } }
     }

--- a/js/admin.js
+++ b/js/admin.js
@@ -510,7 +510,7 @@ function renderAnalyticsCurrent(cur) {
             pb.className = 'progress-bar';
             const fill = document.createElement('div');
             fill.className = 'progress-fill';
-            fill.style.setProperty('--progress-end-color', getProgressColor(pct));
+            fill.style.setProperty('--progress-color', getProgressColor(pct));
             animateProgressFill(fill, pct);
             pb.appendChild(fill);
             pbContainer.appendChild(pb);

--- a/js/adminColors.js
+++ b/js/adminColors.js
@@ -130,7 +130,7 @@ const vividTheme = {
   'secondary-color': '#FFD166',
   'accent-color': '#FF6B6B',
   'tertiary-color': '#FF9C9C',
-  'progress-end-color': '#80FF80'
+  'progress-color': '#80FF80'
 };
 
 function setCssVar(key, val) {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -106,7 +106,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
     } else {
         show(selectors.goalCard);
         if (selectors.goalProgressFill) {
-            selectors.goalProgressFill.style.setProperty('--progress-end-color', getProgressColor(goalProgressPercent));
+            selectors.goalProgressFill.style.setProperty('--progress-color', getProgressColor(goalProgressPercent));
             animateProgressFill(selectors.goalProgressFill, goalProgressPercent);
         }
         if (selectors.goalProgressBar) selectors.goalProgressBar.setAttribute('aria-valuenow', `${Math.round(goalProgressPercent)}`);
@@ -131,7 +131,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
     } else {
         show(selectors.engagementCard);
         if (selectors.engagementProgressFill) {
-            selectors.engagementProgressFill.style.setProperty('--progress-end-color', getProgressColor(engagementScore));
+            selectors.engagementProgressFill.style.setProperty('--progress-color', getProgressColor(engagementScore));
             animateProgressFill(selectors.engagementProgressFill, engagementScore);
         }
         if (selectors.engagementProgressBar) selectors.engagementProgressBar.setAttribute('aria-valuenow', `${Math.round(engagementScore)}`);
@@ -144,7 +144,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
     } else {
         show(selectors.healthCard);
         if (selectors.healthProgressFill) {
-            selectors.healthProgressFill.style.setProperty('--progress-end-color', getProgressColor(healthScore));
+            selectors.healthProgressFill.style.setProperty('--progress-color', getProgressColor(healthScore));
             animateProgressFill(selectors.healthProgressFill, healthScore);
         }
         if (selectors.healthProgressBar) selectors.healthProgressBar.setAttribute('aria-valuenow', `${Math.round(healthScore)}`);
@@ -251,7 +251,7 @@ function populateDashboardDetailedAnalytics(analyticsData) {
                 const value = Number(metric.currentValueNumeric);
                 const percent = value <= 5 ? ((value - 1) / 4) * 100 : Math.max(0, Math.min(100, value));
                 progress.setAttribute('aria-valuenow', `${Math.round(percent)}`);
-                fill.style.setProperty('--progress-end-color', getProgressColor(percent));
+                fill.style.setProperty('--progress-color', getProgressColor(percent));
                 animateProgressFill(fill, percent);
             }
 

--- a/js/themeConfig.js
+++ b/js/themeConfig.js
@@ -46,7 +46,7 @@ export const colorGroups = [
   {
     name: 'Прогрес барове',
     items: [
-      { var: 'progress-end-color', label: 'Краен цвят на прогрес' },
+      { var: 'progress-color', label: 'Цвят на прогрес' },
       { var: 'progress-bar-bg-empty', label: 'Празен прогрес бар' }
     ]
   },
@@ -128,7 +128,7 @@ export const sampleThemes = {
       "border-color-soft": "#e1e8f0",
       "input-bg-disabled": "#e9ecef",
       "input-border-color": "#ced4da",
-      "progress-end-color": "#2ecc71",
+      "progress-color": "#2ecc71",
       "progress-bar-bg-empty": "#e9ecef",
       "macro-protein-color": "#5BC0BE",
       "macro-carbs-color": "#FF6B6B",
@@ -162,7 +162,7 @@ export const sampleThemes = {
       "border-color-soft": "#2D3044",
       "input-bg-disabled": "#2C3147",
       "input-border-color": "#3C425A",
-      "progress-end-color": "#2ecc71",
+      "progress-color": "#2ecc71",
       "progress-bar-bg-empty": "#393E57",
       "macro-protein-color": "#5BC0BE",
       "macro-carbs-color": "#FF6B6B",
@@ -196,7 +196,7 @@ export const sampleThemes = {
       "border-color-soft": "#2D3044",
       "input-bg-disabled": "#2C3147",
       "input-border-color": "#3C425A",
-      "progress-end-color": "#80FF80",
+      "progress-color": "#80FF80",
       "progress-bar-bg-empty": "#393E57",
       "macro-protein-color": "#5BC0BE",
       "macro-carbs-color": "#FF6B6B",


### PR DESCRIPTION
## Summary
- replace deprecated --progress-end-color CSS var with --progress-color and adjust glow color
- update JS/UI and theme configs to use progress-color key
- align personalization tests and code comments with new variable name

## Testing
- `npm run lint`
- `npm test`
- `NODE_OPTIONS=--experimental-vm-modules npx jest js/__tests__/personalizationTemplates.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688eb46104a8832681dcb975f60aaab3