### PR TITLE
feat: refresh macro card subtitle and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ locales/
   "caloriesLabel": "Приети Калории",
   "macros": { "protein": "", "carbs": "", "fat": "" },
   "fromGoal": "от целта",
+  "subtitle": "{percent} от целта",
   "totalCaloriesLabel": "от {calories} kcal"
 }
 ```

--- a/js/__tests__/macroAnalyticsCardComponent.test.js
+++ b/js/__tests__/macroAnalyticsCardComponent.test.js
@@ -18,6 +18,7 @@ beforeEach(async () => {
       caloriesLabel: 'Приети Калории',
       macros: { protein: 'Белтъчини', carbs: 'Въглехидрати', fat: 'Мазнини' },
       fromGoal: 'от целта',
+      subtitle: '{percent} от целта',
       totalCaloriesLabel: 'от {calories} kcal',
       exceedWarning: 'Превишение над 15%: {items}'
     })
@@ -129,6 +130,7 @@ test('data-endpoint и refresh-interval извикват fetch периодич�
             caloriesLabel: 'Приети Калории',
             macros: { protein: 'Белтъчини', carbs: 'Въглехидрати', fat: 'Мазнини' },
             fromGoal: 'от целта',
+            subtitle: '{percent} от целта',
             totalCaloriesLabel: 'от {calories} kcal',
             exceedWarning: 'Превишение над 15%: {items}'
           })

--- a/js/__tests__/macroAnalyticsCardInnerRing.test.js
+++ b/js/__tests__/macroAnalyticsCardInnerRing.test.js
@@ -26,6 +26,7 @@ beforeEach(async () => {
       caloriesLabel: 'Приети Калории',
       macros: { protein: 'Белтъчини', carbs: 'Въглехидрати', fat: 'Мазнини', fiber: 'Фибри' },
       fromGoal: 'от целта',
+      subtitle: '{percent} от целта',
       totalCaloriesLabel: 'от {calories} kcal',
       exceedWarning: 'Превишение над 15%: {items}'
     })

--- a/js/__tests__/renderPendingMacroChart.test.js
+++ b/js/__tests__/renderPendingMacroChart.test.js
@@ -1,0 +1,60 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+describe('renderPendingMacroChart', () => {
+  let renderPendingMacroChart;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        title: '',
+        caloriesLabel: '',
+        macros: { protein: '', carbs: '', fat: '', fiber: '' },
+        fromGoal: 'от целта',
+        subtitle: '{percent} от целта',
+        totalCaloriesLabel: '',
+        exceedWarning: ''
+      })
+    });
+    document.body.innerHTML = `
+      <macro-analytics-card id="macroAnalyticsCard"></macro-analytics-card>
+      <iframe id="macroAnalyticsCardFrame"></iframe>
+    `;
+    await import('../macroAnalyticsCardComponent.js');
+    jest.unstable_mockModule('../uiElements.js', () => ({ selectors: {}, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
+    jest.unstable_mockModule('../utils.js', () => ({ safeGet: jest.fn(), safeParseFloat: jest.fn(), capitalizeFirstLetter: jest.fn(), escapeHtml: jest.fn(), applyProgressFill: jest.fn(), getCssVar: jest.fn(), formatDateBgShort: jest.fn() }));
+    jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id' }));
+    jest.unstable_mockModule('../app.js', () => ({ fullDashboardData: {}, todaysMealCompletionStatus: {}, currentIntakeMacros: {}, planHasRecContent: false, todaysExtraMeals: [], loadCurrentIntake: jest.fn() }));
+    jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
+    jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
+    jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn(), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
+    ({ renderPendingMacroChart } = await import('../populateUI.js'));
+  });
+
+  test('posts updated macro data to iframe on each render', () => {
+    const card = document.getElementById('macroAnalyticsCard');
+    card.renderChart = jest.fn();
+    card.chart = {};
+    card.targetData = { calories: 2000 };
+    card.planData = { calories: 1900 };
+    card.currentData = { calories: 1000 };
+    const frame = document.getElementById('macroAnalyticsCardFrame');
+    frame.contentWindow = { postMessage: jest.fn() };
+
+    renderPendingMacroChart();
+    expect(frame.contentWindow.postMessage).toHaveBeenCalledWith(
+      { type: 'macro-data', data: { target: card.targetData, plan: card.planData, current: card.currentData } },
+      '*'
+    );
+
+    frame.contentWindow.postMessage.mockClear();
+    card.currentData = { calories: 1500 };
+    renderPendingMacroChart();
+    expect(frame.contentWindow.postMessage).toHaveBeenCalledWith(
+      { type: 'macro-data', data: { target: card.targetData, plan: card.planData, current: card.currentData } },
+      '*'
+    );
+  });
+});

--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -191,6 +191,7 @@ export class MacroAnalyticsCard extends HTMLElement {
       caloriesLabel: '',
       macros: { protein: '', carbs: '', fat: '', fiber: '' },
       fromGoal: '',
+      subtitle: '',
       totalCaloriesLabel: '',
       exceedWarning: '',
       planVsTargetLabel: ''
@@ -422,6 +423,9 @@ export class MacroAnalyticsCard extends HTMLElement {
       const displayCurrent = typeof currentRaw === 'number' ? currentRaw : '--';
       const targetVal = target[`${item.key}_grams`];
       const percent = formatPercent(currentRaw / targetVal);
+      const subtitle = this.labels.subtitle
+        ? this.labels.subtitle.replace('{percent}', percent)
+        : `${percent} ${this.labels.fromGoal}`.trim();
       const div = document.createElement('div');
       div.className = `macro-metric ${item.key}`;
       if (typeof currentRaw === 'number' && typeof targetVal === 'number') {
@@ -432,13 +436,13 @@ export class MacroAnalyticsCard extends HTMLElement {
       }
       div.setAttribute('role', 'button');
       div.setAttribute('tabindex', '0');
-      div.setAttribute('aria-label', `${label}: ${displayCurrent} от ${targetVal} грама (${percent} ${this.labels.fromGoal})`);
+      div.setAttribute('aria-label', `${label}: ${displayCurrent} от ${targetVal} грама (${subtitle})`);
       div.setAttribute('aria-pressed', 'false');
       div.innerHTML = `
         <span class="macro-icon"><i class="bi ${item.icon}"></i></span>
         <div class="macro-label">${label}</div>
         <div class="macro-value">${displayCurrent} / ${targetVal}г</div>
