### PR TITLE
Compare intake against plan in macro analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,12 +177,12 @@ Include the common registration logic by importing `setupRegistration`:
 
 ### MacroAnalyticsCard
 
-Компонентът визуализира целеви и текущ прием на макронутриенти чрез карта и двойна кръгова диаграма.
+Компонентът визуализира планов и текущ прием на макронутриенти чрез карта и двойна кръгова диаграма.
 
 **Данни**
 
 ```js
-const targetData = {
+const planData = {
   calories: 2200,
   protein_grams: 140,
   carbs_grams: 248,
@@ -207,14 +207,14 @@ const currentData = {
 ```html
 <macro-analytics-card
   exceed-threshold="1.2"
-  target-data="..."
+  plan-data="..."
   current-data="...">
 </macro-analytics-card>
 ```
 
 **Функции**
 
-- `renderMacroAnalyticsCard(target, current)` изгражда HTML картата и легендата.
+- `renderMacroAnalyticsCard(plan, current)` изгражда HTML картата и легендата.
 - `renderMacroChart()` рисува двойната диаграма с `Chart.js`.
 - `highlightMacro(el, index)` подсветява избрания сегмент в картата и диаграмата.
 
@@ -270,9 +270,9 @@ locales/
 **Динамични данни**
 
 ```js
-const targetData = await fetch('/api/target').then(r => r.json());
+const planData = await fetch('/api/plan').then(r => r.json());
 const currentData = await fetch('/api/current').then(r => r.json());
