### PR TITLE
feat: allow plan regeneration after final plan error

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -13,10 +13,18 @@ body {
   border-radius: 50%;
   background: var(--color-danger);
 }
-#clientsList li { margin-bottom: 5px; }
-#clientsList button {
-  width: 100%;
+#clientsList li {
+  margin-bottom: 5px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+#clientsList button.client-item {
+  flex: 1 1 auto;
   text-align: left;
+}
+#clientsList button.regen-btn {
+  flex: none;
 }
 #clientsControls {
   display: flex;


### PR DESCRIPTION
## Summary
- show regenerate plan button for users with final plan errors
- style client list for inline action button

## Testing
- `npm run lint`
- `sh ./scripts/test.sh js/__tests__/planGenerationLogs.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6891047b54108326bd0c40559da9e3a6