### PR TITLE
Добавяне на текущи макроси за вътрешен пръстен

### DIFF
--- a/js/__tests__/macroAnalyticsCardInnerRing.test.js
+++ b/js/__tests__/macroAnalyticsCardInnerRing.test.js
@@ -1,0 +1,68 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+import { waitFor } from '@testing-library/dom';
+
+class ChartMock {
+  constructor(_ctx, config) {
+    this.config = config;
+    this.data = config.data;
+    this.destroy = jest.fn();
+    global.__lastChartInstance = this;
+  }
+}
+
+beforeEach(async () => {
+  jest.resetModules();
+  global.__lastChartInstance = null;
+  global.IntersectionObserver = class {
+    constructor(cb) { this.cb = cb; }
+    observe() { this.cb([{ isIntersecting: true }]); }
+    disconnect() {}
+  };
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      title: 'Калории и Макронутриенти',
+      caloriesLabel: 'Приети Калории',
+      macros: { protein: 'Белтъчини', carbs: 'Въглехидрати', fat: 'Мазнини', fiber: 'Фибри' },
+      fromGoal: 'от целта',
+      totalCaloriesLabel: 'от {calories} kcal',
+      exceedWarning: 'Превишение над 15%: {items}'
+    })
+  });
+  jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: async () => ChartMock }));
+  await import('../macroAnalyticsCardComponent.js');
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+test('рендерира вътрешен пръстен при текущи макроси', async () => {
+  const card = document.createElement('macro-analytics-card');
+  document.body.appendChild(card);
+  const target = {
+    calories: 2000,
+    protein_grams: 150,
+    protein_percent: 75,
+    carbs_grams: 250,
+    carbs_percent: 50,
+    fat_grams: 70,
+    fat_percent: 35,
+    fiber_grams: 30,
+    fiber_percent: 10
+  };
+  const current = {
+    calories: 1200,
+    protein_grams: 60,
+    carbs_grams: 100,
+    fat_grams: 40,
+    fiber_grams: 20
+  };
+  card.setData({ target, current });
+  await waitFor(() => {
+    expect(global.__lastChartInstance).toBeTruthy();
+    expect(global.__lastChartInstance.data.datasets.length).toBe(2);
+  });
+  expect(global.__lastChartInstance.data.datasets[1].cutout).toBe('65%');
+});

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -402,13 +402,20 @@ export async function populateDashboardMacros(macros) {
     const currentDayKey = dayNames[today.getDay()];
     const dayMenu = fullDashboardData?.planData?.week1Menu?.[currentDayKey] || [];
     const planMacros = calculatePlanMacros(dayMenu);
+    const current = {
+        calories: currentIntakeMacros.calories,
+        protein_grams: currentIntakeMacros.protein,
+        carbs_grams: currentIntakeMacros.carbs,
+        fat_grams: currentIntakeMacros.fat,
+        fiber_grams: currentIntakeMacros.fiber
+    };
+    const card = document.getElementById('macroAnalyticsCard');
+    if (card && typeof card.setData === 'function') {
+        card.setData({ target: macros, plan: planMacros, current });
+    }
     const frame = document.getElementById('macroAnalyticsCardFrame');
     if (frame) {
-        const payload = {
-            target: macros,
-            plan: planMacros,
-            current: currentIntakeMacros
-        };
+        const payload = { target: macros, plan: planMacros, current };
         const sendData = () => frame.contentWindow?.postMessage({ type: 'macro-data', data: payload }, '*');
         if (frame.contentWindow?.document?.readyState === 'complete') {
             sendData();


### PR DESCRIPTION
## Обобщение
- Трансформиране на текущите макроси до `*_grams` и подаването им към `macroAnalyticsCard` и вградената рамка.
- Добавен unit тест, който гарантира визуализация на вътрешния пръстен при наличие на текущи макроси.

## Тестове
- `npm run lint`
- `npm test js/__tests__/populateDashboardMacros.test.js js/__tests__/macroAnalyticsCardInnerRing.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688f910b8f0c8326816c8c1e89d93d6f