### PR TITLE
feat: convert plan macros to grams

### DIFF
--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -83,7 +83,7 @@ test('recalculates macros automatically and shows spinner while loading', async 
   expect(msg).toMatchObject({
     type: 'macro-data',
     data: {
-      plan: expect.objectContaining({ calories: 850, protein: 72, carbs: 70, fat: 28 }),
+      plan: expect.objectContaining({ calories: 850, protein_grams: 72, carbs_grams: 70, fat_grams: 28 }),
       current: expectedCurrent
     }
   });
@@ -95,16 +95,15 @@ test('валидира и отхвърля некоректни макро да�
   const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
   const currentDayKey = dayNames[new Date().getDay()];
   appState.fullDashboardData.planData = { week1Menu: { [currentDayKey]: [] } };
-  Object.assign(appState.todaysPlanMacros, macroUtils.calculatePlanMacros([]));
-  const badMacros = { calories: 2000, protein_grams: 'bad', carbs_grams: 200, fat_grams: 60, fiber_percent: 10, fiber_grams: 30 };
-  await populateDashboardMacros(badMacros);
+  Object.assign(appState.todaysPlanMacros, { calories: 2000, protein: 'bad', carbs: 200, fat: 60, fiber: 30 });
+  await populateDashboardMacros({});
   expect(populateModule.lastMacroPayload).toBe(previous);
 });
 
 test('calculatePlanMacros се извиква само веднъж при кеширани стойности', async () => {
   jest.resetModules();
   const calcMock = jest.fn().mockReturnValue({ calories: 100, protein: 10, carbs: 20, fat: 5, fiber: 3 });
-  jest.unstable_mockModule('../macroUtils.js', () => ({ loadProductMacros: jest.fn(), calculateCurrentMacros: jest.fn(), calculatePlanMacros: calcMock, getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn(), registerNutrientOverrides: jest.fn() }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({ loadProductMacros: jest.fn(), calculateCurrentMacros: jest.fn(), calculatePlanMacros: calcMock, getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), removeMealMacros: jest.fn(), scaleMacros: jest.fn(), registerNutrientOverrides: jest.fn() }));
   const app = await import('../app.js');
   const populate = await import('../populateUI.js');
   const { populateDashboardMacros } = populate;

--- a/js/__tests__/renderPendingMacroChart.test.js
+++ b/js/__tests__/renderPendingMacroChart.test.js
@@ -46,6 +46,7 @@ describe('renderPendingMacroChart', () => {
 
   test('posts updated macro data to iframe on each render', async () => {
     const macros = { calories: 1800, protein_percent: 30, carbs_percent: 40, fat_percent: 30, protein_grams: 135, carbs_grams: 180, fat_grams: 60 };
+    Object.assign(appState.todaysPlanMacros, { calories: 850, protein: 72, carbs: 70, fat: 28 });
     await populateDashboardMacros(macros);
     const frame = document.createElement('iframe');
     frame.id = 'macroAnalyticsCardFrame';
@@ -53,7 +54,7 @@ describe('renderPendingMacroChart', () => {
     selectors.macroAnalyticsCardContainer.appendChild(frame);
     renderPendingMacroChart();
     expect(frame.contentWindow.postMessage).toHaveBeenCalledWith(
-      { type: 'macro-data', data: expect.objectContaining({ plan: expect.any(Object) }) },
+      { type: 'macro-data', data: expect.objectContaining({ plan: expect.objectContaining({ protein_grams: 72 }) }) },
       '*'
     );
 

--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -4,6 +4,15 @@ import { scaleMacros, formatPercent } from './macroUtils.js';
 
 let Chart;
 
+function ensureGramsFields(obj) {
+  if (!obj) return obj;
+  if (obj.protein_grams === undefined && typeof obj.protein === 'number') obj.protein_grams = obj.protein;
+  if (obj.carbs_grams === undefined && typeof obj.carbs === 'number') obj.carbs_grams = obj.carbs;
+  if (obj.fat_grams === undefined && typeof obj.fat === 'number') obj.fat_grams = obj.fat;
+  if (obj.fiber_grams === undefined && typeof obj.fiber === 'number') obj.fiber_grams = obj.fiber;
+  return obj;
+}
+
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
@@ -241,8 +250,8 @@ export class MacroAnalyticsCard extends HTMLElement {
           };
         }
       }
-      if (name === 'plan-data') this.planData = parsed;
-      if (name === 'current-data') this.currentData = parsed;
+      if (name === 'plan-data') this.planData = ensureGramsFields(parsed);
+      if (name === 'current-data') this.currentData = ensureGramsFields(parsed);
       this.renderMetrics();
       this.renderChart();
     } catch (e) {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -443,8 +443,8 @@ function renderMacroPreviewGrid(macros) {
 export function validateMacroPayload({ plan, current }) {
     const isObj = v => v && typeof v === 'object';
     const check = (obj, keys) => isObj(obj) && keys.every(k => typeof obj[k] === 'number' && !isNaN(obj[k]));
-    const planValid = check(plan, ['calories', 'protein', 'carbs', 'fat']) &&
-        (plan?.fiber === undefined || typeof plan.fiber === 'number');
+    const planValid = check(plan, ['calories', 'protein_grams', 'carbs_grams', 'fat_grams']) &&
+        (plan?.fiber_grams === undefined || typeof plan.fiber_grams === 'number');
     const currentValid = check(current, ['calories', 'protein_grams', 'carbs_grams', 'fat_grams']) &&
         (current?.fiber_grams === undefined || typeof current.fiber_grams === 'number');
     return planValid && currentValid;
@@ -479,7 +479,13 @@ export async function populateDashboardMacros(macros) {
         return;
     }
     macroContainer.innerHTML = '';
-    const plan = todaysPlanMacros;
+    const plan = {
+        calories: todaysPlanMacros.calories,
+        protein_grams: todaysPlanMacros.protein,
+        carbs_grams: todaysPlanMacros.carbs,
+        fat_grams: todaysPlanMacros.fat,
+        fiber_grams: todaysPlanMacros.fiber
+    };
     const current = {
         calories: currentIntakeMacros.calories,
         protein_grams: currentIntakeMacros.protein,


### PR DESCRIPTION
## Summary
- convert plan macros to `_grams` fields before sending payloads
- validate payloads using new `_grams` keys and adapt tests
- add `_grams` fallback in macro analytics component

## Testing
- `npm run lint`
- `npm test` *(fails: workerEmail.test.js, passwordReset.test.js, login.test.js, ...)*
- `npm test js/__tests__/populateDashboardMacros.test.js`
- `npm test js/__tests__/renderPendingMacroChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689029095d548326a82deba8db4fa150