### PR TITLE
refactor: streamline macro card updates

### DIFF
--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -100,13 +100,12 @@ test('recalculates macros automatically and shows spinner while loading', async 
 
 test('валидира и отхвърля некоректни макро данни', async () => {
   setupDom();
-  const previous = populateModule.lastMacroPayload;
   const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
   const currentDayKey = dayNames[new Date().getDay()];
   appState.fullDashboardData.planData = { week1Menu: { [currentDayKey]: [] } };
   Object.assign(appState.todaysPlanMacros, { calories: 2000, protein: 'bad', carbs: 200, fat: 60, fiber: 30 });
   await populateDashboardMacros({});
-  expect(populateModule.lastMacroPayload).toBe(previous);
+  expect(document.querySelector('macro-analytics-card')).toBeNull();
 });
 
 test('calculatePlanMacros се извиква само веднъж при кеширани стойности', async () => {

--- a/js/__tests__/renderPendingMacroChart.test.js
+++ b/js/__tests__/renderPendingMacroChart.test.js
@@ -7,7 +7,6 @@ describe('renderPendingMacroChart', () => {
   let appState;
   let selectors;
   let populateModule;
-  let __setLastMacroPayload;
   let ensureMacroAnalyticsElement;
 
   beforeEach(async () => {
@@ -55,7 +54,7 @@ describe('renderPendingMacroChart', () => {
     jest.unstable_mockModule('../eventListeners.js', () => eventListenersMock);
     appState = await import('../app.js');
     populateModule = await import('../populateUI.js');
-    ({ renderPendingMacroChart, populateDashboardMacros, __setLastMacroPayload } = populateModule);
+    ({ renderPendingMacroChart, populateDashboardMacros } = populateModule);
     ({ ensureMacroAnalyticsElement } = await import('../eventListeners.js'));
   });
 
@@ -67,7 +66,7 @@ describe('renderPendingMacroChart', () => {
     ensureMacroAnalyticsElement.mockClear();
     card.setData.mockClear();
     renderPendingMacroChart();
-    expect(ensureMacroAnalyticsElement).not.toHaveBeenCalled();
+    expect(ensureMacroAnalyticsElement).toHaveBeenCalledTimes(1);
     expect(card.setData).toHaveBeenCalledWith(
       expect.objectContaining({ plan: expect.objectContaining({ protein_grams: 72 }) })
     );
@@ -78,37 +77,14 @@ describe('renderPendingMacroChart', () => {
     const sameCard = selectors.macroAnalyticsCardContainer.querySelector('macro-analytics-card');
     sameCard.setData.mockClear();
     renderPendingMacroChart();
-    expect(ensureMacroAnalyticsElement).not.toHaveBeenCalled();
+    expect(ensureMacroAnalyticsElement).toHaveBeenCalledTimes(1);
     expect(sameCard.setData).toHaveBeenCalledWith(
       expect.objectContaining({ current: expect.objectContaining({ calories: 1500 }) })
     );
   });
 
-  test('updates existing chart data without destroying it', () => {
-    const chartMock = {
-      data: { datasets: [{ data: [] }, { data: [] }] },
-      update: jest.fn(),
-      destroy: jest.fn()
-    };
-    __setLastMacroPayload({
-      plan: { protein_grams: 10, carbs_grams: 20, fat_grams: 30, fiber_grams: 40 },
-      current: { protein_grams: 5, carbs_grams: 10, fat_grams: 15, fiber_grams: 20 }
-    });
-    const ctx = { chart: chartMock };
-    renderPendingMacroChart.call(ctx);
-    __setLastMacroPayload({
-      plan: { protein_grams: 1, carbs_grams: 2, fat_grams: 3, fiber_grams: 4 },
-      current: { protein_grams: 0, carbs_grams: 1, fat_grams: 2, fiber_grams: 3 }
-    });
-    renderPendingMacroChart.call(ctx);
-    expect(chartMock.destroy).not.toHaveBeenCalled();
-    expect(chartMock.update).toHaveBeenCalledTimes(2);
-    expect(chartMock.data.datasets[0].data).toEqual([1, 2, 3, 4]);
-    expect(chartMock.data.datasets[1].data).toEqual([0, 1, 2, 3]);
-  });
-
   test('създава елемент за макро анализ при липса', () => {
-    __setLastMacroPayload({ plan: { protein_grams: 1, carbs_grams: 2, fat_grams: 3, fiber_grams: 4 } });
+    document.querySelector('macro-analytics-card')?.remove();
     renderPendingMacroChart();
     expect(ensureMacroAnalyticsElement).toHaveBeenCalledTimes(1);
   });

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -14,7 +14,6 @@ import {
     macroChartInstance,
     progressChartInstance,
     populateDashboardMacros,
-    lastMacroPayload,
     renderPendingMacroChart,
     macroExceedThreshold
 } from './populateUI.js';
@@ -75,9 +74,9 @@ export function ensureMacroAnalyticsElement() {
         el.setAttribute('exceed-threshold', String(macroExceedThreshold));
         selectors.macroAnalyticsCardContainer.appendChild(el);
     }
-    el.setData(lastMacroPayload);
     macroChartInstance?.resize();
     progressChartInstance?.resize();
+    return el;
 }
 
 


### PR DESCRIPTION
## Summary
- remove stale macro payload caching
- update analytics card directly with new data
- adjust tests for new macro update flow

## Testing
- `npm run lint`
- `npm test -- js/__tests__/renderPendingMacroChart.test.js js/__tests__/populateDashboardMacros.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689166b9ae508326ae19050a9c64bcc3