### PR TITLE
Автоматично опресняване на макро-картата

### DIFF
--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -10,7 +10,13 @@ import {
 import { handleLogout } from './auth.js';
 import { openExtraMealModal } from './extraMealForm.js';
 import { apiEndpoints, standaloneMacroUrl } from './config.js';
-import { macroChartInstance, progressChartInstance, populateDashboardMacros, lastMacroPayload } from './populateUI.js';
+import {
+    macroChartInstance,
+    progressChartInstance,
+    populateDashboardMacros,
+    lastMacroPayload,
+    renderPendingMacroChart
+} from './populateUI.js';
 import {
     handleSaveLog, handleFeedbackFormSubmit, // from app.js
     handleChatSend, handleChatInputKeypress, // from app.js / chat.js
@@ -376,6 +382,8 @@ function handleDelegatedClicks(event) {
             }
             loadCurrentIntake();
             populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
+            // Автоматично опресняване на макро-картата
+            renderPendingMacroChart();
             showToast(`Храненето е ${isCompleted ? 'отбелязано' : 'размаркирано'}.`, false, 2000);
         }
         return;

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -5,7 +5,11 @@ import { apiEndpoints } from './config.js';
 import { currentUserId, todaysExtraMeals, currentIntakeMacros, fullDashboardData, loadCurrentIntake } from './app.js';
 import nutrientOverrides from '../kv/DIET_RESOURCES/nutrient_overrides.json' with { type: 'json' };
 import { removeMealMacros, registerNutrientOverrides, getNutrientOverride, loadProductMacros } from './macroUtils.js';
-import { addExtraMealWithOverride, populateDashboardMacros } from './populateUI.js';
+import {
+    addExtraMealWithOverride,
+    populateDashboardMacros,
+    renderPendingMacroChart
+} from './populateUI.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 
 const dynamicNutrientOverrides = { ...nutrientOverrides };
@@ -464,6 +468,8 @@ export async function handleExtraMealFormSubmit(event) {
             fat: dataToSend.fat
         };
         addExtraMealWithOverride(dataToSend.foodDescription, entry);
+        // Автоматично опресняване на макро-картата
+        renderPendingMacroChart();
         genericCloseModal('extraMealEntryModal');
     } catch (error) {
         showToast(`Грешка: ${error.message}`, true);
@@ -478,6 +484,8 @@ export function deleteExtraMeal(index) {
         removeMealMacros(removed, currentIntakeMacros);
         loadCurrentIntake();
         populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
+        // Автоматично опресняване на макро-картата
+        renderPendingMacroChart();
         showToast('Храненето е изтрито.', false, 2000);
     }
 }


### PR DESCRIPTION
## Обобщение
- Автоматично опресняване на макро-картата след маркиране на хранене
- Опресняване на макро-картата при записване или изтриване на извънредно хранене

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fc37ca3288326bcaba00ba9eccc79