-        <div class="macro-subtitle">${percent} ${this.labels.fromGoal}</div>`;
+        <div class="macro-subtitle">${subtitle}</div>`;
       div.addEventListener('click', () => this.highlightMacro(div, idx));
       div.addEventListener('keydown', (e) => {
         if (e.key === 'Enter' || e.key === ' ') {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -308,6 +308,15 @@ export function renderPendingMacroChart() {
     if (!macroCard || typeof macroCard.renderChart !== 'function') return;
     macroCard.renderChart();
     macroChartInstance = macroCard.chart || null;
+    const frame = document.getElementById('macroAnalyticsCardFrame');
+    if (frame?.contentWindow) {
+        const payload = {
+            target: macroCard.targetData,
+            plan: macroCard.planData,
+            current: macroCard.currentData
+        };
+        frame.contentWindow.postMessage({ type: 'macro-data', data: payload }, '*');
+    }
 }
 
 export function addExtraMealWithOverride(name = '', macros = {}, grams) {

--- a/locales/macroCard.bg.json
+++ b/locales/macroCard.bg.json
@@ -8,6 +8,7 @@
     "fiber": "Фибри"
   },
   "fromGoal": "от целта",
+  "subtitle": "{percent} от целта",
   "totalCaloriesLabel": "от {calories} kcal",
   "exceedWarning": "Превишение над 15%: {items}",
   "planVsTargetLabel": "План vs Цел: {plan} / {target} kcal"

--- a/locales/macroCard.en.json
+++ b/locales/macroCard.en.json
@@ -8,6 +8,7 @@
     "fiber": "Fiber"
   },
   "fromGoal": "of goal",
+  "subtitle": "{percent} of goal",
   "totalCaloriesLabel": "of {calories} kcal",
   "exceedWarning": "Exceeds target by >15%: {items}",
   "planVsTargetLabel": "Plan vs Goal: {plan} / {target} kcal"

--- a/macroAnalyticsCardStandalone.html
+++ b/macroAnalyticsCardStandalone.html
@@ -221,6 +221,7 @@
           caloriesLabel: '',
           macros: { protein: '', carbs: '', fat: '' },
           fromGoal: '',
+          subtitle: '',
           totalCaloriesLabel: ''
         };
       }
@@ -374,18 +375,23 @@
           const label = this.labels.macros[item.key];
           const currentVal = current[`${item.key}_grams`];
           const targetVal = target[`${item.key}_grams`];
-          const percent = target[`${item.key}_percent`];
+          const ratio = targetVal ? currentVal / targetVal : 0;
+          const percent = Math.round(ratio * 100);
+          const percentText = `${percent}%`;
+          const subtitle = this.labels.subtitle
+            ? this.labels.subtitle.replace('{percent}', percentText)
+            : `${percentText} ${this.labels.fromGoal}`.trim();
           const div = document.createElement('div');
           div.className = `macro-metric ${item.key}`;
           div.setAttribute('role', 'button');
           div.setAttribute('tabindex', '0');
-          div.setAttribute('aria-label', `${label}: ${currentVal} от ${targetVal} грама (${percent}% ${this.labels.fromGoal})`);
+          div.setAttribute('aria-label', `${label}: ${currentVal} от ${targetVal} грама (${subtitle})`);
           div.setAttribute('aria-pressed', 'false');
           div.innerHTML = `
             <span class="macro-icon"><i class="bi ${item.icon}"></i></span>
             <div class="macro-label">${label}</div>
             <div class="macro-value">${currentVal} / ${targetVal}г</div>
-            <div class="macro-subtitle">${percent}% ${this.labels.fromGoal}</div>`;
+            <div class="macro-subtitle">${subtitle}</div>`;
           const diff = currentVal - targetVal;
           if (diff > 0) {
             div.classList.add('over');


### PR DESCRIPTION
## Summary
- rephrase macro card subtitle via locale template
- re-post macro data to iframe whenever chart re-renders
- add regression test for iframe updates

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: workerEmail.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688f9621310c832695f5cae083a94793