### PR TITLE
feat: allow macros recalculation

### DIFF
--- a/js/__tests__/dashboardDataMacros.test.js
+++ b/js/__tests__/dashboardDataMacros.test.js
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 import { handleDashboardDataRequest } from '../../worker.js';
 
-describe('handleDashboardDataRequest caloriesMacros fallback', () => {
+describe('handleDashboardDataRequest caloriesMacros', () => {
   test('returns caloriesMacros when absent from final plan', async () => {
     const env = {
       USER_METADATA_KV: {
@@ -25,6 +25,35 @@ describe('handleDashboardDataRequest caloriesMacros fallback', () => {
     const res = await handleDashboardDataRequest(request, env);
     expect(res.planData.caloriesMacros).toBeDefined();
     expect(res.planData.caloriesMacros.calories).toBeGreaterThan(0);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
+      'u1_final_plan',
+      expect.stringContaining('"caloriesMacros"')
+    );
+  });
+
+  test('recalculates macros when recalcMacros=1', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(key => {
+          if (key === 'u1_initial_answers') return Promise.resolve(JSON.stringify({
+            name: 'U', weight: '70', height: '170', age: '30', gender: 'мъж', q1745878295708: 'умерено'
+          }));
+          if (key === 'u1_final_plan') return Promise.resolve(JSON.stringify({
+            caloriesMacros: { calories: 1, protein_percent: 1, carbs_percent: 1, fat_percent: 1, protein_grams: 1, carbs_grams: 1, fat_grams: 1 },
+            profileSummary: 's', allowedForbiddenFoods: {}, hydrationCookingSupplements: {}, week1Menu: {}, principlesWeek2_4: []
+          }));
+          if (key === 'plan_status_u1') return Promise.resolve('ready');
+          if (key === 'u1_current_status') return Promise.resolve('{}');
+          return Promise.resolve(null);
+        }),
+        put: jest.fn(),
+        list: jest.fn().mockResolvedValue({ keys: [] })
+      },
+      RESOURCES_KV: { get: jest.fn(() => Promise.resolve('{}')) }
+    };
+    const request = { url: 'https://example.com?userId=u1&recalcMacros=1' };
+    const res = await handleDashboardDataRequest(request, env);
+    expect(res.planData.caloriesMacros.calories).toBeGreaterThan(1);
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
       'u1_final_plan',
       expect.stringContaining('"caloriesMacros"')

--- a/worker.js
+++ b/worker.js
@@ -1036,6 +1036,7 @@ async function handleAnalysisStatusRequest(request, env) {
 async function handleDashboardDataRequest(request, env) {
     const url = new URL(request.url);
     const userId = url.searchParams.get('userId');
+    const recalcMacros = url.searchParams.get('recalcMacros');
     if (!userId) return { success: false, message: 'Липсва ID на потребител.', statusHint: 400 };
     try {
         const [
@@ -1137,7 +1138,7 @@ async function handleDashboardDataRequest(request, env) {
             return { ...baseResponse, success: false, message: 'Грешка при зареждане на данните на Вашия план.', statusHint: 500, planData: null, analytics: null };
         }
 
-        if (!finalPlan.caloriesMacros || Object.keys(finalPlan.caloriesMacros).length === 0) {
+        if (!finalPlan.caloriesMacros || Object.keys(finalPlan.caloriesMacros).length === 0 || recalcMacros === '1') {
             const macros = estimateMacros(initialAnswers);
             if (macros) {
                 finalPlan.caloriesMacros = macros;


### PR DESCRIPTION
## Summary
- allow recalculating calories/macros via `recalcMacros=1`
- cover macro recalculation with dashboard test

## Testing
- `npm run lint`
- `npm test` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*
- `npm test -- js/__tests__/dashboardDataMacros.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688fdee643bc8326b41c093bf772c481