### PR TITLE
fix: preserve meal completion when recalculating intake

### DIFF
--- a/js/__tests__/loadCurrentIntake.test.js
+++ b/js/__tests__/loadCurrentIntake.test.js
@@ -28,3 +28,38 @@ test('loadCurrentIntake агрегира макросите от логовет�
     fiber: 1,
   });
 });
+
+test('loadCurrentIntake не презаписва подаденото състояние', async () => {
+  jest.resetModules();
+  const app = await import('../app.js');
+  Object.assign(app.fullDashboardData, { planData: { week1Menu: {} } });
+  app.todaysMealCompletionStatus.sample = true;
+  app.todaysExtraMeals.length = 0;
+  app.todaysExtraMeals.push({ calories: 100, protein: 5, carbs: 10, fat: 2, fiber: 1 });
+  app.loadCurrentIntake(app.todaysMealCompletionStatus, app.todaysExtraMeals);
+  expect(app.todaysMealCompletionStatus).toEqual({ sample: true });
+  expect(app.currentIntakeMacros).toEqual({
+    calories: 100,
+    protein: 5,
+    carbs: 10,
+    fat: 2,
+    fiber: 1,
+  });
+});
+
+test('recalculateCurrentIntakeMacros преизчислява макросите', async () => {
+  jest.resetModules();
+  const app = await import('../app.js');
+  Object.assign(app.fullDashboardData, { planData: { week1Menu: {} } });
+  app.todaysMealCompletionStatus.sample = true;
+  app.todaysExtraMeals.length = 0;
+  app.todaysExtraMeals.push({ calories: 50, protein: 2, carbs: 5, fat: 1, fiber: 1 });
+  app.recalculateCurrentIntakeMacros();
+  expect(app.currentIntakeMacros).toEqual({
+    calories: 50,
+    protein: 2,
+    carbs: 5,
+    fat: 1,
+    fiber: 1,
+  });
+});

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -25,7 +25,7 @@ import {
     todaysMealCompletionStatus, todaysExtraMeals, currentIntakeMacros,
     fullDashboardData, activeTooltip, currentUserId,
     setChatModelOverride, setChatPromptOverride,
-    loadCurrentIntake
+    recalculateCurrentIntakeMacros
 } from './app.js';
 import { addMealMacros, removeMealMacros } from './macroUtils.js';
 import {
@@ -368,7 +368,7 @@ function handleDelegatedClicks(event) {
             if (meal) {
                 (isCompleted ? addMealMacros : removeMealMacros)(meal, currentIntakeMacros);
             }
-            loadCurrentIntake();
+            recalculateCurrentIntakeMacros();
             populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
             // Автоматично опресняване на макро-картата
             renderPendingMacroChart();


### PR DESCRIPTION
## Summary
- keep meal completion flags by recalculating macros instead of reloading intake
- allow `loadCurrentIntake` to use existing state and expose `recalculateCurrentIntakeMacros`
- expand intake tests to cover new behaviour

## Testing
- `npm run lint`
- `npm test js/__tests__/loadCurrentIntake.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68902c0d4a508326a408f2b3aaa2581e