### PR TITLE
Отложено зареждане на макро графиката

### DIFF
--- a/js/__tests__/populateDashboardMacros.missingComponent.test.js
+++ b/js/__tests__/populateDashboardMacros.missingComponent.test.js
@@ -45,7 +45,7 @@ test('създава контейнер, ако липсва макро анал
   expect(container).not.toBeNull();
   expect(selectors.analyticsCardsContainer.contains(container)).toBe(true);
   const frame = container.querySelector('#macroAnalyticsCardFrame');
-  expect(frame).not.toBeNull();
+  expect(frame).toBeNull();
 });
 
 test('пресъздава контейнер, когато е извън DOM', async () => {

--- a/js/__tests__/renderPendingMacroChart.test.js
+++ b/js/__tests__/renderPendingMacroChart.test.js
@@ -5,14 +5,15 @@ describe('renderPendingMacroChart', () => {
   let renderPendingMacroChart;
   let populateDashboardMacros;
   let appState;
+  let selectors;
 
   beforeEach(async () => {
     jest.resetModules();
     document.body.innerHTML = `
       <div id="macroMetricsPreview"></div>
-      <div id="analyticsCardsContainer"><iframe id="macroAnalyticsCardFrame"></iframe></div>
+      <div id="analyticsCardsContainer"></div>
     `;
-    const selectors = {
+    selectors = {
       macroMetricsPreview: document.getElementById('macroMetricsPreview'),
       analyticsCardsContainer: document.getElementById('analyticsCardsContainer'),
     };
@@ -29,11 +30,12 @@ describe('renderPendingMacroChart', () => {
   });
 
   test('posts updated macro data to iframe on each render', async () => {
-    const frame = document.getElementById('macroAnalyticsCardFrame');
-    Object.defineProperty(frame, 'contentWindow', { value: { postMessage: jest.fn(), document: { readyState: 'complete' } } });
     const macros = { calories: 1800, protein_percent: 30, carbs_percent: 40, fat_percent: 30, protein_grams: 135, carbs_grams: 180, fat_grams: 60 };
     await populateDashboardMacros(macros);
-    frame.contentWindow.postMessage.mockClear();
+    const frame = document.createElement('iframe');
+    frame.id = 'macroAnalyticsCardFrame';
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage: jest.fn(), document: { readyState: 'complete' } } });
+    selectors.macroAnalyticsCardContainer.appendChild(frame);
     renderPendingMacroChart();
     expect(frame.contentWindow.postMessage).toHaveBeenCalledWith(
       { type: 'macro-data', data: expect.objectContaining({ target: macros }) },

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -9,8 +9,8 @@ import {
 } from './uiHandlers.js';
 import { handleLogout } from './auth.js';
 import { openExtraMealModal } from './extraMealForm.js';
-import { apiEndpoints } from './config.js';
-import { macroChartInstance, progressChartInstance, renderPendingMacroChart, populateDashboardMacros } from './populateUI.js';
+import { apiEndpoints, standaloneMacroUrl } from './config.js';
+import { macroChartInstance, progressChartInstance, populateDashboardMacros, lastMacroPayload } from './populateUI.js';
 import {
     handleSaveLog, handleFeedbackFormSubmit, // from app.js
     handleChatSend, handleChatInputKeypress, // from app.js / chat.js
@@ -132,7 +132,22 @@ export function setupStaticEventListeners() {
                 if (preview) preview.style.display = isOpen ? 'grid' : 'none';
                 selectors.detailedAnalyticsAccordion.classList.toggle('index-card', isOpen);
                 if (!isOpen) {
-                    renderPendingMacroChart();
+                    let frame = document.getElementById('macroAnalyticsCardFrame');
+                    if (!frame) {
+                        frame = document.createElement('iframe');
+                        frame.id = 'macroAnalyticsCardFrame';
+                        frame.title = 'Макро анализ';
+                        frame.loading = 'lazy';
+                        frame.style.width = '100%';
+                        frame.style.border = '0';
+                        frame.style.display = 'block';
+                        frame.src = standaloneMacroUrl;
+                        selectors.macroAnalyticsCardContainer.innerHTML = '';
+                        selectors.macroAnalyticsCardContainer.appendChild(frame);
+                    }
+                    const sendData = () => frame.contentWindow?.postMessage({ type: 'macro-data', data: lastMacroPayload }, '*');
+                    if (frame.contentWindow?.document?.readyState === 'complete') sendData();
+                    else frame.addEventListener('load', sendData, { once: true });
                     macroChartInstance?.resize();
                     progressChartInstance?.resize();
                 }
@@ -146,7 +161,22 @@ export function setupStaticEventListeners() {
                     if (preview) preview.style.display = isOpen ? 'grid' : 'none';
                     selectors.detailedAnalyticsAccordion.classList.toggle('index-card', isOpen);
                     if (!isOpen) {
-                        renderPendingMacroChart();
+                        let frame = document.getElementById('macroAnalyticsCardFrame');
+                        if (!frame) {
+                            frame = document.createElement('iframe');
+                            frame.id = 'macroAnalyticsCardFrame';
+                            frame.title = 'Макро анализ';
+                            frame.loading = 'lazy';
+                            frame.style.width = '100%';
+                            frame.style.border = '0';
+                            frame.style.display = 'block';
+                            frame.src = standaloneMacroUrl;
+                            selectors.macroAnalyticsCardContainer.innerHTML = '';
+                            selectors.macroAnalyticsCardContainer.appendChild(frame);
+                        }
+                        const sendData = () => frame.contentWindow?.postMessage({ type: 'macro-data', data: lastMacroPayload }, '*');
+                        if (frame.contentWindow?.document?.readyState === 'complete') sendData();
+                        else frame.addEventListener('load', sendData, { once: true });
                         macroChartInstance?.resize();
                         progressChartInstance?.resize();
                     }

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,7 +1,7 @@
 // populateUI.js - Попълване на UI с данни
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
 import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressFill, getCssVar, formatDateBgShort } from './utils.js';
-import { generateId, standaloneMacroUrl } from './config.js';
+import { generateId } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, loadCurrentIntake } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
 import { ensureChart } from './chartLoader.js';
@@ -9,7 +9,7 @@ import { calculatePlanMacros, getNutrientOverride, addMealMacros, scaleMacros } 
 
 export let macroChartInstance = null;
 export let progressChartInstance = null;
-let lastMacroPayload = null;
+export let lastMacroPayload = null;
 
 // Helper for tests to inject chart instance
 export function __setProgressChartInstance(instance) {
@@ -416,27 +416,8 @@ export async function populateDashboardMacros(macros) {
         fat_grams: currentIntakeMacros.fat,
         fiber_grams: currentIntakeMacros.fiber
     };
-    let frame = document.getElementById('macroAnalyticsCardFrame');
-    if (!frame || !macroContainer.contains(frame)) {
-        if (!frame) {
-            frame = document.createElement('iframe');
-            frame.id = 'macroAnalyticsCardFrame';
-            frame.title = 'Макро анализ';
-            frame.loading = 'lazy';
-            frame.style.width = '100%';
-            frame.style.border = '0';
-            frame.style.display = 'block';
-            frame.src = standaloneMacroUrl;
-        }
-        macroContainer.innerHTML = '';
-        macroContainer.appendChild(frame);
-    }
-    if (frame) {
-        lastMacroPayload = { target: macros, plan: planMacros, current };
-        const sendData = () => frame.contentWindow?.postMessage({ type: 'macro-data', data: lastMacroPayload }, '*');
-        if (frame.contentWindow?.document?.readyState === 'complete') sendData();
-        else frame.addEventListener('load', sendData, { once: true });
-    }
+    lastMacroPayload = { target: macros, plan: planMacros, current };
+    renderPendingMacroChart();
 }
 
 function populateDashboardStreak(streakData) {


### PR DESCRIPTION
## Резюме
- Премахнато автоматичното създаване на iframe в populateDashboardMacros и запазване единствено на последния payload
- Създаване на iframe при отваряне на секцията и изпращане на lastMacroPayload чрез postMessage
- Актуализирани тестове за новото поведение при зареждане на макро картата

## Тестване
- `npm run lint`
- `npm test` *(грешки в workerEmail.test.js, passwordReset.test.js, extraMealFormSubmit.test.js, loadProductMacrosInit.test.js)*
- `npm test js/__tests__/renderPendingMacroChart.test.js`
- `npm test js/__tests__/populateDashboardMacros.test.js`
- `npm test js/__tests__/populateDashboardMacros.missingComponent.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688fbbada16883268b4c9b9ecab2b848