### PR TITLE
Fix missing variables in principle adjustment

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -2925,6 +2925,12 @@ async function handlePrincipleAdjustment(userId, env, calledFromQuizAnalysis = f
              return null;
         }
 
+        const originalGoal = initialAnswers.goal || 'N/A';
+        const calMac = finalPlan.caloriesMacros;
+        const initCalMac = calMac
+            ? `Кал: ${calMac.calories || '?'} P:${calMac.protein_grams || '?'}g C:${calMac.carbs_grams || '?'}g F:${calMac.fat_grams || '?'}g`
+            : 'N/A';
+
         const currentWeightVal = safeParseFloat(currentStatus?.weight);
         const currentWeightStr = currentWeightVal ? `${currentWeightVal.toFixed(1)} кг` : "N/A";
         


### PR DESCRIPTION
## Summary
- define `originalGoal` and `initCalMac` in `handlePrincipleAdjustment`

## Testing
- `npm run lint`
- `sh scripts/test.sh js/__tests__/principleAdjustmentSummary.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892ce80a4908326ae9a73eb8db0f3eb