### PR TITLE
feat: add fiber macro fields

### DIFF
--- a/editclient.html
+++ b/editclient.html
@@ -142,6 +142,10 @@
                                             Мазнини
                                             <span class="badge bg-danger rounded-pill" id="caloriesMacros-fat-view"></span>
                                         </li>
+                                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                                            Фибри
+                                            <span class="badge bg-success rounded-pill" id="caloriesMacros-fiber-view"></span>
+                                        </li>
                                     </ul>
                                 </div>
                                 <!-- Edit Mode -->
@@ -167,6 +171,12 @@
                                         <input type="number" class="form-control" id="caloriesMacros-edit-fat-percent">
                                          <span class="input-group-text">(г)</span>
                                         <input type="number" class="form-control" id="caloriesMacros-edit-fat-grams">
+                                    </div>
+                                    <div class="input-group mb-3">
+                                        <span class="input-group-text">Фибри (%)</span>
+                                        <input type="number" class="form-control" id="caloriesMacros-edit-fiber-percent">
+                                         <span class="input-group-text">(г)</span>
+                                        <input type="number" class="form-control" id="caloriesMacros-edit-fiber-grams">
                                     </div>
                                     <button class="btn btn-success btn-sm save-section-btn">Запази секция</button>
                                     <button class="btn btn-secondary btn-sm cancel-edit-btn" data-target="caloriesMacros-card">Отказ</button>

--- a/js/__tests__/editClient.test.js
+++ b/js/__tests__/editClient.test.js
@@ -27,6 +27,14 @@ test('initCharts uses Chart with parsed data', async () => {
     caloriesMacros: { protein_percent: 40, carbs_percent: 40, fat_percent: 20, protein_grams: 120, carbs_grams: 200, fat_grams: 50, calories: 2000, fiber_percent: 10, fiber_grams: 30 },
     profileSummary: 'Текущо тегло 80 кг (промяна за 7 дни: -1 кг)'
   });
-  expect(ChartMock.mock.calls[0][1].type).toBe('doughnut');
+  const macroConfig = ChartMock.mock.calls[0][1];
+  expect(macroConfig.type).toBe('doughnut');
+  expect(macroConfig.data.labels).toEqual([
+    'Протеини (40%)',
+    'Въглехидрати (40%)',
+    'Мазнини (20%)',
+    'Фибри (10%)'
+  ]);
+  expect(macroConfig.data.datasets[0].data).toEqual([120, 200, 50, 30]);
   expect(ChartMock.mock.calls[1][1].type).toBe('line');
 });

