### PR TITLE
fix: ensure macro analytics container exists

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -392,10 +392,13 @@ function renderMacroPreviewGrid(macros) {
 
 export async function populateDashboardMacros(macros) {
     renderMacroPreviewGrid(macros);
-    const macroContainer = selectors.macroAnalyticsCardContainer;
-    if (!macroContainer || !macroContainer.isConnected) {
-        console.warn('Macro analytics container not found in DOM.');
-        return;
+    let macroContainer = selectors.macroAnalyticsCardContainer;
+    if (!macroContainer || !document.contains(macroContainer)) {
+        macroContainer = document.createElement('div');
+        macroContainer.id = 'macroAnalyticsCardContainer';
+        macroContainer.className = 'card analytics-card';
+        selectors.analyticsCardsContainer?.appendChild(macroContainer);
+        selectors.macroAnalyticsCardContainer = macroContainer;
     }
     if (!macros) {
         console.warn('Macros data is missing.');
@@ -414,15 +417,17 @@ export async function populateDashboardMacros(macros) {
         fiber_grams: currentIntakeMacros.fiber
     };
     let frame = document.getElementById('macroAnalyticsCardFrame');
-    if (!frame) {
-        frame = document.createElement('iframe');
-        frame.id = 'macroAnalyticsCardFrame';
-        frame.title = 'Макро анализ';
-        frame.loading = 'lazy';
-        frame.style.width = '100%';
-        frame.style.border = '0';
-        frame.style.display = 'block';
-        frame.src = standaloneMacroUrl;
+    if (!frame || !macroContainer.contains(frame)) {
+        if (!frame) {
+            frame = document.createElement('iframe');
+            frame.id = 'macroAnalyticsCardFrame';
+            frame.title = 'Макро анализ';
+            frame.loading = 'lazy';
+            frame.style.width = '100%';
+            frame.style.border = '0';
+            frame.style.display = 'block';
+            frame.src = standaloneMacroUrl;
+        }
         macroContainer.innerHTML = '';
         macroContainer.appendChild(frame);
     }


### PR DESCRIPTION
## Summary
- handle missing macro analytics container by creating a new card on the fly
- cover populateDashboardMacros edge cases when container is missing or detached

## Testing
- `npm run lint`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688fb8d83db08326bb1674ed5f06f12c