-renderMacroAnalyticsCard(targetData, currentData);
+renderMacroAnalyticsCard(planData, currentData);
 renderMacroChart();
 ```
 

--- a/docs/macroAnalyticsCard.html
+++ b/docs/macroAnalyticsCard.html
@@ -19,7 +19,7 @@
     <summary>Интеграция</summary>
     <ol>
       <li>Копирайте файла или го вградете с <code>&lt;iframe&gt;</code>.</li>
-      <li>Подайте данни чрез атрибутите <code>target-data</code> и <code>current-data</code> (JSON) или използвайте <code>data-endpoint</code> с <code>refresh-interval</code>.</li>
+      <li>Подайте данни чрез атрибутите <code>plan-data</code> и <code>current-data</code> (JSON) или използвайте <code>data-endpoint</code> с <code>refresh-interval</code>.</li>
       <li>Променете цветовете чрез CSS променливите в <code>:root</code>.</li>
     </ol>
   </details>

--- a/js/__tests__/macroAnalyticsCardComponent.test.js
+++ b/js/__tests__/macroAnalyticsCardComponent.test.js
@@ -20,7 +20,8 @@ beforeEach(async () => {
       fromGoal: 'от целта',
       subtitle: '{percent} от целта',
       totalCaloriesLabel: 'от {calories} kcal',
-      exceedWarning: 'Превишение над 15%: {items}'
+      exceedWarning: 'Превишение над 15%: {items}',
+      intakeVsPlanLabel: 'Прием vs План'
     })
   });
   global.IntersectionObserver = class { observe() {} disconnect() {} };
@@ -37,7 +38,7 @@ afterEach(() => {
 test('рендерира метриките и реагира на highlightMacro', async () => {
   const card = document.createElement('macro-analytics-card');
   document.body.appendChild(card);
-  const target = {
+  const plan = {
     calories: 2000,
     protein_grams: 150,
     protein_percent: 75,
@@ -46,14 +47,13 @@ test('рендерира метриките и реагира на highlightMacr
     fat_grams: 70,
     fat_percent: 35
   };
-  const plan = { calories: 1900 };
   const current = {
     calories: 1200,
     protein_grams: 60,
     carbs_grams: 100,
     fat_grams: 40
   };
-  card.setData({ target, plan, current });
+  card.setData({ plan, current });
   const utils = within(card.shadowRoot);
   await waitFor(() => utils.getByText('Белтъчини'));
   expect(utils.getByText('60 / 150г')).toBeTruthy();
@@ -70,7 +70,7 @@ test('рендерира метриките и реагира на highlightMacr
 test('показва предупреждение при превишаване на макросите', async () => {
   const card = document.createElement('macro-analytics-card');
   document.body.appendChild(card);
-  const target = {
+  const plan = {
     calories: 2000,
     protein_grams: 100,
     protein_percent: 40,
@@ -85,7 +85,7 @@ test('показва предупреждение при превишаване 
     carbs_grams: 150,
     fat_grams: 40
   };
-  card.setData({ target, current });
+  card.setData({ plan, current });
   const utils = within(card.shadowRoot);
   await waitFor(() => utils.getByText(/Превишение над 15%/));
   expect(utils.getByText(/Превишение над 15%/)).toBeTruthy();
@@ -94,7 +94,7 @@ test('показва предупреждение при превишаване 
 test('класифицира over и under макросите', async () => {
   const card = document.createElement('macro-analytics-card');
   document.body.appendChild(card);
-  const target = {
+  const plan = {
     calories: 2000,
     protein_grams: 100,
     protein_percent: 40,
@@ -109,7 +109,7 @@ test('класифицира over и under макросите', async () => {
     carbs_grams: 200,
     fat_grams: 40
   };
-  card.setData({ target, current });
+  card.setData({ plan, current });
   const utils = within(card.shadowRoot);
   await waitFor(() => utils.getByText('Белтъчини'));
   const proteinDiv = utils.getByText('Белтъчини').closest('.macro-metric');
@@ -132,14 +132,15 @@ test('data-endpoint и refresh-interval извикват fetch периодич�
             fromGoal: 'от целта',
             subtitle: '{percent} от целта',
             totalCaloriesLabel: 'от {calories} kcal',
-            exceedWarning: 'Превишение над 15%: {items}'
+            exceedWarning: 'Превишение над 15%: {items}',
+            intakeVsPlanLabel: 'Прием vs План'
           })
         });
       }
     return Promise.resolve({
       ok: true,
       json: async () => ({
-        target: {
+        plan: {
           calories: 2000,
           protein_grams: 150,
           protein_percent: 75,
@@ -148,7 +149,6 @@ test('data-endpoint и refresh-interval извикват fetch периодич�
           fat_grams: 70,
           fat_percent: 35
         },
-        plan: { calories: 1900 },
         current: {
           calories: 1200,
           protein_grams: 60,

--- a/js/__tests__/macroAnalyticsCardInnerRing.test.js
+++ b/js/__tests__/macroAnalyticsCardInnerRing.test.js
@@ -28,7 +28,8 @@ beforeEach(async () => {
       fromGoal: 'от целта',
       subtitle: '{percent} от целта',
       totalCaloriesLabel: 'от {calories} kcal',
-      exceedWarning: 'Превишение над 15%: {items}'
+      exceedWarning: 'Превишение над 15%: {items}',
+      intakeVsPlanLabel: 'Прием vs План'
     })
   });
   jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: async () => ChartMock }));
@@ -42,7 +43,7 @@ afterEach(() => {
 test('рендерира вътрешен пръстен при текущи макроси', async () => {
   const card = document.createElement('macro-analytics-card');
   document.body.appendChild(card);
-  const target = {
+  const plan = {
     calories: 2000,
     protein_grams: 150,
     protein_percent: 75,
@@ -60,7 +61,7 @@ test('рендерира вътрешен пръстен при текущи м�
     fat_grams: 40,
     fiber_grams: 20
   };
-  card.setData({ target, current });
+  card.setData({ plan, current });
   await waitFor(() => {
     expect(global.__lastChartInstance).toBeTruthy();
     expect(global.__lastChartInstance.data.datasets.length).toBe(2);

--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -80,7 +80,6 @@ test('recalculates macros automatically and shows spinner while loading', async 
   expect(msg).toMatchObject({
     type: 'macro-data',
     data: {
-      target: macros,
       plan: expect.objectContaining({ calories: 850, protein: 72, carbs: 70, fat: 28 }),
       current: expectedCurrent
     }

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -137,7 +137,6 @@ test('обновява макро картата чрез postMessage', async ()
     {
       type: 'macro-data',
       data: {
-        target: expect.objectContaining({ calories: 1800 }),
         plan: expect.any(Object),
         current: {}
       }

--- a/js/__tests__/renderPendingMacroChart.test.js
+++ b/js/__tests__/renderPendingMacroChart.test.js
@@ -50,7 +50,7 @@ describe('renderPendingMacroChart', () => {
     selectors.macroAnalyticsCardContainer.appendChild(frame);
     renderPendingMacroChart();
     expect(frame.contentWindow.postMessage).toHaveBeenCalledWith(
-      { type: 'macro-data', data: expect.objectContaining({ target: macros }) },
+      { type: 'macro-data', data: expect.objectContaining({ plan: expect.any(Object) }) },
       '*'
     );
 

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -410,19 +410,17 @@ function renderMacroPreviewGrid(macros) {
 /**
  * Валидира структурата на макро payload-а.
  * Проверява наличието на ключове и че стойностите им са числа.
- * @param {{ target: object, plan: object, current: object }} payload
+ * @param {{ plan: object, current: object }} payload
  * @returns {boolean}
  */
-export function validateMacroPayload({ target, plan, current }) {
+export function validateMacroPayload({ plan, current }) {
     const isObj = v => v && typeof v === 'object';
     const check = (obj, keys) => isObj(obj) && keys.every(k => typeof obj[k] === 'number' && !isNaN(obj[k]));
-    const targetValid = check(target, ['calories', 'protein_grams', 'carbs_grams', 'fat_grams']) &&
-        (target?.fiber_grams === undefined || typeof target.fiber_grams === 'number');
     const planValid = check(plan, ['calories', 'protein', 'carbs', 'fat']) &&
         (plan?.fiber === undefined || typeof plan.fiber === 'number');
     const currentValid = check(current, ['calories', 'protein_grams', 'carbs_grams', 'fat_grams']) &&
         (current?.fiber_grams === undefined || typeof current.fiber_grams === 'number');
-    return targetValid && planValid && currentValid;
+    return planValid && currentValid;
 }
 
 export async function populateDashboardMacros(macros) {
@@ -458,7 +456,7 @@ export async function populateDashboardMacros(macros) {
     const today = new Date();
     const currentDayKey = dayNames[today.getDay()];
     const dayMenu = fullDashboardData?.planData?.week1Menu?.[currentDayKey] || [];
-    const planMacros = calculatePlanMacros(dayMenu);
+    const plan = calculatePlanMacros(dayMenu);
     const current = {
         calories: currentIntakeMacros.calories,
         protein_grams: currentIntakeMacros.protein,
@@ -466,7 +464,7 @@ export async function populateDashboardMacros(macros) {
         fat_grams: currentIntakeMacros.fat,
         fiber_grams: currentIntakeMacros.fiber
     };
-    const payload = { target: macros, plan: planMacros, current };
+    const payload = { plan, current };
     if (!validateMacroPayload(payload)) {
         console.warn('Невалидна структура на макро-данните', payload);
         logMacroPayload({ error: 'Invalid macro payload structure', payload });

--- a/locales/macroCard.bg.json
+++ b/locales/macroCard.bg.json
@@ -11,5 +11,5 @@
   "subtitle": "{percent} от целта",
   "totalCaloriesLabel": "от {calories} kcal",
   "exceedWarning": "Превишение над 15%: {items}",
-  "planVsTargetLabel": "План vs Цел: {plan} / {target} kcal"
+  "intakeVsPlanLabel": "Прием vs План"
 }

--- a/locales/macroCard.en.json
+++ b/locales/macroCard.en.json
@@ -11,5 +11,5 @@
   "subtitle": "{percent} of goal",
   "totalCaloriesLabel": "of {calories} kcal",
   "exceedWarning": "Exceeds target by >15%: {items}",
-  "planVsTargetLabel": "Plan vs Goal: {plan} / {target} kcal"
+  "intakeVsPlanLabel": "Intake vs Plan"
 }

--- a/macroAnalyticsCardStandalone.html
+++ b/macroAnalyticsCardStandalone.html
@@ -5,7 +5,7 @@
   Използва локалния loader (./js/chartLoader.js), който трябва да бъде копиран при самостоятелно използване или в <iframe>.
   Интеграция:
   - копирайте файла или го вградете с <iframe>;
-  - подайте данни чрез атрибутите "current-data" и "target-data" (JSON) или
+  - подайте данни чрез атрибутите "current-data" и "plan-data" (JSON) или
     използвайте "data-endpoint" и "refresh-interval" за автоматично опресняване;
   - цветовете се настройват чрез CSS променливите в :root;
   - преводите се зареждат от locales/macroCard.{lang}.json според атрибута "locale".
@@ -211,7 +211,7 @@
         this.titleEl = this.shadowRoot.querySelector('h5');
         this.chart = null;
         this.activeMacroIndex = null;
-        this.targetData = null;
+        this.planData = null;
         this.currentData = null;
         this.observer = null;
         this.refreshTimer = null;
@@ -227,7 +227,7 @@
       }
 
       static get observedAttributes() {
-        return ['target-data', 'current-data', 'locale', 'data-endpoint', 'refresh-interval'];
+        return ['plan-data', 'current-data', 'locale', 'data-endpoint', 'refresh-interval'];
       }
 
       async connectedCallback() {
@@ -249,7 +249,7 @@
         }
         try {
           const parsed = JSON.parse(newVal);
-          if (name === 'target-data') this.targetData = parsed;
+          if (name === 'plan-data') this.planData = parsed;
           if (name === 'current-data') this.currentData = parsed;
           this.renderMetrics();
           this.renderChart();
@@ -300,7 +300,7 @@
           try {
             const res = await fetch(endpoint);
             const data = await res.json();
-            if (data.target && data.current) {
+            if (data.plan && data.current) {
               this.setData(data);
             }
           } catch (e) {
@@ -311,8 +311,8 @@
         this.refreshTimer = setInterval(fetchData, interval);
       }
 
-      setData({ target, current }) {
-        if (target) this.setAttribute('target-data', JSON.stringify(target));
+      setData({ plan, current }) {
+        if (plan) this.setAttribute('plan-data', JSON.stringify(plan));
         if (current) this.setAttribute('current-data', JSON.stringify(current));
       }
 
@@ -343,22 +343,24 @@
       }
 
       renderMetrics() {
-        const target = this.targetData;
+        const plan = this.planData;
         const current = this.currentData;
-        if (!target || !current) return;
+        if (!plan) return;
         this.grid.innerHTML = '';
+        const consumed = current?.calories ?? '--';
         this.centerText.innerHTML = `
