### PR TITLE
feat: replace macro analytics iframe with element

### DIFF
--- a/js/__tests__/macroCardStandaloneEmbed.test.js
+++ b/js/__tests__/macroCardStandaloneEmbed.test.js
@@ -10,14 +10,20 @@ beforeEach(async () => {
       <div class="accordion-header" aria-expanded="false"></div>
       <div class="accordion-content"></div>
     </div>
-    <iframe id="macroAnalyticsCardFrame"></iframe>
   `;
   jest.unstable_mockModule('../uiElements.js', () => ({ selectors: {}, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
   jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
   jest.unstable_mockModule('../extraMealForm.js', () => ({ openExtraMealModal: jest.fn() }));
   jest.unstable_mockModule('../config.js', () => ({
     generateId: () => 'id-1',
-    apiEndpoints: { dashboard: '/api/dashboardData' }
+    apiEndpoints: { dashboard: '/api/dashboardData' },
+    standaloneMacroUrl: 'macroAnalyticsCardStandalone.html'
+  }));
+  jest.unstable_mockModule('../eventListeners.js', () => ({
+    ensureMacroAnalyticsElement: jest.fn(),
+    setupStaticEventListeners: jest.fn(),
+    setupDynamicEventListeners: jest.fn(),
+    initializeCollapsibleCards: jest.fn(),
   }));
   jest.unstable_mockModule('../app.js', () => ({
     fullDashboardData: {},
@@ -35,21 +41,10 @@ beforeEach(async () => {
   handleAccordionToggle = mod.handleAccordionToggle;
 });
 
-test('не създава iframe при разгръщане', () => {
+test('не създава macro-analytics-card при разгръщане', () => {
   const header = document.querySelector('.accordion-header');
   handleAccordionToggle.call(header);
-  const iframe = document.querySelector('#macroCardIframe');
-  expect(iframe).toBeNull();
+  const card = document.querySelector('macro-analytics-card');
+  expect(card).toBeNull();
 });
 
-test('слушателят за съобщения променя височината', async () => {
-  await import('../populateUI.js');
-  const frame = document.getElementById('macroAnalyticsCardFrame');
-  const newHeight = 420;
-  const evt = new MessageEvent('message', {
-    data: { type: 'macro-card-height', height: newHeight },
-    source: frame.contentWindow,
-  });
-  window.dispatchEvent(evt);
-  expect(frame.style.height).toBe(`${newHeight}px`);
-});

--- a/js/__tests__/populateDashboardMacros.missingComponent.test.js
+++ b/js/__tests__/populateDashboardMacros.missingComponent.test.js
@@ -67,14 +67,15 @@ function setupMocks(selectors) {
   }));
   jest.unstable_mockModule('../auth.js', () => ({ handleLogout: jest.fn() }));
   jest.unstable_mockModule('../eventListeners.js', () => ({
-    ensureMacroAnalyticsFrame: jest.fn(() => {
-      let frame = document.getElementById('macroAnalyticsCardFrame');
-      if (!frame) {
-        frame = document.createElement('iframe');
-        frame.id = 'macroAnalyticsCardFrame';
+    ensureMacroAnalyticsElement: jest.fn(() => {
+      let el = document.querySelector('macro-analytics-card');
+      if (!el) {
+        el = document.createElement('macro-analytics-card');
+        el.setData = jest.fn();
         const container = document.getElementById('macroAnalyticsCardContainer');
-        if (container) container.appendChild(frame);
+        if (container) container.appendChild(el);
       }
+      return el;
     }),
     setupStaticEventListeners: jest.fn(),
     setupDynamicEventListeners: jest.fn(),
@@ -98,8 +99,8 @@ test('създава контейнер, ако липсва макро анал
   const container = document.getElementById('macroAnalyticsCardContainer');
   expect(container).not.toBeNull();
   expect(selectors.analyticsCardsContainer.contains(container)).toBe(true);
-  const frame = container.querySelector('#macroAnalyticsCardFrame');
-  expect(frame).not.toBeNull();
+  const card = container.querySelector('macro-analytics-card');
+  expect(card).not.toBeNull();
 });
 
 test('пресъздава контейнер, когато е извън DOM', async () => {

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -9,15 +9,14 @@ import {
 } from './uiHandlers.js';
 import { handleLogout } from './auth.js';
 import { openExtraMealModal } from './extraMealForm.js';
-import { apiEndpoints, standaloneMacroUrl } from './config.js';
+import { apiEndpoints } from './config.js';
 import {
     macroChartInstance,
     progressChartInstance,
     populateDashboardMacros,
     lastMacroPayload,
     renderPendingMacroChart,
-    macroExceedThreshold,
-    buildMacroCardUrl
+    macroExceedThreshold
 } from './populateUI.js';
 import {
     handleSaveLog, handleFeedbackFormSubmit, // from app.js
@@ -69,27 +68,14 @@ export function handleAdaptiveQuizBtnClick(triggerFn = _handleTriggerAdaptiveQui
     triggerFn();
 }
 
-export function ensureMacroAnalyticsFrame() {
-    let frame = document.getElementById('macroAnalyticsCardFrame');
-    if (!frame) {
-        frame = document.createElement('iframe');
-        frame.id = 'macroAnalyticsCardFrame';
-        frame.title = 'Макро анализ';
-        frame.loading = 'lazy';
-        frame.style.width = '100%';
-        frame.style.border = '0';
-        frame.style.display = 'none';
-        frame.src = buildMacroCardUrl();
-        selectors.macroAnalyticsCardContainer.appendChild(frame);
-        frame.addEventListener('load', () => {
-            selectors.macroAnalyticsCardContainer.classList.remove('loading');
-            selectors.macroAnalyticsCardContainer.querySelectorAll('.skeleton').forEach(el => el.remove());
-            frame.style.display = 'block';
-            frame.contentWindow?.postMessage({ type: 'macro-data', data: lastMacroPayload }, '*');
-        }, { once: true });
-    } else {
-        frame.contentWindow?.postMessage({ type: 'macro-data', data: lastMacroPayload }, '*');
+export function ensureMacroAnalyticsElement() {
+    let el = selectors.macroAnalyticsCardContainer?.querySelector('macro-analytics-card');
+    if (!el) {
+        el = document.createElement('macro-analytics-card');
+        el.setAttribute('exceed-threshold', String(macroExceedThreshold));
+        selectors.macroAnalyticsCardContainer.appendChild(el);
     }
+    el.setData(lastMacroPayload);
     macroChartInstance?.resize();
     progressChartInstance?.resize();
 }
@@ -163,7 +149,7 @@ export function setupStaticEventListeners() {
                 if (accContent) { accContent.style.display = isOpen ? 'none' : 'block'; accContent.classList.toggle('open-active', !isOpen); }
                 if (preview) preview.style.display = isOpen ? 'grid' : 'none';
                 selectors.detailedAnalyticsAccordion.classList.toggle('index-card', isOpen);
-                if (!isOpen) ensureMacroAnalyticsFrame();
+                if (!isOpen) ensureMacroAnalyticsElement();
              });
              header.addEventListener('keydown', function(e) {
                 if(e.key === 'Enter' || e.key === ' ') {
@@ -173,7 +159,7 @@ export function setupStaticEventListeners() {
                     if (accContent) { accContent.style.display = isOpen ? 'none' : 'block'; accContent.classList.toggle('open-active', !isOpen); }
                     if (preview) preview.style.display = isOpen ? 'grid' : 'none';
                     selectors.detailedAnalyticsAccordion.classList.toggle('index-card', isOpen);
-                    if (!isOpen) ensureMacroAnalyticsFrame();
+                    if (!isOpen) ensureMacroAnalyticsElement();
                 }
             });
         }

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -48,7 +48,6 @@ export function initializeSelectors() {
         achievementShareBtn: 'achievementShareBtn',
         analyticsCardsContainer: 'analyticsCardsContainer',
         macroAnalyticsCardContainer: 'macroAnalyticsCardContainer',
-        macroAnalyticsCardFrame: 'macroAnalyticsCardFrame',
         macroMetricsGrid: 'macroMetricsGrid',
         macroMetricsPreview: 'macroMetricsPreview',
         tooltipTracker: 'tooltip-tracker',
@@ -76,7 +75,7 @@ export function initializeSelectors() {
                 'planModChatSend', 'planModChatClose', 'planModChatClear',
                 'streakGrid', 'analyticsCardsContainer', 'achievementShareBtn',
                 'goalCard', 'engagementCard', 'healthCard', 'streakCard',
-                'macroAnalyticsCardContainer', 'macroAnalyticsCardFrame', 'macroMetricsGrid',
+                'macroAnalyticsCardContainer', 'macroMetricsGrid',
                 'macroMetricsPreview',
                 'recFoodAllowedCard', 'recFoodLimitCard', 'recHydrationCard',
                 'recCookingMethodsCard', 'recSupplementsCard'


### PR DESCRIPTION
## Summary
- swap macro analytics iframe with `<macro-analytics-card>` element and send data via `setData`
- align UI utilities and event listeners with new card element
- update tests for macro analytics element behaviour

## Testing
- `npm run lint`
- `npm test -- js/__tests__/renderPendingMacroChart.test.js`
- `npm test -- js/__tests__/populateDashboardMacros.test.js`
- `npm test -- js/__tests__/populateDashboardMacros.missingComponent.test.js`
- `npm test -- js/__tests__/macroCardStandaloneEmbed.test.js`
- `npm test -- js/__tests__/populateUI.test.js` *(fails: FATAL ERROR: Reached heap limit Allocation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68915f5b59b48326875b69996271236d