### PR TITLE
Wrap macro analytics iframe in card container

### DIFF
--- a/code.html
+++ b/code.html
@@ -524,11 +524,11 @@
                   </div>
                 </div>
                 <div id="analyticsCardsContainer" class="analytics-cards-grid">
-                  <iframe id="macroAnalyticsCardFrame"
-                          class="analytics-card"
-                          src="macroAnalyticsCardStandalone.html"
-                          title="Макро анализ">
-                  </iframe>
+                  <div class="card analytics-card">
+                    <iframe id="macroAnalyticsCardFrame"
+                            src="macroAnalyticsCardStandalone.html"
+                            title="Макро анализ"></iframe>
+                  </div>
                 </div>
               </div>
             </div>

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -169,6 +169,10 @@ body.vivid-theme .index-card .index-value {
 }
 .analytics-card { cursor: pointer; transition: transform 0.3s ease; }
 .analytics-card.open { transform: scale(1.03); }
+.analytics-card iframe {
+  width: 100%;
+  border: 0;
+}
 .metric-current-text {
   margin-bottom: var(--space-sm);
   font-weight: 600;


### PR DESCRIPTION
## Summary
- wrap macro analytics iframe in card container for grid layout
- ensure analytics iframe fills card width

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688faabef29483269cb21185e0702ca0