-          <div class="consumed-calories">${current.calories}</div>
-          <div class="total-calories-label">${this.labels.totalCaloriesLabel.replace('{calories}', target.calories)}</div>`;
+          <div class="consumed-calories">${consumed} / ${plan.calories}</div>
+          <div class="total-calories-label">${this.labels.intakeVsPlanLabel || 'Прием vs План'}</div>`;
+        if (!current) return;
         const calDiv = document.createElement('div');
         calDiv.className = 'macro-metric calories';
         calDiv.setAttribute('role', 'listitem');
-        calDiv.setAttribute('aria-label', `${this.labels.caloriesLabel}: ${current.calories} ${this.labels.totalCaloriesLabel.replace('{calories}', target.calories)}`);
+        calDiv.setAttribute('aria-label', `${this.labels.caloriesLabel}: ${current.calories} ${this.labels.totalCaloriesLabel.replace('{calories}', plan.calories)}`);
         calDiv.innerHTML = `
           <span class="macro-icon"><i class="bi bi-fire"></i></span>
           <div class="macro-label">${this.labels.caloriesLabel}</div>
-          <div class="macro-value">${current.calories} / ${target.calories} kcal</div>`;
-        const calDiff = current.calories - target.calories;
+          <div class="macro-value">${current.calories} / ${plan.calories} kcal</div>`;
+        const calDiff = current.calories - plan.calories;
         if (calDiff > 0) {
           calDiv.classList.add('over');
         } else if (calDiff < 0) {
@@ -374,8 +376,8 @@
         macros.forEach((item, idx) => {
           const label = this.labels.macros[item.key];
           const currentVal = current[`${item.key}_grams`];
-          const targetVal = target[`${item.key}_grams`];
-          const ratio = targetVal ? currentVal / targetVal : 0;
+          const planVal = plan[`${item.key}_grams`];
+          const ratio = planVal ? currentVal / planVal : 0;
           const percent = Math.round(ratio * 100);
           const percentText = `${percent}%`;
           const subtitle = this.labels.subtitle
@@ -385,14 +387,14 @@
           div.className = `macro-metric ${item.key}`;
           div.setAttribute('role', 'button');
           div.setAttribute('tabindex', '0');
-          div.setAttribute('aria-label', `${label}: ${currentVal} от ${targetVal} грама (${subtitle})`);
+          div.setAttribute('aria-label', `${label}: ${currentVal} от ${planVal} грама (${subtitle})`);
           div.setAttribute('aria-pressed', 'false');
           div.innerHTML = `
             <span class="macro-icon"><i class="bi ${item.icon}"></i></span>
             <div class="macro-label">${label}</div>
