### PR TITLE
Добавен избор на AI модел

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -382,9 +382,10 @@
         редактират от този панел. Полето „Admin Token" се използва за
         удостоверяване на заявките към API.</p>
       <label>Admin Token: <input id="adminToken" type="text"></label>
+      <datalist id="modelOptions"></datalist>
       <fieldset>
         <legend>Генериране на план</legend>
-        <label>Модел: <input id="planModel" type="text"> <button type="button" id="testPlanModel">Тествай</button></label>
+        <label>Модел: <input id="planModel" type="text" list="modelOptions"> <button type="button" id="testPlanModel">Тествай</button></label>
         <label>Промпт:<br><textarea id="planPrompt" rows="3"></textarea></label>
         <label>Token limit: <input id="planTokens" type="number" min="1"></label>
         <label>Temperature: <input id="planTemperature" type="number" min="0" max="1" step="0.1"></label>
@@ -392,7 +393,7 @@
       </fieldset>
       <fieldset>
         <legend>Чат</legend>
-        <label>Модел: <input id="chatModel" type="text"> <button type="button" id="testChatModel">Тествай</button></label>
+        <label>Модел: <input id="chatModel" type="text" list="modelOptions"> <button type="button" id="testChatModel">Тествай</button></label>
         <label>Промпт:<br><textarea id="chatPrompt" rows="2"></textarea></label>
         <label>Token limit: <input id="chatTokens" type="number" min="1"></label>
         <label>Temperature: <input id="chatTemperature" type="number" min="0" max="1" step="0.1"></label>
@@ -400,7 +401,7 @@
       </fieldset>
       <fieldset>
         <legend>Модификация на плана</legend>
-        <label>Модел: <input id="modModel" type="text"> <button type="button" id="testModModel">Тествай</button></label>
+        <label>Модел: <input id="modModel" type="text" list="modelOptions"> <button type="button" id="testModModel">Тествай</button></label>
         <label>Промпт:<br><textarea id="modPrompt" rows="2"></textarea></label>
         <label>Token limit: <input id="modTokens" type="number" min="1"></label>
         <label>Temperature: <input id="modTemperature" type="number" min="0" max="1" step="0.1"></label>
@@ -408,7 +409,7 @@
       </fieldset>
       <fieldset>
         <legend>Анализ на изображение</legend>
-        <label>Модел: <input id="imageModel" type="text"> <button type="button" id="testImageModel">Тествай</button></label>
+        <label>Модел: <input id="imageModel" type="text" list="modelOptions"> <button type="button" id="testImageModel">Тествай</button></label>
         <label>Промпт:<br><textarea id="imagePrompt" rows="2" required></textarea></label>
         <label>Token limit: <input id="imageTokens" type="number" min="1"></label>
         <label>Temperature: <input id="imageTemperature" type="number" min="0" max="1" step="0.1"></label>
@@ -416,7 +417,7 @@
       </fieldset>
       <fieldset>
         <legend>Анализ на въпросник</legend>
-        <label>Модел: <input id="analysisModel" type="text"> <button type="button" id="testAnalysisModel">Тествай</button></label>
+        <label>Модел: <input id="analysisModel" type="text" list="modelOptions"> <button type="button" id="testAnalysisModel">Тествай</button></label>
         <label>Промпт:<br><textarea id="analysisPrompt" rows="2"></textarea></label>
       </fieldset>
       <div class="preset-controls">

