### PR TITLE
Refactor plan regeneration handling

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -518,8 +518,8 @@
   <div id="priorityGuidanceModal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
     <div class="modal-content">
       <button id="priorityGuidanceClose" class="close-button" aria-label="Затвори прозореца">&times;</button>
-      <label for="priorityGuidanceInput">Приоритетни указания</label>
-      <textarea id="priorityGuidanceInput" rows="4"></textarea>
+      <label for="priorityGuidanceInput">Причина за регенериране</label>
+      <textarea id="priorityGuidanceInput" rows="4" placeholder="Опишете защо се регенерира планът"></textarea>
       <div class="modal-actions">
         <button id="priorityGuidanceConfirm" class="button">Потвърди</button>
         <button id="priorityGuidanceCancel" class="button button-secondary">Отказ</button>

--- a/js/__tests__/planRegenerator.test.js
+++ b/js/__tests__/planRegenerator.test.js
@@ -33,11 +33,27 @@ test('изпраща reason при потвърждение', async () => {
   const regenProgress = document.getElementById('regenProgress');
   setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
   regenBtn.click();
+  const input = document.getElementById('priorityGuidanceInput');
+  input.value = 'причина';
   document.getElementById('priorityGuidanceConfirm').click();
   await Promise.resolve();
   expect(fetch).toHaveBeenCalledWith('/regen', expect.objectContaining({
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId: 'u1', priorityGuidance: '', reason: 'Админ регенерация' })
+    body: JSON.stringify({ userId: 'u1', reason: 'причина' })
   }));
+});
+
+test('деактивира и реактивира бутона', async () => {
+  const regenBtn = document.getElementById('regen');
+  const regenProgress = document.getElementById('regenProgress');
+  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
+  regenBtn.click();
+  document.getElementById('priorityGuidanceConfirm').click();
+  await Promise.resolve();
+  expect(regenBtn.disabled).toBe(true);
+  jest.advanceTimersByTime(3000);
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(regenBtn.disabled).toBe(false);
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -720,22 +720,13 @@ function renderClients() {
             regen.className = 'regen-plan-btn button-small';
             regen.textContent = 'Нов план';
             regen.title = 'Генерирай нов план';
-            regen.addEventListener('click', async e => {
-                e.stopPropagation();
-                try {
-                    await fetch(apiEndpoints.regeneratePlan, {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        // Причината е задължителна за API; подаваме стандартна стойност.
-                        body: JSON.stringify({ userId: c.userId, reason: 'Админ регенерация' })
-                    });
-                    alert('Стартирана е нова генерация.');
-                } catch (err) {
-                    console.error('regeneratePlan error:', err);
-                    alert('Грешка при стартиране на генерирането.');
-                }
-            });
+            const progress = document.createElement('span');
+            progress.className = 'regen-progress hidden';
+            progress.setAttribute('aria-live', 'polite');
             li.appendChild(regen);
+            li.appendChild(progress);
+            regen.addEventListener('click', e => e.stopPropagation());
+            setupPlanRegeneration({ regenBtn: regen, regenProgress: progress, getUserId: () => c.userId });
         }
 
         clientsList?.appendChild(li);


### PR DESCRIPTION
## Summary
- delegate plan regeneration buttons to shared setupPlanRegeneration helper
- allow admins to enter regeneration reason and show progress feedback
- cover regeneration flow with unit tests

## Testing
- `npm run lint -- js/admin.js js/planRegenerator.js admin.html js/__tests__/planRegenerator.test.js`
- `npm test js/__tests__/planRegenerator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892cb4838608326a6c98c915beeaf34