### PR TITLE
feat: auto recalc dashboard macros

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -416,23 +416,24 @@ export async function populateDashboardMacros(macros) {
         selectors.macroAnalyticsCardContainer = macroContainer;
     }
     if (!macros) {
-        console.warn('Macros data is missing.');
-        macroContainer.innerHTML = '<p class="placeholder">Липсват данни за макроси.</p>' +
-            '<button id="recalcMacrosBtn" class="btn btn-primary btn-sm">Пресметни отново</button>';
-        const btn = macroContainer.querySelector('#recalcMacrosBtn');
-        btn?.addEventListener('click', async () => {
-            try {
-                const res = await fetch(`${apiEndpoints.dashboard}?userId=${currentUserId}&recalcMacros=1`);
-                const data = await res.json();
-                await populateDashboardMacros(data?.planData?.caloriesMacros);
-            } catch (e) {
-                console.error('Failed to recalc macros', e);
-                showToast('Неуспешно изчисляване на макроси.', true);
+        macroContainer.innerHTML = '<div class="spinner-border" role="status"></div>';
+        try {
+            const res = await fetch(`${apiEndpoints.dashboard}?userId=${currentUserId}&recalcMacros=1`);
+            const data = await res.json();
+            const newMacros = data?.planData?.caloriesMacros;
+            if (newMacros) {
+                await populateDashboardMacros(newMacros);
+            } else {
+                macroContainer.innerHTML = '<p class="placeholder">Липсват данни за макроси.</p>';
             }
-        }, { once: true });
+        } catch (e) {
+            console.error('Failed to recalc macros', e);
+            showToast('Неуспешно изчисляване на макроси.', true);
+            macroContainer.innerHTML = '<p class="placeholder">Липсват данни за макроси.</p>';
+        }
         return;
     }
-    if (macroContainer.querySelector('#recalcMacrosBtn')) macroContainer.innerHTML = '';
+    macroContainer.innerHTML = '';
     const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
     const today = new Date();
     const currentDayKey = dayNames[today.getDay()];


### PR DESCRIPTION
## Summary
- trigger automatic dashboard macro recalculation via API when no macro data
- show loading spinner until recalculation finishes
- add test for spinner and auto fetch behavior

## Testing
- `npm run lint`
- `npm test` *(fails: renderPendingMacroChart.test.js, extraMealFormSubmit.test.js, workerEmail.test.js, passwordReset.test.js, loadProductMacrosInit.test.js, extraMealNutrientLookup.test.js, extraMealAutofill.test.js, registerEmail.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688fe96c737c83269fe4b2fce2d1d3eb