### PR TITLE
Оцветяване на progressHistoryCard с цвета на хедъра

### DIFF
--- a/js/__tests__/progressChartTheme.test.js
+++ b/js/__tests__/progressChartTheme.test.js
@@ -2,19 +2,18 @@ import { jest } from '@jest/globals';
 import * as ui from '../populateUI.js';
 
 // Mock getComputedStyle to provide CSS variables
-function mockStyles(primary, text, card = '#ffffff') {
+function mockStyles(primary, card = '#ffffff') {
   global.getComputedStyle = () => ({
     getPropertyValue: (prop) => {
       if (prop === '--primary-color') return primary;
-      if (prop === '--text-color-primary') return text;
       if (prop === '--card-bg') return card;
       return '';
     }
   });
 }
 
-function setup(primary = '#123456', text = '#654321', card = '#ffffff') {
-  mockStyles(primary, text, card);
+function setup(primary = '#123456', card = '#ffffff') {
+  mockStyles(primary, card);
   ui.__setProgressChartInstance({
     data: { datasets: [{ borderColor: '', backgroundColor: '' }] },
     options: {
@@ -33,14 +32,14 @@ describe('updateProgressChartColors', () => {
   test('applies colors based on CSS variables', () => {
     ui.updateProgressChartColors();
     expect(ui.progressChartInstance.data.datasets[0].borderColor).toBe('#123456');
-    expect(ui.progressChartInstance.options.scales.y.ticks.color).toBe('#654321');
+    expect(ui.progressChartInstance.options.scales.y.ticks.color).toBe('#123456');
     expect(ui.progressChartInstance.data.datasets[0].backgroundColor).toContain(', 0.1)');
     expect(ui.progressChartInstance.options.scales.y.grid.color).toContain(', 0.1)');
     expect(ui.progressChartInstance.update).toHaveBeenCalled();
   });
 
   test('uses stronger contrast on dark card background', () => {
-    setup('#123456', '#eeeeee', '#000000');
+    setup('#123456', '#000000');
     ui.updateProgressChartColors();
     expect(ui.progressChartInstance.data.datasets[0].backgroundColor).toContain(', 0.3)');
     expect(ui.progressChartInstance.options.scales.y.grid.color).toContain(', 0.2)');

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -53,17 +53,16 @@ function getBrightness(color) {
 
 function getProgressChartColors() {
     const styles = getComputedStyle(document.documentElement);
-    const primary = styles.getPropertyValue('--primary-color').trim();
-    const text = styles.getPropertyValue('--text-color-primary').trim();
+    const header = styles.getPropertyValue('--primary-color').trim();
     const cardBg = (styles.getPropertyValue('--card-bg') || '#fff').trim();
     const darkBg = getBrightness(cardBg) < 0.5;
     const fillAlpha = darkBg ? 0.3 : 0.1;
     const gridAlpha = darkBg ? 0.2 : 0.1;
     return {
-        border: primary,
-        fill: addAlpha(primary, fillAlpha),
-        grid: addAlpha(text, gridAlpha),
-        tick: text
+        border: header,
+        fill: addAlpha(header, fillAlpha),
+        grid: addAlpha(header, gridAlpha),
+        tick: header
     };
 }
 


### PR DESCRIPTION
## Резюме
- използван е цвета на хедъра за линия, решетка и етикети в картата за история на прогреса
- актуализирани са тестовете за темата на прогрес графиката да очакват новите цветове

## Тестване
- `npm run lint`
- `npm test` *(част от тестовете се провалиха; виж логовете)*

------
https://chatgpt.com/codex/tasks/task_e_688ec15e58f483269ff42c5b906185fd