### PR TITLE
chore: добавяне на migrate-macros към деплоя

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,16 +1162,18 @@ The script expects `vendor/autoload.php` to reside one directory above the PHP f
 ## KV migrations
 
 За еднократни актуализации на Cloudflare KV се използват помощни скриптове от директория `scripts/`.
-Миграцията за планове без макроси се стартира така:
+
+## Поддръжка на макро данни
+
+Скриптът `scripts/migrate-final-plan-macros.js` попълва липсващите полета `caloriesMacros` в `USER_METADATA_KV`.
+За автоматизация е добавен `npm` скрипт:
 
 ```bash
-node scripts/migrate-final-plan-macros.js
+npm run migrate-macros
 ```
 
-Скриптът обхожда всички ключове `<userId>_final_plan` в `USER_METADATA_KV`,
-изчислява липсващите `caloriesMacros` на база началните отговори и записва
-резултата обратно чрез `wrangler kv key put`. Преди и след изпълнение е добре да
-се проверяват стойностите с `wrangler kv key get`.
+Препоръчително е да се изпълнява след всеки деплой (например чрез `npm run deploy`), за да останат макро данните актуални.
+Преди и след миграцията проверявайте стойностите с `wrangler kv key get`.
 
 ## Cron configuration
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test:file": "node scripts/test.sh --runTestsByPath",
     "test:related": "node scripts/test-related.js",
     "coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
-    "docs": "typedoc"
+    "docs": "typedoc",
+    "migrate-macros": "node scripts/migrate-final-plan-macros.js",
+    "deploy": "wrangler deploy && npm run migrate-macros"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- добавяне на `migrate-macros` и `deploy` npm скриптове
- документация за поддръжка на макро данните

## Testing
- `node scripts/migrate-final-plan-macros.js` *(error: wrangler kv key list --binding USER_METADATA_KV failed)*
- `npm run lint`
- `npm test` *(fails: sendAnalysisLinkEmail loads subject/body from KV, sendContactEmail uses contact_form_label from KV, ...)*

------
https://chatgpt.com/codex/tasks/task_e_688fe2edbf5483268a32e842149f51f5