### PR TITLE
feat: show plan vs target line and clean plan-data

### DIFF
--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -191,7 +191,8 @@ export class MacroAnalyticsCard extends HTMLElement {
       macros: { protein: '', carbs: '', fat: '', fiber: '' },
       fromGoal: '',
       totalCaloriesLabel: '',
-      exceedWarning: ''
+      exceedWarning: '',
+      planVsTargetLabel: ''
     };
   }
 
@@ -372,7 +373,10 @@ export class MacroAnalyticsCard extends HTMLElement {
       this.warningEl.classList.remove('show');
       this.warningEl.textContent = '';
     }
-    const planLine = plan ? `<div class="plan-vs-target">План: ${plan.calories} kcal / Препоръка: ${target.calories} kcal</div>` : '';
+    const hasPlan = plan && typeof plan.calories === 'number';
+    const planLine = hasPlan
+      ? `<div class="plan-vs-target">${this.labels.planVsTargetLabel.replace('{plan}', plan.calories).replace('{target}', target.calories)}</div>`
+      : '';
     const consumedCaloriesRaw = hasMacroData ? current.calories : undefined;
     const consumedCalories = typeof consumedCaloriesRaw === 'number' ? consumedCaloriesRaw : '--';
     this.centerText.innerHTML = `

--- a/locales/macroCard.bg.json
+++ b/locales/macroCard.bg.json
@@ -9,5 +9,6 @@
   },
   "fromGoal": "от целта",
   "totalCaloriesLabel": "от {calories} kcal",
-  "exceedWarning": "Превишение над 15%: {items}"
+  "exceedWarning": "Превишение над 15%: {items}",
+  "planVsTargetLabel": "План vs Цел: {plan} / {target} kcal"
 }

--- a/locales/macroCard.en.json
+++ b/locales/macroCard.en.json
@@ -9,5 +9,6 @@
   },
   "fromGoal": "of goal",
   "totalCaloriesLabel": "of {calories} kcal",
-  "exceedWarning": "Exceeds target by >15%: {items}"
+  "exceedWarning": "Exceeds target by >15%: {items}",
+  "planVsTargetLabel": "Plan vs Goal: {plan} / {target} kcal"
 }

--- a/macroAnalyticsCardStandalone.html
+++ b/macroAnalyticsCardStandalone.html
@@ -296,9 +296,8 @@
         this.refreshTimer = setInterval(fetchData, interval);
       }
 
-      setData({ target, plan, current }) {
+      setData({ target, current }) {
         if (target) this.setAttribute('target-data', JSON.stringify(target));
-        if (plan) this.setAttribute('plan-data', JSON.stringify(plan));
         if (current) this.setAttribute('current-data', JSON.stringify(current));
       }
 


### PR DESCRIPTION
## Summary
- show "Plan vs Goal" line when plan data is provided
- add locale strings for the plan comparison
- remove unused `plan-data` handling from standalone macro card

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ed0fda99c8326922b4b1242afb1dc