### PR TITLE
Добавяне на полета за фибри в плана на клиента

### DIFF
--- a/editclient.html
+++ b/editclient.html
@@ -142,6 +142,10 @@
                                             Мазнини
                                             <span class="badge bg-danger rounded-pill" id="caloriesMacros-fat-view"></span>
                                         </li>
+                                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                                            Фибри
+                                            <span class="badge bg-success rounded-pill" id="caloriesMacros-fiber-view"></span>
+                                        </li>
                                     </ul>
                                 </div>
                                 <!-- Edit Mode -->
@@ -162,11 +166,17 @@
                                          <span class="input-group-text">(г)</span>
                                         <input type="number" class="form-control" id="caloriesMacros-edit-carbs-grams">
                                     </div>
-                                    <div class="input-group mb-3">
+                                    <div class="input-group mb-2">
                                         <span class="input-group-text">Мазнини (%)</span>
                                         <input type="number" class="form-control" id="caloriesMacros-edit-fat-percent">
                                          <span class="input-group-text">(г)</span>
                                         <input type="number" class="form-control" id="caloriesMacros-edit-fat-grams">
+                                    </div>
+                                    <div class="input-group mb-3">
+                                        <span class="input-group-text">Фибри (%)</span>
+                                        <input type="number" class="form-control" id="caloriesMacros-edit-fiber-percent">
+                                         <span class="input-group-text">(г)</span>
+                                        <input type="number" class="form-control" id="caloriesMacros-edit-fiber-grams">
                                     </div>
                                     <button class="btn btn-success btn-sm save-section-btn">Запази секция</button>
                                     <button class="btn btn-secondary btn-sm cancel-edit-btn" data-target="caloriesMacros-card">Отказ</button>

--- a/js/__tests__/editClient.test.js
+++ b/js/__tests__/editClient.test.js
@@ -24,9 +24,20 @@ test('initCharts uses Chart with parsed data', async () => {
   const { __testExports } = await import('../editClient.js');
   const { initCharts } = __testExports;
   await initCharts({
-    caloriesMacros: { protein_percent: 40, carbs_percent: 40, fat_percent: 20, protein_grams: 120, carbs_grams: 200, fat_grams: 50, calories: 2000 },
+    caloriesMacros: {
+      protein_percent: 40,
+      carbs_percent: 40,
+      fat_percent: 15,
+      fiber_percent: 5,
+      protein_grams: 120,
+      carbs_grams: 200,
+      fat_grams: 50,
+      fiber_grams: 25,
+      calories: 2000
+    },
     profileSummary: 'Текущо тегло 80 кг (промяна за 7 дни: -1 кг)'
   });
   expect(ChartMock.mock.calls[0][1].type).toBe('doughnut');
+  expect(ChartMock.mock.calls[0][1].data.datasets[0].data).toEqual([120, 200, 50, 25]);
   expect(ChartMock.mock.calls[1][1].type).toBe('line');
 });

