### PR TITLE
Ensure macro chart loads when iframe missing

### DIFF
--- a/js/__tests__/renderPendingMacroChart.test.js
+++ b/js/__tests__/renderPendingMacroChart.test.js
@@ -8,6 +8,7 @@ describe('renderPendingMacroChart', () => {
   let selectors;
   let populateModule;
   let __setLastMacroPayload;
+  let ensureMacroAnalyticsFrame;
 
   beforeEach(async () => {
     jest.resetModules();
@@ -18,6 +19,7 @@ describe('renderPendingMacroChart', () => {
     selectors = {
       macroMetricsPreview: document.getElementById('macroMetricsPreview'),
       analyticsCardsContainer: document.getElementById('analyticsCardsContainer'),
+      macroAnalyticsCardContainer: document.getElementById('analyticsCardsContainer'),
     };
     jest.unstable_mockModule('../uiElements.js', () => ({ selectors, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
     jest.unstable_mockModule('../utils.js', () => ({ safeGet: jest.fn(), safeParseFloat: jest.fn(), capitalizeFirstLetter: jest.fn(), escapeHtml: jest.fn(), applyProgressFill: jest.fn(), getCssVar: jest.fn(), formatDateBgShort: jest.fn() }));
@@ -39,20 +41,25 @@ describe('renderPendingMacroChart', () => {
     jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
     jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
     jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn().mockReturnValue({ calories: 850, protein: 72, carbs: 70, fat: 28 }), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
+    const eventListenersMock = { ensureMacroAnalyticsFrame: jest.fn() };
+    jest.unstable_mockModule('../eventListeners.js', () => eventListenersMock);
     appState = await import('../app.js');
     populateModule = await import('../populateUI.js');
     ({ renderPendingMacroChart, populateDashboardMacros, __setLastMacroPayload } = populateModule);
+    ({ ensureMacroAnalyticsFrame } = await import('../eventListeners.js'));
   });
 
   test('posts updated macro data to iframe on each render', async () => {
     const macros = { calories: 1800, protein_percent: 30, carbs_percent: 40, fat_percent: 30, protein_grams: 135, carbs_grams: 180, fat_grams: 60 };
     Object.assign(appState.todaysPlanMacros, { calories: 850, protein: 72, carbs: 70, fat: 28 });
     await populateDashboardMacros(macros);
+    ensureMacroAnalyticsFrame.mockClear();
     const frame = document.createElement('iframe');
     frame.id = 'macroAnalyticsCardFrame';
     Object.defineProperty(frame, 'contentWindow', { value: { postMessage: jest.fn(), document: { readyState: 'complete' } } });
     selectors.macroAnalyticsCardContainer.appendChild(frame);
     renderPendingMacroChart();
+    expect(ensureMacroAnalyticsFrame).not.toHaveBeenCalled();
     expect(frame.contentWindow.postMessage).toHaveBeenCalledWith(
       { type: 'macro-data', data: expect.objectContaining({ plan: expect.objectContaining({ protein_grams: 72 }) }) },
       '*'
@@ -60,9 +67,11 @@ describe('renderPendingMacroChart', () => {
 
     appState.currentIntakeMacros.calories = 1500;
     await populateDashboardMacros(macros);
+    ensureMacroAnalyticsFrame.mockClear();
     selectors.macroAnalyticsCardContainer.appendChild(frame);
     frame.contentWindow.postMessage.mockClear();
     renderPendingMacroChart();
+    expect(ensureMacroAnalyticsFrame).not.toHaveBeenCalled();
     expect(frame.contentWindow.postMessage).toHaveBeenCalledWith(
       { type: 'macro-data', data: expect.objectContaining({ current: expect.objectContaining({ calories: 1500 }) }) },
       '*'
@@ -90,5 +99,11 @@ describe('renderPendingMacroChart', () => {
     expect(chartMock.update).toHaveBeenCalledTimes(2);
     expect(chartMock.data.datasets[0].data).toEqual([1, 2, 3, 4]);
     expect(chartMock.data.datasets[1].data).toEqual([0, 1, 2, 3]);
+  });
+
+  test('creates analytics frame when missing', () => {
+    __setLastMacroPayload({ plan: { protein_grams: 1, carbs_grams: 2, fat_grams: 3, fiber_grams: 4 } });
+    renderPendingMacroChart();
+    expect(ensureMacroAnalyticsFrame).toHaveBeenCalledTimes(1);
   });
 });

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -366,7 +366,10 @@ export function renderPendingMacroChart() {
         return;
     }
     const frame = document.getElementById('macroAnalyticsCardFrame');
-    if (frame?.contentWindow && lastMacroPayload) {
+    if (!frame && lastMacroPayload) {
+        logMacroPayload(lastMacroPayload);
+        ensureMacroAnalyticsFrame();
+    } else if (frame?.contentWindow && lastMacroPayload) {
         logMacroPayload(lastMacroPayload);
         frame.contentWindow.postMessage({ type: 'macro-data', data: lastMacroPayload }, '*');
     }


### PR DESCRIPTION
## Summary
- auto-create macro analytics iframe when missing
- add tests confirming behavior when frame absent or present

## Testing
- `npm run lint`
- `npm test js/__tests__/renderPendingMacroChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689110ec865c8326840f795e4d793e3b