### PR TITLE
Вграждане на макро картата чрез iframe

### DIFF
--- a/code.html
+++ b/code.html
@@ -524,7 +524,11 @@
                   </div>
                 </div>
                 <div id="analyticsCardsContainer" class="analytics-cards-grid">
-                  <macro-analytics-card id="macroAnalyticsCard"></macro-analytics-card>
+                  <iframe id="macroAnalyticsCardFrame"
+                          class="analytics-card"
+                          src="macroAnalyticsCardStandalone.html"
+                          title="Макро анализ">
+                  </iframe>
                 </div>
               </div>
             </div>
@@ -1387,9 +1391,15 @@
     <!-- End #appWrapper -->
 
     <!-- Коригирана JavaScript Връзка -->
-    <script type="module" src="js/macroAnalyticsCardComponent.js"></script>
     <script type="module" src="js/app.js" defer></script>
     <script type="module" src="js/planModChat.js" defer></script>
+    <script>
+      window.addEventListener('message', e => {
+        if (e.data?.type === 'macro-card-height') {
+          document.getElementById('macroAnalyticsCardFrame').style.height = `${e.data.height}px`;
+        }
+      });
+    </script>
     
   </body>
 </html>

--- a/js/__tests__/populateDashboardMacros.missingComponent.test.js
+++ b/js/__tests__/populateDashboardMacros.missingComponent.test.js
@@ -1,8 +1,7 @@
 /** @jest-environment jsdom */
 import { jest } from '@jest/globals';
 
-test('логва предупреждение при липсващ macro-analytics-card компонент', async () => {
-  jest.unstable_mockModule('../macroAnalyticsCardComponent.js', () => ({}));
+test('не хвърля грешка при липсващ iframe', async () => {
   document.body.innerHTML = `
     <div id="macroMetricsPreview"></div>
     <div id="analyticsCardsContainer"></div>
@@ -21,7 +20,7 @@ test('логва предупреждение при липсващ macro-analyt
     getCssVar: () => '',
     formatDateBgShort: () => ''
   }));
-  jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id' }));
+  jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id', standaloneMacroUrl: 'macroAnalyticsCardStandalone.html' }));
   jest.unstable_mockModule('../app.js', () => ({
     fullDashboardData: {},
     todaysMealCompletionStatus: {},
@@ -30,9 +29,6 @@ test('логва предупреждение при липсващ macro-analyt
     planHasRecContent: false,
   }));
   jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
-  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   const { populateDashboardMacros } = await import('../populateUI.js');
-  await populateDashboardMacros({ calories: 1000, protein_percent: 30, carbs_percent: 40, fat_percent: 30 });
-  expect(warnSpy).toHaveBeenCalled();
-  expect(document.getElementById('macroAnalyticsCard')).toBeNull();
+  await expect(populateDashboardMacros({ calories: 1000, protein_percent: 30, carbs_percent: 40, fat_percent: 30 })).resolves.not.toThrow();
 });

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -378,30 +378,11 @@ function renderMacroPreviewGrid(macros) {
     });
 }
 
-async function ensureMacroCard() {
-    if (!customElements.get('macro-analytics-card')) {
-        await import('./macroAnalyticsCardComponent.js');
-    }
-}
-
 export async function populateDashboardMacros(macros) {
     renderMacroPreviewGrid(macros);
-    await ensureMacroCard();
-    if (!customElements.get('macro-analytics-card')) {
-        console.warn('macro-analytics-card component is missing.');
-        return;
-    }
-    const container = selectors.analyticsCardsContainer;
-    if (!container) {
+    if (!selectors.analyticsCardsContainer) {
         console.warn('Analytics cards container not found.');
         return;
-    }
-
-    let card = document.getElementById('macroAnalyticsCard');
-    if (!card) {
-        card = document.createElement('macro-analytics-card');
-        card.id = 'macroAnalyticsCard';
-        container.appendChild(card);
     }
     if (!macros) {
         console.warn('Macros data is missing.');
@@ -412,7 +393,12 @@ export async function populateDashboardMacros(macros) {
     const currentDayKey = dayNames[today.getDay()];
     const dayMenu = fullDashboardData?.planData?.week1Menu?.[currentDayKey] || [];
     const planMacros = calculatePlanMacros(dayMenu);
-    card.setData({ target: macros, plan: planMacros, current: currentIntakeMacros });
+    const frame = document.getElementById('macroAnalyticsCardFrame');
+    frame?.contentWindow?.postMessage(
+        { type: 'macro-data',
+          data: { target: macros, plan: planMacros, current: currentIntakeMacros } },
+        '*'
+    );
     renderPendingMacroChart();
 }
 

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -47,7 +47,7 @@ export function initializeSelectors() {
         streakGrid: 'streakGrid',
         achievementShareBtn: 'achievementShareBtn',
         analyticsCardsContainer: 'analyticsCardsContainer',
-        macroAnalyticsCard: 'macroAnalyticsCard',
+        macroAnalyticsCardFrame: 'macroAnalyticsCardFrame',
         macroMetricsGrid: 'macroMetricsGrid',
         macroMetricsPreview: 'macroMetricsPreview',
         tooltipTracker: 'tooltip-tracker',
@@ -75,7 +75,7 @@ export function initializeSelectors() {
                 'planModChatSend', 'planModChatClose', 'planModChatClear',
                 'streakGrid', 'analyticsCardsContainer', 'achievementShareBtn',
                 'goalCard', 'engagementCard', 'healthCard', 'streakCard',
-                'macroAnalyticsCard', 'macroMetricsGrid',
+                'macroAnalyticsCardFrame', 'macroMetricsGrid',
                 'macroMetricsPreview',
                 'recFoodAllowedCard', 'recFoodLimitCard', 'recHydrationCard',
                 'recCookingMethodsCard', 'recSupplementsCard'


### PR DESCRIPTION
## Резюме
- заменен `<macro-analytics-card>` в `code.html` с iframe към `macroAnalyticsCardStandalone.html`
- функцията `populateDashboardMacros` вече изпраща данните към iframe чрез `postMessage`
- добавен слушател в основната страница за настройка на височината на iframe
- актуализирани селектори и тестове

## Тестове
- `npm run lint`
- `npm test` *(част от тестовете се провалят: workerEmail.test.js, passwordReset.test.js, extraMealFormSubmit.test.js и други)*

------
https://chatgpt.com/codex/tasks/task_e_688f7c1d9d208326bbcee1fade0f8c55