--- a/js/__tests__/macroCalc.test.js
+++ b/js/__tests__/macroCalc.test.js
@@ -10,3 +10,8 @@ test('calcMacroGrams calculates grams from calories and percent', () => {
 test('calcMacroPercent calculates percent from grams', () => {
   expect(calcMacroPercent(2000, 200, 4)).toBe(40);
 });
+
+test('calculations support fiber at 2 kcal/g', () => {
+  expect(calcMacroGrams(2000, 10, 2)).toBe(100);
+  expect(calcMacroPercent(2000, 100, 2)).toBe(10);
+});

--- a/js/editClient.js
+++ b/js/editClient.js
@@ -75,6 +75,7 @@ export async function initEditClient(userId) {
     document.getElementById('caloriesMacros-protein-view').textContent = `${data.caloriesMacros?.protein_percent || 0}% / ${data.caloriesMacros?.protein_grams || 0}г`;
     document.getElementById('caloriesMacros-carbs-view').textContent = `${data.caloriesMacros?.carbs_percent || 0}% / ${data.caloriesMacros?.carbs_grams || 0}г`;
     document.getElementById('caloriesMacros-fat-view').textContent = `${data.caloriesMacros?.fat_percent || 0}% / ${data.caloriesMacros?.fat_grams || 0}г`;
+    document.getElementById('caloriesMacros-fiber-view').textContent = `${data.caloriesMacros?.fiber_percent || 0}% / ${data.caloriesMacros?.fiber_grams || 0}г`;
 
     document.getElementById('caloriesMacros-edit-calories').value = data.caloriesMacros?.calories || 0;
     document.getElementById('caloriesMacros-edit-protein-percent').value = data.caloriesMacros?.protein_percent || 0;
@@ -83,6 +84,8 @@ export async function initEditClient(userId) {
     document.getElementById('caloriesMacros-edit-carbs-grams').value = data.caloriesMacros?.carbs_grams || 0;
     document.getElementById('caloriesMacros-edit-fat-percent').value = data.caloriesMacros?.fat_percent || 0;
     document.getElementById('caloriesMacros-edit-fat-grams').value = data.caloriesMacros?.fat_grams || 0;
+    document.getElementById('caloriesMacros-edit-fiber-percent').value = data.caloriesMacros?.fiber_percent || 0;
+    document.getElementById('caloriesMacros-edit-fiber-grams').value = data.caloriesMacros?.fiber_grams || 0;
 
     populateList('main_allowed_foods', data.allowedForbiddenFoods?.main_allowed_foods || []);
     populateList('main_forbidden_foods', data.allowedForbiddenFoods?.main_forbidden_foods || []);
@@ -400,13 +403,16 @@ export async function initEditClient(userId) {
     const cGram = document.getElementById("caloriesMacros-edit-carbs-grams");
     const fPct = document.getElementById("caloriesMacros-edit-fat-percent");
     const fGram = document.getElementById("caloriesMacros-edit-fat-grams");
-  if (!calInput || !pPct || !pGram || !cPct || !cGram || !fPct || !fGram) return;
+    const fibPct = document.getElementById("caloriesMacros-edit-fiber-percent");
+    const fibGram = document.getElementById("caloriesMacros-edit-fiber-grams");
+  if (!calInput || !pPct || !pGram || !cPct || !cGram || !fPct || !fGram || !fibPct || !fibGram) return;
 
     function updateGrams() {
       const cal = parseInt(calInput.value);
       pGram.value = calcMacroGrams(cal, pPct.value, 4);
       cGram.value = calcMacroGrams(cal, cPct.value, 4);
       fGram.value = calcMacroGrams(cal, fPct.value, 9);
+      fibGram.value = calcMacroGrams(cal, fibPct.value, 2);
     }
 
     function updatePercents() {
@@ -415,12 +421,13 @@ export async function initEditClient(userId) {
       pPct.value = calcMacroPercent(cal, pGram.value, 4);
       cPct.value = calcMacroPercent(cal, cGram.value, 4);
       fPct.value = calcMacroPercent(cal, fGram.value, 9);
+      fibPct.value = calcMacroPercent(cal, fibGram.value, 2);
     }
 
-    [calInput, pPct, cPct, fPct].forEach(el => {
+    [calInput, pPct, cPct, fPct, fibPct].forEach(el => {
       el.addEventListener('input', updateGrams);
     });
-    [pGram, cGram, fGram].forEach(el => {
+    [pGram, cGram, fGram, fibGram].forEach(el => {
       el.addEventListener('input', updatePercents);
     });
   }
@@ -447,7 +454,9 @@ export async function initEditClient(userId) {
       carbs_percent: parseInt(document.getElementById('caloriesMacros-edit-carbs-percent').value),
       carbs_grams: parseInt(document.getElementById('caloriesMacros-edit-carbs-grams').value),
       fat_percent: parseInt(document.getElementById('caloriesMacros-edit-fat-percent').value),
-      fat_grams: parseInt(document.getElementById('caloriesMacros-edit-fat-grams').value)
+      fat_grams: parseInt(document.getElementById('caloriesMacros-edit-fat-grams').value),
+      fiber_percent: parseInt(document.getElementById('caloriesMacros-edit-fiber-percent').value),
+      fiber_grams: parseInt(document.getElementById('caloriesMacros-edit-fiber-grams').value)
     };
     planData.allowedForbiddenFoods = {
       main_allowed_foods: Array.from(document.querySelectorAll('#main_allowed_foods-edit input')).map(i => i.value).filter(Boolean),
@@ -676,11 +685,21 @@ export async function initCharts(data) {
     macroChart = new Chart(macroCtx, {
       type: 'doughnut',
       data: {
-        labels: [`Протеини (${data.caloriesMacros.protein_percent}%)`, `Въглехидрати (${data.caloriesMacros.carbs_percent}%)`, `Мазнини (${data.caloriesMacros.fat_percent}%)`],
+        labels: [
+          `Протеини (${data.caloriesMacros.protein_percent}%)`,
+          `Въглехидрати (${data.caloriesMacros.carbs_percent}%)`,
+          `Мазнини (${data.caloriesMacros.fat_percent}%)`,
+          `Фибри (${data.caloriesMacros.fiber_percent}%)`
+        ],
         datasets: [{
           label: 'Разпределение на макроси',
-          data: [data.caloriesMacros.protein_grams, data.caloriesMacros.carbs_grams, data.caloriesMacros.fat_grams],
-          backgroundColor: ['rgb(54,162,235)', 'rgb(255,205,86)', 'rgb(255,99,132)'],
+          data: [
+            data.caloriesMacros.protein_grams,
+            data.caloriesMacros.carbs_grams,
+            data.caloriesMacros.fat_grams,
+            data.caloriesMacros.fiber_grams
+          ],
+          backgroundColor: ['rgb(54,162,235)', 'rgb(255,205,86)', 'rgb(255,99,132)', 'rgb(111,207,151)'],
           hoverOffset: 4
         }]
       },


### PR DESCRIPTION
## Резюме
- Добавени са фибри като четвърти макро елемент в editclient.html и свързаните JS логики.
- Автоматичните преизчисления и диаграмата включват фибри (2 kcal/грам).
- Разширени са тестовете за калкулации и UI.

## Тестове
- `npm run lint`
- `npm test` (част от тестовете се провалиха: workerEmail, passwordReset, loadProductMacrosInit, extraMealNutrientLookup, extraMealAutofill)


------
https://chatgpt.com/codex/tasks/task_e_689013564e148326966740a6655927cc