### PR TITLE
Speed up AI config menu in admin panel

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1847,18 +1847,20 @@ document.addEventListener('DOMContentLoaded', () => {
     generateEmailFieldsets();
     initEmailPreviews();
 
-    // Стартира асинхронните операции в отделен IIFE,
+    // Стартира асинхронните операции паралелно,
     // за да не блокират работата на интерфейса
     (async () => {
         await ensureLoggedIn();
-        await loadClients();
-        await checkForNotifications();
-        await loadNotifications();
         loadAdminToken();
-        await loadAiConfig();
-        await loadAiPresets();
-        if (emailSettingsForm) await loadEmailSettings();
-        if (testEmailSection?.open) await loadTestEmailTemplate();
+        await Promise.all([
+            loadClients(),
+            checkForNotifications(),
+            loadNotifications(),
+            loadAiConfig(),
+            loadAiPresets(),
+            emailSettingsForm ? loadEmailSettings() : Promise.resolve(),
+            testEmailSection?.open ? loadTestEmailTemplate() : Promise.resolve()
+        ]);
         setInterval(checkForNotifications, 60000);
         setInterval(loadNotifications, 60000);
     })();


### PR DESCRIPTION
## Summary
- cache AI configuration on client and update cache on save
- fetch clients, notifications and AI settings in parallel for faster admin load

## Testing
- `npm run lint -- js/adminConfig.js js/admin.js`
- `sh ./scripts/test.sh js/__tests__/adminConfigRelated.test.js`
- `sh ./scripts/test.sh js/__tests__/adminSendTests.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892514fb4608326addb4cadd7b6ed9f