### PR TITLE
feat: handle missing dashboard macros

### DIFF
--- a/js/__tests__/extraMealAutofill.test.js
+++ b/js/__tests__/extraMealAutofill.test.js
@@ -13,7 +13,7 @@ beforeEach(async () => {
     closeModal: jest.fn()
   }));
   jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
-  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn() }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), renderPendingMacroChart: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({
     currentUserId: 'u1',
     todaysExtraMeals: [],

--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -24,11 +24,13 @@ beforeEach(async () => {
     addMealMacros: addMealMacrosMock,
     removeMealMacros: jest.fn(),
     registerNutrientOverrides: jest.fn(),
-    getNutrientOverride: jest.fn(() => null)
+    getNutrientOverride: jest.fn(() => null),
+    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] })
   }));
   jest.unstable_mockModule('../populateUI.js', () => ({
     addExtraMealWithOverride: jest.fn(),
-    populateDashboardMacros: jest.fn()
+    populateDashboardMacros: jest.fn(),
+    renderPendingMacroChart: jest.fn()
   }));
   jest.unstable_mockModule('../app.js', () => {
     currentIntakeMacrosRef = {};

--- a/js/__tests__/extraMealNutrientLookup.test.js
+++ b/js/__tests__/extraMealNutrientLookup.test.js
@@ -21,7 +21,7 @@ beforeEach(async () => {
     closeModal: jest.fn()
   }));
   jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
-  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn() }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), renderPendingMacroChart: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({
     currentUserId: 'u1',
     todaysExtraMeals: [],

--- a/js/__tests__/macroCardStandaloneEmbed.test.js
+++ b/js/__tests__/macroCardStandaloneEmbed.test.js
@@ -15,8 +15,19 @@ beforeEach(async () => {
   jest.unstable_mockModule('../uiElements.js', () => ({ selectors: {}, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
   jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
   jest.unstable_mockModule('../extraMealForm.js', () => ({ openExtraMealModal: jest.fn() }));
-  jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id-1' }));
-  jest.unstable_mockModule('../app.js', () => ({ fullDashboardData: {}, todaysMealCompletionStatus: {}, todaysExtraMeals: [], currentIntakeMacros: {}, planHasRecContent: false, loadCurrentIntake: jest.fn() }));
+  jest.unstable_mockModule('../config.js', () => ({
+    generateId: () => 'id-1',
+    apiEndpoints: { dashboard: '/api/dashboardData' }
+  }));
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: {},
+    todaysMealCompletionStatus: {},
+    todaysExtraMeals: [],
+    currentIntakeMacros: {},
+    planHasRecContent: false,
+    loadCurrentIntake: jest.fn(),
+    currentUserId: 'u1'
+  }));
   jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
   jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn(), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
   const mod = await import('../populateUI.js');

--- a/js/__tests__/populateDashboardMacros.missingComponent.test.js
+++ b/js/__tests__/populateDashboardMacros.missingComponent.test.js
@@ -16,7 +16,11 @@ function setupMocks(selectors) {
     getCssVar: () => '',
     formatDateBgShort: () => ''
   }));
-  jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id', standaloneMacroUrl: 'macroAnalyticsCardStandalone.html' }));
+  jest.unstable_mockModule('../config.js', () => ({
+    generateId: () => 'id',
+    standaloneMacroUrl: 'macroAnalyticsCardStandalone.html',
+    apiEndpoints: { dashboard: '/api/dashboardData' }
+  }));
   jest.unstable_mockModule('../app.js', () => ({
     fullDashboardData: {},
     todaysMealCompletionStatus: {},
@@ -24,6 +28,7 @@ function setupMocks(selectors) {
     currentIntakeMacros: {},
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),
+    currentUserId: 'u1'
   }));
   jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
 }

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -78,7 +78,8 @@ beforeEach(async () => {
     todaysExtraMeals: [],
     currentIntakeMacros: {},
     planHasRecContent: false,
-    loadCurrentIntake: jest.fn()
+    loadCurrentIntake: jest.fn(),
+    currentUserId: 'u1'
   }));
   ({ populateUI } = await import('../populateUI.js'));
 });
@@ -124,6 +125,7 @@ test('обновява макро картата чрез postMessage', async ()
     currentIntakeMacros: {},
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),
+    currentUserId: 'u1'
   }));
   ({ populateUI } = await import('../populateUI.js'));
   const frame = document.getElementById('macroAnalyticsCardFrame');
@@ -161,7 +163,8 @@ test('hides modules when values are zero', async () => {
     ...zeroData,
     todaysExtraMeals: [],
     currentIntakeMacros: {},
-    loadCurrentIntake: jest.fn()
+    loadCurrentIntake: jest.fn(),
+    currentUserId: 'u1'
   }));
   ({ populateUI } = await import('../populateUI.js'));
   await populateUI();
