### PR TITLE
Интеграция на самостоятелната макро карта в таблото

### DIFF
--- a/code.html
+++ b/code.html
@@ -524,11 +524,7 @@
                   </div>
                 </div>
                 <div id="analyticsCardsContainer" class="analytics-cards-grid">
-                  <div class="card analytics-card">
-                    <iframe id="macroAnalyticsCardFrame"
-                            src="macroAnalyticsCardStandalone.html"
-                            title="Макро анализ"></iframe>
-                  </div>
+                  <div id="macroAnalyticsCardContainer" class="card analytics-card"></div>
                 </div>
               </div>
             </div>

--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -11,7 +11,7 @@ beforeAll(async () => {
 });
 
 function setupDom() {
-  document.body.innerHTML = '<div id="macroMetricsPreview"></div><div id="analyticsCardsContainer"><iframe id="macroAnalyticsCardFrame"></iframe><div id="macroAnalyticsCard"></div></div>';
+  document.body.innerHTML = '<div id="macroMetricsPreview"></div><div id="analyticsCardsContainer"><iframe id="macroAnalyticsCardFrame"></iframe></div>';
   selectors.macroMetricsPreview = document.getElementById('macroMetricsPreview');
   selectors.analyticsCardsContainer = document.getElementById('analyticsCardsContainer');
 }
@@ -37,14 +37,11 @@ test('placeholder shown when macros missing and populates after migration', asyn
     { id: 'o-01', meal_name: 'Печено пилешко с ориз/картофи и салата' }
   ];
   appState.fullDashboardData.planData = { week1Menu: { [currentDayKey]: dayMenu } };
-  const card = document.getElementById('macroAnalyticsCard');
-  card.setData = jest.fn();
-  await populateDashboardMacros(macros);
-  expect(selectors.macroMetricsPreview.classList.contains('hidden')).toBe(false);
-  expect(selectors.macroMetricsPreview.textContent).toContain('1800');
   const frame = document.getElementById('macroAnalyticsCardFrame');
   Object.defineProperty(frame, 'contentWindow', { value: { postMessage: jest.fn(), document: { readyState: 'complete' } } });
   await populateDashboardMacros(macros);
