### PR TITLE
refactor: unify text color variables

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -15,8 +15,8 @@
   --accent-opacity: 1;
   --tertiary-color: #CBBADD;
 
-  --text-color-primary: #2c3e50;
-  --text-color-secondary: #555;
+  --text-color-primary: #E0E0E0;
+  --text-color-secondary: #A0A5C0;
   --text-color-muted: #7f8c8d;
   --text-color-on-primary: #FFFFFF;
   --text-color-on-secondary: #FFFFFF;
@@ -156,8 +156,8 @@ body.dark-theme {
   --accent-opacity: 1;
   --tertiary-color: #8E6CC3;
 
-  --text-color-primary: #F0F2F5;
-  --text-color-secondary: #A0A5B9;
+  --text-color-primary: #E0E0E0;
+  --text-color-secondary: #A0A5C0;
   --text-color-muted: #bbb;
   --text-color-on-primary: #1C1F2E;
   --text-color-on-secondary: #FFFFFF;
@@ -246,8 +246,8 @@ body.vivid-theme {
   --accent-opacity: 1;
   --tertiary-color: #FF9C9C;
 
-  --text-color-primary: #F0F2F5;
-  --text-color-secondary: #A0A5B9;
+  --text-color-primary: #E0E0E0;
+  --text-color-secondary: #A0A5C0;
   --text-color-muted: #bbb;
   --text-color-on-primary: #1C1F2E;
   --text-color-on-secondary: #FFFFFF;

--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -35,7 +35,7 @@ template.innerHTML = `
       font-size: 1.25rem;
       font-weight: 600;
       margin-bottom: 1.5rem;
-      color: var(--text-color);
+      color: var(--text-color-primary, #E0E0E0);
     }
     .chart-container {
       position: relative;
@@ -68,11 +68,11 @@ template.innerHTML = `
       font-size: 2.5rem;
       font-weight: 700;
       line-height: 1.1;
-      color: var(--text-color);
+      color: var(--text-color-primary, #E0E0E0);
     }
     .chart-center-text .total-calories-label {
       font-size: 0.8rem;
-      color: var(--text-secondary-color);
+      color: var(--text-color-secondary, #A0A5C0);
       text-transform: uppercase;
       letter-spacing: 0.5px;
     }
@@ -115,7 +115,7 @@ template.innerHTML = `
     .macro-icon { font-size: 1.2rem; }
     .macro-label { font-size: 0.85rem; margin-top: 0.25rem; }
     .macro-value { font-size: 1.1rem; font-weight: 600; }
-    .macro-subtitle { font-size: 0.75rem; color: var(--text-secondary-color); }
+    .macro-subtitle { font-size: 0.75rem; color: var(--text-color-secondary, #A0A5C0); }
 
     .macro-warning {
       margin-top: 0.75rem;

--- a/macroAnalyticsCardStandalone.html
+++ b/macroAnalyticsCardStandalone.html
@@ -14,8 +14,8 @@
   :root {
     --main-bg: #1A1D2D;
     --card-bg: #2C314A;
-    --text-color: #E0E0E0;
-    --text-secondary-color: #A0A5C0;
+    --text-color-primary: #E0E0E0;
+    --text-color-secondary: #A0A5C0;
     --macro-protein-color: #5BC0BE;
     --macro-carbs-color: #FFD166;
     --macro-fat-color: #FF6B6B;
@@ -24,7 +24,7 @@
   body {
     background: var(--main-bg);
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-    color: var(--text-color);
+    color: var(--text-color-primary, #E0E0E0);
     padding: 1rem;
   }
   @media (max-width: 480px) {

--- a/style.css
+++ b/style.css
@@ -51,8 +51,8 @@
     --header-bg-solid: rgb(40, 40, 60);
     /* Цвят на мобилното меню - следва хедъра */
     --mobile-menu-bg: var(--header-bg-solid);
-    --text-color-primary: #e0e6f0;
-    --text-color-secondary: #a0b0c5;
+    --text-color-primary: #E0E0E0;
+    --text-color-secondary: #A0A5C0;
     --border-color: rgba(91, 192, 190, 0.2);
     --shadow-sm: 0 4px 8px rgba(0, 0, 0, 0.2);
     --shadow-md: 0 8px 20px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
## Summary
- replace legacy text color variables with `--text-color-primary` and `--text-color-secondary`
- align base and dark themes with standalone card palette
- add fallbacks for primary and secondary text colors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68916a167fd08326834fa90a243c4354