### PR TITLE
Кеширан динамичен импорт за MacroAnalyticsCardComponent

### DIFF
--- a/js/__tests__/populateDashboardMacros.importOnce.test.js
+++ b/js/__tests__/populateDashboardMacros.importOnce.test.js
@@ -1,0 +1,68 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+test('динамичният импорт на macroAnalyticsCardComponent се изпълнява само веднъж', async () => {
+  jest.resetModules();
+  document.body.innerHTML = '<div id="macroMetricsPreview"></div><div id="analyticsCardsContainer"></div>';
+  const selectors = {
+    macroMetricsPreview: document.getElementById('macroMetricsPreview'),
+    analyticsCardsContainer: document.getElementById('analyticsCardsContainer'),
+    macroAnalyticsCardContainer: null,
+  };
+  let importCount = 0;
+  jest.unstable_mockModule('../macroAnalyticsCardComponent.js', () => {
+    importCount++;
+    return {};
+  });
+  jest.unstable_mockModule('../uiElements.js', () => ({ selectors, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
+  jest.unstable_mockModule('../utils.js', () => ({
+    safeGet: () => {},
+    safeParseFloat: () => {},
+    capitalizeFirstLetter: () => {},
+    escapeHtml: () => {},
+    applyProgressFill: () => {},
+    getCssVar: () => '',
+    formatDateBgShort: () => ''
+  }));
+  jest.unstable_mockModule('../config.js', () => ({
+    generateId: () => 'id',
+    standaloneMacroUrl: 'macroAnalyticsCardStandalone.html',
+    apiEndpoints: { dashboard: '/api/dashboardData' }
+  }));
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: {},
+    todaysMealCompletionStatus: {},
+    todaysExtraMeals: [],
+    todaysPlanMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
+    currentIntakeMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
+    planHasRecContent: false,
+    loadCurrentIntake: jest.fn(),
+    currentUserId: 'u1'
+  }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
+  jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({ getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
+  jest.unstable_mockModule('../../utils/debug.js', () => ({ logMacroPayload: jest.fn() }));
+  const eventListenersMock = {
+    ensureMacroAnalyticsElement: jest.fn(() => {
+      const el = document.createElement('macro-analytics-card');
+      el.setData = jest.fn();
+      if (!selectors.macroAnalyticsCardContainer) {
+        selectors.macroAnalyticsCardContainer = document.createElement('div');
+        selectors.macroAnalyticsCardContainer.id = 'macroAnalyticsCardContainer';
+        selectors.analyticsCardsContainer.appendChild(selectors.macroAnalyticsCardContainer);
+      }
+      selectors.macroAnalyticsCardContainer.appendChild(el);
+      return el;
+    }),
+    setupStaticEventListeners: jest.fn(),
+    setupDynamicEventListeners: jest.fn(),
+    initializeCollapsibleCards: jest.fn()
+  };
+  jest.unstable_mockModule('../eventListeners.js', () => eventListenersMock);
+  const { populateDashboardMacros } = await import('../populateUI.js');
+  const macros = { calories: 1000, protein_percent: 30, carbs_percent: 40, fat_percent: 30 };
+  await populateDashboardMacros(macros);
+  await populateDashboardMacros(macros);
+  expect(importCount).toBe(1);
+});

--- a/js/__tests__/populateDashboardMacros.missingComponent.test.js
+++ b/js/__tests__/populateDashboardMacros.missingComponent.test.js
@@ -6,6 +6,7 @@ afterEach(() => {
 });
 
 function setupMocks(selectors) {
+  jest.unstable_mockModule('../macroAnalyticsCardComponent.js', () => ({}));
   jest.unstable_mockModule('../uiElements.js', () => ({ selectors, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
   jest.unstable_mockModule('../utils.js', () => ({
     safeGet: () => {},

--- a/js/__tests__/populateDashboardMacros.noSetData.test.js
+++ b/js/__tests__/populateDashboardMacros.noSetData.test.js
@@ -6,6 +6,7 @@ afterEach(() => {
 });
 
 function setupMocks(selectors) {
+  jest.unstable_mockModule('../macroAnalyticsCardComponent.js', () => ({}));
   jest.unstable_mockModule('../uiElements.js', () => ({ selectors, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
   jest.unstable_mockModule('../utils.js', () => ({
     safeGet: () => {},

--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -8,6 +8,7 @@ let selectors;
 let appState;
 let macroUtils;
 
+jest.unstable_mockModule('../macroAnalyticsCardComponent.js', () => ({}));
 jest.unstable_mockModule('../eventListeners.js', () => ({
   ensureMacroAnalyticsElement: jest.fn(() => {
     let el = document.querySelector('macro-analytics-card');

--- a/js/__tests__/renderPendingMacroChart.test.js
+++ b/js/__tests__/renderPendingMacroChart.test.js
@@ -11,6 +11,7 @@ describe('renderPendingMacroChart', () => {
 
   beforeEach(async () => {
     jest.resetModules();
+    jest.unstable_mockModule('../macroAnalyticsCardComponent.js', () => ({}));
     document.body.innerHTML = `
       <div id="macroMetricsPreview"></div>
       <div id="analyticsCardsContainer"></div>

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -9,6 +9,7 @@ import { getNutrientOverride, addMealMacros, scaleMacros } from './macroUtils.js
 import { logMacroPayload } from '../utils/debug.js';
 import { ensureMacroAnalyticsElement } from './eventListeners.js';
 
+let macroAnalyticsComponentPromise;
 export let macroChartInstance = null;
 export let progressChartInstance = null;
 export let macroExceedThreshold = 1.15;
@@ -493,6 +494,9 @@ export async function populateDashboardMacros(macros) {
         logMacroPayload({ error: 'Invalid macro payload structure', payload });
         return;
     }
+    // Зареждаме компонента за макро анализ при първа нужда
+    macroAnalyticsComponentPromise ||= import('./macroAnalyticsCardComponent.js');
+    await macroAnalyticsComponentPromise;
     // Създаваме или взимаме макро-картата и я обновяваме с текущите данни
     const card = ensureMacroAnalyticsElement();
     if (typeof card.setData !== 'function') {


### PR DESCRIPTION
## Обобщение
- Кеширан динамичен импорт на `macroAnalyticsCardComponent` в `populateDashboardMacros` и изчакване преди създаване на картата.
- Добавен тест гарантиращ, че компонентът се импортира само веднъж.
- Актуализирани тестове за новия механизъм.

## Тестване
- `npm run lint`
- `npm test js/__tests__/populateDashboardMacros.test.js js/__tests__/populateDashboardMacros.missingComponent.test.js js/__tests__/populateDashboardMacros.noSetData.test.js js/__tests__/renderPendingMacroChart.test.js js/__tests__/populateDashboardMacros.importOnce.test.js js/__tests__/macroAnalyticsCardComponent.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68916cc11c008326b1d6875b02d63de4