--- a/js/__tests__/saveAiConfig.test.js
+++ b/js/__tests__/saveAiConfig.test.js
@@ -8,23 +8,24 @@ beforeEach(async () => {
 
   document.body.innerHTML = `
     <form id="aiConfigForm">
-      <input id="planModel" />
+      <datalist id="modelOptions"></datalist>
+      <input id="planModel" list="modelOptions" />
       <textarea id="planPrompt"></textarea>
       <input id="planTokens" />
       <input id="planTemperature" />
-      <input id="chatModel" />
+      <input id="chatModel" list="modelOptions" />
       <textarea id="chatPrompt"></textarea>
       <input id="chatTokens" />
       <input id="chatTemperature" />
-      <input id="modModel" />
+      <input id="modModel" list="modelOptions" />
       <textarea id="modPrompt"></textarea>
       <input id="modTokens" />
       <input id="modTemperature" />
-      <input id="imageModel" />
+      <input id="imageModel" list="modelOptions" />
       <textarea id="imagePrompt"></textarea>
       <input id="imageTokens" />
       <input id="imageTemperature" />
-      <input id="analysisModel" />
+      <input id="analysisModel" list="modelOptions" />
       <textarea id="analysisPrompt"></textarea>
       <input id="adminToken" />
     </form>
@@ -32,6 +33,7 @@ beforeEach(async () => {
     <button id="sendQuery"></button>
   `;
   sessionStorage.clear();
+  localStorage.clear();
   sessionStorage.setItem('adminToken', 'secret');
 
   const form = document.getElementById('aiConfigForm');
@@ -53,6 +55,7 @@ beforeEach(async () => {
 afterEach(() => {
   global.fetch && global.fetch.mockRestore();
   sessionStorage.clear();
+  localStorage.clear();
 });
 
 test('saveAiConfig sends updates payload with Authorization header', async () => {

--- a/js/admin.js
+++ b/js/admin.js
@@ -97,6 +97,29 @@ const testImageBtn = document.getElementById('testImageModel');
 const analysisModelInput = document.getElementById('analysisModel');
 const analysisPromptInput = document.getElementById('analysisPrompt');
 const testAnalysisBtn = document.getElementById('testAnalysisModel');
+
+const modelOptionsList = document.getElementById('modelOptions');
+let availableModels = new Set(JSON.parse(localStorage.getItem('aiModelHistory') || '[]'));
+
+function populateModelOptions() {
+    if (!modelOptionsList) return;
+    modelOptionsList.innerHTML = '';
+    for (const m of availableModels) {
+        if (!m) continue;
+        const opt = document.createElement('option');
+        opt.value = m;
+        modelOptionsList.appendChild(opt);
+    }
+}
+
+function recordSuccessfulModel(modelName) {
+    if (!modelName) return;
+    availableModels.add(modelName);
+    localStorage.setItem('aiModelHistory', JSON.stringify(Array.from(availableModels)));
+    populateModelOptions();
+}
+
+populateModelOptions();
 const emailSettingsForm = document.getElementById('emailSettingsForm');
 const fromEmailNameInput = document.getElementById('fromEmailName');
 const emailTypesContainer = document.getElementById('emailTypesContainer');
@@ -1295,6 +1318,9 @@ async function loadAiConfig() {
         updateHints(chatModelInput, chatHints);
         updateHints(modModelInput, modHints);
         updateHints(imageModelInput, imageHints);
+        ['model_plan_generation', 'model_chat', 'model_principle_adjustment', 'model_image_analysis', 'model_questionnaire_analysis']
+            .forEach(k => { if (cfg[k]) availableModels.add(cfg[k]); });
+        populateModelOptions();
     } catch (err) {
         console.error('Error loading AI config:', err);
         alert('Грешка при зареждане на AI конфигурацията.');
@@ -1741,6 +1767,7 @@ async function testAiModel(modelName) {
             alert(data.message || 'Неуспешен тест.');
         } else {
             alert('Връзката е успешна.');
+            recordSuccessfulModel(modelName);
         }
     } catch (err) {
         console.error('Error testing AI model:', err);


### PR DESCRIPTION
## Резюме
- добавен споделен datalist за избор на AI модел в админ панела
- попълване на опциите от конфигурацията и успешните тестове
- актуализиран тест за запазване на AI конфигурация

## Тестване
- `npm run lint`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js js/__tests__/saveAiConfig.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6890e08987d8832681e44dbce9f48bd9