### PR TITLE
Improve progress chart contrast across themes

### DIFF
--- a/js/__tests__/progressChartTheme.test.js
+++ b/js/__tests__/progressChartTheme.test.js
@@ -2,11 +2,12 @@ import { jest } from '@jest/globals';
 import * as ui from '../populateUI.js';
 
 // Mock getComputedStyle to provide CSS variables
-function mockStyles(primary, text) {
+function mockStyles(secondary, text, border) {
   global.getComputedStyle = () => ({
     getPropertyValue: (prop) => {
-      if (prop === '--primary-color') return primary;
+      if (prop === '--secondary-color') return secondary;
       if (prop === '--text-color-primary') return text;
+      if (prop === '--border-color') return border;
       return '';
     }
   });
@@ -14,7 +15,7 @@ function mockStyles(primary, text) {
 
 describe('updateProgressChartColors', () => {
   beforeEach(() => {
-    mockStyles('#123456', '#654321');
+    mockStyles('#123456', '#654321', '#abcdef');
     ui.__setProgressChartInstance({
       data: { datasets: [{ borderColor: '', backgroundColor: '' }] },
       options: {
@@ -25,10 +26,19 @@ describe('updateProgressChartColors', () => {
     });
   });
 
+  function addAlpha(color, alpha) {
+    const hex = color.slice(1);
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
   test('applies colors based on CSS variables', () => {
     ui.updateProgressChartColors();
     expect(ui.progressChartInstance.data.datasets[0].borderColor).toBe('#123456');
     expect(ui.progressChartInstance.options.scales.y.ticks.color).toBe('#654321');
+    expect(ui.progressChartInstance.options.scales.y.grid.color).toBe(addAlpha('#abcdef', 0.3));
     expect(ui.progressChartInstance.update).toHaveBeenCalled();
   });
 

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -34,14 +34,17 @@ function addAlpha(color, alpha) {
     return c;
 }
 
+// Изчислява цветовете на графиката, така че линията да изпъква на всички теми.
+// Линията използва вторичния цвят, а мрежата - цвета на рамките за по-добър контраст.
 function getProgressChartColors() {
     const styles = getComputedStyle(document.documentElement);
-    const primary = styles.getPropertyValue('--primary-color').trim();
+    const secondary = styles.getPropertyValue('--secondary-color').trim();
     const text = styles.getPropertyValue('--text-color-primary').trim();
+    const borderColor = styles.getPropertyValue('--border-color').trim();
     return {
-        border: primary,
-        fill: addAlpha(primary, 0.1),
-        grid: addAlpha(text, 0.1),
+        border: secondary,
+        fill: addAlpha(secondary, 0.15),
+        grid: addAlpha(borderColor, 0.3),
         tick: text
     };
 }


### PR DESCRIPTION
## Summary
- use secondary and border colors for progress history chart to improve contrast across themes
- test progress chart color updates with secondary/border variables

## Testing
- `npm run lint`
- `npm test` (fails: workerEmail.test.js, passwordReset.test.js, extraMealFormSubmit.test.js, extraMealNutrientLookup.test.js, populateDashboardMacros.test.js, extraMealAutofill.test.js, registerEmail.test.js, submitQuestionnaireEmailFlag.test.js, macroCardLocales.test.js, workerBackendCache.test.js, login.test.js, getProgressColor.test.js)


------
https://chatgpt.com/codex/tasks/task_e_688ebc13bb888326b241ccd20921e30c