### PR TITLE
refactor: embed macro analytics card via iframe

### DIFF
--- a/code.html
+++ b/code.html
@@ -1393,13 +1393,5 @@
     <!-- Коригирана JavaScript Връзка -->
     <script type="module" src="js/app.js" defer></script>
     <script type="module" src="js/planModChat.js" defer></script>
-    <script>
-      window.addEventListener('message', e => {
-        if (e.data?.type === 'macro-card-height') {
-          document.getElementById('macroAnalyticsCardFrame').style.height = `${e.data.height}px`;
-        }
-      });
-    </script>
-    
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load macro analytics through `macroAnalyticsCardStandalone.html` iframe
- send macro data to iframe after load and resize on postMessage
- streamline accordion toggle and update related tests

## Testing
- `npm run lint`
- `npm test` *(fails: workerEmail.test.js)*
- `NODE_OPTIONS=--experimental-vm-modules npx jest js/__tests__/macroCardStandaloneEmbed.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688f8b3be3048326959fa5d351aa5f77