-            <div class="macro-value">${currentVal} / ${targetVal}г</div>
+            <div class="macro-value">${currentVal} / ${planVal}г</div>
             <div class="macro-subtitle">${subtitle}</div>`;
-          const diff = currentVal - targetVal;
+          const diff = currentVal - planVal;
           if (diff > 0) {
             div.classList.add('over');
           } else if (diff < 0) {
@@ -410,9 +412,9 @@
       }
 
       renderChart() {
-        const target = this.targetData;
+        const plan = this.planData;
         const current = this.currentData;
-        if (!target || !current || !this.canvas || typeof Chart === 'undefined') return;
+        if (!plan || !this.canvas || typeof Chart === 'undefined') return;
         const skeleton = this.shadowRoot.querySelector('.chart-skeleton');
         if (skeleton) skeleton.remove();
         if (this.canvas.hasAttribute('hidden')) this.canvas.removeAttribute('hidden');
@@ -424,34 +426,37 @@
           this.getCssVar('--macro-fat-color'),
           this.getCssVar('--macro-fiber-color')
         ];
+        const datasets = [
+          {
+            label: 'План',
+            data: [plan.protein_grams, plan.carbs_grams, plan.fat_grams, plan.fiber_grams],
+            backgroundColor: current ? macroColors.map((c) => `${c}40`) : macroColors,
+            borderWidth: 0,
+            cutout: current ? '80%' : '65%'
+          }
+        ];
+        if (current) {
+          datasets.push({
+            label: 'Прием',
+            data: [current.protein_grams, current.carbs_grams, current.fat_grams, current.fiber_grams],
+            backgroundColor: macroColors,
+            borderColor: this.getCssVar('--card-bg'),
+            borderWidth: 4,
+            borderRadius: 8,
+            cutout: '65%',
+            hoverOffset: 12
+          });
+        }
         this.chart = new Chart(ctx, {
           type: 'doughnut',
           data: {
             labels: [
-              `${this.labels.macros.protein} (${target.protein_percent}%)`,
-              `${this.labels.macros.carbs} (${target.carbs_percent}%)`,
-              `${this.labels.macros.fat} (${target.fat_percent}%)`,
-              `${this.labels.macros.fiber} (${target.fiber_percent}%)`
+              `${this.labels.macros.protein} (${plan.protein_percent}%)`,
+              `${this.labels.macros.carbs} (${plan.carbs_percent}%)`,
+              `${this.labels.macros.fat} (${plan.fat_percent}%)`,
+              `${this.labels.macros.fiber} (${plan.fiber_percent}%)`
             ],
-            datasets: [
-              {
-                label: 'Цел',
-                data: [target.protein_grams, target.carbs_grams, target.fat_grams, target.fiber_grams],
-                backgroundColor: macroColors.map((c) => `${c}40`),
-                borderWidth: 0,
-                cutout: '80%'
-              },
-              {
-                label: 'Прием',
-                data: [current.protein_grams, current.carbs_grams, current.fat_grams, current.fiber_grams],
-                backgroundColor: macroColors,
-                borderColor: this.getCssVar('--card-bg'),
-                borderWidth: 4,
-                borderRadius: 8,
-                cutout: '65%',
-                hoverOffset: 12
-              }
-            ]
+            datasets
           },
           options: {
             responsive: true,


### PR DESCRIPTION
## Summary
- Update macro analytics card to use plan data, show "Прием vs План" in center text, and label dataset as Plan (g)
- Simplify macro payloads to `{ plan, current }` and validate only those fields
- Refresh localization and docs for the new intake-vs-plan comparison

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689019bafcd88326909c05bd789d1a06