### PR TITLE
Пропускане на адаптивен въпросник за нови потребители

### DIFF
--- a/backend/tests/processSingleUserPlanAdaptiveQuiz.test.js
+++ b/backend/tests/processSingleUserPlanAdaptiveQuiz.test.js
@@ -1,0 +1,69 @@
+import { jest } from '@jest/globals';
+import * as worker from '../../worker.js';
+
+describe('processSingleUserPlan', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+  test('инициализира last_adaptive_quiz_ts при генериране на план', async () => {
+    const kvStore = new Map();
+    const USER_METADATA_KV = {
+      get: jest.fn(key => Promise.resolve(kvStore.get(key))),
+      put: jest.fn((key, val) => { kvStore.set(key, val); return Promise.resolve(); }),
+      delete: jest.fn(key => { kvStore.delete(key); return Promise.resolve(); }),
+      list: jest.fn(() => Promise.resolve({ keys: [] }))
+    };
+    const RESOURCES_KV = {
+      get: jest.fn(key => {
+        const data = {
+          question_definitions: '[]',
+          base_diet_model: '',
+          allowed_meal_combinations: '',
+          eating_psychology: '',
+          recipe_data: '{}',
+          model_plan_generation: 'gpt-test',
+          prompt_unified_plan_generation_v2: 'prompt'
+        };
+        return Promise.resolve(data[key]);
+      })
+    };
+    kvStore.set('u1_initial_answers', JSON.stringify({ email: 'test@exam.com' }));
+
+    const env = {
+      USER_METADATA_KV,
+      RESOURCES_KV,
+      GEMINI_API_KEY: 'g',
+      OPENAI_API_KEY: 'o'
+    };
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  profileSummary: 'ps',
+                  caloriesMacros: { plan: {}, recommendation: {} },
+                  week1Menu: {},
+                  principlesWeek2_4: [],
+                  detailedTargets: {}
+                })
+              }
+            }
+          ]
+        }),
+        text: async () => ''
+      })
+    );
+
+    await worker.processSingleUserPlan('u1', env);
+    const ts = kvStore.get('u1_last_adaptive_quiz_ts');
+    expect(ts).toBeDefined();
+    expect(Number(ts)).not.toBeNaN();
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -713,6 +713,8 @@ export default {
                 const lastQuizTs = lastQuizTsStr ? parseInt(lastQuizTsStr, 10) : 0;
                 const daysSinceLastQuiz = (Date.now() - lastQuizTs) / (1000 * 60 * 60 * 24);
 
+                if (lastQuizTs === 0) continue;
+
                 const isQuizAlreadyPending = await env.USER_METADATA_KV.get(`${userId}_adaptive_quiz_pending`);
                 if (isQuizAlreadyPending === "true") {
                     // console.log(`[CRON-AdaptiveQuiz] Quiz already pending for user ${userId}. Skipping generation.`);
@@ -3012,6 +3014,11 @@ async function processSingleUserPlan(userId, env, priorityGuidance = '') {
             await env.USER_METADATA_KV.put(`${userId}_last_significant_update_ts`, Date.now().toString());
             const summary = createPlanUpdateSummary(planBuilder, previousPlan);
             await env.USER_METADATA_KV.put(`${userId}_ai_update_pending_ack`, JSON.stringify(summary));
+
+            if (!(await env.USER_METADATA_KV.get(`${userId}_last_adaptive_quiz_ts`))) {
+                await env.USER_METADATA_KV.put(`${userId}_last_adaptive_quiz_ts`, Date.now().toString());
+            }
+
             console.log(`PROCESS_USER_PLAN (${userId}): Successfully generated and saved UNIFIED plan. Status set to 'ready'.`);
         }
     } catch (error) {


### PR DESCRIPTION
## Резюме
- добавен е guard в cron блокa, който прескача потребители без проведен адаптивен въпросник
- запис на `last_adaptive_quiz_ts` при първоначално генериране на плана
- unit тест за инициализация на `last_adaptive_quiz_ts`

## Тестване
- `npm run lint`
- `npm test backend/tests/processSingleUserPlanAdaptiveQuiz.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892a35ae65083269a0a4b5a03c58e0d