### PR TITLE
feat: използване на macros поле в calculatePlanMacros

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -36,6 +36,15 @@ test('calculatePlanMacros sums macros for day menu', () => {
   expect(result).toEqual({ calories: 850, protein: 72, carbs: 70, fat: 28, fiber: 0 });
 });
 
+test('calculatePlanMacros използва наличното поле macros', () => {
+  const dayMenu = [
+    { macros: { calories: 100, protein: 10, carbs: 20, fat: 5, fiber: 3 } },
+    { macros: { calories: 200, protein: 20, carbs: 30, fat: 10, fiber: 5 } }
+  ];
+  const result = calculatePlanMacros(dayMenu);
+  expect(result).toEqual({ calories: 300, protein: 30, carbs: 50, fat: 15, fiber: 8 });
+});
+
 test('addMealMacros и removeMealMacros актуализират акумулатора', () => {
   const acc = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
   const meal = { calories: 290, protein: 20, carbs: 30, fat: 10, fiber: 5 };

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -172,7 +172,26 @@ export function removeMealMacros(meal, acc) {
 export function calculatePlanMacros(dayMenu = []) {
   const acc = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
   if (!Array.isArray(dayMenu)) return acc;
-  dayMenu.forEach((meal) => addMealMacros(meal, acc));
+  dayMenu.forEach((meal) => {
+    const macros = meal && typeof meal.macros === 'object' ? meal.macros : null;
+    if (macros) {
+      const normalized = {
+        calories: Number(macros.calories) || 0,
+        protein: Number(macros.protein) || 0,
+        carbs: Number(macros.carbs) || 0,
+        fat: Number(macros.fat) || 0,
+        fiber: Number(macros.fiber) || 0
+      };
+      validateMacroCalories(normalized);
+      acc.calories += normalized.calories;
+      acc.protein += normalized.protein;
+      acc.carbs += normalized.carbs;
+      acc.fat += normalized.fat;
+      acc.fiber += normalized.fiber;
+    } else {
+      addMealMacros(meal, acc);
+    }
+  });
   return acc;
 }
 


### PR DESCRIPTION
## Summary
- четене на `macros` от храненията в `calculatePlanMacros`
- тест за новото поведение и fallback към стария механизъм

## Testing
- `npm test` (част от тестовете се провалиха)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689016df06188326aba12532d4404766