### PR TITLE
Handle Cohere provider for command-r-plus

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -4084,9 +4084,10 @@ async function callOpenAiAPI(prompt, apiKey, model, options = {}) {
 }
 // ------------- END FUNCTION: callOpenAiAPI -------------
 
+
 function getModelProvider(model) {
     if (!model) return 'gemini';
-    if (model === 'command-r-plus') return 'cf';
+    if (model === 'command-r-plus') return 'cohere';
     if (model.startsWith('@cf/')) return 'cf';
     if (model.startsWith('gpt-')) return 'openai';
     return 'gemini';
@@ -4094,7 +4095,7 @@ function getModelProvider(model) {
 
 async function callModel(model, prompt, env, { temperature = 0.7, maxTokens = 800 } = {}) {
     const provider = getModelProvider(model);
-    if (provider === 'cf') {
+    if (provider === 'cf' || provider === 'cohere') {
         return callCfAi(
             model,
             {


### PR DESCRIPTION
## Summary
- Map `command-r-plus` to the `cohere` provider and allow `callModel` to invoke CF AI for Cohere models.

## Testing
- `npm run lint`
- `npm test js/__tests__/callModel.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68909c8212ac832691b949019fe5a76e