### PR TITLE
feat: add fiber data to macro tests

### DIFF
--- a/js/__tests__/aiConfig.test.js
+++ b/js/__tests__/aiConfig.test.js
@@ -41,7 +41,7 @@ describe('AI config handlers', () => {
           if (key.endsWith('_initial_answers')) return Promise.resolve('{"name":"U","goal":"gain"}');
           if (key.endsWith('_final_plan')) return Promise.resolve(JSON.stringify({
             profileSummary: 's',
-            caloriesMacros: { calories: 1800, protein_grams: 1, carbs_grams: 1, fat_grams: 1 },
+            caloriesMacros: { calories: 1800, protein_grams: 1, carbs_grams: 1, fat_grams: 1, fiber_percent: 10, fiber_grams: 30 },
             allowedForbiddenFoods: { main_allowed_foods: [], main_forbidden_foods: [] },
             hydrationCookingSupplements: { hydration_recommendations: { daily_liters: '2' }, cooking_methods: { recommended: [] }, supplement_suggestions: [] },
             week1Menu: { sunday: [] }

--- a/js/__tests__/clientProfileChart.test.js
+++ b/js/__tests__/clientProfileChart.test.js
@@ -57,7 +57,9 @@ test('fillDashboard initializes doughnut charts and destroys previous', async ()
         fat_percent: 20,
         protein_grams: 120,
         carbs_grams: 200,
-        fat_grams: 44
+        fat_grams: 44,
+        fiber_percent: 10,
+        fiber_grams: 30
       },
       week1Menu: {},
       allowedForbiddenFoods: {},

--- a/js/__tests__/dashboardDataMacros.test.js
+++ b/js/__tests__/dashboardDataMacros.test.js
@@ -39,7 +39,7 @@ describe('handleDashboardDataRequest caloriesMacros', () => {
             name: 'U', weight: '70', height: '170', age: '30', gender: 'мъж', q1745878295708: 'умерено'
           }));
           if (key === 'u1_final_plan') return Promise.resolve(JSON.stringify({
-            caloriesMacros: { calories: 1, protein_percent: 1, carbs_percent: 1, fat_percent: 1, protein_grams: 1, carbs_grams: 1, fat_grams: 1 },
+            caloriesMacros: { calories: 1, protein_percent: 1, carbs_percent: 1, fat_percent: 1, protein_grams: 1, carbs_grams: 1, fat_grams: 1, fiber_percent: 10, fiber_grams: 30 },
             profileSummary: 's', allowedForbiddenFoods: {}, hydrationCookingSupplements: {}, week1Menu: {}, principlesWeek2_4: []
           }));
           if (key === 'plan_status_u1') return Promise.resolve('ready');

--- a/js/__tests__/editClient.test.js
+++ b/js/__tests__/editClient.test.js
@@ -24,7 +24,7 @@ test('initCharts uses Chart with parsed data', async () => {
   const { __testExports } = await import('../editClient.js');
   const { initCharts } = __testExports;
   await initCharts({
-    caloriesMacros: { protein_percent: 40, carbs_percent: 40, fat_percent: 20, protein_grams: 120, carbs_grams: 200, fat_grams: 50, calories: 2000 },
+    caloriesMacros: { protein_percent: 40, carbs_percent: 40, fat_percent: 20, protein_grams: 120, carbs_grams: 200, fat_grams: 50, calories: 2000, fiber_percent: 10, fiber_grams: 30 },
     profileSummary: 'Текущо тегло 80 кг (промяна за 7 дни: -1 кг)'
   });
   expect(ChartMock.mock.calls[0][1].type).toBe('doughnut');

--- a/js/__tests__/extraMealAutofill.test.js
+++ b/js/__tests__/extraMealAutofill.test.js
@@ -19,7 +19,7 @@ beforeEach(async () => {
     todaysExtraMeals: [],
     todaysMealCompletionStatus: {},
     currentIntakeMacros: {},
-    fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: {} } },
+    fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: { fiber_percent: 10, fiber_grams: 30 } } },
     loadCurrentIntake: jest.fn()
   }));
   ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));

--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -41,7 +41,7 @@ beforeEach(async () => {
       todaysMealCompletionStatus: {},
       todaysExtraMeals: [],
       currentIntakeMacros: currentIntakeMacrosRef,
-      fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: {} } },
+      fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: { fiber_percent: 10, fiber_grams: 30 } } },
       planHasRecContent: false,
       loadCurrentIntake: jest.fn()
     };

--- a/js/__tests__/extraMealNutrientLookup.test.js
+++ b/js/__tests__/extraMealNutrientLookup.test.js
@@ -27,7 +27,7 @@ beforeEach(async () => {
     todaysExtraMeals: [],
     todaysMealCompletionStatus: {},
     currentIntakeMacros: {},
-    fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: {} } },
+    fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: { fiber_percent: 10, fiber_grams: 30 } } },
     loadCurrentIntake: jest.fn()
   }));
   ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));

