### PR TITLE
refactor: rely on loadCurrentIntake for extra meals

### DIFF
--- a/js/__tests__/extraMealAutofill.test.js
+++ b/js/__tests__/extraMealAutofill.test.js
@@ -25,7 +25,7 @@ beforeEach(async () => {
   ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));
 });
 
-test('автопопълва макросите при разпозната храна', () => {
+test('автопопълва макросите при разпозната храна', async () => {
   document.body.innerHTML = `<div id="c">
     <form id="extraMealEntryFormActual">
       <div class="form-step"></div>
@@ -47,7 +47,7 @@ test('автопопълва макросите при разпозната хр
     </form>
   </div>`;
   const container = document.getElementById('c');
-  initializeExtraMealFormLogic(container);
+  await initializeExtraMealFormLogic(container);
   const input = container.querySelector('#foodDescription');
   input.value = 'ябълка';
   input.dispatchEvent(new Event('input', { bubbles: true }));

--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -3,14 +3,12 @@ import { jest } from '@jest/globals';
 
 let handleExtraMealFormSubmit;
 let showToastMock;
-let addMealMacrosMock;
 let addExtraMealWithOverrideMock;
 let currentIntakeMacrosRef;
 
 beforeEach(async () => {
   jest.resetModules();
   showToastMock = jest.fn();
-  addMealMacrosMock = jest.fn();
   jest.unstable_mockModule('../uiHandlers.js', () => ({
     showLoading: jest.fn(),
     showToast: showToastMock,
@@ -22,7 +20,6 @@ beforeEach(async () => {
     apiEndpoints: { logExtraMeal: '/api' }
   }));
   jest.unstable_mockModule('../macroUtils.js', () => ({
-    addMealMacros: addMealMacrosMock,
     removeMealMacros: jest.fn(),
     registerNutrientOverrides: jest.fn(),
     getNutrientOverride: jest.fn(() => null),
@@ -58,7 +55,6 @@ test('показва съобщение при липса на количест�
   await handleExtraMealFormSubmit(e);
   expect(showToastMock).toHaveBeenCalled();
   expect(fetch).not.toHaveBeenCalled();
-  expect(addMealMacrosMock).not.toHaveBeenCalled();
 });
 
 test('изпраща макро стойности при попълнени полета', async () => {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -5,7 +5,7 @@ import { generateId, apiEndpoints, standaloneMacroUrl } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, loadCurrentIntake, currentUserId, todaysPlanMacros } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
 import { ensureChart } from './chartLoader.js';
-import { getNutrientOverride, addMealMacros, scaleMacros } from './macroUtils.js';
+import { getNutrientOverride, scaleMacros } from './macroUtils.js';
 import { logMacroPayload } from '../utils/debug.js';
 import { ensureMacroAnalyticsElement } from './eventListeners.js';
 
@@ -365,7 +365,6 @@ export function addExtraMealWithOverride(name = '', macros = {}, grams) {
     const scaled = gramValue ? scaleMacros(base, gramValue) : base;
     const entry = gramValue ? { ...scaled, grams: gramValue } : scaled;
     todaysExtraMeals.push(entry);
-    addMealMacros(entry, currentIntakeMacros);
     loadCurrentIntake();
     populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
 }


### PR DESCRIPTION
## Summary
- remove redundant addMealMacros when adding extra meal
- adjust tests to reflect simplified macro recalculation
- await extra meal form initialization in autofill tests

## Testing
- `npm run lint`
- `npm test js/__tests__/extraMealFormSubmit.test.js js/__tests__/extraMealAutofill.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68917f1802748326b86ac9adf8b9a0a5