### PR TITLE
refactor macros recalc

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -45,13 +45,22 @@ test('calculatePlanMacros използва наличното поле macros', 
   expect(result).toEqual({ calories: 300, protein: 30, carbs: 50, fat: 15, fiber: 8 });
 });
 
-test('addMealMacros и removeMealMacros актуализират акумулатора', () => {
+test('addMealMacros и removeMealMacros актуализират и clamp-ват акумулатора', () => {
   const acc = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
   const meal = { calories: 290, protein: 20, carbs: 30, fat: 10, fiber: 5 };
   addMealMacros(meal, acc);
   expect(acc).toEqual({ calories: 290, protein: 20, carbs: 30, fat: 10, fiber: 5 });
   removeMealMacros(meal, acc);
   expect(acc).toEqual({ calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 });
+  // repeat removal to ensure clamp to 0
+  removeMealMacros(meal, acc);
+  expect(acc).toEqual({ calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 });
+});
+
+test('removeMealMacros нормализира липсващи полета', () => {
+  const acc = { calories: 100, protein: 10, carbs: 10, fat: 5, fiber: 2 };
+  removeMealMacros({ calories: 150, protein: 20 }, acc);
+  expect(acc).toEqual({ calories: 0, protein: 0, carbs: 10, fat: 5, fiber: 2 });
 });
 
 test('scaleMacros скалира макросите спрямо грамовете', () => {

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -22,12 +22,11 @@ import {
     handleChatSend, handleChatInputKeypress, // from app.js / chat.js
     _handlePrevQuizQuestion, _handleNextQuizQuestion, _handleSubmitQuizAnswersClientSide, // from app.js
     _handleTriggerAdaptiveQuizClientSide, // from app.js
-    todaysMealCompletionStatus, todaysExtraMeals, currentIntakeMacros,
+    todaysMealCompletionStatus,
     fullDashboardData, activeTooltip, currentUserId,
     setChatModelOverride, setChatPromptOverride,
     recalculateCurrentIntakeMacros
 } from './app.js';
-import { addMealMacros, removeMealMacros } from './macroUtils.js';
 import {
     openPlanModificationChat,
     clearPlanModChat,
@@ -364,10 +363,6 @@ function handleDelegatedClicks(event) {
         if (day && index !== undefined) {
             const isCompleted = mealCard.classList.toggle('completed');
             todaysMealCompletionStatus[`${day}_${index}`] = isCompleted;
-            const meal = fullDashboardData.planData?.week1Menu?.[day]?.[index];
-            if (meal) {
-                (isCompleted ? addMealMacros : removeMealMacros)(meal, currentIntakeMacros);
-            }
             recalculateCurrentIntakeMacros();
             populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
             // Автоматично опресняване на макро-картата

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -169,13 +169,13 @@ export function addMealMacros(meal, acc) {
 }
 
 export function removeMealMacros(meal, acc) {
-  const m = resolveMacros(meal, meal?.grams);
+  const m = normalizeMacros(resolveMacros(meal, meal?.grams));
   validateMacroCalories(m);
-  acc.calories = (acc.calories || 0) - m.calories;
-  acc.protein = (acc.protein || 0) - m.protein;
-  acc.carbs = (acc.carbs || 0) - m.carbs;
-  acc.fat = (acc.fat || 0) - m.fat;
-  acc.fiber = (acc.fiber || 0) - m.fiber;
+  acc.calories = Math.max(0, (acc.calories || 0) - m.calories);
+  acc.protein = Math.max(0, (acc.protein || 0) - m.protein);
+  acc.carbs = Math.max(0, (acc.carbs || 0) - m.carbs);
+  acc.fat = Math.max(0, (acc.fat || 0) - m.fat);
+  acc.fiber = Math.max(0, (acc.fiber || 0) - m.fiber);
   return acc;
 }
 


### PR DESCRIPTION
## Summary
- rely solely on macro recalculation when toggling meals
- guard macro removal to normalize inputs and avoid negative totals
- expand macroUtils tests for clamping and normalization

## Testing
- `npm run lint js/eventListeners.js js/macroUtils.js js/__tests__/macroUtils.test.js js/__tests__/loadCurrentIntake.test.js`
- `npm test js/__tests__/macroUtils.test.js js/__tests__/loadCurrentIntake.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68909d64e90c8326b70c7512d8a7b351