### PR TITLE
Интеграция на самостоятелната макро карта в таблото

### DIFF
--- a/code.html
+++ b/code.html
@@ -524,11 +524,7 @@
                   </div>
                 </div>
                 <div id="analyticsCardsContainer" class="analytics-cards-grid">
-                  <div class="card analytics-card">
-                    <iframe id="macroAnalyticsCardFrame"
-                            src="macroAnalyticsCardStandalone.html"
-                            title="Макро анализ"></iframe>
-                  </div>
+                  <div id="macroAnalyticsCardContainer" class="card analytics-card"></div>
                 </div>
               </div>
             </div>

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,7 +1,7 @@
 // populateUI.js - Попълване на UI с данни
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
 import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressFill, getCssVar, formatDateBgShort } from './utils.js';
-import { generateId } from './config.js';
+import { generateId, standaloneMacroUrl } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, loadCurrentIntake } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
 import { ensureChart } from './chartLoader.js';
@@ -422,7 +422,16 @@ export async function populateDashboardMacros(macros) {
     if (card && typeof card.setData === 'function') {
         card.setData({ target: macros, plan: planMacros, current });
     }
-    const frame = document.getElementById('macroAnalyticsCardFrame');
+    let frame = document.getElementById('macroAnalyticsCardFrame');
+    if (!frame && selectors.macroAnalyticsCardContainer) {
+        frame = document.createElement('iframe');
+        frame.id = 'macroAnalyticsCardFrame';
+        frame.title = 'Макро анализ';
+        frame.loading = 'lazy';
+        frame.src = standaloneMacroUrl;
+        selectors.macroAnalyticsCardContainer.innerHTML = '';
+        selectors.macroAnalyticsCardContainer.appendChild(frame);
+    }
     if (frame) {
         const payload = { target: macros, plan: planMacros, current };
         const sendData = () => frame.contentWindow?.postMessage({ type: 'macro-data', data: payload }, '*');

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -47,6 +47,7 @@ export function initializeSelectors() {
         streakGrid: 'streakGrid',
         achievementShareBtn: 'achievementShareBtn',
         analyticsCardsContainer: 'analyticsCardsContainer',
+        macroAnalyticsCardContainer: 'macroAnalyticsCardContainer',
         macroAnalyticsCardFrame: 'macroAnalyticsCardFrame',
         macroMetricsGrid: 'macroMetricsGrid',
         macroMetricsPreview: 'macroMetricsPreview',
@@ -75,7 +76,7 @@ export function initializeSelectors() {
                 'planModChatSend', 'planModChatClose', 'planModChatClear',
                 'streakGrid', 'analyticsCardsContainer', 'achievementShareBtn',
                 'goalCard', 'engagementCard', 'healthCard', 'streakCard',
-                'macroAnalyticsCardFrame', 'macroMetricsGrid',
+                'macroAnalyticsCardContainer', 'macroAnalyticsCardFrame', 'macroMetricsGrid',
                 'macroMetricsPreview',
                 'recFoodAllowedCard', 'recFoodLimitCard', 'recHydrationCard',
                 'recCookingMethodsCard', 'recSupplementsCard'


### PR DESCRIPTION
## Обобщение
- Добавен е контейнер в `code.html`, където динамично се зарежда `macroAnalyticsCardStandalone.html`.
- Актуализиран е `uiElements.js` с нов селектор за контейнера и е отбелязан като динамичен.
- `populateUI.js` вече създава iframe при нужда и подава макро данни към него.

## Тестове
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688facdf9a308326bd5853240da4f814