--- a/js/__tests__/macroCalc.test.js
+++ b/js/__tests__/macroCalc.test.js
@@ -10,3 +10,11 @@ test('calcMacroGrams calculates grams from calories and percent', () => {
 test('calcMacroPercent calculates percent from grams', () => {
   expect(calcMacroPercent(2000, 200, 4)).toBe(40);
 });
+
+test('calcMacroGrams handles fiber with 2 kcal/g', () => {
+  expect(calcMacroGrams(2000, 10, 2)).toBe(100);
+});
+
+test('calcMacroPercent handles fiber with 2 kcal/g', () => {
+  expect(calcMacroPercent(2000, 100, 2)).toBe(10);
+});

--- a/js/editClient.js
+++ b/js/editClient.js
@@ -75,6 +75,7 @@ export async function initEditClient(userId) {
     document.getElementById('caloriesMacros-protein-view').textContent = `${data.caloriesMacros?.protein_percent || 0}% / ${data.caloriesMacros?.protein_grams || 0}г`;
     document.getElementById('caloriesMacros-carbs-view').textContent = `${data.caloriesMacros?.carbs_percent || 0}% / ${data.caloriesMacros?.carbs_grams || 0}г`;
     document.getElementById('caloriesMacros-fat-view').textContent = `${data.caloriesMacros?.fat_percent || 0}% / ${data.caloriesMacros?.fat_grams || 0}г`;
+    document.getElementById('caloriesMacros-fiber-view').textContent = `${data.caloriesMacros?.fiber_percent || 0}% / ${data.caloriesMacros?.fiber_grams || 0}г`;
 
     document.getElementById('caloriesMacros-edit-calories').value = data.caloriesMacros?.calories || 0;
     document.getElementById('caloriesMacros-edit-protein-percent').value = data.caloriesMacros?.protein_percent || 0;
@@ -83,6 +84,8 @@ export async function initEditClient(userId) {
     document.getElementById('caloriesMacros-edit-carbs-grams').value = data.caloriesMacros?.carbs_grams || 0;
     document.getElementById('caloriesMacros-edit-fat-percent').value = data.caloriesMacros?.fat_percent || 0;
     document.getElementById('caloriesMacros-edit-fat-grams').value = data.caloriesMacros?.fat_grams || 0;
+    document.getElementById('caloriesMacros-edit-fiber-percent').value = data.caloriesMacros?.fiber_percent || 0;
+    document.getElementById('caloriesMacros-edit-fiber-grams').value = data.caloriesMacros?.fiber_grams || 0;
 
     populateList('main_allowed_foods', data.allowedForbiddenFoods?.main_allowed_foods || []);
     populateList('main_forbidden_foods', data.allowedForbiddenFoods?.main_forbidden_foods || []);
@@ -400,13 +403,16 @@ export async function initEditClient(userId) {
     const cGram = document.getElementById("caloriesMacros-edit-carbs-grams");
     const fPct = document.getElementById("caloriesMacros-edit-fat-percent");
     const fGram = document.getElementById("caloriesMacros-edit-fat-grams");
-  if (!calInput || !pPct || !pGram || !cPct || !cGram || !fPct || !fGram) return;
+    const fiPct = document.getElementById("caloriesMacros-edit-fiber-percent");
+    const fiGram = document.getElementById("caloriesMacros-edit-fiber-grams");
+  if (!calInput || !pPct || !pGram || !cPct || !cGram || !fPct || !fGram || !fiPct || !fiGram) return;
 
     function updateGrams() {
       const cal = parseInt(calInput.value);
       pGram.value = calcMacroGrams(cal, pPct.value, 4);
       cGram.value = calcMacroGrams(cal, cPct.value, 4);
       fGram.value = calcMacroGrams(cal, fPct.value, 9);
+      fiGram.value = calcMacroGrams(cal, fiPct.value, 2);
     }
 
     function updatePercents() {
@@ -415,12 +421,13 @@ export async function initEditClient(userId) {
       pPct.value = calcMacroPercent(cal, pGram.value, 4);
       cPct.value = calcMacroPercent(cal, cGram.value, 4);
       fPct.value = calcMacroPercent(cal, fGram.value, 9);
+      fiPct.value = calcMacroPercent(cal, fiGram.value, 2);
     }
 
-    [calInput, pPct, cPct, fPct].forEach(el => {
+    [calInput, pPct, cPct, fPct, fiPct].forEach(el => {
       el.addEventListener('input', updateGrams);
     });
-    [pGram, cGram, fGram].forEach(el => {
+    [pGram, cGram, fGram, fiGram].forEach(el => {
       el.addEventListener('input', updatePercents);
     });
   }
@@ -447,7 +454,9 @@ export async function initEditClient(userId) {
       carbs_percent: parseInt(document.getElementById('caloriesMacros-edit-carbs-percent').value),
       carbs_grams: parseInt(document.getElementById('caloriesMacros-edit-carbs-grams').value),
       fat_percent: parseInt(document.getElementById('caloriesMacros-edit-fat-percent').value),
-      fat_grams: parseInt(document.getElementById('caloriesMacros-edit-fat-grams').value)
+      fat_grams: parseInt(document.getElementById('caloriesMacros-edit-fat-grams').value),
+      fiber_percent: parseInt(document.getElementById('caloriesMacros-edit-fiber-percent').value),
+      fiber_grams: parseInt(document.getElementById('caloriesMacros-edit-fiber-grams').value)
     };
     planData.allowedForbiddenFoods = {
       main_allowed_foods: Array.from(document.querySelectorAll('#main_allowed_foods-edit input')).map(i => i.value).filter(Boolean),
@@ -676,11 +685,26 @@ export async function initCharts(data) {
     macroChart = new Chart(macroCtx, {
       type: 'doughnut',
       data: {
-        labels: [`Протеини (${data.caloriesMacros.protein_percent}%)`, `Въглехидрати (${data.caloriesMacros.carbs_percent}%)`, `Мазнини (${data.caloriesMacros.fat_percent}%)`],
+        labels: [
+          `Протеини (${data.caloriesMacros.protein_percent}%)`,
+          `Въглехидрати (${data.caloriesMacros.carbs_percent}%)`,
+          `Мазнини (${data.caloriesMacros.fat_percent}%)`,
+          `Фибри (${data.caloriesMacros.fiber_percent}%)`
+        ],
         datasets: [{
           label: 'Разпределение на макроси',
-          data: [data.caloriesMacros.protein_grams, data.caloriesMacros.carbs_grams, data.caloriesMacros.fat_grams],
-          backgroundColor: ['rgb(54,162,235)', 'rgb(255,205,86)', 'rgb(255,99,132)'],
+          data: [
+            data.caloriesMacros.protein_grams,
+            data.caloriesMacros.carbs_grams,
+            data.caloriesMacros.fat_grams,
+            data.caloriesMacros.fiber_grams
+          ],
+          backgroundColor: [
+            'rgb(54,162,235)',
+            'rgb(255,205,86)',
+            'rgb(255,99,132)',
+            'rgb(111,207,151)'
+          ],
           hoverOffset: 4
         }]
       },


### PR DESCRIPTION
## Summary
- add fiber field to macro list and editing form
- support fiber percent/grams and chart segment
- cover fiber calculations in tests

## Testing
- `npm run lint`
- `npm test js/__tests__/macroCalc.test.js js/__tests__/editClient.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689015186dbc8326b28724bdf981737d