### PR TITLE
Remove macro estimation from initial analysis

### DIFF
--- a/js/__tests__/initialAnalysis.test.js
+++ b/js/__tests__/initialAnalysis.test.js
@@ -32,8 +32,9 @@ describe('initial analysis handlers', () => {
     }
     await worker.handleAnalyzeInitialAnswers('u1', env)
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis', '{"ok":true}')
-    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_macros', JSON.stringify({ status: 'initial', data: null }))
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_analysis_status', 'ready')
+    const macrosCall = env.USER_METADATA_KV.put.mock.calls.find(c => c[0] === 'u1_analysis_macros')
+    expect(macrosCall).toBeUndefined()
     expect(global.fetch).toHaveBeenCalled()
   })
 

--- a/worker.js
+++ b/worker.js
@@ -2006,7 +2006,6 @@ async function handleAnalyzeInitialAnswers(userId, env) {
             return;
         }
         const answers = safeParseJson(answersStr, {});
-        const macros = estimateMacros(answers);
         const promptTpl = await env.RESOURCES_KV.get('prompt_questionnaire_analysis');
         const modelName = await env.RESOURCES_KV.get('model_questionnaire_analysis');
         const provider = getModelProvider(modelName);
@@ -2020,8 +2019,6 @@ async function handleAnalyzeInitialAnswers(userId, env) {
         const raw = await callModel(modelName, populated, env, { temperature: 0.5, maxTokens: 2500 });
         const cleaned = cleanGeminiJson(raw);
         await env.USER_METADATA_KV.put(`${userId}_analysis`, cleaned);
-        const macrosRecord = { status: 'initial', data: macros };
-        await env.USER_METADATA_KV.put(`${userId}_analysis_macros`, JSON.stringify(macrosRecord));
         await env.USER_METADATA_KV.put(`${userId}_analysis_status`, 'ready');
         console.log(`INITIAL_ANALYSIS (${userId}): Analysis stored.`);
         // Имейлът с линк към анализа вече се изпраща при подаване на въпросника,


### PR DESCRIPTION
## Summary
- stop calculating or storing macros during initial questionnaire analysis
- adjust tests to expect no `_analysis_macros` entry after initial analysis

## Testing
- `npm run lint`
- `npm test js/__tests__/initialAnalysis.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689178e419d48326b087bb3ee6f4405e