### PR TITLE
Съобразяване на прогрес графиката с активната тема

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -52,7 +52,9 @@ function getBrightness(color) {
 }
 
 function getProgressChartColors() {
-    const styles = getComputedStyle(document.documentElement);
+    // Вземаме цветовете от body, за да се съобразят с активната тема
+    const root = document.body || document.documentElement;
+    const styles = getComputedStyle(root);
     const header = styles.getPropertyValue('--primary-color').trim();
     const cardBg = (styles.getPropertyValue('--card-bg') || '#fff').trim();
     const darkBg = getBrightness(cardBg) < 0.5;


### PR DESCRIPTION
## Резюме
- оцветяване на линията, решетката и надписите на прогрес графиката по цвета на хедъра на текущата тема

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ec64ae8548326992324041ecc5bc7