### PR TITLE
feat: unify macro analysis kv entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,7 +915,7 @@ curl -X POST /api/aiHelper \
 |------|-----------|
 | 1800 kcal / 135 г P / 180 г C / 60 г F | 1900 kcal / 140 г P / 200 г C / 65 г F |
 
-Разликата се визуализира в `macroAnalyticsCard` и се записва в ключ `<userId>_analysis_macros`.
+Разликата се визуализира в `macroAnalyticsCard` и се записва в ключ `<userId>_analysis_macros` със `status` (`initial` или `final`).
 
 Ендпойнтът `/api/peekAdminQueries` връща списък с неприключени запитвания, без да ги маркира като прочетени. Използва се основно за показване на индикатора, докато `/api/getAdminQueries` обновява флага `read` при зареждане на данните.
 

--- a/docs/final_plan_kv_example.md
+++ b/docs/final_plan_kv_example.md
@@ -18,15 +18,18 @@
 
 ## Макро записи
 
-За проследяване на промените се използва помощният ключ:
+За проследяване на промените се използва същият ключ като при първоначалния анализ:
 
-- `<userId>_final_analysis_macros` – сравнение „План vs Препоръка“.
+- `<userId>_analysis_macros` – сравнение „План vs Препоръка“ с флаг `status: "final"`.
 
 ```json
-// <userId>_final_analysis_macros
+// <userId>_analysis_macros
 {
-  "plan": { "calories": 1800, "protein_grams": 135, "carbs_grams": 180, "fat_grams": 60 },
-  "recommendation": { "calories": 1900, "protein_grams": 140, "carbs_grams": 190, "fat_grams": 65 }
+  "status": "final",
+  "data": {
+    "plan": { "calories": 1800, "protein_grams": 135, "carbs_grams": 180, "fat_grams": 60 },
+    "recommendation": { "calories": 1900, "protein_grams": 140, "carbs_grams": 190, "fat_grams": 65 }
+  }
 }
 ```
 

--- a/docs/questionnaire_kv_example.md
+++ b/docs/questionnaire_kv_example.md
@@ -52,13 +52,16 @@
 
 След обработка се създава KV запис:
 
-- `<userId>_analysis_macros` – резултат от AI оценка „План vs Препоръка“.
+- `<userId>_analysis_macros` – резултат от AI оценка „План vs Препоръка“ с флаг `status` (`initial` или `final`).
 
 ```json
 // <userId>_analysis_macros
 {
-  "plan": { "calories": 1700, "protein_grams": 120, "carbs_grams": 150, "fat_grams": 55 },
-  "recommendation": { "calories": 1800, "protein_grams": 130, "carbs_grams": 160, "fat_grams": 60 }
+  "status": "initial",
+  "data": {
+    "plan": { "calories": 1700, "protein_grams": 120, "carbs_grams": 150, "fat_grams": 55 },
+    "recommendation": { "calories": 1800, "protein_grams": 130, "carbs_grams": 160, "fat_grams": 60 }
+  }
 }
 ```
 

--- a/js/__tests__/initialAnalysis.test.js
+++ b/js/__tests__/initialAnalysis.test.js
@@ -32,7 +32,7 @@ describe('initial analysis handlers', () => {
     }
     await worker.handleAnalyzeInitialAnswers('u1', env)
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis', '{"ok":true}')
-    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_macros', 'null')
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_macros', JSON.stringify({ status: 'initial', data: null }))
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_status', 'ready')
     expect(global.fetch).toHaveBeenCalled()
   })

--- a/js/__tests__/updatePlanData.test.js
+++ b/js/__tests__/updatePlanData.test.js
@@ -4,10 +4,14 @@ import { handleUpdatePlanRequest } from '../../worker.js';
 describe('handleUpdatePlanRequest', () => {
   test('stores plan data using final plan key', async () => {
     const env = { USER_METADATA_KV: { put: jest.fn() } };
-    const planData = { week: 1 };
+    const planData = { week: 1, caloriesMacros: { calories: 2000 } };
     const request = { json: async () => ({ userId: 'u1', planData }) };
     const res = await handleUpdatePlanRequest(request, env);
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_final_plan', JSON.stringify(planData));
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
+      'u1_analysis_macros',
+      JSON.stringify({ status: 'final', data: planData.caloriesMacros })
+    );
     expect(res.success).toBe(true);
   });
 });

--- a/worker.js
+++ b/worker.js
@@ -1536,6 +1536,8 @@ async function handleUpdatePlanRequest(request, env) {
             return { success: false, message: 'Невалидни данни за плана.', statusHint: 400 };
         }
         await env.USER_METADATA_KV.put(`${userId}_final_plan`, JSON.stringify(planData));
+        const macrosRecord = { status: 'final', data: planData.caloriesMacros || null };
+        await env.USER_METADATA_KV.put(`${userId}_analysis_macros`, JSON.stringify(macrosRecord));
         await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'ready', { metadata: { status: 'ready' } });
         return { success: true, message: 'Планът е обновен успешно' };
     } catch (error) {
@@ -1980,7 +1982,8 @@ async function handleAnalyzeInitialAnswers(userId, env) {
         const raw = await callModel(modelName, populated, env, { temperature: 0.5, maxTokens: 2500 });
         const cleaned = cleanGeminiJson(raw);
         await env.USER_METADATA_KV.put(`${userId}_analysis`, cleaned);
-        await env.USER_METADATA_KV.put(`${userId}_analysis_macros`, JSON.stringify(macros));
+        const macrosRecord = { status: 'initial', data: macros };
+        await env.USER_METADATA_KV.put(`${userId}_analysis_macros`, JSON.stringify(macrosRecord));
         await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'ready');
         console.log(`INITIAL_ANALYSIS (${userId}): Analysis stored.`);
         // Имейлът с линк към анализа вече се изпраща при подаване на въпросника,


### PR DESCRIPTION
## Summary
- add status flag to analysis_macros entry
- store final macros alongside final plan
- update docs and tests for unified record

## Testing
- `npm run lint`
- `npm test js/__tests__/initialAnalysis.test.js js/__tests__/updatePlanData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688fd8f2b5648326937db510fd3571e1