### PR TITLE
Добавени анимации за макросите при превишение и недостиг

### DIFF
--- a/js/__tests__/macroAnalyticsCardComponent.test.js
+++ b/js/__tests__/macroAnalyticsCardComponent.test.js
@@ -88,6 +88,33 @@ test('показва предупреждение при превишаване 
   expect(utils.getByText(/Превишение над 15%/)).toBeTruthy();
 });
 
+test('класифицира over и under макросите', async () => {
+  const card = document.createElement('macro-analytics-card');
+  document.body.appendChild(card);
+  const target = {
+    calories: 2000,
+    protein_grams: 100,
+    protein_percent: 40,
+    carbs_grams: 200,
+    carbs_percent: 40,
+    fat_grams: 50,
+    fat_percent: 20
+  };
+  const current = {
+    calories: 1800,
+    protein_grams: 120,
+    carbs_grams: 200,
+    fat_grams: 40
+  };
+  card.setData({ target, current });
+  const utils = within(card.shadowRoot);
+  await waitFor(() => utils.getByText('Белтъчини'));
+  const proteinDiv = utils.getByText('Белтъчини').closest('.macro-metric');
+  const fatDiv = utils.getByText('Мазнини').closest('.macro-metric');
+  expect(proteinDiv.classList.contains('over')).toBe(true);
+  expect(fatDiv.classList.contains('under')).toBe(true);
+});
+
 test('data-endpoint и refresh-interval извикват fetch периодично', async () => {
   jest.useFakeTimers();
   const endpoint = '/macros';

--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -91,6 +91,22 @@ template.innerHTML = `
     .macro-metric.carbs.active { border-color: var(--macro-carbs-color); }
     .macro-metric.fat.active { border-color: var(--macro-fat-color); }
     .macro-metric.fiber.active { border-color: var(--macro-fiber-color); }
+    .macro-metric.over {
+      border-color: var(--color-danger);
+      animation: macro-over-pulse 1s ease-in-out infinite alternate;
+    }
+    .macro-metric.under {
+      border-color: var(--color-warning);
+      animation: macro-under-pulse 1s ease-in-out infinite alternate;
+    }
+    @keyframes macro-over-pulse {
+      from { box-shadow: 0 0 0 0 rgba(231, 76, 60, 0.7); }
+      to { box-shadow: 0 0 10px 4px rgba(231, 76, 60, 0); }
+    }
+    @keyframes macro-under-pulse {
+      from { box-shadow: 0 0 0 0 rgba(243, 156, 18, 0.7); }
+      to { box-shadow: 0 0 10px 4px rgba(243, 156, 18, 0); }
+    }
     .macro-icon { font-size: 1.2rem; }
     .macro-label { font-size: 0.85rem; margin-top: 0.25rem; }
     .macro-value { font-size: 1.1rem; font-weight: 600; }
@@ -383,6 +399,11 @@ export class MacroAnalyticsCard extends HTMLElement {
       const percent = target[`${item.key}_percent`];
       const div = document.createElement('div');
       div.className = `macro-metric ${item.key}`;
+      if (typeof currentRaw === 'number' && typeof targetVal === 'number') {
+        const delta = currentRaw - targetVal;
+        if (delta > 0) div.classList.add('over');
+        else if (delta < 0) div.classList.add('under');
+      }
       div.setAttribute('role', 'button');
       div.setAttribute('tabindex', '0');
       div.setAttribute('aria-label', `${label}: ${displayCurrent} от ${targetVal} грама (${percent}% ${this.labels.fromGoal})`);


### PR DESCRIPTION
## Обобщение
- Добавени са класове `over` и `under` с пулсиращи анимации за различаване на превишени и недостигащи макроси.
- `renderMetrics` вече изчислява отклонението и маркира елементите със съответния клас.
- Добавен е тест за визуалната класификация `over`/`under`.

## Тестове
- `npm run lint`
- `NODE_OPTIONS=--max_old_space_size=4096 npm test` *(някои тестове се провалят: workerEmail.test.js, passwordReset.test.js, extraMealFormSubmit.test.js, extraMealNutrientLookup.test.js, populateDashboardMacros.test.js, extraMealAutofill.test.js, registerEmail.test.js, submitQuestionnaireEmailFlag.test.js, login.test.js, macroCardLocales.test.js, workerBackendCache.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688ecbcb7c788326b6b92a3caa7d7887