### PR TITLE
Обновяване на макро приема при промяна на дневния лог

### DIFF
--- a/js/__tests__/adminConfigRelated.test.js
+++ b/js/__tests__/adminConfigRelated.test.js
@@ -178,7 +178,8 @@ describe('uiHandlers.loadAndApplyColors', () => {
       todaysMealCompletionStatus: {},
       todaysExtraMeals: [],
       currentIntakeMacros: {},
-      planHasRecContent: false
+      planHasRecContent: false,
+      loadCurrentIntake: jest.fn()
     }));
     ({ loadAndApplyColors } = await import('../uiHandlers.js'));
   });

--- a/js/__tests__/extraMealAutofill.test.js
+++ b/js/__tests__/extraMealAutofill.test.js
@@ -13,12 +13,14 @@ beforeEach(async () => {
     closeModal: jest.fn()
   }));
   jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({
     currentUserId: 'u1',
     todaysExtraMeals: [],
     todaysMealCompletionStatus: {},
     currentIntakeMacros: {},
-    fullDashboardData: { planData: { week1Menu: {} } }
+    fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: {} } },
+    loadCurrentIntake: jest.fn()
   }));
   ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));
 });

--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -26,6 +26,10 @@ beforeEach(async () => {
     registerNutrientOverrides: jest.fn(),
     getNutrientOverride: jest.fn(() => null)
   }));
+  jest.unstable_mockModule('../populateUI.js', () => ({
+    addExtraMealWithOverride: jest.fn(),
+    populateDashboardMacros: jest.fn()
+  }));
   jest.unstable_mockModule('../app.js', () => {
     currentIntakeMacrosRef = {};
     return {
@@ -33,8 +37,9 @@ beforeEach(async () => {
       todaysMealCompletionStatus: {},
       todaysExtraMeals: [],
       currentIntakeMacros: currentIntakeMacrosRef,
-      fullDashboardData: { planData: { week1Menu: {} } },
-      planHasRecContent: false
+      fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: {} } },
+      planHasRecContent: false,
+      loadCurrentIntake: jest.fn()
     };
   });
   global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });

--- a/js/__tests__/extraMealNutrientLookup.test.js
+++ b/js/__tests__/extraMealNutrientLookup.test.js
@@ -21,12 +21,14 @@ beforeEach(async () => {
     closeModal: jest.fn()
   }));
   jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({
     currentUserId: 'u1',
     todaysExtraMeals: [],
     todaysMealCompletionStatus: {},
     currentIntakeMacros: {},
-    fullDashboardData: { planData: { week1Menu: {} } }
+    fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: {} } },
+    loadCurrentIntake: jest.fn()
   }));
   ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));
 });

--- a/js/__tests__/macroCardStandaloneEmbed.test.js
+++ b/js/__tests__/macroCardStandaloneEmbed.test.js
@@ -17,7 +17,7 @@ beforeEach(async () => {
   jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
   jest.unstable_mockModule('../extraMealForm.js', () => ({ openExtraMealModal: jest.fn() }));
   jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id-1', standaloneMacroUrl: 'macroAnalyticsCardStandalone.html' }));
-  jest.unstable_mockModule('../app.js', () => ({ fullDashboardData: {}, todaysMealCompletionStatus: {}, todaysExtraMeals: [], currentIntakeMacros: {}, planHasRecContent: false }));
+  jest.unstable_mockModule('../app.js', () => ({ fullDashboardData: {}, todaysMealCompletionStatus: {}, todaysExtraMeals: [], currentIntakeMacros: {}, planHasRecContent: false, loadCurrentIntake: jest.fn() }));
   jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
   jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn(), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
   const mod = await import('../populateUI.js');

--- a/js/__tests__/populateDashboardMacros.missingComponent.test.js
+++ b/js/__tests__/populateDashboardMacros.missingComponent.test.js
@@ -27,6 +27,7 @@ test('не хвърля грешка при липсващ iframe', async () => 
     todaysExtraMeals: [],
     currentIntakeMacros: {},
     planHasRecContent: false,
+    loadCurrentIntake: jest.fn(),
   }));
   jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
   const { populateDashboardMacros } = await import('../populateUI.js');

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -77,7 +77,8 @@ beforeEach(async () => {
     todaysMealCompletionStatus: {},
     todaysExtraMeals: [],
     currentIntakeMacros: {},
-    planHasRecContent: false
+    planHasRecContent: false,
+    loadCurrentIntake: jest.fn()
   }));
   ({ populateUI } = await import('../populateUI.js'));
 });
