### PR TITLE
feat: add skeleton loader for macro analytics

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -654,6 +654,26 @@ body.vivid-theme .tracker .metric-rating .rating-value {
     font-size: 1.05rem;
 }
 
+/* Skeleton loading for macro analytics card */
+.loading .skeleton {
+    position: relative;
+    overflow: hidden;
+    background-color: rgba(255, 255, 255, 0.1);
+}
+.loading .skeleton::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    transform: translateX(-100%);
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
+    animation: shimmer 1.2s infinite;
+}
+@keyframes shimmer {
+    100% { transform: translateX(100%); }
+}
+.loading .chart-skeleton { width: 100%; height: 200px; border-radius: 50%; }
+.loading .metric-skeleton { height: 60px; border-radius: 12px; }
+
 @media (max-width: 480px) {
   .meal-card {
     padding: var(--space-md);

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -68,6 +68,31 @@ export function handleAdaptiveQuizBtnClick(triggerFn = _handleTriggerAdaptiveQui
     triggerFn();
 }
 
+function ensureMacroAnalyticsFrame() {
+    let frame = document.getElementById('macroAnalyticsCardFrame');
+    if (!frame) {
+        frame = document.createElement('iframe');
+        frame.id = 'macroAnalyticsCardFrame';
+        frame.title = 'Макро анализ';
+        frame.loading = 'lazy';
+        frame.style.width = '100%';
+        frame.style.border = '0';
+        frame.style.display = 'none';
+        frame.src = standaloneMacroUrl;
+        selectors.macroAnalyticsCardContainer.appendChild(frame);
+        frame.addEventListener('load', () => {
+            selectors.macroAnalyticsCardContainer.classList.remove('loading');
+            selectors.macroAnalyticsCardContainer.querySelectorAll('.skeleton').forEach(el => el.remove());
+            frame.style.display = 'block';
+            frame.contentWindow?.postMessage({ type: 'macro-data', data: lastMacroPayload }, '*');
+        }, { once: true });
+    } else {
+        frame.contentWindow?.postMessage({ type: 'macro-data', data: lastMacroPayload }, '*');
+    }
+    macroChartInstance?.resize();
+    progressChartInstance?.resize();
+}
+
 
 export function setupStaticEventListeners() {
     if (staticListenersSet) {
@@ -137,26 +162,7 @@ export function setupStaticEventListeners() {
                 if (accContent) { accContent.style.display = isOpen ? 'none' : 'block'; accContent.classList.toggle('open-active', !isOpen); }
                 if (preview) preview.style.display = isOpen ? 'grid' : 'none';
                 selectors.detailedAnalyticsAccordion.classList.toggle('index-card', isOpen);
-                if (!isOpen) {
-                    let frame = document.getElementById('macroAnalyticsCardFrame');
-                    if (!frame) {
-                        frame = document.createElement('iframe');
-                        frame.id = 'macroAnalyticsCardFrame';
-                        frame.title = 'Макро анализ';
-                        frame.loading = 'lazy';
-                        frame.style.width = '100%';
-                        frame.style.border = '0';
-                        frame.style.display = 'block';
-                        frame.src = standaloneMacroUrl;
-                        selectors.macroAnalyticsCardContainer.innerHTML = '';
-                        selectors.macroAnalyticsCardContainer.appendChild(frame);
-                    }
-                    const sendData = () => frame.contentWindow?.postMessage({ type: 'macro-data', data: lastMacroPayload }, '*');
-                    if (frame.contentWindow?.document?.readyState === 'complete') sendData();
-                    else frame.addEventListener('load', sendData, { once: true });
-                    macroChartInstance?.resize();
-                    progressChartInstance?.resize();
-                }
+                if (!isOpen) ensureMacroAnalyticsFrame();
              });
              header.addEventListener('keydown', function(e) {
                 if(e.key === 'Enter' || e.key === ' ') {
@@ -166,26 +172,7 @@ export function setupStaticEventListeners() {
                     if (accContent) { accContent.style.display = isOpen ? 'none' : 'block'; accContent.classList.toggle('open-active', !isOpen); }
                     if (preview) preview.style.display = isOpen ? 'grid' : 'none';
                     selectors.detailedAnalyticsAccordion.classList.toggle('index-card', isOpen);
-                    if (!isOpen) {
-                        let frame = document.getElementById('macroAnalyticsCardFrame');
-                        if (!frame) {
-                            frame = document.createElement('iframe');
-                            frame.id = 'macroAnalyticsCardFrame';
-                            frame.title = 'Макро анализ';
-                            frame.loading = 'lazy';
-                            frame.style.width = '100%';
-                            frame.style.border = '0';
-                            frame.style.display = 'block';
-                            frame.src = standaloneMacroUrl;
-                            selectors.macroAnalyticsCardContainer.innerHTML = '';
-                            selectors.macroAnalyticsCardContainer.appendChild(frame);
-                        }
-                        const sendData = () => frame.contentWindow?.postMessage({ type: 'macro-data', data: lastMacroPayload }, '*');
-                        if (frame.contentWindow?.document?.readyState === 'complete') sendData();
-                        else frame.addEventListener('load', sendData, { once: true });
-                        macroChartInstance?.resize();
-                        progressChartInstance?.resize();
-                    }
+                    if (!isOpen) ensureMacroAnalyticsFrame();
                 }
             });
         }

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -191,7 +191,22 @@ function populateDashboardDetailedAnalytics(analyticsData) {
         return;
     }
     cardsContainer.innerHTML = '';
-    if (macroContainer) cardsContainer.appendChild(macroContainer);
+    if (macroContainer) {
+        macroContainer.classList.add('loading');
+        macroContainer.innerHTML = `
+            <h5></h5>
+            <div class="chart-container">
+                <div class="chart-skeleton skeleton"></div>
+            </div>
+            <div class="macro-metrics-grid">
+                <div class="macro-metric metric-skeleton skeleton"></div>
+                <div class="macro-metric metric-skeleton skeleton"></div>
+                <div class="macro-metric metric-skeleton skeleton"></div>
+                <div class="macro-metric metric-skeleton skeleton"></div>
+                <div class="macro-metric metric-skeleton skeleton"></div>
+            </div>`;
+        cardsContainer.appendChild(macroContainer);
+    }
     textualAnalysisContainer.innerHTML = '';
 
 


### PR DESCRIPTION
## Summary
- show skeleton placeholders in macro analytics card until iframe loads
- hide loader on iframe load and animate skeleton
- add skeleton CSS animation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fe0f9e7d88326b95556aa8c411389