### PR TITLE
refactor: centralize progress fill

### DIFF
--- a/js/__tests__/adminSendTests.test.js
+++ b/js/__tests__/adminSendTests.test.js
@@ -154,8 +154,7 @@ describe('sendTestImage', () => {
     jest.unstable_mockModule('../utils.js', () => ({
       fileToDataURL: jest.fn(async () => 'data:image/png;base64,imgdata'),
       fileToText: jest.fn(),
-      getProgressColor: jest.fn(() => 'rgb(0,0,0)'),
-      animateProgressFill: jest.fn()
+      applyProgressFill: jest.fn()
     }));
     const mod = await import('../admin.js');
     send = mod.sendTestImage;
@@ -200,8 +199,7 @@ describe('sendTestQuestionnaire', () => {
     jest.unstable_mockModule('../utils.js', () => ({
       fileToText: jest.fn(async () => '{"a":1}'),
       fileToDataURL: jest.fn(),
-      getProgressColor: jest.fn(() => 'rgb(0,0,0)'),
-      animateProgressFill: jest.fn()
+      applyProgressFill: jest.fn()
     }));
     const mod = await import('../admin.js');
     send = mod.sendTestQuestionnaire;

--- a/js/__tests__/applyProgressFill.test.js
+++ b/js/__tests__/applyProgressFill.test.js
@@ -1,0 +1,9 @@
+/** @jest-environment jsdom */
+import { applyProgressFill, getProgressColor } from '../utils.js';
+
+test('applyProgressFill задава цвят и ширина', () => {
+  const el = document.createElement('div');
+  applyProgressFill(el, 55);
+  expect(el.style.getPropertyValue('--progress-color')).toBe(getProgressColor(55));
+  expect(el.style.width).toBe('55%');
+});

--- a/js/__tests__/populateDashboardMacros.missingComponent.test.js
+++ b/js/__tests__/populateDashboardMacros.missingComponent.test.js
@@ -17,9 +17,9 @@ test('логва предупреждение при липсващ macro-analyt
     safeParseFloat: () => {},
     capitalizeFirstLetter: () => {},
     escapeHtml: () => {},
-    getProgressColor: () => {},
-    animateProgressFill: () => {},
-    getCssVar: () => ''
+    applyProgressFill: () => {},
+    getCssVar: () => '',
+    formatDateBgShort: () => ''
   }));
   jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id' }));
   jest.unstable_mockModule('../app.js', () => ({

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,7 +1,7 @@
 import { apiEndpoints } from './config.js';
 import { loadConfig, saveConfig } from './adminConfig.js';
 import { labelMap, statusMap } from './labelMap.js';
-import { fileToDataURL, fileToText, getProgressColor, animateProgressFill } from './utils.js';
+import { fileToDataURL, fileToText, applyProgressFill } from './utils.js';
 import { loadTemplateInto } from './templateLoader.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 import { loadMaintenanceFlag, setMaintenanceFlag } from './maintenanceMode.js';
@@ -510,8 +510,7 @@ function renderAnalyticsCurrent(cur) {
             pb.className = 'progress-bar';
             const fill = document.createElement('div');
             fill.className = 'progress-fill';
-            fill.style.setProperty('--progress-color', getProgressColor(pct));
-            animateProgressFill(fill, pct);
+            applyProgressFill(fill, pct);
             pb.appendChild(fill);
             pbContainer.appendChild(pb);
             dd.appendChild(pbContainer);

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,6 +1,6 @@
 // populateUI.js - Попълване на UI с данни
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
-import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, getProgressColor, animateProgressFill, getCssVar, formatDateBgShort } from './utils.js';
+import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressFill, getCssVar, formatDateBgShort } from './utils.js';
 import { generateId } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
@@ -106,8 +106,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
     } else {
         show(selectors.goalCard);
         if (selectors.goalProgressFill) {
-            selectors.goalProgressFill.style.setProperty('--progress-color', getProgressColor(goalProgressPercent));
-            animateProgressFill(selectors.goalProgressFill, goalProgressPercent);
+            applyProgressFill(selectors.goalProgressFill, goalProgressPercent);
         }
         if (selectors.goalProgressBar) selectors.goalProgressBar.setAttribute('aria-valuenow', `${Math.round(goalProgressPercent)}`);
         if (selectors.goalProgressText) {
@@ -131,8 +130,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
     } else {
         show(selectors.engagementCard);
         if (selectors.engagementProgressFill) {
-            selectors.engagementProgressFill.style.setProperty('--progress-color', getProgressColor(engagementScore));
-            animateProgressFill(selectors.engagementProgressFill, engagementScore);
+            applyProgressFill(selectors.engagementProgressFill, engagementScore);
         }
         if (selectors.engagementProgressBar) selectors.engagementProgressBar.setAttribute('aria-valuenow', `${Math.round(engagementScore)}`);
         if (selectors.engagementProgressText) selectors.engagementProgressText.textContent = `${Math.round(engagementScore)}%`;
@@ -144,8 +142,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
     } else {
         show(selectors.healthCard);
         if (selectors.healthProgressFill) {
-            selectors.healthProgressFill.style.setProperty('--progress-color', getProgressColor(healthScore));
-            animateProgressFill(selectors.healthProgressFill, healthScore);
+            applyProgressFill(selectors.healthProgressFill, healthScore);
         }
         if (selectors.healthProgressBar) selectors.healthProgressBar.setAttribute('aria-valuenow', `${Math.round(healthScore)}`);
         if (selectors.healthProgressText) selectors.healthProgressText.textContent = `${Math.round(healthScore)}%`;
@@ -251,8 +248,7 @@ function populateDashboardDetailedAnalytics(analyticsData) {
                 const value = Number(metric.currentValueNumeric);
                 const percent = value <= 5 ? ((value - 1) / 4) * 100 : Math.max(0, Math.min(100, value));
                 progress.setAttribute('aria-valuenow', `${Math.round(percent)}`);
-                fill.style.setProperty('--progress-color', getProgressColor(percent));
-                animateProgressFill(fill, percent);
+                applyProgressFill(fill, percent);
             }
 
             cardsContainer.appendChild(card);

--- a/js/utils.js
+++ b/js/utils.js
@@ -144,6 +144,17 @@ export function animateProgressFill(el, percent) {
 }
 
 /**
+ * Задава цвета на прогрес бара и анимира запълването.
+ * @param {HTMLElement} el Елементът, представляващ запълването.
+ * @param {number} percent Процент за крайна широчина.
+ */
+export function applyProgressFill(el, percent) {
+    if (!el) return;
+    el.style.setProperty('--progress-color', getProgressColor(percent));
+    animateProgressFill(el, percent);
+}
+
+/**
  * Взема стойност на CSS променлива от :root.
  * @param {string} name Името на променливата (например '--primary-color').
  * @param {string} [fallback=''] Резервна стойност при липса.


### PR DESCRIPTION
## Summary
- add applyProgressFill helper for consistent progress bar color and animation
- refactor admin and dashboard modules to use applyProgressFill
- cover applyProgressFill with unit tests and update existing mocks

## Testing
- `npm run lint`
- `npm test js/__tests__/applyProgressFill.test.js js/__tests__/adminSendTests.test.js js/__tests__/populateDashboardMacros.missingComponent.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688eb60d72808326ade5627d9f921c9c