### PR TITLE
Добавяне на поддръжка за модела command-r-plus

### DIFF
--- a/js/__tests__/callModel.test.js
+++ b/js/__tests__/callModel.test.js
@@ -49,3 +49,27 @@ describe('callModel with CF provider', () => {
     await expect(callModel(model, 'hi', env)).rejects.toThrow('CF AI error: bad');
   });
 });
+
+describe('callModel with command-r-plus model', () => {
+  const env = { CF_ACCOUNT_ID: 'acc', CF_AI_TOKEN: 'token' };
+  const model = 'command-r-plus';
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('uses Cloudflare endpoint', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { response: 'ok' } })
+    });
+
+    await callModel(model, 'hi', env);
+
+    const expectedUrl = 'https://api.cloudflare.com/client/v4/accounts/acc/ai/run/command-r-plus';
+    expect(global.fetch).toHaveBeenCalledWith(
+      expectedUrl,
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -4086,6 +4086,7 @@ async function callOpenAiAPI(prompt, apiKey, model, options = {}) {
 
 function getModelProvider(model) {
     if (!model) return 'gemini';
+    if (model === 'command-r-plus') return 'cf';
     if (model.startsWith('@cf/')) return 'cf';
     if (model.startsWith('gpt-')) return 'openai';
     return 'gemini';


### PR DESCRIPTION
## Обобщение
- добавена е проверка, която връща `cf` при модел `command-r-plus`
- тест, който гарантира, че `callModel` използва Cloudflare за този модел

## Тестване
- `npm run lint`
- `npm test js/__tests__/callModel.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6890373efb048326be7a2ed24c2b041b