### PR TITLE
fix: подаване на причина при регенериране на план

### DIFF
--- a/js/__tests__/adminRegeneratePlan.test.js
+++ b/js/__tests__/adminRegeneratePlan.test.js
@@ -5,10 +5,15 @@ jest.unstable_mockModule('../clientProfile.js', () => ({ initClientProfile: jest
 jest.unstable_mockModule('../templateLoader.js', () => ({
   loadTemplateInto: async () => {}
 }));
+jest.unstable_mockModule('../config.js', () => ({
+  apiEndpoints: { regeneratePlan: '/regen' }
+}));
 
 let admin;
 
 beforeEach(async () => {
+  global.fetch = jest.fn();
+  jest.resetModules();
   document.body.innerHTML = `
     <ul id="clientsList"></ul>
     <span id="clientsCount"></span>
@@ -26,4 +31,18 @@ test('показва бутон за нов план при статус "в п�
   const btn = document.querySelector('.regen-plan-btn');
   expect(btn).not.toBeNull();
   expect(btn.textContent).toContain('Нов план');
+});
+
+test('праща reason при клик върху бутона', async () => {
+  admin.allClients.length = 0;
+  admin.allClients.push({ userId: 'u1', name: 'Test', status: 'processing', tags: [] });
+  admin.renderClients();
+  const btn = document.querySelector('.regen-plan-btn');
+  await btn.click();
+  await Promise.resolve();
+  expect(fetch).toHaveBeenCalledWith('/regen', expect.objectContaining({
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId: 'u1', reason: 'Админ регенерация' })
+  }));
 });

--- a/js/__tests__/planRegenerator.test.js
+++ b/js/__tests__/planRegenerator.test.js
@@ -1,0 +1,43 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../config.js', () => ({
+  apiEndpoints: { regeneratePlan: '/regen', planStatus: '/status' }
+}));
+
+let setupPlanRegeneration;
+
+beforeEach(async () => {
+  jest.useFakeTimers();
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, planStatus: 'ready' }) });
+  document.body.innerHTML = `
+    <button id="regen"></button>
+    <div id="regenProgress" class="hidden"></div>
+    <div id="priorityGuidanceModal" aria-hidden="true">
+      <textarea id="priorityGuidanceInput"></textarea>
+      <button id="priorityGuidanceConfirm"></button>
+      <button id="priorityGuidanceCancel"></button>
+      <button id="priorityGuidanceClose"></button>
+    </div>
+  `;
+  ({ setupPlanRegeneration } = await import('../planRegenerator.js'));
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+test('изпраща reason при потвърждение', async () => {
+  const regenBtn = document.getElementById('regen');
+  const regenProgress = document.getElementById('regenProgress');
+  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
+  regenBtn.click();
+  document.getElementById('priorityGuidanceConfirm').click();
+  await Promise.resolve();
+  expect(fetch).toHaveBeenCalledWith('/regen', expect.objectContaining({
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId: 'u1', priorityGuidance: '', reason: 'Админ регенерация' })
+  }));
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -726,7 +726,8 @@ function renderClients() {
                     await fetch(apiEndpoints.regeneratePlan, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ userId: c.userId })
+                        // Причината е задължителна за API; подаваме стандартна стойност.
+                        body: JSON.stringify({ userId: c.userId, reason: 'Админ регенерация' })
                     });
                     alert('Стартирана е нова генерация.');
                 } catch (err) {

--- a/js/planRegenerator.js
+++ b/js/planRegenerator.js
@@ -39,7 +39,8 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
       await fetch(apiEndpoints.regeneratePlan, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId, priorityGuidance })
+        // "reason" се изисква от бекенда; използваме указанията или стандартен текст.
+        body: JSON.stringify({ userId, priorityGuidance, reason: priorityGuidance || 'Админ регенерация' })
       });
     } catch (err) {
       console.error('regeneratePlan error:', err);


### PR DESCRIPTION
## Summary
- подаване на стандартна причина при натискане на бутона "Нов план" в списъка с клиенти
- изпращане на задължителното поле `reason` и от диалоговия прозорец за регенерация
- добавени тестове за двата сценария на регенериране

## Testing
- `npm run lint`
- `npm test js/__tests__/planRegenerator.test.js`
- `npm test js/__tests__/adminRegeneratePlan.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892c51d9c40832695816bdde722d247