### PR TITLE
Добавяне на разделени макро план и препоръка

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,23 +934,21 @@ localStorage.setItem('initialBotMessage', 'Добре дошли!');
 
 ### Изчисления на макросите
 
-Макросите се съхраняват в речник `caloriesMacros` с калории и грамове:
+Макросите се съхраняват в речник `caloriesMacros` с две части – `plan` (стойности в плана) и `recommendation` (целеви стойности):
 
 ```json
 {
-  "calories": 1800,
-  "protein_grams": 135,
-  "carbs_grams": 180,
-  "fat_grams": 60
+  "plan": { "calories": 1800, "protein_grams": 135, "carbs_grams": 180, "fat_grams": 60 },
+  "recommendation": { "calories": 1900, "protein_grams": 140, "carbs_grams": 190, "fat_grams": 65 }
 }
 ```
 
-Този обект се изпраща към AI модела за оценка на съотношението:
+Блокът `plan` се изпраща към AI модела за оценка на съотношението:
 
 ```bash
 curl -X POST /api/aiHelper \
   -H 'Content-Type: application/json' \
-  -d '{"prompt":"macro check","macros":{"calories":1800,"protein_grams":135,"carbs_grams":180,"fat_grams":60}}'
+ -d '{"prompt":"macro check","macros":{"calories":1800,"protein_grams":135,"carbs_grams":180,"fat_grams":60}}'
 ```
 
 Отговорът позволява сравнение **План vs Препоръка**:
@@ -1209,7 +1207,7 @@ The script expects `vendor/autoload.php` to reside one directory above the PHP f
 
 ## Поддръжка на макро данни
 