@@ -122,6 +123,7 @@ test('обновява макро картата чрез postMessage', async ()
     todaysExtraMeals: [],
     currentIntakeMacros: {},
     planHasRecContent: false,
+    loadCurrentIntake: jest.fn(),
   }));
   ({ populateUI } = await import('../populateUI.js'));
   const frame = document.getElementById('macroAnalyticsCardFrame');
@@ -158,7 +160,8 @@ test('hides modules when values are zero', async () => {
   jest.unstable_mockModule('../app.js', () => ({
     ...zeroData,
     todaysExtraMeals: [],
-    currentIntakeMacros: {}
+    currentIntakeMacros: {},
+    loadCurrentIntake: jest.fn()
   }));
   ({ populateUI } = await import('../populateUI.js'));
   await populateUI();
@@ -192,7 +195,8 @@ test('показва картата за историята на теглото 
     todaysMealCompletionStatus: {},
     todaysExtraMeals: [],
     currentIntakeMacros: {},
-    planHasRecContent: false
+    planHasRecContent: false,
+    loadCurrentIntake: jest.fn()
   }));
   ({ populateUI } = await import('../populateUI.js'));
   await populateUI();
@@ -225,7 +229,8 @@ test('populates daily plan with color bars and meal types', async () => {
     todaysMealCompletionStatus: {},
     todaysExtraMeals: [],
     currentIntakeMacros: {},
-    planHasRecContent: false
+    planHasRecContent: false,
+    loadCurrentIntake: jest.fn()
   }));
   ({ populateUI } = await import('../populateUI.js'));
   await populateUI();
@@ -268,7 +273,8 @@ test('handles meal type variations', async () => {
     todaysMealCompletionStatus: {},
     todaysExtraMeals: [],
     currentIntakeMacros: {},
-    planHasRecContent: false
+    planHasRecContent: false,
+    loadCurrentIntake: jest.fn()
   }));
   ({ populateUI } = await import('../populateUI.js'));
   await populateUI();
@@ -303,7 +309,8 @@ test('applies success color to completed meal bar', async () => {
     todaysMealCompletionStatus: {},
     todaysExtraMeals: [],
     currentIntakeMacros: {},
-    planHasRecContent: false
+    planHasRecContent: false,
+    loadCurrentIntake: jest.fn()
   }));
   ({ populateUI } = await import('../populateUI.js'));
 
@@ -346,7 +353,8 @@ test('clicking a meal card toggles completion status', async () => {
       todaysMealCompletionStatus: {},
       todaysExtraMeals: [],
       currentIntakeMacros: {},
-      planHasRecContent: false
+      planHasRecContent: false,
+      loadCurrentIntake: jest.fn()
     };
   });
 
@@ -386,7 +394,8 @@ describe('progress bar width handling', () => {
       todaysMealCompletionStatus: {},
       todaysExtraMeals: [],
       currentIntakeMacros: {},
-      planHasRecContent: false
+      planHasRecContent: false,
+      loadCurrentIntake: jest.fn()
     }));
     ({ populateUI } = await import('../populateUI.js'));
     await populateUI();

--- a/js/__tests__/themeCycle.test.js
+++ b/js/__tests__/themeCycle.test.js
@@ -25,7 +25,8 @@ describe('theme cycling', () => {
       todaysMealCompletionStatus: {},
       todaysExtraMeals: [],
       currentIntakeMacros: {},
-      planHasRecContent: false
+      planHasRecContent: false,
+      loadCurrentIntake: jest.fn()
     }));
     ({ toggleTheme, applyTheme, updateThemeButtonText, initializeTheme } = await import('../uiHandlers.js'));
   });

--- a/js/__tests__/uiHandlersEscapeHtml.test.js
+++ b/js/__tests__/uiHandlersEscapeHtml.test.js
@@ -27,7 +27,8 @@ describe('uiHandlers escapeHtml usage', () => {
       todaysMealCompletionStatus: {},
       todaysExtraMeals: [],
       currentIntakeMacros: {},
-      planHasRecContent: false
+      planHasRecContent: false,
+      loadCurrentIntake: jest.fn()
     }));
 
     const { openInfoModalWithDetails } = await import('../uiHandlers.js');
