### PR TITLE
feat: track current intake macros

### DIFF
--- a/js/__tests__/loadCurrentIntake.test.js
+++ b/js/__tests__/loadCurrentIntake.test.js
@@ -1,0 +1,30 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+test('loadCurrentIntake агрегира макросите от логовете', async () => {
+  jest.resetModules();
+  const app = await import('../app.js');
+  const todayStr = new Date().toISOString().split('T')[0];
+  app.fullDashboardData = {
+    planData: { week1Menu: {} },
+    dailyLogs: [
+      {
+        date: todayStr,
+        data: {
+          completedMealsStatus: { sample: true },
+          extraMeals: [{ calories: 200, protein: 10, carbs: 20, fat: 5, fiber: 1 }],
+        },
+      },
+    ],
+  };
+  app.loadCurrentIntake();
+  expect(app.todaysMealCompletionStatus).toEqual({ sample: true });
+  expect(app.todaysExtraMeals).toHaveLength(1);
+  expect(app.currentIntakeMacros).toEqual({
+    calories: 200,
+    protein: 10,
+    carbs: 20,
+    fat: 5,
+    fiber: 1,
+  });
+});

--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -54,6 +54,6 @@ test('placeholder shown when macros missing and populates after migration', asyn
   expect(card.setData).toHaveBeenCalledWith({
     target: macros,
     plan: { calories: 850, protein: 72, carbs: 70, fat: 28 },
-    current: null
+    current: appState.currentIntakeMacros
   });
 });

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -131,10 +131,11 @@ test('обновява макро картата чрез setData', async () => 
   const card = document.getElementById('macroAnalyticsCard');
   card.setData = jest.fn();
   await populateUI();
-  expect(card.setData).toHaveBeenCalledWith(
-    expect.objectContaining({ calories: 1800 }),
-    null,
-  );
+  expect(card.setData).toHaveBeenCalledWith({
+    target: expect.objectContaining({ calories: 1800 }),
+    plan: expect.any(Object),
+    current: {}
+  });
 });
 
 test('hides modules when values are zero', async () => {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -407,15 +407,12 @@ export async function populateDashboardMacros(macros) {
         console.warn('Macros data is missing.');
         return;
     }
-    const current = currentIntakeMacros && Object.keys(currentIntakeMacros).length > 0
-        ? currentIntakeMacros
-        : null;
     const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
     const today = new Date();
     const currentDayKey = dayNames[today.getDay()];
     const dayMenu = fullDashboardData?.planData?.week1Menu?.[currentDayKey] || [];
     const planMacros = calculatePlanMacros(dayMenu);
-    card.setData({ target: macros, plan: planMacros, current });
+    card.setData({ target: macros, plan: planMacros, current: currentIntakeMacros });
     renderPendingMacroChart();
 }
 


### PR DESCRIPTION
## Summary
- load saved meal data into `currentIntakeMacros`
- wire current macros into macro analytics card
- cover intake loading with tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f74ca90a4832684391475de65f277