### PR TITLE
feat: sync metric text color with progress fill

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -172,7 +172,7 @@ body.vivid-theme .index-card .index-value {
 .metric-current-text {
   margin-bottom: var(--space-sm);
   font-weight: 600;
-  color: var(--secondary-color);
+  color: var(--progress-color);
 }
 .analytics-card-details {
   overflow: hidden;

--- a/js/utils.js
+++ b/js/utils.js
@@ -145,12 +145,18 @@ export function animateProgressFill(el, percent) {
 
 /**
  * Задава цвета на прогрес бара и анимира запълването.
+ * Освен това синхронизира цвета с най-близката карта
+ * за анализи, за да може свързаният текст да наследи
+ * същия оттенък.
  * @param {HTMLElement} el Елементът, представляващ запълването.
  * @param {number} percent Процент за крайна широчина.
  */
 export function applyProgressFill(el, percent) {
     if (!el) return;
-    el.style.setProperty('--progress-color', getProgressColor(percent));
+    const color = getProgressColor(percent);
+    el.style.setProperty('--progress-color', color);
+    const card = el.closest('.analytics-card');
+    if (card) card.style.setProperty('--progress-color', color);
     animateProgressFill(el, percent);
 }
 


### PR DESCRIPTION
## Summary
- ensure `.metric-current-text` inherits the same `--progress-color` as its progress bar
- propagate progress color to the closest analytics card in `applyProgressFill`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ebc6809a08326bb318d2da95c1cfb