### PR TITLE
Add fiber macros to plan templates and client profile

### DIFF
--- a/docs/final_plan_kv_example.md
+++ b/docs/final_plan_kv_example.md
@@ -5,7 +5,7 @@
 ## Основни полета
 
 - `profileSummary` – кратък преглед на целта, медицинските особености и предпочитанията на потребителя.
-- `caloriesMacros` – обект с две части: `plan` и `recommendation`, всяка с калории и макронутриенти.
+- `caloriesMacros` – обект с две части: `plan` и `recommendation`, всяка с калории и макронутриенти (включително фибри).
 - `allowedForbiddenFoods` – списък с основни позволени и ограничени храни, включително допълнителни предложения.
 - `week1Menu` – меню по дни за първата седмица.
 - `principlesWeek2_4` – принципи и насоки за седмици 2‑4.
@@ -20,8 +20,22 @@
 
 ```json
 "caloriesMacros": {
-  "plan": { "calories": 1800, "protein_grams": 135, "carbs_grams": 180, "fat_grams": 60 },
-  "recommendation": { "calories": 1900, "protein_grams": 140, "carbs_grams": 190, "fat_grams": 65 }
+  "plan": {
+    "calories": 1800,
+    "protein_grams": 135,
+    "carbs_grams": 180,
+    "fat_grams": 60,
+    "fiber_percent": 10,
+    "fiber_grams": 30
+  },
+  "recommendation": {
+    "calories": 1900,
+    "protein_grams": 140,
+    "carbs_grams": 190,
+    "fat_grams": 65,
+    "fiber_percent": 12,
+    "fiber_grams": 35
+  }
 }
 ```
 
@@ -36,8 +50,22 @@
 {
   "status": "final",
   "data": {
-    "plan": { "calories": 1800, "protein_grams": 135, "carbs_grams": 180, "fat_grams": 60 },
-    "recommendation": { "calories": 1900, "protein_grams": 140, "carbs_grams": 190, "fat_grams": 65 }
+    "plan": {
+      "calories": 1800,
+      "protein_grams": 135,
+      "carbs_grams": 180,
+      "fat_grams": 60,
+      "fiber_percent": 10,
+      "fiber_grams": 30
+    },
+    "recommendation": {
+      "calories": 1900,
+      "protein_grams": 140,
+      "carbs_grams": 190,
+      "fat_grams": 65,
+      "fiber_percent": 12,
+      "fiber_grams": 35
+    }
   }
 }
 ```

--- a/docs/final_plan_template.json
+++ b/docs/final_plan_template.json
@@ -8,7 +8,9 @@
       "fat_percent": 30,
       "protein_grams": 135,
       "carbs_grams": 180,
-      "fat_grams": 60
+      "fat_grams": 60,
+      "fiber_percent": 10,
+      "fiber_grams": 30
     },
     "recommendation": {
       "calories": 1900,
@@ -17,7 +19,9 @@
       "fat_percent": 30,
       "protein_grams": 140,
       "carbs_grams": 190,
-      "fat_grams": 65
+      "fat_grams": 65,
+      "fiber_percent": 12,
+      "fiber_grams": 35
     }
   },
   "allowedForbiddenFoods": {

--- a/js/clientProfile.js
+++ b/js/clientProfile.js
@@ -164,7 +164,8 @@ async function fillDashboard(data) {
       { l: 'Калории', v: macros.calories, s: 'kcal дневно' },
       { l: 'Протеини', v: macros.protein_grams, s: macros.protein_percent ? `${macros.protein_percent}% от калориите` : '' },
       { l: 'Въглехидрати', v: macros.carbs_grams, s: macros.carbs_percent ? `${macros.carbs_percent}% от калориите` : '' },
-      { l: 'Мазнини', v: macros.fat_grams, s: macros.fat_percent ? `${macros.fat_percent}% от калориите` : '' }
+      { l: 'Мазнини', v: macros.fat_grams, s: macros.fat_percent ? `${macros.fat_percent}% от калориите` : '' },
+      { l: 'Фибри', v: macros.fiber_grams, s: macros.fiber_percent ? `${macros.fiber_percent}% от калориите` : '' }
     ];
     list.forEach(item => {
       const col = document.createElement('div');
@@ -187,11 +188,21 @@ async function fillDashboard(data) {
       macroChartPlan = new Chart(ctxPlan, {
         type: 'doughnut',
         data: {
-          labels: [`Протеини (${m.protein_percent}%)`, `Въглехидрати (${m.carbs_percent}%)`, `Мазнини (${m.fat_percent}%)`],
+          labels: [
+            `Протеини (${m.protein_percent}%)`,
+            `Въглехидрати (${m.carbs_percent}%)`,
+            `Мазнини (${m.fat_percent}%)`,
+            `Фибри (${m.fiber_percent}%)`
+          ],
           datasets: [{
             label: 'Разпределение на макроси',
-            data: [m.protein_grams, m.carbs_grams, m.fat_grams],
-            backgroundColor: ['rgb(54,162,235)', 'rgb(255,205,86)', 'rgb(255,99,132)'],
+            data: [m.protein_grams, m.carbs_grams, m.fat_grams, m.fiber_grams],
+            backgroundColor: [
+              'rgb(54,162,235)',
+              'rgb(255,205,86)',
+              'rgb(255,99,132)',
+              '#6FCF97'
+            ],
             hoverOffset: 4
           }]
         },
@@ -209,11 +220,21 @@ async function fillDashboard(data) {
       macroChartAnalytics = new Chart(ctxAnal, {
         type: 'doughnut',
         data: {
-          labels: [`Протеини (${m.protein_percent}%)`, `Въглехидрати (${m.carbs_percent}%)`, `Мазнини (${m.fat_percent}%)`],
+          labels: [
+            `Протеини (${m.protein_percent}%)`,
+            `Въглехидрати (${m.carbs_percent}%)`,
+            `Мазнини (${m.fat_percent}%)`,
+            `Фибри (${m.fiber_percent}%)`
+          ],
           datasets: [{
             label: 'Разпределение на макроси',
-            data: [m.protein_grams, m.carbs_grams, m.fat_grams],
-            backgroundColor: ['rgb(54,162,235)', 'rgb(255,205,86)', 'rgb(255,99,132)'],
+            data: [m.protein_grams, m.carbs_grams, m.fat_grams, m.fiber_grams],
+            backgroundColor: [
+              'rgb(54,162,235)',
+              'rgb(255,205,86)',
+              'rgb(255,99,132)',
+              '#6FCF97'
+            ],
             hoverOffset: 4
           }]
         },


### PR DESCRIPTION
## Summary
- expand final plan docs with `fiber_percent` and `fiber_grams`
- show fiber totals in client profile cards and macro charts

## Testing
- `npm run lint`
- `npm test js/__tests__/planSummary.test.js js/__tests__/clientProfileChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892236cf3b88326aedef6740caa5d3d