@@ -196,7 +199,8 @@ test('показва картата за историята на теглото 
     todaysExtraMeals: [],
     currentIntakeMacros: {},
     planHasRecContent: false,
-    loadCurrentIntake: jest.fn()
+    loadCurrentIntake: jest.fn(),
+    currentUserId: 'u1'
   }));
   ({ populateUI } = await import('../populateUI.js'));
   await populateUI();
@@ -230,7 +234,8 @@ test('populates daily plan with color bars and meal types', async () => {
     todaysExtraMeals: [],
     currentIntakeMacros: {},
     planHasRecContent: false,
-    loadCurrentIntake: jest.fn()
+    loadCurrentIntake: jest.fn(),
+    currentUserId: 'u1'
   }));
   ({ populateUI } = await import('../populateUI.js'));
   await populateUI();
@@ -274,7 +279,8 @@ test('handles meal type variations', async () => {
     todaysExtraMeals: [],
     currentIntakeMacros: {},
     planHasRecContent: false,
-    loadCurrentIntake: jest.fn()
+    loadCurrentIntake: jest.fn(),
+    currentUserId: 'u1'
   }));
   ({ populateUI } = await import('../populateUI.js'));
   await populateUI();
@@ -310,7 +316,8 @@ test('applies success color to completed meal bar', async () => {
     todaysExtraMeals: [],
     currentIntakeMacros: {},
     planHasRecContent: false,
-    loadCurrentIntake: jest.fn()
+    loadCurrentIntake: jest.fn(),
+    currentUserId: 'u1'
   }));
   ({ populateUI } = await import('../populateUI.js'));
 
@@ -354,7 +361,8 @@ test('clicking a meal card toggles completion status', async () => {
       todaysExtraMeals: [],
       currentIntakeMacros: {},
       planHasRecContent: false,
-      loadCurrentIntake: jest.fn()
+      loadCurrentIntake: jest.fn(),
+      currentUserId: 'u1'
     };
   });
 
@@ -395,7 +403,8 @@ describe('progress bar width handling', () => {
       todaysExtraMeals: [],
       currentIntakeMacros: {},
       planHasRecContent: false,
-      loadCurrentIntake: jest.fn()
+      loadCurrentIntake: jest.fn(),
+      currentUserId: 'u1'
     }));
     ({ populateUI } = await import('../populateUI.js'));
     await populateUI();

--- a/js/__tests__/renderPendingMacroChart.test.js
+++ b/js/__tests__/renderPendingMacroChart.test.js
@@ -19,8 +19,20 @@ describe('renderPendingMacroChart', () => {
     };
     jest.unstable_mockModule('../uiElements.js', () => ({ selectors, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
     jest.unstable_mockModule('../utils.js', () => ({ safeGet: jest.fn(), safeParseFloat: jest.fn(), capitalizeFirstLetter: jest.fn(), escapeHtml: jest.fn(), applyProgressFill: jest.fn(), getCssVar: jest.fn(), formatDateBgShort: jest.fn() }));
-    jest.unstable_mockModule('../config.js', () => ({ generateId: () => 'id', standaloneMacroUrl: 'macroAnalyticsCardStandalone.html' }));
-    jest.unstable_mockModule('../app.js', () => ({ fullDashboardData: {}, todaysMealCompletionStatus: {}, currentIntakeMacros: { calories: 1000, protein: 0, carbs: 0, fat: 0, fiber: 0 }, planHasRecContent: false, todaysExtraMeals: [], loadCurrentIntake: jest.fn() }));
+    jest.unstable_mockModule('../config.js', () => ({
+      generateId: () => 'id',
+      standaloneMacroUrl: 'macroAnalyticsCardStandalone.html',
+      apiEndpoints: { dashboard: '/api/dashboardData' }
+    }));
+    jest.unstable_mockModule('../app.js', () => ({
+      fullDashboardData: {},
+      todaysMealCompletionStatus: {},
+      currentIntakeMacros: { calories: 1000, protein: 0, carbs: 0, fat: 0, fiber: 0 },
+      planHasRecContent: false,
+      todaysExtraMeals: [],
+      loadCurrentIntake: jest.fn(),
+      currentUserId: 'u1'
+    }));
     jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
     jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
     jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn().mockReturnValue({ calories: 850, protein: 72, carbs: 70, fat: 28 }), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));


### PR DESCRIPTION
## Summary
- show a placeholder with "Пресметни отново" button when dashboard macros are missing
- allow recalculation by fetching the backend macros and refreshing the preview
- add supporting test mocks and coverage

## Testing
- `npm run lint` *(fails: no, warnings only)*
- `sh scripts/test.sh js/__tests__/populateDashboardMacros.test.js js/__tests__/renderPendingMacroChart.test.js js/__tests__/extraMealFormSubmit.test.js` *(fails: extraMealFormSubmit.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688fce7cc5d483269dec799c25953556