### PR TITLE
feat: calculate macro progress dynamically

### DIFF
--- a/js/__tests__/macroAnalyticsCardComponent.test.js
+++ b/js/__tests__/macroAnalyticsCardComponent.test.js
@@ -57,6 +57,8 @@ test('рендерира метриките и реагира на highlightMacr
   await waitFor(() => utils.getByText('Белтъчини'));
   expect(utils.getByText('60 / 150г')).toBeTruthy();
   const proteinDiv = utils.getByText('Белтъчини').closest('.macro-metric');
+  expect(proteinDiv.getAttribute('aria-label')).toContain('40%');
+  expect(within(proteinDiv).getByText('40% от целта')).toBeTruthy();
   expect(proteinDiv.classList.contains('active')).toBe(false);
   fireEvent.click(proteinDiv);
   expect(proteinDiv.classList.contains('active')).toBe(true);

--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 import { jest } from '@jest/globals';
-import { calculateCurrentMacros, addMealMacros, removeMealMacros, registerNutrientOverrides, getNutrientOverride, calculatePlanMacros, loadProductMacros, scaleMacros, __testExports } from '../macroUtils.js';
+import { calculateCurrentMacros, addMealMacros, removeMealMacros, registerNutrientOverrides, getNutrientOverride, calculatePlanMacros, loadProductMacros, scaleMacros, formatPercent, __testExports } from '../macroUtils.js';
 
 test('calculateCurrentMacros sums macros from completed meals and extras', () => {
   const planMenu = {
@@ -83,4 +83,10 @@ test('loadProductMacros позволява търсене на продукт п
   addMealMacros({ name: 'ябълка' }, acc);
   expect(acc).toEqual({ calories: 52, protein: 0.3, carbs: 13.8, fat: 0.2, fiber: 2.4 });
   registerNutrientOverrides({});
+});
+
+test('formatPercent форматира съотношения', () => {
+  expect(formatPercent(0.4)).toBe('40%');
+  expect(formatPercent(0)).toBe('0%');
+  expect(formatPercent('na')).toBe('--%');
 });

--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -1,6 +1,6 @@
 import { loadLocale } from './macroCardLocales.js';
 import { ensureChart } from './chartLoader.js';
-import { scaleMacros } from './macroUtils.js';
+import { scaleMacros, formatPercent } from './macroUtils.js';
 
 let Chart;
 
@@ -376,9 +376,12 @@ export class MacroAnalyticsCard extends HTMLElement {
       this.warningEl.textContent = '';
     }
     const hasPlan = plan && typeof plan.calories === 'number';
-    const planLine = hasPlan
-      ? `<div class="plan-vs-target">${this.labels.planVsTargetLabel.replace('{plan}', plan.calories).replace('{target}', target.calories)}</div>`
-      : '';
+    const planLine =
+      hasPlan && this.labels.planVsTargetLabel
+        ? `<div class="plan-vs-target">${this.labels.planVsTargetLabel
+            .replace('{plan}', plan.calories)
+            .replace('{target}', target.calories)}</div>`
+        : '';
     const consumedCaloriesRaw = hasMacroData ? current.calories : undefined;
     const consumedCalories = typeof consumedCaloriesRaw === 'number' ? consumedCaloriesRaw : '--';
     const caloriesExceeded =
@@ -418,7 +421,7 @@ export class MacroAnalyticsCard extends HTMLElement {
       const currentRaw = hasMacroData ? current[`${item.key}_grams`] : undefined;
       const displayCurrent = typeof currentRaw === 'number' ? currentRaw : '--';
       const targetVal = target[`${item.key}_grams`];
-      const percent = target[`${item.key}_percent`];
+      const percent = formatPercent(currentRaw / targetVal);
       const div = document.createElement('div');
       div.className = `macro-metric ${item.key}`;
       if (typeof currentRaw === 'number' && typeof targetVal === 'number') {
@@ -429,13 +432,13 @@ export class MacroAnalyticsCard extends HTMLElement {
       }
       div.setAttribute('role', 'button');
       div.setAttribute('tabindex', '0');
-      div.setAttribute('aria-label', `${label}: ${displayCurrent} от ${targetVal} грама (${percent}% ${this.labels.fromGoal})`);
+      div.setAttribute('aria-label', `${label}: ${displayCurrent} от ${targetVal} грама (${percent} ${this.labels.fromGoal})`);
       div.setAttribute('aria-pressed', 'false');
       div.innerHTML = `
         <span class="macro-icon"><i class="bi ${item.icon}"></i></span>
         <div class="macro-label">${label}</div>
         <div class="macro-value">${displayCurrent} / ${targetVal}г</div>
-        <div class="macro-subtitle">${percent}% ${this.labels.fromGoal}</div>`;
+        <div class="macro-subtitle">${percent} ${this.labels.fromGoal}</div>`;
       div.addEventListener('click', () => this.highlightMacro(div, idx));
       div.addEventListener('keydown', (e) => {
         if (e.key === 'Enter' || e.key === ' ') {

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -88,6 +88,18 @@ export function scaleMacros(macros = {}, grams = 100) {
   };
 }
 
+/**
+ * Форматира съотношение като процент.
+ * @param {number} ratio - Стойност между 0 и 1.
+ * @param {number} fractionDigits - Брой десетични знаци.
+ * @returns {string}
+ */
+export function formatPercent(ratio, fractionDigits = 0) {
+  const val = Number(ratio);
+  if (!Number.isFinite(val)) return '--%';
+  return `${(val * 100).toFixed(fractionDigits)}%`;
+}
+
 function resolveMacros(meal, grams) {
   if (!meal) return { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
   let macros;


### PR DESCRIPTION
## Summary
- compute macro percentages from current intake and target
- add shared formatPercent helper
- cover percentage formatting and rendering in tests

## Testing
- `npm run lint`
- `npm test js/__tests__/macroAnalyticsCardComponent.test.js`
- `npm test js/__tests__/macroUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688f776f2b7c83268acddb9ba35f449e