### PR TITLE
docs: clarify progress bar colors

### DIFF
--- a/docs/progress_bars_guide.html
+++ b/docs/progress_bars_guide.html
@@ -30,14 +30,26 @@
 
     <section>
         <h2>2. Линеен прогрес бар</h2>
-        <p>Използва се в таблото на потребителя за показване на общия напредък. Цветът се променя според процента.</p>
+        <p>Използва се в таблото на потребителя за показване на общия напредък. Вместо градиент, прогрес барът използва пет ясно разграничени нива без плавен преход:</p>
+        <table>
+            <thead>
+                <tr><th>Процент</th><th>Цвят</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>0–20%</td><td style="color: var(--progress-level-1);">Червено</td></tr>
+                <tr><td>21–40%</td><td style="color: var(--progress-level-2);">Оранжево</td></tr>
+                <tr><td>41–60%</td><td style="color: var(--progress-level-3);">Жълто</td></tr>
+                <tr><td>61–80%</td><td style="color: var(--progress-level-4);">Светлозелено</td></tr>
+                <tr><td>81–100%</td><td style="color: var(--progress-level-5);">Зелено</td></tr>
+            </tbody>
+        </table>
         <div class="progress" style="max-width: 300px;">
-            <div class="progress-bar bg-success" id="goalProgressBar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
+            <div class="progress-bar" id="goalProgressBar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
         </div>
         <pre><code>&lt;div class="progress"&gt;
     &lt;div class="progress-bar" id="goalProgressBar" role="progressbar" style="width: 75%"&gt;&lt;/div&gt;
 &lt;/div&gt;</code></pre>
-        <p>Функцията <code>animateProgressFill()</code> в <code>utils.js</code> плавно анимира запълването, а <code>getProgressColor()</code> определя цвета.</p>
+        <p>Функцията <code>animateProgressFill()</code> в <code>utils.js</code> плавно анимира запълването, а <code>getProgressColor()</code> присвоява правилния цвят според прага.</p>
     </section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- document five discrete color levels for progress bars
- add table mapping percentage ranges to colors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688eb624e7ac8326b8c9084a00c5a4dc