### PR TITLE
feat: add progress level colors

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -115,6 +115,12 @@
   --rating-1: #e74c3c; --rating-2: #f39c12; --rating-3: #f1c40f;
   --rating-4: #a6d96a; --rating-5: #2ecc71;
 
+  --progress-level-1: var(--rating-1);
+  --progress-level-2: var(--rating-2);
+  --progress-level-3: var(--rating-3);
+  --progress-level-4: var(--rating-4);
+  --progress-level-5: var(--rating-5);
+
   --chat-widget-bg: color-mix(in srgb, var(--surface-background) 95%, var(--accent-color) 5%);
   --chat-header-bg: var(--primary-color);
   --chat-header-text: #fff;

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -53,6 +53,18 @@
   animation: progress-grow 0.4s forwards;
 }
 
+/* Progress bar color levels */
+.progress-fill.level-1,
+.mini-progress-fill.level-1 { --progress-color: var(--progress-level-1); }
+.progress-fill.level-2,
+.mini-progress-fill.level-2 { --progress-color: var(--progress-level-2); }
+.progress-fill.level-3,
+.mini-progress-fill.level-3 { --progress-color: var(--progress-level-3); }
+.progress-fill.level-4,
+.mini-progress-fill.level-4 { --progress-color: var(--progress-level-4); }
+.progress-fill.level-5,
+.mini-progress-fill.level-5 { --progress-color: var(--progress-level-5); }
+
 .accordion-container {
   border: 1px solid var(--border-color-soft); border-radius: var(--radius-lg);
   overflow: hidden; margin-bottom: var(--space-md);

--- a/js/utils.js
+++ b/js/utils.js
@@ -109,11 +109,11 @@ export function fileToText(file) {
  * color - CSS променлива за съответния цвят.
  */
 export const progressLevels = [
-    { limit: 20, color: 'var(--rating-1)' },
-    { limit: 40, color: 'var(--rating-2)' },
-    { limit: 60, color: 'var(--rating-3)' },
-    { limit: 80, color: 'var(--rating-4)' },
-    { limit: 100, color: 'var(--rating-5)' }
+    { limit: 20, color: 'var(--progress-level-1)' },
+    { limit: 40, color: 'var(--progress-level-2)' },
+    { limit: 60, color: 'var(--progress-level-3)' },
+    { limit: 80, color: 'var(--progress-level-4)' },
+    { limit: 100, color: 'var(--progress-level-5)' }
 ];
 
 /**


### PR DESCRIPTION
## Summary
- map new CSS variables `--progress-level-1`…`--progress-level-5` to rating colors
- apply `--progress-color` through level classes for progress bars
- use the new level variables in `progressLevels` utility

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688eb41c72c48326a29dc484334175f1