### PR TITLE
refactor: flatten plan macros structure

### DIFF
--- a/js/__tests__/updatePlanData.test.js
+++ b/js/__tests__/updatePlanData.test.js
@@ -2,27 +2,18 @@ import { jest } from '@jest/globals';
 import { handleUpdatePlanRequest } from '../../worker.js';
 
 describe('handleUpdatePlanRequest', () => {
-  test('stores plan data with plan and recommendation macros', async () => {
+  test('stores plan data with flat macros', async () => {
     const env = { USER_METADATA_KV: { put: jest.fn() } };
     const planData = {
       week: 1,
-      caloriesMacros: {
-        plan: { calories: 2000, fiber_percent: 10, fiber_grams: 30 },
-        recommendation: { calories: 2100, fiber_percent: 12, fiber_grams: 35 }
-      }
+      caloriesMacros: { calories: 2000, fiber_percent: 10, fiber_grams: 30 }
     };
     const request = { json: async () => ({ userId: 'u1', planData }) };
     const res = await handleUpdatePlanRequest(request, env);
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_final_plan', JSON.stringify(planData));
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
       'u1_analysis_macros',
-      JSON.stringify({
-        status: 'final',
-        data: {
-          plan: planData.caloriesMacros.plan,
-          recommendation: planData.caloriesMacros.recommendation
-        }
-      })
+      JSON.stringify({ status: 'final', data: planData.caloriesMacros })
     );
     expect(res.success).toBe(true);
   });

--- a/js/editClient.js
+++ b/js/editClient.js
@@ -72,6 +72,7 @@ export async function initEditClient(userId) {
       document.getElementById('weight-change-display').textContent = weightMatch[2];
     }
 
+    // caloriesMacros е плосък обект; стойностите се четат директно
     document.getElementById('caloriesMacros-calories-view').textContent = `${data.caloriesMacros?.calories || 0} kcal`;
     document.getElementById('caloriesMacros-protein-view').textContent = `${data.caloriesMacros?.protein_percent || 0}% / ${data.caloriesMacros?.protein_grams || 0}г`;
     document.getElementById('caloriesMacros-carbs-view').textContent = `${data.caloriesMacros?.carbs_percent || 0}% / ${data.caloriesMacros?.carbs_grams || 0}г`;

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -112,6 +112,7 @@ export async function populateUI() {
     try { populateUserInfo(data.userName); } catch(e) { console.error("Error in populateUserInfo:", e); }
     try { populateDashboardMainIndexes(data.analytics?.current); } catch(e) { console.error("Error in populateDashboardMainIndexes:", e); }
     try { populateDashboardDetailedAnalytics(data.analytics); } catch(e) { console.error("Error in populateDashboardDetailedAnalytics:", e); }
+    // планът съдържа плосък обект caloriesMacros
     try { await populateDashboardMacros(data.planData?.caloriesMacros); } catch(e) { console.error("Error in populateDashboardMacros:", e); }
     try { populateDashboardStreak(data.analytics?.streak); } catch(e) { console.error("Error in populateDashboardStreak:", e); }
     try { populateDashboardDailyPlan(data.planData?.week1Menu, data.dailyLogs, data.recipeData); } catch(e) { console.error("Error in populateDashboardDailyPlan:", e); }

--- a/kv/DIET_RESOURCES/prompt_unified_plan_generation_v2.txt
+++ b/kv/DIET_RESOURCES/prompt_unified_plan_generation_v2.txt
@@ -22,9 +22,8 @@ Your primary goal is to analyze the provided user questionnaire answers and gene
   // Example: "Потребител с цел Отслабване, има Инсулинова резистентност, предпочита Вегетариански режим и има Средно ниво на активност."
   // Ако има налични данни за скорошен прогрес, спомени накратко теглото: "Текущо тегло %%RECENT_WEIGHT_KG%% (промяна за 7 дни: %%WEIGHT_CHANGE_LAST_7_DAYS%%)".
 
-  "caloriesMacros": {
-    "plan": {
-      // Calculations use a universal formula (напр. Mifflin-St Jeor) модифицирана според индивидуалните параметри, както и цел, медицинско състояние, и други релевантни данни
+    "caloriesMacros": {
+      // Calculations use a universal formula (напр. Mifflin-St Jeor) модифицирана според индивидуалните параметри, както и цел, медицинско състояние и други релевантни данни
       "calories": "number (integer)",
       "protein_percent": "number (integer)",
       "carbs_percent": "number (integer)",
@@ -35,31 +34,12 @@ Your primary goal is to analyze the provided user questionnaire answers and gene
       "fat_grams": "number (integer)",
       "fiber_grams": "number (integer)"
     },
-    "recommendation": {
-      "calories": "number (integer)",
-      "protein_percent": "number (integer)",
-      "carbs_percent": "number (integer)",
-      "fat_percent": "number (integer)",
-      "fiber_percent": "number (integer)",
-      "protein_grams": "number (integer)",
-      "carbs_grams": "number (integer)",
-      "fat_grams": "number (integer)",
-      "fiber_grams": "number (integer)"
-    }
-  },
-  // Пример:
-  // "caloriesMacros": {
-  //   "plan": {
-  //     "calories": 1800,
-  //     "protein_percent": 30, "carbs_percent": 40, "fat_percent": 20, "fiber_percent": 10,
-  //     "protein_grams": 135, "carbs_grams": 180, "fat_grams": 40, "fiber_grams": 45
-  //   },
-  //   "recommendation": {
-  //     "calories": 1900,
-  //     "protein_percent": 30, "carbs_percent": 40, "fat_percent": 20, "fiber_percent": 10,
-  //     "protein_grams": 140, "carbs_grams": 190, "fat_grams": 50, "fiber_grams": 40
-  //   }
-  // }
+    // Пример:
+    // "caloriesMacros": {
+    //   "calories": 1800,
+    //   "protein_percent": 30, "carbs_percent": 40, "fat_percent": 20, "fiber_percent": 10,
+    //   "protein_grams": 135, "carbs_grams": 180, "fat_grams": 40, "fiber_grams": 45
+    // }
 
   "allowedForbiddenFoods": {
     // All lists in Bulgarian. Base on %%BASE_DIET_MODEL_SUMMARY%%, user's %%FOOD_PREFERENCE%%, %%INTOLERANCES%%, %%DISLIKED_FOODS%%, %%CONDITIONS%%.

--- a/worker.js
+++ b/worker.js
@@ -1553,12 +1553,7 @@ async function handleUpdatePlanRequest(request, env) {
         await env.USER_METADATA_KV.put(`${userId}_final_plan`, JSON.stringify(planData));
         const macrosRecord = {
             status: 'final',
-            data: planData.caloriesMacros
-                ? {
-                    plan: planData.caloriesMacros.plan,
-                    recommendation: planData.caloriesMacros.recommendation
-                }
-                : null
+            data: planData.caloriesMacros || null
         };
         await env.USER_METADATA_KV.put(`${userId}_analysis_macros`, JSON.stringify(macrosRecord));
         await env.USER_METADATA_KV.put(`plan_status_${userId}`, 'ready', { metadata: { status: 'ready' } });
@@ -2844,8 +2839,7 @@ async function processSingleUserPlan(userId, env, priorityGuidance = '', regenRe
                 }
             };
             if (planBuilder.caloriesMacros) {
-                ensureFiber(planBuilder.caloriesMacros.plan);
-                ensureFiber(planBuilder.caloriesMacros.recommendation);
+                ensureFiber(planBuilder.caloriesMacros);
             }
             if (generationMetadata && Array.isArray(generationMetadata.errors)) planBuilder.generationMetadata.errors.push(...generationMetadata.errors);
         } catch (e) {


### PR DESCRIPTION
## Summary
- remove nested recommendation macros from prompt template
- save plan macros directly in `worker.js`
- note flat macro structure in client UI and update tests

## Testing
- `npm run lint`
- `npm test js/__tests__/updatePlanData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892c950d530832697d497a30fc61a53