### PR TITLE
Проверка за възраст на плана и дневниците в checkLowEngagementTrigger

### DIFF
--- a/checkLowEngagementTrigger.test.js
+++ b/checkLowEngagementTrigger.test.js
@@ -1,0 +1,60 @@
+import { jest } from '@jest/globals';
+import { checkLowEngagementTrigger } from './worker.js';
+
+describe('checkLowEngagementTrigger', () => {
+  test('връща false при нов план', async () => {
+    const userId = 'u1';
+    const now = Date.now();
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(async (key) => {
+          if (key === `${userId}_last_significant_update_ts`) {
+            return String(now - 24 * 60 * 60 * 1000); // 1 ден
+          }
+          return null;
+        }),
+        list: jest.fn(async () => ({ keys: [] })),
+      },
+    };
+    await expect(checkLowEngagementTrigger(userId, env)).resolves.toBe(false);
+  });
+
+  test('връща false при липса на дневници', async () => {
+    const userId = 'u2';
+    const now = Date.now();
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(async (key) => {
+          if (key === `${userId}_last_significant_update_ts`) {
+            return String(now - 10 * 24 * 60 * 60 * 1000); // 10 дни
+          }
+          return null;
+        }),
+        list: jest.fn(async () => ({ keys: [] })),
+      },
+    };
+    await expect(checkLowEngagementTrigger(userId, env)).resolves.toBe(false);
+  });
+
+  test('връща true при стари дневници', async () => {
+    const userId = 'u3';
+    const now = Date.now();
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(async (key) => {
+          if (key === `${userId}_last_significant_update_ts`) {
+            return String(now - 30 * 24 * 60 * 60 * 1000); // 30 дни
+          }
+          const eightDaysAgo = new Date();
+          eightDaysAgo.setDate(eightDaysAgo.getDate() - 8);
+          if (key === `${userId}_log_${eightDaysAgo.toISOString().split('T')[0]}`) {
+            return 'exists';
+          }
+          return null;
+        }),
+        list: jest.fn(async () => ({ keys: [{ name: 'dummy' }] })),
+      },
+    };
+    await expect(checkLowEngagementTrigger(userId, env)).resolves.toBe(true);
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -3310,13 +3310,20 @@ async function checkWeightStagnationTrigger(userId, initialAnswers, env) {
 
 // ------------- START FUNCTION: checkLowEngagementTrigger -------------
 async function checkLowEngagementTrigger(userId, env) {
-    let daysSinceLastLog = ADAPTIVE_QUIZ_LOW_ENGAGEMENT_DAYS + 1; // Assume no logs initially
+    const planTs = await env.USER_METADATA_KV.get(`${userId}_last_significant_update_ts`);
+    if (planTs) {
+        const planAgeDays = (Date.now() - Number(planTs)) / (1000 * 60 * 60 * 24);
+        if (planAgeDays < ADAPTIVE_QUIZ_LOW_ENGAGEMENT_DAYS) return false;
+    }
+    const logList = await env.USER_METADATA_KV.list({ prefix: `${userId}_log_`, limit: 1 });
+    if (!logList.keys || logList.keys.length === 0) return false;
+    let daysSinceLastLog = ADAPTIVE_QUIZ_LOW_ENGAGEMENT_DAYS + 1;
     for (let i = 0; i < ADAPTIVE_QUIZ_LOW_ENGAGEMENT_DAYS; i++) {
         const date = new Date();
         date.setDate(date.getDate() - i);
         const logKey = `${userId}_log_${date.toISOString().split('T')[0]}`;
         // Просто проверяваме дали ключът съществува, get с type:'arrayBuffer' е ефективен за това
-        const logExists = await env.USER_METADATA_KV.get(logKey, { type: "arrayBuffer" }); 
+        const logExists = await env.USER_METADATA_KV.get(logKey, { type: "arrayBuffer" });
         if (logExists !== null) {
             daysSinceLastLog = i;
             // console.log(`[ADAPT_QUIZ_TRIGGER_ENGAGEMENT] User ${userId}: Found log from ${i} days ago. Days since last log: ${daysSinceLastLog}.`);
@@ -4784,4 +4791,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRegeneratePlanRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleDashboardDataRequest, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleContactFormRequest, handleGetContactRequestsRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, sendAnalysisLinkEmail, sendContactEmail, getEmailConfig };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRegeneratePlanRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleDashboardDataRequest, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleContactFormRequest, handleGetContactRequestsRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, sendAnalysisLinkEmail, sendContactEmail, getEmailConfig, checkLowEngagementTrigger };


### PR DESCRIPTION
## Резюме
- Проверка за възраст на плана чрез `${userId}_last_significant_update_ts` и ранно прекъсване при нов план.
- Връщане на `false`, когато няма дневници, и запазване на алгоритъма за засичане на ниска активност.
- Jest тестове, покриващи случаи за нов план, липса на дневници и стари дневници.

## Тестване
- `npm run lint`
- `npm test checkLowEngagementTrigger.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892a586815c8326b31141d3e8ae4ffd