### PR TITLE
Preserve macro analytics card in dashboard

### DIFF
--- a/js/__tests__/populateDashboardDetailedAnalytics.retainMacroFrame.test.js
+++ b/js/__tests__/populateDashboardDetailedAnalytics.retainMacroFrame.test.js
@@ -1,0 +1,74 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let populateDashboardDetailedAnalytics;
+
+beforeEach(async () => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <div id="analyticsCardsContainer">
+      <div class="card analytics-card">
+        <iframe id="macroAnalyticsCardFrame"></iframe>
+      </div>
+    </div>
+    <div id="detailedAnalyticsContent"></div>
+    <div id="dashboardTextualAnalysis"></div>
+    <div id="detailedAnalyticsAccordion"><div class="accordion-header" aria-expanded="false"><svg class="arrow"></svg></div></div>
+  `;
+  const selectors = {
+    analyticsCardsContainer: document.getElementById('analyticsCardsContainer'),
+    detailedAnalyticsContent: document.getElementById('detailedAnalyticsContent'),
+    dashboardTextualAnalysis: document.getElementById('dashboardTextualAnalysis'),
+    detailedAnalyticsAccordion: document.getElementById('detailedAnalyticsAccordion')
+  };
+  jest.unstable_mockModule('../uiElements.js', () => ({
+    selectors,
+    trackerInfoTexts: {},
+    detailedMetricInfoTexts: {}
+  }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    showToast: jest.fn(),
+    closeModal: jest.fn(),
+    displayPlanModChatTypingIndicator: jest.fn(),
+    openModal: jest.fn(),
+    showLoading: jest.fn()
+  }));
+  jest.unstable_mockModule('../extraMealForm.js', () => ({ openExtraMealModal: jest.fn() }));
+  jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id-1' }));
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: {},
+    todaysMealCompletionStatus: {},
+    todaysExtraMeals: [],
+    currentIntakeMacros: {},
+    planHasRecContent: false,
+    loadCurrentIntake: jest.fn()
+  }));
+  jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({
+    calculatePlanMacros: jest.fn(),
+    getNutrientOverride: jest.fn(),
+    addMealMacros: jest.fn(),
+    scaleMacros: jest.fn()
+  }));
+  ({ populateDashboardDetailedAnalytics } = await import('../populateUI.js'));
+});
+
+test('запазва макро iframe и добавя нови карти', () => {
+  const data = {
+    detailed: [
+      {
+        label: 'Тест',
+        currentValueText: '10',
+        initialValueText: '0',
+        expectedValueText: '20',
+        currentValueNumeric: 5
+      }
+    ]
+  };
+  populateDashboardDetailedAnalytics(data);
+  const frame = document.getElementById('macroAnalyticsCardFrame');
+  expect(frame).not.toBeNull();
+  const cards = document.querySelectorAll('#analyticsCardsContainer .analytics-card');
+  expect(cards.length).toBe(2);
+  expect(cards[0].contains(frame)).toBe(true);
+});

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -179,7 +179,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
     }
 }
 
-function populateDashboardDetailedAnalytics(analyticsData) {
+export function populateDashboardDetailedAnalytics(analyticsData) {
     const cardsContainer = selectors.analyticsCardsContainer;
     const accordionContent = selectors.detailedAnalyticsContent;
     const textualAnalysisContainer = selectors.dashboardTextualAnalysis;
@@ -188,7 +188,12 @@ function populateDashboardDetailedAnalytics(analyticsData) {
         console.warn("Detailed analytics elements for dashboard not found.");
         return;
     }
+
+    const macroCard = cardsContainer
+        .querySelector('#macroAnalyticsCardFrame')?.closest('.analytics-card');
+
     cardsContainer.innerHTML = '';
+    if (macroCard) cardsContainer.appendChild(macroCard);
     textualAnalysisContainer.innerHTML = '';
 
 
@@ -283,7 +288,7 @@ function populateDashboardDetailedAnalytics(analyticsData) {
 
             cardsContainer.appendChild(card);
         });
-    } else {
+    } else if (!macroCard) {
         cardsContainer.innerHTML = '<p class="placeholder">Няма налични детайлни показатели за показване.</p>';
     }
 


### PR DESCRIPTION
## Summary
- keep the standalone macro analytics iframe when rebuilding detailed analytics cards
- expose helper to allow testing and add coverage for macro card retention

## Testing
- `npm run lint`
- `npm test`
- `NODE_OPTIONS=--experimental-vm-modules npx --no-install jest js/__tests__/populateDashboardDetailedAnalytics.retainMacroFrame.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688facdf9a308326bd5853240da4f814