### PR TITLE
feat: normalize meal macros

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 import { jest } from '@jest/globals';
-import { calculateCurrentMacros, addMealMacros, removeMealMacros, registerNutrientOverrides, getNutrientOverride, calculatePlanMacros, loadProductMacros, scaleMacros, formatPercent, __testExports } from '../macroUtils.js';
+import { calculateCurrentMacros, addMealMacros, removeMealMacros, registerNutrientOverrides, getNutrientOverride, calculatePlanMacros, loadProductMacros, scaleMacros, formatPercent, normalizeMacros, __testExports } from '../macroUtils.js';
 
 test('calculateCurrentMacros sums macros from completed meals and extras', () => {
   const planMenu = {
@@ -98,4 +98,9 @@ test('formatPercent форматира съотношения', () => {
   expect(formatPercent(0.4)).toBe('40%');
   expect(formatPercent(0)).toBe('0%');
   expect(formatPercent('na')).toBe('--%');
+});
+
+test('normalizeMacros попълва липсващи полета с 0', () => {
+  const result = normalizeMacros({ calories: 50, protein: 10 });
+  expect(result).toEqual({ calories: 50, protein: 10, carbs: 0, fat: 0, fiber: 0 });
 });


### PR DESCRIPTION
## Summary
- add `normalizeMacros` helper to fill missing macro fields with zeroes
- use `normalizeMacros` in `addMealMacros` and `calculateCurrentMacros`
- cover missing-field defaults with tests

## Testing
- `npm run lint`
- `npm test`
- `NODE_OPTIONS=--experimental-vm-modules npx --no-install jest js/__tests__/macroUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6890219871408326b2d159017fb6ab29