### PR TITLE
fix: improve progress history chart colors

### DIFF
--- a/js/__tests__/progressChartTheme.test.js
+++ b/js/__tests__/progressChartTheme.test.js
@@ -2,34 +2,48 @@ import { jest } from '@jest/globals';
 import * as ui from '../populateUI.js';
 
 // Mock getComputedStyle to provide CSS variables
-function mockStyles(primary, text) {
+function mockStyles(primary, text, card = '#ffffff') {
   global.getComputedStyle = () => ({
     getPropertyValue: (prop) => {
       if (prop === '--primary-color') return primary;
       if (prop === '--text-color-primary') return text;
+      if (prop === '--card-bg') return card;
       return '';
     }
   });
 }
 
+function setup(primary = '#123456', text = '#654321', card = '#ffffff') {
+  mockStyles(primary, text, card);
+  ui.__setProgressChartInstance({
+    data: { datasets: [{ borderColor: '', backgroundColor: '' }] },
+    options: {
+      scales: { x: { ticks: {} }, y: { ticks: {}, title: {}, grid: {} } },
+      plugins: { legend: { labels: {} } }
+    },
+    update: jest.fn()
+  });
+}
+
 describe('updateProgressChartColors', () => {
   beforeEach(() => {
-    mockStyles('#123456', '#654321');
-    ui.__setProgressChartInstance({
-      data: { datasets: [{ borderColor: '', backgroundColor: '' }] },
-      options: {
-        scales: { x: { ticks: {} }, y: { ticks: {}, title: {}, grid: {} } },
-        plugins: { legend: { labels: {} } }
-      },
-      update: jest.fn()
-    });
+    setup();
   });
 
   test('applies colors based on CSS variables', () => {
     ui.updateProgressChartColors();
     expect(ui.progressChartInstance.data.datasets[0].borderColor).toBe('#123456');
     expect(ui.progressChartInstance.options.scales.y.ticks.color).toBe('#654321');
+    expect(ui.progressChartInstance.data.datasets[0].backgroundColor).toContain(', 0.1)');
+    expect(ui.progressChartInstance.options.scales.y.grid.color).toContain(', 0.1)');
     expect(ui.progressChartInstance.update).toHaveBeenCalled();
+  });
+
+  test('uses stronger contrast on dark card background', () => {
+    setup('#123456', '#eeeeee', '#000000');
+    ui.updateProgressChartColors();
+    expect(ui.progressChartInstance.data.datasets[0].backgroundColor).toContain(', 0.3)');
+    expect(ui.progressChartInstance.options.scales.y.grid.color).toContain(', 0.2)');
   });
 
   test('event triggers color update', () => {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -34,14 +34,35 @@ function addAlpha(color, alpha) {
     return c;
 }
 
+function getBrightness(color) {
+    const c = color.trim();
+    let r, g, b;
+    if (c.startsWith('#')) {
+        let hex = c.slice(1);
+        if (hex.length === 3) hex = hex.split('').map(ch => ch + ch).join('');
+        r = parseInt(hex.slice(0, 2), 16);
+        g = parseInt(hex.slice(2, 4), 16);
+        b = parseInt(hex.slice(4, 6), 16);
+    } else if (c.startsWith('rgb')) {
+        [r, g, b] = c.replace(/rgba?\(|\)|\s/g, '').split(',').map(Number);
+    } else {
+        return 1; // assume light background
+    }
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
 function getProgressChartColors() {
     const styles = getComputedStyle(document.documentElement);
     const primary = styles.getPropertyValue('--primary-color').trim();
     const text = styles.getPropertyValue('--text-color-primary').trim();
+    const cardBg = (styles.getPropertyValue('--card-bg') || '#fff').trim();
+    const darkBg = getBrightness(cardBg) < 0.5;
+    const fillAlpha = darkBg ? 0.3 : 0.1;
+    const gridAlpha = darkBg ? 0.2 : 0.1;
     return {
         border: primary,
-        fill: addAlpha(primary, 0.1),
-        grid: addAlpha(text, 0.1),
+        fill: addAlpha(primary, fillAlpha),
+        grid: addAlpha(text, gridAlpha),
         tick: text
     };
 }


### PR DESCRIPTION
## Summary
- adjust progress history chart colors based on background brightness
- cover progress chart theme behavior with tests

## Testing
- `npm run lint`
- `npm test`
- `sh ./scripts/test.sh js/__tests__/progressChartTheme.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688ebc13bb888326b241ccd20921e30c