### PR TITLE
feat: embed standalone macro analytics card

### DIFF
--- a/js/__tests__/macroCardStandaloneEmbed.test.js
+++ b/js/__tests__/macroCardStandaloneEmbed.test.js
@@ -1,0 +1,47 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let handleAccordionToggle;
+let standaloneMacroUrl;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <div id="detailedAnalyticsAccordion">
+      <div class="accordion-header" aria-expanded="false"></div>
+      <div class="accordion-content"></div>
+    </div>
+    <macro-analytics-card id="macroAnalyticsCard" target-data='{"calories":1}' plan-data='{}' current-data='{}'></macro-analytics-card>
+  `;
+  jest.unstable_mockModule('../uiElements.js', () => ({ selectors: {}, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
+  jest.unstable_mockModule('../extraMealForm.js', () => ({ openExtraMealModal: jest.fn() }));
+  jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id-1', standaloneMacroUrl: 'macroAnalyticsCardStandalone.html' }));
+  jest.unstable_mockModule('../app.js', () => ({ fullDashboardData: {}, todaysMealCompletionStatus: {}, todaysExtraMeals: [], currentIntakeMacros: {}, planHasRecContent: false }));
+  jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn(), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
+  const mod = await import('../populateUI.js');
+  handleAccordionToggle = mod.handleAccordionToggle;
+  ({ standaloneMacroUrl } = await import('../config.js'));
+});
+
+test('заменя макро картата с iframe при разгръщане', () => {
+  const header = document.querySelector('.accordion-header');
+  handleAccordionToggle.call(header);
+  const iframe = document.querySelector('#macroCardIframe');
+  expect(iframe).not.toBeNull();
+  expect(iframe.src).toContain(standaloneMacroUrl);
+});
+
+test('актуализира височината на iframe чрез postMessage', () => {
+  const header = document.querySelector('.accordion-header');
+  handleAccordionToggle.call(header);
+  const iframe = document.querySelector('#macroCardIframe');
+  const newHeight = 700;
+  const evt = new MessageEvent('message', {
+    data: { type: 'macro-card-height', height: newHeight },
+    source: iframe.contentWindow,
+  });
+  window.dispatchEvent(evt);
+  expect(iframe.style.height).toBe(`${newHeight}px`);
+});

--- a/js/__tests__/planModChat.test.js
+++ b/js/__tests__/planModChat.test.js
@@ -60,7 +60,8 @@ describe('handleChatSend plan modification', () => {
       isLocalDevelopment: false,
       workerBaseUrl: '',
       apiEndpoints: { chat: '/chat' },
-      generateId: jest.fn()
+      generateId: jest.fn(),
+      standaloneMacroUrl: 'macroAnalyticsCardStandalone.html'
     }));
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
@@ -182,7 +183,8 @@ describe('plan modification chat modal close/reset', () => {
       workerBaseUrl: '',
       apiEndpoints: {},
       cloudflareAccountId: 'c',
-      generateId: jest.fn()
+      generateId: jest.fn(),
+      standaloneMacroUrl: 'macroAnalyticsCardStandalone.html'
     }));
     jest.unstable_mockModule('../swipeUtils.js', () => ({ computeSwipeTargetIndex: jest.fn() }));
     jest.unstable_mockModule('../achievements.js', () => ({
@@ -353,7 +355,8 @@ describe('planModPrompt fail modal close', () => {
       isLocalDevelopment: false,
       workerBaseUrl: '',
       apiEndpoints: { getPlanModificationPrompt: '/prompt' },
-      generateId: jest.fn()
+      generateId: jest.fn(),
+      standaloneMacroUrl: 'macroAnalyticsCardStandalone.html'
     }));
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
@@ -428,7 +431,8 @@ describe('openPlanModificationChat errors', () => {
       isLocalDevelopment: false,
       workerBaseUrl: '',
       apiEndpoints: { getPlanModificationPrompt: '/prompt' },
-      generateId: jest.fn()
+      generateId: jest.fn(),
+      standaloneMacroUrl: 'macroAnalyticsCardStandalone.html'
     }));
     global.fetch = jest.fn(() => Promise.reject(new Error('fail')));
     app = await import('../app.js');

--- a/js/config.js
+++ b/js/config.js
@@ -70,3 +70,6 @@ export const initialBotMessage =
     (typeof sessionStorage !== 'undefined' && sessionStorage.getItem('initialBotMessage')) ||
     (typeof localStorage !== 'undefined' && localStorage.getItem('initialBotMessage')) ||
     'Здравейте! Аз съм вашият виртуален асистент MyBody.Best. Как мога да ви помогна днес?';
+
+// URL към самостоятелната макро карта
+export const standaloneMacroUrl = 'macroAnalyticsCardStandalone.html';

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,7 +1,7 @@
 // populateUI.js - Попълване на UI с данни
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
 import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressFill, getCssVar, formatDateBgShort } from './utils.js';
-import { generateId } from './config.js';
+import { generateId, standaloneMacroUrl } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
 import { ensureChart } from './chartLoader.js';
@@ -403,7 +403,6 @@ export async function populateDashboardMacros(macros) {
         card.id = 'macroAnalyticsCard';
         container.appendChild(card);
     }
-
     if (!macros) {
         console.warn('Macros data is missing.');
         return;
@@ -923,6 +922,36 @@ export function handleAccordionToggle(event) {
     if (!isOpen && this.closest('#detailedAnalyticsAccordion')) {
         macroChartInstance?.resize();
         progressChartInstance?.resize();
+        const card = document.getElementById('macroAnalyticsCard');
+        if (card && !document.getElementById('macroCardIframe')) {
+            const data = {
+                target: card.getAttribute('target-data') ? JSON.parse(card.getAttribute('target-data')) : null,
+                plan: card.getAttribute('plan-data') ? JSON.parse(card.getAttribute('plan-data')) : null,
+                current: card.getAttribute('current-data') ? JSON.parse(card.getAttribute('current-data')) : null,
+            };
+            const wrapper = document.createElement('div');
+            wrapper.className = 'card analytics-card';
+
+            const iframe = document.createElement('iframe');
+            iframe.id = 'macroCardIframe';
+            iframe.src = standaloneMacroUrl;
+            iframe.style.width = '100%';
+            iframe.style.border = 'none';
+            iframe.style.height = '0px';
+
+            window.addEventListener('message', function resizeIframe(event) {
+                if (event.source === iframe.contentWindow && event.data?.type === 'macro-card-height') {
+                    iframe.style.height = `${event.data.height}px`;
+                }
+            });
+
+            iframe.addEventListener('load', () => {
+                iframe.contentWindow?.postMessage({ type: 'macro-data', data }, '*');
+            });
+
+            wrapper.appendChild(iframe);
+            card.replaceWith(wrapper);
+        }
     }
 }
 

--- a/macroAnalyticsCardStandalone.html
+++ b/macroAnalyticsCardStandalone.html
@@ -43,8 +43,6 @@
   <macro-analytics-card
     locale="bg"
     exceed-threshold="1.2"
-    target-data='{"calories":2200,"protein_grams":140,"protein_percent":25,"carbs_grams":248,"carbs_percent":45,"fat_grams":73,"fat_percent":30,"fiber_grams":30,"fiber_percent":100}'
-    current-data='{"calories":950,"protein_grams":70,"carbs_grams":90,"fat_grams":40,"fiber_grams":15}'
   ></macro-analytics-card>
 
   <script type="module">
@@ -477,6 +475,28 @@
     }
 
     customElements.define('macro-analytics-card', MacroAnalyticsCard);
+
+    function postHeight() {
+      const height = document.documentElement.scrollHeight;
+      window.parent?.postMessage({ type: 'macro-card-height', height }, '*');
+    }
+
+    window.addEventListener('load', postHeight);
+    if ('ResizeObserver' in window) {
+      new ResizeObserver(postHeight).observe(document.body);
+    } else {
+      window.addEventListener('resize', postHeight);
+    }
+
+    // Приемане на данни от родителския прозорец
+    window.addEventListener('message', (e) => {
+      const payload = e.data;
+      if (payload && payload.type === 'macro-data') {
+        const card = document.querySelector('macro-analytics-card');
+        card?.setData(payload.data);
+        requestAnimationFrame(postHeight);
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed standalone macro analytics card within dashboard instead of redirecting
- expose standalone card URL via config
- pass client macro data to standalone card through `postMessage`
- resize embedded macro card iframe dynamically to content

## Testing
- `npm run lint`
- `npm test` *(fails: sendAnalysisLinkEmail loads subject/body from KV, sendContactEmail uses contact_form_label from KV, macroAnalyticsCardComponent, passwordReset, extraMealFormSubmit)*
- `sh ./scripts/test.sh js/__tests__/macroCardStandaloneEmbed.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688ed40e24d08326a1dce3f3b8629a89