### PR TITLE
Добавяне на reason към регенерирането на план

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,6 +978,9 @@ curl -X POST /api/aiHelper \
 - `POST /api/saveAiPreset` – съхранява нов пресет или обновява съществуващ.
 - `POST /api/testAiModel` – проверява връзката с конкретен AI модел.
 - `POST /api/submitQuestionnaire` – изпраща отговорите от началния въпросник.
+- `POST /api/regeneratePlan` – генерира изцяло нов план. Тяло на заявката:
+  `{ "userId": "u1", "reason": "по-балансиран режим", "priorityGuidance": "повече протеин" }`.
+  Полето `reason` е задължително и се използва като контекст при генерирането.
 - `GET /api/analysisStatus` – връща текущия статус на персоналния анализ.
 - `GET /api/getInitialAnalysis` – връща първоначалния анализ.
 - `POST /api/analyzeImage` – анализира качено изображение и връща резултат. Изпращайте поле `image` с пълен `data:` URL. Ендпойнтът не изисква `WORKER_ADMIN_TOKEN`, освен ако изрично не сте го добавили като защита.

--- a/backend/tests/regeneratePlan.test.js
+++ b/backend/tests/regeneratePlan.test.js
@@ -2,15 +2,32 @@ import { jest } from '@jest/globals';
 import { handleRegeneratePlanRequest } from '../../worker.js';
 
 describe('POST /api/regeneratePlan', () => {
-  test('предава priorityGuidance към процесора', async () => {
-    const env = { USER_METADATA_KV: { put: jest.fn() } };
+  test('записва reason и го предава към процесора', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        put: jest.fn(),
+        get: jest.fn(async key => (key === 'u1_initial_answers' ? '{"x":1}' : null))
+      },
+      RESOURCES_KV: { get: jest.fn(async () => 'model') },
+      GEMINI_API_KEY: 'key'
+    };
     const ctx = { waitUntil: jest.fn() };
     const mockProcessor = jest.fn().mockResolvedValue();
-    const request = { json: async () => ({ userId: 'u1', priorityGuidance: 'повече протеин' }) };
+    const request = { json: async () => ({ userId: 'u1', priorityGuidance: 'повече протеин', reason: 'нова цел' }) };
     const res = await handleRegeneratePlanRequest(request, env, ctx, mockProcessor);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('pending_plan_mod_u1', 'нова цел');
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('plan_status_u1', 'processing', { metadata: { status: 'processing' } });
     expect(ctx.waitUntil).toHaveBeenCalled();
-    expect(mockProcessor).toHaveBeenCalledWith('u1', env, 'повече протеин');
+    expect(mockProcessor).toHaveBeenCalledWith('u1', env, 'повече протеин', 'нова цел');
     expect(res.success).toBe(true);
+  });
+
+  test('връща грешка при липсващ reason', async () => {
+    const env = { USER_METADATA_KV: { put: jest.fn() } };
+    const request = { json: async () => ({ userId: 'u1', reason: '' }) };
+    const res = await handleRegeneratePlanRequest(request, env, null, jest.fn());
+    expect(res.success).toBe(false);
+    expect(res.statusHint).toBe(400);
+    expect(env.USER_METADATA_KV.put).not.toHaveBeenCalled();
   });
 });

--- a/js/__tests__/regeneratePlan.test.js
+++ b/js/__tests__/regeneratePlan.test.js
@@ -2,15 +2,32 @@ import { jest } from '@jest/globals';
 import { handleRegeneratePlanRequest } from '../../worker.js';
 
 describe('handleRegeneratePlanRequest', () => {
-  test('стартира генерирането и предава priorityGuidance', async () => {
-    const env = { USER_METADATA_KV: { put: jest.fn() } };
+  test('записва reason и стартира генерирането', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        put: jest.fn(),
+        get: jest.fn(async key => (key === 'u1_initial_answers' ? '{"x":1}' : null))
+      },
+      RESOURCES_KV: { get: jest.fn(async () => 'model') },
+      GEMINI_API_KEY: 'key'
+    };
     const ctx = { waitUntil: jest.fn() };
     const mockProcessor = jest.fn().mockResolvedValue();
-    const request = { json: async () => ({ userId: 'u1', priorityGuidance: 'повече протеин' }) };
+    const request = { json: async () => ({ userId: 'u1', priorityGuidance: 'повече протеин', reason: 'нова цел' }) };
     const res = await handleRegeneratePlanRequest(request, env, ctx, mockProcessor);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('pending_plan_mod_u1', 'нова цел');
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('plan_status_u1', 'processing', { metadata: { status: 'processing' } });
     expect(ctx.waitUntil).toHaveBeenCalled();
-    expect(mockProcessor).toHaveBeenCalledWith('u1', env, 'повече протеин');
+    expect(mockProcessor).toHaveBeenCalledWith('u1', env, 'повече протеин', 'нова цел');
     expect(res.success).toBe(true);
+  });
+
+  test('връща грешка при липсващ reason', async () => {
+    const env = { USER_METADATA_KV: { put: jest.fn() } };
+    const request = { json: async () => ({ userId: 'u1', reason: '' }) };
+    const res = await handleRegeneratePlanRequest(request, env, null, jest.fn());
+    expect(res.success).toBe(false);
+    expect(res.statusHint).toBe(400);
+    expect(env.USER_METADATA_KV.put).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Резюме
- добавена е задължителна причина при `POST /api/regeneratePlan`
- `processSingleUserPlan` приема нов аргумент `regenReason` и го включва в промпта
- документацията описва новото поле `reason`

## Тестване
- `npm run lint -- worker.js backend/tests/regeneratePlan.test.js js/__tests__/regeneratePlan.test.js README.md`
- `npm test backend/tests/regeneratePlan.test.js js/__tests__/regeneratePlan.test.js js/__tests__/pendingPlanModIntegration.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892a857223c8326b5b10d8cb002b988