### PR TITLE
Добавена поддръжка за priorityGuidance и фибри в плана

### DIFF
--- a/backend/tests/regeneratePlan.test.js
+++ b/backend/tests/regeneratePlan.test.js
@@ -1,8 +1,8 @@
 import { jest } from '@jest/globals';
 import { handleRegeneratePlanRequest } from '../../worker.js';
 
-describe('handleRegeneratePlanRequest', () => {
-  test('стартира генерирането и предава priorityGuidance', async () => {
+describe('POST /api/regeneratePlan', () => {
+  test('предава priorityGuidance към процесора', async () => {
     const env = { USER_METADATA_KV: { put: jest.fn() } };
     const ctx = { waitUntil: jest.fn() };
     const mockProcessor = jest.fn().mockResolvedValue();


### PR DESCRIPTION
## Резюме
- Обработва се новото поле `priorityGuidance` и се вмъква в промпта при генериране на план
- Гарантират се `fiber_grams` и `fiber_percent` за всеки план
- Добавени са unit тестове за endpoint-а `/api/regeneratePlan`

## Тестване
- `npm run lint`
- `npm test backend/tests/regeneratePlan.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892212e54408326aaf6c8ab5f0ca539