### PR TITLE
refactor: use addMealMacros in current macros calculation

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -27,6 +27,22 @@ test('calculateCurrentMacros sums macros from completed meals and extras', () =>
   expect(result).toEqual({ calories: 880, protein: 67, carbs: 48, fat: 42, fiber: 0 });
 });
 
+test('calculateCurrentMacros използва meal.macros и overrides', () => {
+  registerNutrientOverrides({
+    'override meal': { calories: 50, protein: 5, carbs: 5, fat: 2, fiber: 1 }
+  });
+  const planMenu = {
+    monday: [
+      { meal_name: 'Override Meal' },
+      { macros: { calories: 100, protein: 10, carbs: 20, fat: 5, fiber: 3 } }
+    ]
+  };
+  const completionStatus = { monday_0: true, monday_1: true };
+  const result = calculateCurrentMacros(planMenu, completionStatus, []);
+  expect(result).toEqual({ calories: 150, protein: 15, carbs: 25, fat: 7, fiber: 4 });
+  registerNutrientOverrides({});
+});
+
 test('calculatePlanMacros sums macros for day menu', () => {
   const dayMenu = [
     { id: 'z-01', meal_name: 'Протеинов шейк' },

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -218,48 +218,19 @@ export function calculatePlanMacros(dayMenu = []) {
  * @returns {{ calories:number, protein:number, carbs:number, fat:number, fiber:number }}
  */
 export function calculateCurrentMacros(planMenu = {}, completionStatus = {}, extraMeals = []) {
-  let calories = 0;
-  let protein = 0;
-  let carbs = 0;
-  let fat = 0;
-  let fiber = 0;
+  const acc = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
 
   Object.entries(planMenu).forEach(([day, meals]) => {
     (meals || []).forEach((meal, idx) => {
       const key = `${day}_${idx}`;
-      if (completionStatus[key]) {
-        const macros =
-          macrosByIdOrName.get(meal.id) ||
-          macrosByIdOrName.get((meal.meal_name || '').toLowerCase());
-        if (macros) {
-          const m = normalizeMacros({
-            calories: macros['калории'],
-            protein: macros['белтъчини'],
-            carbs: macros['въглехидрати'],
-            fat: macros['мазнини'],
-            fiber: macros['фибри']
-          });
-          calories += m.calories;
-          protein += m.protein;
-          carbs += m.carbs;
-          fat += m.fat;
-          fiber += m.fiber;
-        }
-      }
+      if (completionStatus[key]) addMealMacros(meal?.macros || meal, acc);
     });
   });
 
   if (Array.isArray(extraMeals)) {
-    extraMeals.forEach((m) => {
-      const n = normalizeMacros(m);
-      calories += n.calories;
-      protein += n.protein;
-      carbs += n.carbs;
-      fat += n.fat;
-      fiber += n.fiber;
-    });
+    extraMeals.forEach((m) => addMealMacros(m, acc));
   }
 
-  return { calories, protein, carbs, fat, fiber };
+  return acc;
 }
 export const __testExports = { macrosByIdOrName, nutrientCache, resolveMacros };


### PR DESCRIPTION
## Summary
- refactor calculateCurrentMacros to reuse addMealMacros and honor meal.macros overrides
- test calculateCurrentMacros with meal.macros and nutrient overrides

## Testing
- `npm run lint`
- `npm test js/__tests__/macroUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68917dba7b208326b871db393c3f157f