-Скриптът `scripts/migrate-final-plan-macros.js` попълва липсващите полета `caloriesMacros` в `USER_METADATA_KV`.
+Скриптът `scripts/migrate-final-plan-macros.js` попълва липсващите полета `caloriesMacros` (структура с `plan` и `recommendation`) в `USER_METADATA_KV`.
 За автоматизация е добавен `npm` скрипт:
 
 ```bash

--- a/docs/final_plan_kv_example.md
+++ b/docs/final_plan_kv_example.md
@@ -5,7 +5,7 @@
 ## Основни полета
 
 - `profileSummary` – кратък преглед на целта, медицинските особености и предпочитанията на потребителя.
-- `caloriesMacros` – препоръчителен дневен калориен прием и съотношение на макронутриенти.
+- `caloriesMacros` – обект с две части: `plan` и `recommendation`, всяка с калории и макронутриенти.
 - `allowedForbiddenFoods` – списък с основни позволени и ограничени храни, включително допълнителни предложения.
 - `week1Menu` – меню по дни за първата седмица.
 - `principlesWeek2_4` – принципи и насоки за седмици 2‑4.
@@ -15,6 +15,15 @@
 - `generationMetadata` – технически данни за генерирането (timestamp, използван модел и др.).
 
 Пълният примерен запис може да се види във файла [`final_plan_template.json`](final_plan_template.json). Структурата следва camelCase именуване и съдържа текст на български език.
+
+Примерна секция `caloriesMacros`:
+
+```json
+"caloriesMacros": {
+  "plan": { "calories": 1800, "protein_grams": 135, "carbs_grams": 180, "fat_grams": 60 },
+  "recommendation": { "calories": 1900, "protein_grams": 140, "carbs_grams": 190, "fat_grams": 65 }
+}
+```
 
 ## Макро записи
 

--- a/docs/final_plan_template.json
+++ b/docs/final_plan_template.json
@@ -1,13 +1,24 @@
 {
   "profileSummary": "Потребител с цел Отслабване, има Инсулинова резистентност и предпочита балансиран режим. Ниво на активност: Средно. Текущо тегло 85 кг (промяна за 7 дни: -0.5 кг).",
   "caloriesMacros": {
-    "calories": 1800,
-    "protein_percent": 30,
-    "carbs_percent": 40,
-    "fat_percent": 30,
-    "protein_grams": 135,
-    "carbs_grams": 180,
-    "fat_grams": 60
+    "plan": {
+      "calories": 1800,
+      "protein_percent": 30,
+      "carbs_percent": 40,
+      "fat_percent": 30,
+      "protein_grams": 135,
+      "carbs_grams": 180,
+      "fat_grams": 60
+    },
+    "recommendation": {
+      "calories": 1900,
+      "protein_percent": 30,
+      "carbs_percent": 40,
+      "fat_percent": 30,
+      "protein_grams": 140,
+      "carbs_grams": 190,
+      "fat_grams": 65
+    }
   },
   "allowedForbiddenFoods": {
     "main_allowed_foods": ["пилешко филе", "яйца", "кафяв ориз"],

--- a/js/__tests__/updatePlanData.test.js
+++ b/js/__tests__/updatePlanData.test.js
@@ -2,15 +2,27 @@ import { jest } from '@jest/globals';
 import { handleUpdatePlanRequest } from '../../worker.js';
 
 describe('handleUpdatePlanRequest', () => {
-  test('stores plan data using final plan key', async () => {
+  test('stores plan data with plan and recommendation macros', async () => {
     const env = { USER_METADATA_KV: { put: jest.fn() } };
-    const planData = { week: 1, caloriesMacros: { calories: 2000, fiber_percent: 10, fiber_grams: 30 } };
+    const planData = {
+      week: 1,
+      caloriesMacros: {
+        plan: { calories: 2000, fiber_percent: 10, fiber_grams: 30 },
+        recommendation: { calories: 2100, fiber_percent: 12, fiber_grams: 35 }
+      }
+    };
     const request = { json: async () => ({ userId: 'u1', planData }) };
     const res = await handleUpdatePlanRequest(request, env);
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_final_plan', JSON.stringify(planData));
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
       'u1_analysis_macros',
-      JSON.stringify({ status: 'final', data: planData.caloriesMacros })
+      JSON.stringify({
+        status: 'final',
+        data: {
+          plan: planData.caloriesMacros.plan,
+          recommendation: planData.caloriesMacros.recommendation
+        }
+      })
     );
     expect(res.success).toBe(true);
   });

--- a/kv/DIET_RESOURCES/prompt_unified_plan_generation_v2.txt
+++ b/kv/DIET_RESOURCES/prompt_unified_plan_generation_v2.txt
@@ -23,22 +23,42 @@ Your primary goal is to analyze the provided user questionnaire answers and gene
   // Ако има налични данни за скорошен прогрес, спомени накратко теглото: "Текущо тегло %%RECENT_WEIGHT_KG%% (промяна за 7 дни: %%WEIGHT_CHANGE_LAST_7_DAYS%%)".
 
   "caloriesMacros": {
-    // Calculations use a universal formula (напр. Mifflin-St Jeor) модифицирана според индивидуалните параметри, както и цел, медицинско състояние, и други релевантни данни
-    "calories": "number (integer)",
-    "protein_percent": "number (integer)",
-    "carbs_percent": "number (integer)",
-    "fat_percent": "number (integer)",
-    "fiber_percent": "number (integer)",
-    "protein_grams": "number (integer)",
-    "carbs_grams": "number (integer)",
-    "fat_grams": "number (integer)",
-    "fiber_grams": "number (integer)"
+    "plan": {
+      // Calculations use a universal formula (напр. Mifflin-St Jeor) модифицирана според индивидуалните параметри, както и цел, медицинско състояние, и други релевантни данни
+      "calories": "number (integer)",
+      "protein_percent": "number (integer)",
+      "carbs_percent": "number (integer)",
+      "fat_percent": "number (integer)",
+      "fiber_percent": "number (integer)",
+      "protein_grams": "number (integer)",
+      "carbs_grams": "number (integer)",
+      "fat_grams": "number (integer)",
+      "fiber_grams": "number (integer)"
+    },
+    "recommendation": {
+      "calories": "number (integer)",
+      "protein_percent": "number (integer)",
+      "carbs_percent": "number (integer)",
+      "fat_percent": "number (integer)",
+      "fiber_percent": "number (integer)",
+      "protein_grams": "number (integer)",
+      "carbs_grams": "number (integer)",
+      "fat_grams": "number (integer)",
+      "fiber_grams": "number (integer)"
+    }
   },
   // Пример:
   // "caloriesMacros": {
-  //   "calories": 1800,
-  //   "protein_percent": 30, "carbs_percent": 40, "fat_percent": 20, "fiber_percent": 10,
-  //   "protein_grams": 135, "carbs_grams": 180, "fat_grams": 40, "fiber_grams": 45
+  //   "plan": {
+  //     "calories": 1800,
+  //     "protein_percent": 30, "carbs_percent": 40, "fat_percent": 20, "fiber_percent": 10,
+  //     "protein_grams": 135, "carbs_grams": 180, "fat_grams": 40, "fiber_grams": 45
+  //   },
+  //   "recommendation": {
+  //     "calories": 1900,
+  //     "protein_percent": 30, "carbs_percent": 40, "fat_percent": 20, "fiber_percent": 10,
+  //     "protein_grams": 140, "carbs_grams": 190, "fat_grams": 50, "fiber_grams": 40
+  //   }
   // }
 
   "allowedForbiddenFoods": {

--- a/worker.js
+++ b/worker.js
@@ -1570,7 +1570,15 @@ async function handleUpdatePlanRequest(request, env) {
             return { success: false, message: 'Невалидни данни за плана.', statusHint: 400 };
         }
         await env.USER_METADATA_KV.put(`${userId}_final_plan`, JSON.stringify(planData));
-        const macrosRecord = { status: 'final', data: planData.caloriesMacros || null };
+        const macrosRecord = {
+            status: 'final',
+            data: planData.caloriesMacros
+                ? {
+                    plan: planData.caloriesMacros.plan,
+                    recommendation: planData.caloriesMacros.recommendation
+                }
+                : null
+        };
         await env.USER_METADATA_KV.put(`${userId}_analysis_macros`, JSON.stringify(macrosRecord));
         await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'ready', { metadata: { status: 'ready' } });
         return { success: true, message: 'Планът е обновен успешно' };


### PR DESCRIPTION
## Резюме
- обособени подструктури `plan` и `recommendation` в `caloriesMacros`
- записване на двустранната структура в `handleUpdatePlanRequest`
- обновена документация и тест за очакване на двата макро блока

## Тестване
- `npm run lint`
- `npm test` *(неуспешни: js/__tests__/workerEmail.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68917b3a0ef083268241d92edf5c2291