### PR TITLE
feat: open standalone macro card directly

### DIFF
--- a/js/__tests__/macroCardStandaloneEmbed.test.js
+++ b/js/__tests__/macroCardStandaloneEmbed.test.js
@@ -31,6 +31,8 @@ test('заменя макро картата с iframe при разгръщан
   const iframe = document.querySelector('#macroCardIframe');
   expect(iframe).not.toBeNull();
   expect(iframe.src).toContain(standaloneMacroUrl);
+  expect(document.querySelector('macro-analytics-card')).toBeNull();
+  expect(document.querySelector('.card.analytics-card')).toBeNull();
 });
 
 test('актуализира височината на iframe чрез postMessage', () => {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -929,9 +929,6 @@ export function handleAccordionToggle(event) {
                 plan: card.getAttribute('plan-data') ? JSON.parse(card.getAttribute('plan-data')) : null,
                 current: card.getAttribute('current-data') ? JSON.parse(card.getAttribute('current-data')) : null,
             };
-            const wrapper = document.createElement('div');
-            wrapper.className = 'card analytics-card';
-
             const iframe = document.createElement('iframe');
             iframe.id = 'macroCardIframe';
             iframe.src = standaloneMacroUrl;
@@ -949,8 +946,7 @@ export function handleAccordionToggle(event) {
                 iframe.contentWindow?.postMessage({ type: 'macro-data', data }, '*');
             });
 
-            wrapper.appendChild(iframe);
-            card.replaceWith(wrapper);
+            card.replaceWith(iframe);
         }
     }
 }


### PR DESCRIPTION
## Summary
- embed `macroAnalyticsCardStandalone.html` directly via iframe instead of wrapper
- verify replacement and missing wrapper in tests

## Testing
- `npm run lint`
- `npm test js/__tests__/macroCardStandaloneEmbed.test.js`
- `npm test` *(fails: FATAL ERROR: Reached heap limit. workerEmail.test.js and macroAnalyticsCardComponent.test.js failing)*

------
https://chatgpt.com/codex/tasks/task_e_688f62134c5083269a1a3a2f2d7ee953