### PR TITLE
fix: load macro analytics card component

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,4 +1,5 @@
 // populateUI.js - Попълване на UI с данни
+import './macroAnalyticsCardComponent.js';
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
 import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressFill, getCssVar, formatDateBgShort } from './utils.js';
 import { generateId, apiEndpoints, standaloneMacroUrl } from './config.js';


### PR DESCRIPTION
## Summary
- load macro analytics card component in populateUI to register custom element

## Testing
- `npm run lint`
- `npm test` *(fails: NotSupportedError and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68916a9ec6dc8326b9a24ec766df1823