### PR TITLE
Показване на бутон за нов план при грешка

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -13,10 +13,17 @@ body {
   border-radius: 50%;
   background: var(--color-danger);
 }
-#clientsList li { margin-bottom: 5px; }
-#clientsList button {
-  width: 100%;
+#clientsList li {
+  margin-bottom: 5px;
+  display: flex;
+  gap: 5px;
+}
+#clientsList .client-open {
+  flex: 1;
   text-align: left;
+}
+#clientsList .regen-plan-btn {
+  flex: 0 0 auto;
 }
 #clientsControls {
   display: flex;

--- a/js/admin.js
+++ b/js/admin.js
@@ -677,6 +677,7 @@ function renderClients() {
     list.forEach(c => {
         const li = document.createElement('li');
         const btn = document.createElement('button');
+        btn.className = 'client-open';
         const dateText = c.registrationDate ? ` - ${new Date(c.registrationDate).toLocaleDateString('bg-BG')}` : '';
         const lastText = c.lastUpdated ? ` (обновено ${new Date(c.lastUpdated).toLocaleDateString('bg-BG')})` : '';
         btn.textContent = `${c.name}${dateText}${lastText}`;
@@ -697,6 +698,30 @@ function renderClients() {
         }
         btn.addEventListener('click', () => showClient(c.userId));
         li.appendChild(btn);
+
+        const needsPlan = c.status === 'pending' || c.status === 'error' || c.status === 'unknown';
+        if (needsPlan) {
+            const regen = document.createElement('button');
+            regen.className = 'regen-plan-btn button-small';
+            regen.textContent = 'Нов план';
+            regen.title = 'Генерирай нов план';
+            regen.addEventListener('click', async e => {
+                e.stopPropagation();
+                try {
+                    await fetch(apiEndpoints.regeneratePlan, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ userId: c.userId })
+                    });
+                    alert('Стартирана е нова генерация.');
+                } catch (err) {
+                    console.error('regeneratePlan error:', err);
+                    alert('Грешка при стартиране на генерирането.');
+                }
+            });
+            li.appendChild(regen);
+        }
+
         clientsList?.appendChild(li);
     });
 }


### PR DESCRIPTION
## Резюме
- добавен е втори бутон „Нов план“ към клиентите със статус pending/error/unknown
- обновен е CSS за хоризонтално подреждане на бутона в списъка

## Тестване
- `npm run lint`
- `npm test js/__tests__/passwordReset.test.js` *(неуспешен тест)*

------
https://chatgpt.com/codex/tasks/task_e_6891047b54108326bd0c40559da9e3a6