--- a/js/__tests__/handleChatRequestModel.test.js
+++ b/js/__tests__/handleChatRequestModel.test.js
@@ -8,7 +8,7 @@ describe('handleChatRequest model option', () => {
         if (key.endsWith('_initial_answers')) return Promise.resolve('{"name":"U","goal":"gain"}');
         if (key.endsWith('_final_plan')) return Promise.resolve(JSON.stringify({
           profileSummary: 's',
-          caloriesMacros: { calories: 1800, protein_grams: 1, carbs_grams: 1, fat_grams: 1 },
+          caloriesMacros: { calories: 1800, protein_grams: 1, carbs_grams: 1, fat_grams: 1, fiber_percent: 10, fiber_grams: 30 },
           allowedForbiddenFoods: { main_allowed_foods: [], main_forbidden_foods: [] },
           hydrationCookingSupplements: { hydration_recommendations: { daily_liters: '2' }, cooking_methods: { recommended: [] }, supplement_suggestions: [] },
           week1Menu: { sunday: [] }

--- a/js/__tests__/handleChatRequestPlanMod.test.js
+++ b/js/__tests__/handleChatRequestPlanMod.test.js
@@ -9,7 +9,7 @@ describe('handleChatRequest plan modification marker', () => {
         if (key.endsWith('_initial_answers')) return Promise.resolve('{"name":"U","goal":"gain","weight":"70"}');
         if (key.endsWith('_final_plan')) return Promise.resolve(JSON.stringify({
           profileSummary: 's',
-          caloriesMacros: { calories: 1800, protein_grams: 1, carbs_grams: 1, fat_grams: 1 },
+          caloriesMacros: { calories: 1800, protein_grams: 1, carbs_grams: 1, fat_grams: 1, fiber_percent: 10, fiber_grams: 30 },
           allowedForbiddenFoods: { main_allowed_foods: [], main_forbidden_foods: [] },
           hydrationCookingSupplements: { hydration_recommendations: { daily_liters: '2' }, cooking_methods: { recommended: [] }, supplement_suggestions: [] },
           week1Menu: { sunday: [] },

--- a/js/__tests__/pendingPlanModIntegration.test.js
+++ b/js/__tests__/pendingPlanModIntegration.test.js
@@ -28,7 +28,7 @@ describe('processSingleUserPlan with pending modification', () => {
           if (['base_diet_model','allowed_meal_combinations','eating_psychology'].includes(key)) return '';
           if (key === 'recipe_data') return '{}';
           if (key === 'model_plan_generation') return 'model';
-          if (key === 'prompt_unified_plan_generation_v2') return '{"profileSummary":"X","caloriesMacros":{},"week1Menu":{},"principlesWeek2_4":[],"detailedTargets":{}}';
+          if (key === 'prompt_unified_plan_generation_v2') return '{"profileSummary":"X","caloriesMacros":{"fiber_percent":10,"fiber_grams":30},"week1Menu":{},"principlesWeek2_4":[],"detailedTargets":{}}';
           return null;
         })
       },
@@ -39,7 +39,7 @@ describe('processSingleUserPlan with pending modification', () => {
     let sentPrompt = '';
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ candidates: [{ content: { parts: [{ text: '{"profileSummary":"ok","caloriesMacros":{},"week1Menu":{},"principlesWeek2_4":[],"detailedTargets":{}}' }] } }] })
+      json: async () => ({ candidates: [{ content: { parts: [{ text: '{"profileSummary":"ok","caloriesMacros":{"fiber_percent":10,"fiber_grams":30},"week1Menu":{},"principlesWeek2_4":[],"detailedTargets":{}}' }] } }] })
     });
 
     await mod.processSingleUserPlan(userId, env);

--- a/js/__tests__/planGenerationLogs.test.js
+++ b/js/__tests__/planGenerationLogs.test.js
@@ -33,7 +33,7 @@ describe('processSingleUserPlan log metrics', () => {
           if (key === 'recipe_data') return '{}';
           if (key === 'model_plan_generation') return 'model';
           if (key === 'prompt_unified_plan_generation_v2') {
-            return '{"profileSummary":"Weight %%RECENT_WEIGHT_KG%% diff %%WEIGHT_CHANGE_LAST_7_DAYS%% mood %%AVG_MOOD_LAST_7_DAYS%% energy %%AVG_ENERGY_LAST_7_DAYS%%","caloriesMacros":{},"week1Menu":{},"principlesWeek2_4":[],"detailedTargets":{}}';
+            return '{"profileSummary":"Weight %%RECENT_WEIGHT_KG%% diff %%WEIGHT_CHANGE_LAST_7_DAYS%% mood %%AVG_MOOD_LAST_7_DAYS%% energy %%AVG_ENERGY_LAST_7_DAYS%%","caloriesMacros":{"fiber_percent":10,"fiber_grams":30},"week1Menu":{},"principlesWeek2_4":[],"detailedTargets":{}}';
           }
           return null;
         })
@@ -45,7 +45,7 @@ describe('processSingleUserPlan log metrics', () => {
     let sentPrompt = '';
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ candidates: [{ content: { parts: [{ text: '{"profileSummary":"ok","caloriesMacros":{},"week1Menu":{},"principlesWeek2_4":[],"detailedTargets":{}}' }] } }] })
+      json: async () => ({ candidates: [{ content: { parts: [{ text: '{"profileSummary":"ok","caloriesMacros":{"fiber_percent":10,"fiber_grams":30},"week1Menu":{},"principlesWeek2_4":[],"detailedTargets":{}}' }] } }] })
     });
 
     await mod.processSingleUserPlan(userId, env);
@@ -64,6 +64,6 @@ describe('processSingleUserPlan log metrics', () => {
     const putCalls = env.USER_METADATA_KV.put.mock.calls;
     const finalPlanCall = putCalls.find(c => c[0] === 'u1_final_plan');
     expect(finalPlanCall).toBeDefined();
-    expect(finalPlanCall[1]).toContain('"caloriesMacros": {}');
+    expect(finalPlanCall[1]).toContain('"caloriesMacros":{"fiber_percent":10,"fiber_grams":30}');
   });
 });

--- a/js/__tests__/planSummary.test.js
+++ b/js/__tests__/planSummary.test.js
@@ -3,7 +3,7 @@ import { createPlanUpdateSummary } from '../../worker.js';
 describe('createPlanUpdateSummary', () => {
   test('creates summary from new plan without truncating short text', () => {
     const newPlan = {
-      caloriesMacros: { calories: 1800 },
+      caloriesMacros: { calories: 1800, fiber_percent: 10, fiber_grams: 30 },
       principlesWeek2_4: 'Принцип 1\nПринцип 2\nПринцип 3'
     };
     const summary = createPlanUpdateSummary(newPlan, {});
@@ -15,7 +15,7 @@ describe('createPlanUpdateSummary', () => {
   test('limits number of changes when text is long', () => {
     const longLine = 'Много дълъг принцип който увеличава дължината на текста';
     const newPlan = {
-      caloriesMacros: { calories: 1800 },
+      caloriesMacros: { calories: 1800, fiber_percent: 10, fiber_grams: 30 },
       principlesWeek2_4: Array(6).fill(longLine).join('\n')
     };
     const summary = createPlanUpdateSummary(newPlan, {});

--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -29,7 +29,9 @@ test('recalculates macros automatically and shows spinner while loading', async 
     fat_percent: 30,
     protein_grams: 135,
     carbs_grams: 180,
-    fat_grams: 60
+    fat_grams: 60,
+    fiber_percent: 10,
+    fiber_grams: 30
   };
   const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
   const currentDayKey = dayNames[new Date().getDay()];
@@ -91,7 +93,7 @@ test('валидира и отхвърля некоректни макро да�
   const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
   const currentDayKey = dayNames[new Date().getDay()];
   appState.fullDashboardData.planData = { week1Menu: { [currentDayKey]: [] } };
-  const badMacros = { calories: 2000, protein_grams: 'bad', carbs_grams: 200, fat_grams: 60 };
+  const badMacros = { calories: 2000, protein_grams: 'bad', carbs_grams: 200, fat_grams: 60, fiber_percent: 10, fiber_grams: 30 };
   const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   await populateDashboardMacros(badMacros);
   expect(warnSpy).toHaveBeenCalled();

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -111,6 +111,8 @@ test('обновява макро картата чрез postMessage', async ()
         carbs_percent: 40,
         fat_grams: 50,
         fat_percent: 20,
+        fiber_percent: 10,
+        fiber_grams: 30,
       },
     },
     dailyLogs: [],

--- a/js/__tests__/updatePlanData.test.js
+++ b/js/__tests__/updatePlanData.test.js
@@ -4,7 +4,7 @@ import { handleUpdatePlanRequest } from '../../worker.js';
 describe('handleUpdatePlanRequest', () => {
   test('stores plan data using final plan key', async () => {
     const env = { USER_METADATA_KV: { put: jest.fn() } };
-    const planData = { week: 1, caloriesMacros: { calories: 2000 } };
+    const planData = { week: 1, caloriesMacros: { calories: 2000, fiber_percent: 10, fiber_grams: 30 } };
     const request = { json: async () => ({ userId: 'u1', planData }) };
     const res = await handleUpdatePlanRequest(request, env);
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_final_plan', JSON.stringify(planData));


### PR DESCRIPTION
## Summary
- add fiber_percent and fiber_grams to macro fixtures across tests
- refresh JSON mocks and expectations for new macro shape

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: sendAnalysisLinkEmail loads subject/body from KV; sendContactEmail uses contact_form_label from KV; OOM)*

------
https://chatgpt.com/codex/tasks/task_e_68901024bf548326ab7c5a295293dbba