+  expect(selectors.macroMetricsPreview.classList.contains('hidden')).toBe(false);
+  expect(selectors.macroMetricsPreview.textContent).toContain('1800');
   expect(frame.contentWindow.postMessage).toHaveBeenCalled();
   const expectedCurrent = {
     calories: appState.currentIntakeMacros.calories,
@@ -53,7 +50,6 @@ test('placeholder shown when macros missing and populates after migration', asyn
     fat_grams: appState.currentIntakeMacros.fat,
     fiber_grams: appState.currentIntakeMacros.fiber
   };
-  expect(card.setData).toHaveBeenCalledWith({ target: macros, plan: expect.anything(), current: expectedCurrent });
   const [msg, origin] = frame.contentWindow.postMessage.mock.calls[0];
   expect(origin).toBe('*');
   expect(msg).toMatchObject({

--- a/js/__tests__/renderPendingMacroChart.test.js
+++ b/js/__tests__/renderPendingMacroChart.test.js
@@ -3,57 +3,49 @@ import { jest } from '@jest/globals';
 
 describe('renderPendingMacroChart', () => {
   let renderPendingMacroChart;
+  let populateDashboardMacros;
+  let appState;
 
   beforeEach(async () => {
     jest.resetModules();
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        title: '',
-        caloriesLabel: '',
-        macros: { protein: '', carbs: '', fat: '', fiber: '' },
-        fromGoal: 'от целта',
-        subtitle: '{percent} от целта',
-        totalCaloriesLabel: '',
-        exceedWarning: ''
-      })
-    });
     document.body.innerHTML = `
-      <macro-analytics-card id="macroAnalyticsCard"></macro-analytics-card>
-      <iframe id="macroAnalyticsCardFrame"></iframe>
+      <div id="macroMetricsPreview"></div>
+      <div id="analyticsCardsContainer"><iframe id="macroAnalyticsCardFrame"></iframe></div>
     `;
-    await import('../macroAnalyticsCardComponent.js');
-    jest.unstable_mockModule('../uiElements.js', () => ({ selectors: {}, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
+    const selectors = {
+      macroMetricsPreview: document.getElementById('macroMetricsPreview'),
+      analyticsCardsContainer: document.getElementById('analyticsCardsContainer'),
+    };
+    jest.unstable_mockModule('../uiElements.js', () => ({ selectors, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
     jest.unstable_mockModule('../utils.js', () => ({ safeGet: jest.fn(), safeParseFloat: jest.fn(), capitalizeFirstLetter: jest.fn(), escapeHtml: jest.fn(), applyProgressFill: jest.fn(), getCssVar: jest.fn(), formatDateBgShort: jest.fn() }));
-    jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id' }));
-    jest.unstable_mockModule('../app.js', () => ({ fullDashboardData: {}, todaysMealCompletionStatus: {}, currentIntakeMacros: {}, planHasRecContent: false, todaysExtraMeals: [], loadCurrentIntake: jest.fn() }));
+    jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id', standaloneMacroUrl: 'macroAnalyticsCardStandalone.html' }));
+    jest.unstable_mockModule('../app.js', () => ({ fullDashboardData: {}, todaysMealCompletionStatus: {}, currentIntakeMacros: { calories: 1000, protein: 0, carbs: 0, fat: 0, fiber: 0 }, planHasRecContent: false, todaysExtraMeals: [], loadCurrentIntake: jest.fn() }));
     jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
     jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
-    jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn(), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
-    ({ renderPendingMacroChart } = await import('../populateUI.js'));
+    jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn().mockReturnValue({ calories: 850, protein: 72, carbs: 70, fat: 28 }), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
+    appState = await import('../app.js');
+    const mod = await import('../populateUI.js');
+    ({ renderPendingMacroChart, populateDashboardMacros } = mod);
   });
 
-  test('posts updated macro data to iframe on each render', () => {
-    const card = document.getElementById('macroAnalyticsCard');
-    card.renderChart = jest.fn();
-    card.chart = {};
-    card.targetData = { calories: 2000 };
-    card.planData = { calories: 1900 };
-    card.currentData = { calories: 1000 };
+  test('posts updated macro data to iframe on each render', async () => {
     const frame = document.getElementById('macroAnalyticsCardFrame');
-    frame.contentWindow = { postMessage: jest.fn() };
-
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage: jest.fn(), document: { readyState: 'complete' } } });
+    const macros = { calories: 1800, protein_percent: 30, carbs_percent: 40, fat_percent: 30, protein_grams: 135, carbs_grams: 180, fat_grams: 60 };
+    await populateDashboardMacros(macros);
+    frame.contentWindow.postMessage.mockClear();
     renderPendingMacroChart();
     expect(frame.contentWindow.postMessage).toHaveBeenCalledWith(
-      { type: 'macro-data', data: { target: card.targetData, plan: card.planData, current: card.currentData } },
+      { type: 'macro-data', data: expect.objectContaining({ target: macros }) },
       '*'
     );
 
+    appState.currentIntakeMacros.calories = 1500;
+    await populateDashboardMacros(macros);
     frame.contentWindow.postMessage.mockClear();
-    card.currentData = { calories: 1500 };
     renderPendingMacroChart();
     expect(frame.contentWindow.postMessage).toHaveBeenCalledWith(
-      { type: 'macro-data', data: { target: card.targetData, plan: card.planData, current: card.currentData } },
+      { type: 'macro-data', data: expect.objectContaining({ current: expect.objectContaining({ calories: 1500 }) }) },
       '*'
     );
   });

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -47,6 +47,7 @@ export function initializeSelectors() {
         streakGrid: 'streakGrid',
         achievementShareBtn: 'achievementShareBtn',
         analyticsCardsContainer: 'analyticsCardsContainer',
+        macroAnalyticsCardContainer: 'macroAnalyticsCardContainer',
         macroAnalyticsCardFrame: 'macroAnalyticsCardFrame',
         macroMetricsGrid: 'macroMetricsGrid',
         macroMetricsPreview: 'macroMetricsPreview',
@@ -75,7 +76,7 @@ export function initializeSelectors() {
                 'planModChatSend', 'planModChatClose', 'planModChatClear',
                 'streakGrid', 'analyticsCardsContainer', 'achievementShareBtn',
                 'goalCard', 'engagementCard', 'healthCard', 'streakCard',
-                'macroAnalyticsCardFrame', 'macroMetricsGrid',
+                'macroAnalyticsCardContainer', 'macroAnalyticsCardFrame', 'macroMetricsGrid',
                 'macroMetricsPreview',
                 'recFoodAllowedCard', 'recFoodLimitCard', 'recHydrationCard',
                 'recCookingMethodsCard', 'recSupplementsCard'


### PR DESCRIPTION
## Обобщение
- Обновена е логиката за макро картата: iframe получава данни чрез `postMessage`, а последният пакет се пази за последващи обновявания.
- Тестовете са адаптирани към iframe варианта, за да се проверява коректното подаване на данни.

## Тестове
- `npm run lint`
- `npm test` *(няколко съществуващи теста се провалят: workerEmail.test.js, extraMealFormSubmit.test.js и други)*

------
https://chatgpt.com/codex/tasks/task_e_688facdf9a308326bd5853240da4f814