### PR TITLE
test: add cohere chat coverage

### DIFF
--- a/js/__tests__/callModel.test.js
+++ b/js/__tests__/callModel.test.js
@@ -51,25 +51,30 @@ describe('callModel with CF provider', () => {
 });
 
 describe('callModel with command-r-plus model', () => {
-  const env = { CF_ACCOUNT_ID: 'acc', CF_AI_TOKEN: 'token' };
   const model = 'command-r-plus';
+  const env = { COHERE_API_KEY: 'key' };
 
   afterEach(() => {
     global.fetch = originalFetch;
   });
 
-  test('uses Cloudflare endpoint', async () => {
+  test('uses Cohere chat endpoint', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ result: { response: 'ok' } })
+      json: async () => ({ text: 'ok' })
     });
 
-    await callModel(model, 'hi', env);
+    const res = await callModel(model, 'hi', env);
 
-    const expectedUrl = 'https://api.cloudflare.com/client/v4/accounts/acc/ai/run/command-r-plus';
+    expect(res).toBe('ok');
+    const expectedUrl = 'https://api.cohere.ai/v1/chat';
     expect(global.fetch).toHaveBeenCalledWith(
       expectedUrl,
       expect.objectContaining({ method: 'POST' })
     );
+  });
+
+  test('throws if API key missing', async () => {
+    await expect(callModel(model, 'hi', {})).rejects.toThrow('Missing Cohere API key.');
   });
 });

--- a/worker.js
+++ b/worker.js
@@ -4090,10 +4090,10 @@ async function callCohereAI(model, prompt, apiKey, options = {}) {
     if (!model) {
         throw new Error('Cohere model name is missing.');
     }
-    const url = 'https://api.cohere.ai/v1/generate';
+    const url = 'https://api.cohere.ai/v1/chat';
     const body = {
         model,
-        prompt,
+        message: prompt,
         ...(options.temperature !== undefined && { temperature: options.temperature }),
         ...(options.maxTokens !== undefined && { max_tokens: options.maxTokens })
     };
@@ -4110,7 +4110,7 @@ async function callCohereAI(model, prompt, apiKey, options = {}) {
         const msg = data?.message || data?.error || `HTTP ${resp.status}`;
         throw new Error(`Cohere API Error (${model}): ${msg}`);
     }
-    const text = data?.generations?.[0]?.text;
+    const text = data?.text;
     if (text === undefined || text === null) {
         throw new Error(`Cohere API Error (${model}): No text in response.`);
     }


### PR DESCRIPTION
## Summary
- test cohere callModel with chat endpoint
- use Cohere chat API in callCohereAI helper

## Testing
- `npx eslint js/__tests__/callModel.test.js worker.js`
- `npm test js/__tests__/callModel.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6890c156dc888326b70dfd65b6e9f581