### PR TITLE
use command-r-plus secret for Cohere model

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ Before deploying, configure the following secrets in Cloudflare (via the dashboa
 - `PHP_FILE_API_TOKEN`
 - `CF_AI_TOKEN` – API token used for Cloudflare AI requests
 - `OPENAI_API_KEY` – set via `wrangler secret put OPENAI_API_KEY`, used by `worker.js`
-- `COHERE_API_KEY` – API ключ за Cohere модели
+- `command-r-plus` – API ключ за Cohere модела `command-r-plus`
 - `FROM_EMAIL` – optional sender address for outgoing emails
 - `FROM_NAME` – optional display name shown in the "From" header
 
@@ -714,27 +714,36 @@ await fetch(CF_URL, {
 }
 ```
 
-#### Cohere чат модели
+#### Cohere чат модел `command-r-plus`
 
-За работа с моделите на Cohere задайте секрет `COHERE_API_KEY`.
-
-Кратък пример за заявка:
+За работа с този модел задайте секрет `command-r-plus`:
 
 ```bash
-curl -X POST https://api.cohere.ai/v1/chat \
-  -H "Authorization: Bearer $COHERE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"model":"command","message":"Здравей","temperature":0.7,"max_tokens":50}'
+wrangler secret put command-r-plus
 ```
 
-JSON форматът на заявката:
+Примерен `curl` към Cohere:
+
+```bash
+curl https://api.cohere.ai/v1/chat \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "model": "command-r-plus",
+        "message": "Analyze the following Bulgarian text...",
+        "temperature": 0.3,
+        "max_tokens": 512
+      }'
+```
+
+Пълен JSON пример:
 
 ```json
 {
-  "model": "command",
-  "message": "Здравей",
-  "temperature": 0.7,
-  "max_tokens": 50
+  "model": "command-r-plus",
+  "message": "Analyze the following Bulgarian text.\n\nPerform the following tasks:\n\n1. Identify the main topic(s) and summarize them concisely.\n2. Extract the central claim and any supporting arguments.\n3. Detect any logical inconsistencies or contradictions.\n4. Infer one implicit assumption that is not explicitly stated.\n\nText:\n\n„Човекът е по природа социално същество, но съвременното общество създава изолация чрез дигитализацията. Макар да сме по-свързани от всякога, расте чувството на самота. Следователно технологичният прогрес подкопава човешката природа.“",
+  "temperature": 0.3,
+  "max_tokens": 512
 }
 ```
 

--- a/js/__tests__/callModel.test.js
+++ b/js/__tests__/callModel.test.js
@@ -52,7 +52,7 @@ describe('callModel with CF provider', () => {
 
 describe('callModel with command-r-plus model', () => {
   const model = 'command-r-plus';
-  const env = { COHERE_API_KEY: 'key' };
+  const env = { 'command-r-plus': 'key' };
 
   afterEach(() => {
     global.fetch = originalFetch;
@@ -75,6 +75,6 @@ describe('callModel with command-r-plus model', () => {
   });
 
   test('throws if API key missing', async () => {
-    await expect(callModel(model, 'hi', {})).rejects.toThrow('Missing Cohere API key.');
+    await expect(callModel(model, 'hi', {})).rejects.toThrow('Missing command-r-plus API key.');
   });
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -228,7 +228,7 @@ const modelHints = {
     '@cf/llava-hf/llava-v1.6b': { tokens: 'до 4096', temperature: 'препоръчително 0.2' },
     '@cf/stabilityai/clip': { tokens: 'до 77', temperature: 'препоръчително 0.2' },
     'gpt-3.5-turbo': { tokens: 'до 8192', temperature: 'препоръчително 0.3' },
-    'command-r-plus': { tokens: 'до 128000', temperature: 'по подразбиране 0.75' },
+    'command-r-plus': { tokens: 'до 8192', temperature: 'препоръчително 0.3' },
     'gemini-pro': { tokens: 'до 2048', temperature: 'по подразбиране 0.2' }
 };
 

--- a/worker.js
+++ b/worker.js
@@ -285,7 +285,7 @@ async function sendPasswordResetEmail(to, token, env) {
 // ------------- START BLOCK: GlobalConstantsAndBindings -------------
 const GEMINI_API_KEY_SECRET_NAME = 'GEMINI_API_KEY';
 const OPENAI_API_KEY_SECRET_NAME = 'OPENAI_API_KEY';
-const COHERE_API_KEY_SECRET_NAME = 'COHERE_API_KEY';
+const COMMAND_R_PLUS_SECRET_NAME = 'command-r-plus';
 const CF_AI_TOKEN_SECRET_NAME = 'CF_AI_TOKEN';
 const CF_ACCOUNT_ID_VAR_NAME = 'CF_ACCOUNT_ID';
 const WORKER_ADMIN_TOKEN_SECRET_NAME = 'WORKER_ADMIN_TOKEN';
@@ -4141,8 +4141,8 @@ async function callModel(model, prompt, env, { temperature = 0.7, maxTokens = 80
         );
     }
     if (provider === 'cohere') {
-        const key = env[COHERE_API_KEY_SECRET_NAME];
-        if (!key) throw new Error('Missing Cohere API key.');
+        const key = env[COMMAND_R_PLUS_SECRET_NAME];
+        if (!key) throw new Error('Missing command-r-plus API key.');
         return callCohereAI(model, prompt, key, { temperature, maxTokens });
     }
     if (provider === 'openai') {


### PR DESCRIPTION
## Summary
- switch worker to read Cohere key from `command-r-plus` secret
- update admin hints and docs for `command-r-plus`
- adjust tests for new secret name

## Testing
- `npm run lint`
- `npm test js/__tests__/callModel.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68903689a49c832696021ffd31060225