### PR TITLE
Trigger plan generation on questionnaire submit

### DIFF
--- a/backend/tests/submitQuestionnairePlanStart.test.js
+++ b/backend/tests/submitQuestionnairePlanStart.test.js
@@ -1,0 +1,46 @@
+import { jest } from '@jest/globals';
+import * as worker from '../../worker.js';
+
+describe('handleSubmitQuestionnaire', () => {
+  test('стартира генериране на план веднага', async () => {
+    const kvStore = new Map();
+    const USER_METADATA_KV = {
+      get: jest.fn(key => Promise.resolve(kvStore.get(key))),
+      put: jest.fn((key, val) => { kvStore.set(key, val); return Promise.resolve(); })
+    };
+    kvStore.set('email_to_uuid_test@example.com', 'u1');
+    const RESOURCES_KV = {
+      get: jest.fn(key => {
+        const data = {
+          prompt_questionnaire_analysis: 'tpl',
+          model_questionnaire_analysis: '@cf/mock'
+        };
+        return Promise.resolve(data[key]);
+      })
+    };
+    const env = {
+      USER_METADATA_KV,
+      RESOURCES_KV,
+      send_analysis_email: '0',
+      AI: { run: jest.fn(async () => ({ response: '{}' })) }
+    };
+    const ctx = { waitUntil: jest.fn() };
+
+    const request = {
+      json: async () => ({
+        email: 'test@example.com',
+        gender: 'm',
+        age: 30,
+        height: 170,
+        weight: 70,
+        goal: 'lose',
+        medicalConditions: ['none']
+      })
+    };
+
+    await worker.handleSubmitQuestionnaire(request, env, ctx);
+
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(2);
+    expect(USER_METADATA_KV.put).toHaveBeenCalledWith('u1_last_significant_update_ts', expect.any(String));
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -914,7 +914,15 @@ async function handleSubmitQuestionnaire(request, env, ctx) {
         questionnaireData.submissionDate = new Date().toISOString();
         await env.USER_METADATA_KV.put(`${userId}_initial_answers`, JSON.stringify(questionnaireData));
         await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'pending', { metadata: { status: 'pending' } });
+        await env.USER_METADATA_KV.put(`${userId}_last_significant_update_ts`, Date.now().toString());
         console.log(`SUBMIT_QUESTIONNAIRE (${userId}): Saved initial answers, status set to pending.`);
+
+        const planTask = processSingleUserPlan(userId, env);
+        if (ctx) {
+            ctx.waitUntil(planTask);
+        } else {
+            await planTask;
+        }
 
         const baseUrl = env[ANALYSIS_PAGE_URL_VAR_NAME] ||
             'https://radilovk.github.io/bodybest/reganalize/analyze.html';


### PR DESCRIPTION
## Summary
- start plan processing immediately after questionnaire submission
- track last significant update timestamp for adaptive quiz delay
- test for immediate plan generation

## Testing
- `npm run lint`
- `npm test backend/tests/regeneratePlan.test.js backend/tests/submitQuestionnairePlanStart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892ae465f4c832682bcd476c35c425f