### PR TITLE
feat: preload dashboard macros

### DIFF
--- a/js/__tests__/loadProductMacrosInit.test.js
+++ b/js/__tests__/loadProductMacrosInit.test.js
@@ -29,7 +29,7 @@ test('initializeApp продължава при грешка в loadProductMacro
     showToast: jest.fn(),
     updateTabsOverflowIndicator: jest.fn()
   }));
-  jest.unstable_mockModule('../populateUI.js', () => ({ populateUI: jest.fn(), populateProgressHistory: jest.fn() }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ populateUI: jest.fn(), populateProgressHistory: jest.fn(), populateDashboardMacros: jest.fn() }));
   jest.unstable_mockModule('../eventListeners.js', () => ({
     setupStaticEventListeners: jest.fn(),
     setupDynamicEventListeners: jest.fn(),

--- a/js/app.js
+++ b/js/app.js
@@ -10,7 +10,7 @@ import {
     openModal, closeModal,
     showLoading, showToast, updateTabsOverflowIndicator
 } from './uiHandlers.js';
-import { populateUI, populateProgressHistory } from './populateUI.js';
+import { populateUI, populateProgressHistory, populateDashboardMacros } from './populateUI.js';
 // КОРЕКЦИЯ: Премахваме handleDelegatedClicks от импорта тук
 import { setupStaticEventListeners, setupDynamicEventListeners, initializeCollapsibleCards } from './eventListeners.js';
 import { loadProductMacros, calculateCurrentMacros } from './macroUtils.js';
@@ -445,6 +445,7 @@ export async function loadDashboardData() { // Exported for adaptiveQuiz.js to c
 
         fullDashboardData.dailyLogs = normalizeDailyLogs(fullDashboardData.dailyLogs);
         loadCurrentIntake();
+        await populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
 
         if(selectors.planPendingState) selectors.planPendingState.classList.add('hidden');
         if(selectors.appWrapper) selectors.appWrapper.style.display = 'block';


### PR DESCRIPTION
## Summary
- preload dashboard macros after current intake loads
- align tests with dashboard macro population

## Testing
- `npm run lint`
- `npm test js/__tests__/populateDashboardMacros.test.js`
- `npm test` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688fd2ba510c8326bca6d30fa98b5dfe