### PR TITLE
Replace macro analytics iframe with web component

### DIFF
--- a/code.html
+++ b/code.html
@@ -55,6 +55,7 @@
       import { loadAndApplyColors } from './js/uiHandlers.js';
       loadAndApplyColors();
     </script>
+    <script type="module" src="js/macroAnalyticsCardComponent.js"></script>
     <!-- Chart.js - зарежда се в края на body за по-добра производителност -->
   </head>
   <body class="code-page">
@@ -524,11 +525,11 @@
                   </div>
                 </div>
                 <div id="analyticsCardsContainer" class="analytics-cards-grid">
-                  <iframe id="macroAnalyticsCardFrame"
-                          class="analytics-card"
-                          src="macroAnalyticsCardStandalone.html"
-                          title="Макро анализ">
-                  </iframe>
+                  <macro-analytics-card
+                      id="macroAnalyticsCard"
+                      locale="bg"
+                      exceed-threshold="1.2">
+                  </macro-analytics-card>
                 </div>
               </div>
             </div>

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -86,14 +86,6 @@ export function updateProgressChartColors() {
 
 document.addEventListener('progressChartThemeChange', updateProgressChartColors);
 
-// Управление на postMessage съобщенията от iframe за макро анализ
-window.addEventListener('message', (event) => {
-    const frame = document.getElementById('macroAnalyticsCardFrame');
-    if (event.source === frame?.contentWindow && event.data?.type === 'macro-card-height') {
-        frame.style.height = `${event.data.height}px`;
-    }
-});
-
 export async function populateUI() {
     const data = fullDashboardData; // Access global state
     if (!data || Object.keys(data).length === 0) {
@@ -308,15 +300,6 @@ export function renderPendingMacroChart() {
     if (!macroCard || typeof macroCard.renderChart !== 'function') return;
     macroCard.renderChart();
     macroChartInstance = macroCard.chart || null;
-    const frame = document.getElementById('macroAnalyticsCardFrame');
-    if (frame?.contentWindow) {
-        const payload = {
-            target: macroCard.targetData,
-            plan: macroCard.planData,
-            current: macroCard.currentData
-        };
-        frame.contentWindow.postMessage({ type: 'macro-data', data: payload }, '*');
-    }
 }
 
 export function addExtraMealWithOverride(name = '', macros = {}, grams) {
@@ -421,16 +404,6 @@ export async function populateDashboardMacros(macros) {
     const card = document.getElementById('macroAnalyticsCard');
     if (card && typeof card.setData === 'function') {
         card.setData({ target: macros, plan: planMacros, current });
-    }
-    const frame = document.getElementById('macroAnalyticsCardFrame');
-    if (frame) {
-        const payload = { target: macros, plan: planMacros, current };
-        const sendData = () => frame.contentWindow?.postMessage({ type: 'macro-data', data: payload }, '*');
-        if (frame.contentWindow?.document?.readyState === 'complete') {
-            sendData();
-        } else {
-            frame.addEventListener('load', sendData, { once: true });
-        }
     }
     renderPendingMacroChart();
 }


### PR DESCRIPTION
## Summary
- swap iframe macro analytics card for native `macro-analytics-card` component and load its module
- simplify `populateUI` by removing iframe messaging and using component APIs only

## Testing
- `npm run lint`
- `npm test` *(fails: workerEmail, passwordReset, extraMealFormSubmit, renderPendingMacroChart, populateDashboardMacros, extraMealNutrientLookup, extraMealAutofill, macroCardStandaloneEmbed, registerEmail, macroCardLocales, workerBackendCache, loadCurrentIntake, getProgressColor, login, submitQuestionnaireEmailFlag, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688fa7928a248326ad2e7f0ad1f45680