### PR TITLE
Добавяне на спинър при повторно изчисляване на макроси

### DIFF
--- a/js/__tests__/populateDashboardMacros.importOnce.test.js
+++ b/js/__tests__/populateDashboardMacros.importOnce.test.js
@@ -33,7 +33,7 @@ test('динамичният импорт на macroAnalyticsCardComponent се 
     fullDashboardData: {},
     todaysMealCompletionStatus: {},
     todaysExtraMeals: [],
-    todaysPlanMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
+    todaysPlanMacros: { calories: 2000, protein: 150, carbs: 200, fat: 70, fiber: 30 },
     currentIntakeMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),

--- a/js/__tests__/populateDashboardMacros.missingComponent.test.js
+++ b/js/__tests__/populateDashboardMacros.missingComponent.test.js
@@ -26,7 +26,7 @@ function setupMocks(selectors) {
     fullDashboardData: {},
     todaysMealCompletionStatus: {},
     todaysExtraMeals: [],
-    todaysPlanMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
+    todaysPlanMacros: { calories: 1800, protein: 120, carbs: 200, fat: 60, fiber: 30 },
     currentIntakeMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),

--- a/js/__tests__/populateDashboardMacros.noSetData.test.js
+++ b/js/__tests__/populateDashboardMacros.noSetData.test.js
@@ -26,7 +26,7 @@ function setupMocks(selectors) {
     fullDashboardData: {},
     todaysMealCompletionStatus: {},
     todaysExtraMeals: [],
-    todaysPlanMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
+    todaysPlanMacros: { calories: 1800, protein: 120, carbs: 200, fat: 60, fiber: 30 },
     currentIntakeMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),

--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -70,6 +70,7 @@ test('recalculates macros automatically and shows spinner while loading', async 
   const promise = populateDashboardMacros(null);
   const container = selectors.macroAnalyticsCardContainer;
   expect(container.innerHTML).toContain('spinner-border');
+  expect(container.innerHTML).toContain('Изчисляват се макроси');
   expect(selectors.macroMetricsPreview.classList.contains('hidden')).toBe(true);
   expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('recalcMacros=1'));
 
@@ -79,6 +80,7 @@ test('recalculates macros automatically and shows spinner while loading', async 
   expect(selectors.macroMetricsPreview.classList.contains('hidden')).toBe(false);
   expect(selectors.macroMetricsPreview.textContent).toContain('1800');
   expect(container.innerHTML).not.toContain('spinner-border');
+  expect(container.innerHTML).not.toContain('Изчисляват се макроси');
   global.fetch = originalFetch;
   const card = container.querySelector('macro-analytics-card');
   expect(card).not.toBeNull();
@@ -109,7 +111,7 @@ test('валидира и отхвърля некоректни макро да�
   expect(document.querySelector('macro-analytics-card')).toBeNull();
 });
 
-test('показва placeholder при нулеви макроси', async () => {
+test('показва спинър и съобщение при нулеви макроси и fallback при неуспех', async () => {
   setupDom();
   Object.assign(appState.todaysPlanMacros, { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 });
   Object.assign(appState.currentIntakeMacros, { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 });
@@ -123,11 +125,21 @@ test('показва placeholder при нулеви макроси', async () =
     fat_grams: 0,
     fiber_grams: 0
   };
-  await populateDashboardMacros(macros);
+  const originalFetch = global.fetch;
+  let resolveFetch;
+  global.fetch = jest.fn().mockImplementation(() => new Promise(res => {
+    resolveFetch = () => res({ ok: true, json: async () => ({ planData: { caloriesMacros: macros } }) });
+  }));
+  const promise = populateDashboardMacros(macros);
   const container = selectors.macroAnalyticsCardContainer;
+  expect(container.innerHTML).toContain('spinner-border');
+  expect(container.innerHTML).toContain('Изчисляват се макроси');
+  resolveFetch();
+  await promise;
   expect(container.innerHTML).toContain('Липсват данни за макроси.');
   expect(selectors.macroMetricsPreview.classList.contains('hidden')).toBe(true);
   expect(document.querySelector('macro-analytics-card')).toBeNull();
+  global.fetch = originalFetch;
 });
 
 test('calculatePlanMacros се извиква само веднъж при кеширани стойности', async () => {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -455,7 +455,7 @@ export async function populateDashboardMacros(macros) {
     }
     if (!macros) {
         renderMacroPreviewGrid(null);
-        macroContainer.innerHTML = '<div class="spinner-border" role="status"></div>';
+        macroContainer.innerHTML = '<div class="spinner-border" role="status"></div><p class="placeholder">Изчисляват се макроси...</p>';
         try {
             const res = await fetch(`${apiEndpoints.dashboard}?userId=${currentUserId}&recalcMacros=1`);
             const data = await res.json();
@@ -495,17 +495,20 @@ export async function populateDashboardMacros(macros) {
     }
     if (isAllZero(plan) && isAllZero(current)) {
         renderMacroPreviewGrid(null);
-        macroContainer.innerHTML = '<p class="placeholder">Липсват данни за макроси.</p>';
+        macroContainer.innerHTML = '<div class="spinner-border" role="status"></div><p class="placeholder">Изчисляват се макроси...</p>';
         try {
             const res = await fetch(`${apiEndpoints.dashboard}?userId=${currentUserId}&recalcMacros=1`);
             const data = await res.json();
             const newMacros = data?.planData?.caloriesMacros;
             if (newMacros && !(isAllZero(newMacros.plan) && isAllZero(newMacros.current))) {
                 await populateDashboardMacros(newMacros);
+            } else {
+                macroContainer.innerHTML = '<p class="placeholder">Липсват данни за макроси.</p>';
             }
         } catch (e) {
             console.error('Failed to recalc macros', e);
             showToast('Неуспешно изчисляване на макроси.', true);
+            macroContainer.innerHTML = '<p class="placeholder">Липсват данни за макроси.</p>';
         }
         return;
     }


### PR DESCRIPTION
## Summary
- Показване на спинър и съобщение "Изчисляват се макроси..." при липсващи или нулеви макро данни
- Тестовете са обновени да очакват новото поведение и да покриват fallback сценарии

## Testing
- `npm run lint js/populateUI.js js/__tests__/populateDashboardMacros.test.js`
- `sh ./scripts/test.sh js/__tests__/populateDashboardMacros.test.js js/__tests__/populateDashboardMacros.importOnce.test.js js/__tests__/populateDashboardMacros.missingComponent.test.js js/__tests__/populateDashboardMacros.noSetData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689188c1666c8326b27f2a1517a435c9