### PR TITLE
Добавена проверка за локален proxy и fallback към production worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ API requests to paths starting with `/api` are automatically proxied to
 
 The application will be available at `http://localhost:5173` by default.
 
+### Локален proxy
+
+По подразбиране `config.js` използва production worker URL. Ако работите локално и имате собствен proxy, задайте `window.USE_LOCAL_PROXY = true`, например в конзолата:
+
+```js
+window.USE_LOCAL_PROXY = true;
+```
+
+При липса на тази променлива заявките се насочват към `https://openapichatbot.radilov-k.workers.dev`, така че приложението функционира без допълнителна настройка.
+
 ### Динамична тема
 
 Интерфейсът следва системната светла/тъмна настройка. Ако в LocalStorage е избрана опцията "system", промяната на темата в операционната система се отразява моментално.

--- a/js/config.js
+++ b/js/config.js
@@ -1,10 +1,13 @@
 // config.js - Конфигурация и Глобални Променливи
 
-// Определяваме базовия URL според средата
-export const isLocalDevelopment = window.location.hostname === 'localhost' ||
-                               window.location.hostname === '127.0.0.1' ||
-                               window.location.hostname.includes('replit') ||
-                               window.location.hostname.includes('preview');
+// Определяме базовия URL според средата.
+// За да се използва локален proxy, задайте `window.USE_LOCAL_PROXY = true`.
+export const isLocalDevelopment = (
+    window.location.hostname === 'localhost' ||
+    window.location.hostname === '127.0.0.1' ||
+    window.location.hostname.includes('replit') ||
+    window.location.hostname.includes('preview')
+) && Boolean(window.USE_LOCAL_PROXY);
 
 export const workerBaseUrl = isLocalDevelopment
     ? '' // Използваме локалния proxy в развойна среда


### PR DESCRIPTION
## Резюме
- проверка за `window.USE_LOCAL_PROXY` в `config.js`
- автоматичен fallback към production worker URL
- README описва как да се активира локален proxy

## Тестване
- `npm run lint`
- `npm test` *(някои съществуващи тестове се провалят: workerEmail, renderPendingMacroChart, extraMealFormSubmit и др.)*

------
https://chatgpt.com/codex/tasks/task_e_688feea444dc832694bf84b8691b9be2