### PR TITLE
feat: embed standalone macro analytics card

### DIFF
--- a/js/__tests__/macroCardStandaloneEmbed.test.js
+++ b/js/__tests__/macroCardStandaloneEmbed.test.js
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let handleAccordionToggle;
+let standaloneMacroUrl;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <div id="detailedAnalyticsAccordion">
+      <div class="accordion-header" aria-expanded="false"></div>
+      <div class="accordion-content"></div>
+    </div>
+    <macro-analytics-card id="macroAnalyticsCard" target-data='{"calories":1}' plan-data='{}' current-data='{}'></macro-analytics-card>
+  `;
+  jest.unstable_mockModule('../uiElements.js', () => ({ selectors: {}, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
+  jest.unstable_mockModule('../extraMealForm.js', () => ({ openExtraMealModal: jest.fn() }));
+  jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id-1', standaloneMacroUrl: 'macroAnalyticsCardStandalone.html' }));
+  jest.unstable_mockModule('../app.js', () => ({ fullDashboardData: {}, todaysMealCompletionStatus: {}, todaysExtraMeals: [], currentIntakeMacros: {}, planHasRecContent: false }));
+  jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn(), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
+  const mod = await import('../populateUI.js');
+  handleAccordionToggle = mod.handleAccordionToggle;
+  ({ standaloneMacroUrl } = await import('../config.js'));
+});
+
+test('заменя макро картата с iframe при разгръщане', () => {
+  const header = document.querySelector('.accordion-header');
+  handleAccordionToggle.call(header);
+  const iframe = document.querySelector('#macroCardIframe');
+  expect(iframe).not.toBeNull();
+  expect(iframe.src).toContain(standaloneMacroUrl);
+});

--- a/js/__tests__/planModChat.test.js
+++ b/js/__tests__/planModChat.test.js
@@ -60,7 +60,8 @@ describe('handleChatSend plan modification', () => {
       isLocalDevelopment: false,
       workerBaseUrl: '',
       apiEndpoints: { chat: '/chat' },
-      generateId: jest.fn()
+      generateId: jest.fn(),
+      standaloneMacroUrl: 'macroAnalyticsCardStandalone.html'
     }));
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
@@ -182,7 +183,8 @@ describe('plan modification chat modal close/reset', () => {
       workerBaseUrl: '',
       apiEndpoints: {},
       cloudflareAccountId: 'c',
-      generateId: jest.fn()
+      generateId: jest.fn(),
+      standaloneMacroUrl: 'macroAnalyticsCardStandalone.html'
     }));
     jest.unstable_mockModule('../swipeUtils.js', () => ({ computeSwipeTargetIndex: jest.fn() }));
     jest.unstable_mockModule('../achievements.js', () => ({
@@ -353,7 +355,8 @@ describe('planModPrompt fail modal close', () => {
       isLocalDevelopment: false,
       workerBaseUrl: '',
       apiEndpoints: { getPlanModificationPrompt: '/prompt' },
-      generateId: jest.fn()
+      generateId: jest.fn(),
+      standaloneMacroUrl: 'macroAnalyticsCardStandalone.html'
     }));
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
@@ -428,7 +431,8 @@ describe('openPlanModificationChat errors', () => {
       isLocalDevelopment: false,
       workerBaseUrl: '',
       apiEndpoints: { getPlanModificationPrompt: '/prompt' },
-      generateId: jest.fn()
+      generateId: jest.fn(),
+      standaloneMacroUrl: 'macroAnalyticsCardStandalone.html'
     }));
     global.fetch = jest.fn(() => Promise.reject(new Error('fail')));
     app = await import('../app.js');

--- a/js/config.js
+++ b/js/config.js
@@ -70,3 +70,6 @@ export const initialBotMessage =
     (typeof sessionStorage !== 'undefined' && sessionStorage.getItem('initialBotMessage')) ||
     (typeof localStorage !== 'undefined' && localStorage.getItem('initialBotMessage')) ||
     'Здравейте! Аз съм вашият виртуален асистент MyBody.Best. Как мога да ви помогна днес?';
+
+// URL към самостоятелната макро карта
+export const standaloneMacroUrl = 'macroAnalyticsCardStandalone.html';

--- a/macroAnalyticsCardStandalone.html
+++ b/macroAnalyticsCardStandalone.html
@@ -43,8 +43,6 @@
   <macro-analytics-card
     locale="bg"
     exceed-threshold="1.2"
-    target-data='{"calories":2200,"protein_grams":140,"protein_percent":25,"carbs_grams":248,"carbs_percent":45,"fat_grams":73,"fat_percent":30,"fiber_grams":30,"fiber_percent":100}'
-    current-data='{"calories":950,"protein_grams":70,"carbs_grams":90,"fat_grams":40,"fiber_grams":15}'
   ></macro-analytics-card>
 
   <script type="module">
@@ -477,6 +475,15 @@
     }
 
     customElements.define('macro-analytics-card', MacroAnalyticsCard);
+
+    // Приемане на данни от родителския прозорец
+    window.addEventListener('message', (e) => {
+      const payload = e.data;
+      if (payload && payload.type === 'macro-data') {
+        const card = document.querySelector('macro-analytics-card');
+        card?.setData(payload.data);
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed standalone macro analytics card within dashboard instead of redirecting
- expose standalone card URL via config
- pass client macro data to standalone card through `postMessage`

## Testing
- `npm run lint`
- `npm test`
- `sh ./scripts/test.sh js/__tests__/macroCardStandaloneEmbed.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688ed40e24d08326a1dce3f3b8629a89