### PR TITLE
Добавяне на бутон за нов план при статус „В процес“

### DIFF
--- a/js/__tests__/adminRegeneratePlan.test.js
+++ b/js/__tests__/adminRegeneratePlan.test.js
@@ -1,0 +1,29 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../clientProfile.js', () => ({ initClientProfile: jest.fn() }));
+jest.unstable_mockModule('../templateLoader.js', () => ({
+  loadTemplateInto: async () => {}
+}));
+
+let admin;
+
+beforeEach(async () => {
+  document.body.innerHTML = `
+    <ul id="clientsList"></ul>
+    <span id="clientsCount"></span>
+    <input id="clientSearch" />
+    <select id="statusFilter"><option value="all">all</option></select>
+    <button id="showStats"></button>
+  `;
+  admin = await import('../admin.js');
+});
+
+test('показва бутон за нов план при статус "в процес"', () => {
+  admin.allClients.length = 0;
+  admin.allClients.push({ userId: 'u1', name: 'Test', status: 'processing', tags: [] });
+  admin.renderClients();
+  const btn = document.querySelector('.regen-plan-btn');
+  expect(btn).not.toBeNull();
+  expect(btn.textContent).toContain('Нов план');
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -709,7 +709,12 @@ function renderClients() {
         btn.addEventListener('click', () => showClient(c.userId));
         li.appendChild(btn);
 
-        const needsPlan = c.status === 'pending' || c.status === 'error' || c.status === 'unknown';
+        // Позволява повторно генериране дори при зациклил статус "В процес"
+        const needsPlan =
+            c.status === 'pending' ||
+            c.status === 'error' ||
+            c.status === 'unknown' ||
+            c.status === 'processing';
         if (needsPlan) {
             const regen = document.createElement('button');
             regen.className = 'regen-plan-btn button-small';


### PR DESCRIPTION
## Обобщение
- Разширена логика в админ клиентския списък за показване на бутон „Нов план“ при статус `processing`.
- Добавен unit тест, който потвърждава визуализацията на бутона при зациклил статус.

## Тестване
- `npx eslint js/admin.js js/__tests__/adminRegeneratePlan.test.js`
- `npm test js/__tests__/adminNotifications.test.js js/__tests__/adminRegeneratePlan.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68928512c5b48326ace5350bb4c1653a