### PR TITLE
Добавен прогрес при регенерация на план

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -268,6 +268,11 @@
       </form>
     </details>
     <button id="regeneratePlan">Генерирай нов план</button>
+    <div id="regenProgress" class="hidden">
+      <div class="progress">
+        <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 100%"></div>
+      </div>
+    </div>
     <button id="aiSummary">AI резюме</button>
     <div class="profile-nav-container">
       <button id="profileCardNavToggle" class="profile-nav-toggle" aria-label="Показване на навигацията">

--- a/editclient.html
+++ b/editclient.html
@@ -82,6 +82,12 @@
         </div>
     </nav>
 
+    <div id="regenProgress" class="hidden">
+        <div class="progress">
+            <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 100%"></div>
+        </div>
+    </div>
+
     <div class="container-fluid mt-4">
         <div class="row">
             <!-- Main Content Column -->


### PR DESCRIPTION
## Обобщение
- UI: добавен прогрес-бар за регенериране на план в admin и editclient страниците.
- JS: показване на прогрес и периодична проверка на `planStatus` до `ready` или `error`.

## Тестване
- `npm run lint`
- `npm test js/__tests__/regeneratePlan.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6890f46daa348326a1e05656131c6a66