### PR TITLE
feat: add plan prerequisite validation

### DIFF
--- a/backend/tests/regeneratePlan.test.js
+++ b/backend/tests/regeneratePlan.test.js
@@ -3,7 +3,20 @@ import { handleRegeneratePlanRequest } from '../../worker.js';
 
 describe('POST /api/regeneratePlan', () => {
   test('предава priorityGuidance към процесора', async () => {
-    const env = { USER_METADATA_KV: { put: jest.fn() } };
+    const env = {
+      USER_METADATA_KV: {
+        put: jest.fn(),
+        get: jest.fn(key => (key === 'u1_initial_answers' ? '{"q":"a"}' : null))
+      },
+      RESOURCES_KV: {
+        get: jest.fn(key => {
+          if (key === 'model_plan_generation') return 'model';
+          if (key === 'prompt_unified_plan_generation_v2') return 'prompt';
+          return null;
+        })
+      },
+      GEMINI_API_KEY: 'key'
+    };
     const ctx = { waitUntil: jest.fn() };
     const mockProcessor = jest.fn().mockResolvedValue();
     const request = { json: async () => ({ userId: 'u1', priorityGuidance: 'повече протеин' }) };

--- a/js/__tests__/pendingPlanModIntegration.test.js
+++ b/js/__tests__/pendingPlanModIntegration.test.js
@@ -21,6 +21,7 @@ describe('processSingleUserPlan with pending modification', () => {
         }),
         put: jest.fn(),
         delete: jest.fn(),
+        list: jest.fn(async () => ({ keys: [] }))
       },
       RESOURCES_KV: {
         get: jest.fn(key => {

--- a/js/__tests__/regeneratePlan.test.js
+++ b/js/__tests__/regeneratePlan.test.js
@@ -3,7 +3,20 @@ import { handleRegeneratePlanRequest } from '../../worker.js';
 
 describe('handleRegeneratePlanRequest', () => {
   test('стартира генерирането и предава priorityGuidance', async () => {
-    const env = { USER_METADATA_KV: { put: jest.fn() } };
+    const env = {
+      USER_METADATA_KV: {
+        put: jest.fn(),
+        get: jest.fn(key => (key === 'u1_initial_answers' ? '{"q":"a"}' : null))
+      },
+      RESOURCES_KV: {
+        get: jest.fn(key => {
+          if (key === 'model_plan_generation') return 'model';
+          if (key === 'prompt_unified_plan_generation_v2') return 'prompt';
+          return null;
+        })
+      },
+      GEMINI_API_KEY: 'key'
+    };
     const ctx = { waitUntil: jest.fn() };
     const mockProcessor = jest.fn().mockResolvedValue();
     const request = { json: async () => ({ userId: 'u1', priorityGuidance: 'повече протеин' }) };


### PR DESCRIPTION
## Summary
- add `validatePlanPrerequisites` to ensure plan model, prompt, initial answers and API keys exist before generation
- invoke validator in `handleRegeneratePlanRequest` and `processSingleUserPlan`
- adjust plan regeneration tests to account for prerequisite checks

## Testing
- `npm run lint`
- `npm test js/__tests__/regeneratePlan.test.js backend/tests/regeneratePlan.test.js js/__tests__/pendingPlanModIntegration.test.js js/__tests__/planGenerationLogs.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68928fee052483269235856f28fe0e5e