### PR TITLE
Уеднаквяване на цветовете на оценките

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -594,11 +594,11 @@ body.vivid-theme .tracker .metric-rating .rating-value {
   flex-basis: calc(20% - 5px); /* За 5 правоъгълника с gap 6px (4 gaps * 6px = 24px) */
 }
 .rating-square:hover { transform: scale(1.1); }
-.rating-square.filled.level-1 { background-color: var(--rating-1); border-color: var(--rating-1); }
-.rating-square.filled.level-2 { background-color: var(--rating-2); border-color: var(--rating-2); }
-.rating-square.filled.level-3 { background-color: var(--rating-3); border-color: var(--rating-3); }
-.rating-square.filled.level-4 { background-color: var(--rating-4); border-color: var(--rating-4); }
-.rating-square.filled.level-5 { background-color: var(--rating-5); border-color: var(--rating-5); }
+.rating-square.filled.level-1 { background-color: var(--progress-level-1); border-color: var(--progress-level-1); }
+.rating-square.filled.level-2 { background-color: var(--progress-level-2); border-color: var(--progress-level-2); }
+.rating-square.filled.level-3 { background-color: var(--progress-level-3); border-color: var(--progress-level-3); }
+.rating-square.filled.level-4 { background-color: var(--progress-level-4); border-color: var(--progress-level-4); }
+.rating-square.filled.level-5 { background-color: var(--progress-level-5); border-color: var(--progress-level-5); }
 
 
 .tooltip-tracker {

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -348,8 +348,9 @@ function handleDelegatedClicks(event) {
             if (hiddenInput) hiddenInput.value = selectedValue;
             squaresContainer.querySelectorAll('.rating-square').forEach(s => {
                 const sValue = parseInt(s.dataset.value);
-                s.classList.remove('filled'); for(let i=1; i<=5; i++) s.classList.remove(`level-${i}`);
-                if (sValue <= selectedValue) s.classList.add('filled', `level-${sValue}`);
+                s.classList.remove('filled');
+                for(let i=1; i<=5; i++) s.classList.remove(`level-${i}`);
+                if (sValue <= selectedValue) s.classList.add('filled', `level-${selectedValue}`);
             });
             metricRatingDiv.classList.toggle('active', selectedValue > 0);
         }

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -651,7 +651,7 @@ function populateDashboardLog(dailyLogs, currentStatus, initialData) {
                 ${[1,2,3,4,5].map(val => {
                     const levelDescription = trackerInfoTexts[metric.key]?.levels?.[val] || `Оценка ${val} от 5`;
                     return `<div
-                                class="rating-square ${val <= currentValue ? `filled level-${val}` : ''}"
+                                class="rating-square ${val <= currentValue ? `filled level-${currentValue}` : ''}"
                                 data-value="${val}"
                                 title="${levelDescription}"
                                 aria-label="${levelDescription}"></div>`;


### PR DESCRIPTION
## Обобщение
- Уеднаквяване на цветовете на квадратчетата за рейтинг с палитрата на прогрес бара
- Цветът на всички запълнени квадратчета вече следва избраното ниво

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68901ff39f7c8326b4ac14e0ba9659bb