@@ -62,7 +63,8 @@ describe('uiHandlers escapeHtml usage', () => {
       todaysMealCompletionStatus: {},
       todaysExtraMeals: [],
       currentIntakeMacros: {},
-      planHasRecContent: false
+      planHasRecContent: false,
+      loadCurrentIntake: jest.fn()
     }));
 
     const { openMainIndexInfo } = await import('../uiHandlers.js');

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -10,7 +10,7 @@ import {
 import { handleLogout } from './auth.js';
 import { openExtraMealModal } from './extraMealForm.js';
 import { apiEndpoints } from './config.js';
-import { macroChartInstance, progressChartInstance, renderPendingMacroChart } from './populateUI.js';
+import { macroChartInstance, progressChartInstance, renderPendingMacroChart, populateDashboardMacros } from './populateUI.js';
 import {
     handleSaveLog, handleFeedbackFormSubmit, // from app.js
     handleChatSend, handleChatInputKeypress, // from app.js / chat.js
@@ -18,7 +18,8 @@ import {
     _handleTriggerAdaptiveQuizClientSide, // from app.js
     todaysMealCompletionStatus, todaysExtraMeals, currentIntakeMacros,
     fullDashboardData, activeTooltip, currentUserId,
-    setChatModelOverride, setChatPromptOverride
+    setChatModelOverride, setChatPromptOverride,
+    loadCurrentIntake
 } from './app.js';
 import { addMealMacros, removeMealMacros } from './macroUtils.js';
 import {
@@ -343,7 +344,8 @@ function handleDelegatedClicks(event) {
             if (meal) {
                 (isCompleted ? addMealMacros : removeMealMacros)(meal, currentIntakeMacros);
             }
-            renderPendingMacroChart();
+            loadCurrentIntake();
+            populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
             showToast(`Храненето е ${isCompleted ? 'отбелязано' : 'размаркирано'}.`, false, 2000);
         }
         return;

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -2,10 +2,10 @@
 import { selectors } from './uiElements.js';
 import { showLoading, showToast, openModal as genericOpenModal, closeModal as genericCloseModal } from './uiHandlers.js';
 import { apiEndpoints } from './config.js';
-import { currentUserId, todaysExtraMeals, currentIntakeMacros } from './app.js';
+import { currentUserId, todaysExtraMeals, currentIntakeMacros, fullDashboardData, loadCurrentIntake } from './app.js';
 import nutrientOverrides from '../kv/DIET_RESOURCES/nutrient_overrides.json' with { type: 'json' };
 import { removeMealMacros, registerNutrientOverrides, getNutrientOverride, loadProductMacros } from './macroUtils.js';
-import { addExtraMealWithOverride, renderPendingMacroChart } from './populateUI.js';
+import { addExtraMealWithOverride, populateDashboardMacros } from './populateUI.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 
 const dynamicNutrientOverrides = { ...nutrientOverrides };
@@ -476,7 +476,8 @@ export function deleteExtraMeal(index) {
     const [removed] = todaysExtraMeals.splice(index, 1);
     if (removed) {
         removeMealMacros(removed, currentIntakeMacros);
-        renderPendingMacroChart();
+        loadCurrentIntake();
+        populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
         showToast('Храненето е изтрито.', false, 2000);
     }
 }

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -2,7 +2,7 @@
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
 import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressFill, getCssVar, formatDateBgShort } from './utils.js';
 import { generateId, standaloneMacroUrl } from './config.js';
-import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals } from './app.js';
+import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, loadCurrentIntake } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
 import { ensureChart } from './chartLoader.js';
 import { calculatePlanMacros, getNutrientOverride, addMealMacros, scaleMacros } from './macroUtils.js';
@@ -316,7 +316,8 @@ export function addExtraMealWithOverride(name = '', macros = {}, grams) {
     const entry = gramValue ? { ...scaled, grams: gramValue } : scaled;
     todaysExtraMeals.push(entry);
     addMealMacros(entry, currentIntakeMacros);
-    renderPendingMacroChart();
+    loadCurrentIntake();
+    populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
 }
 
 function renderMacroPreviewGrid(macros) {


### PR DESCRIPTION
## Резюме
- Обновяване на приема и макро данните при маркиране на хранене
- Пресмятане на макросите при добавяне или изтриване на извънредно хранене
- Изпращане на актуализираните макро стойности към вградения iframe

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f81055f9c8326b17ed689107349bf