### PR TITLE
feat: map input macro grams directly

### DIFF
--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -129,3 +129,31 @@ test('calculatePlanMacros се извиква само веднъж при ке�
   await populateDashboardMacros({});
   expect(calcMock).toHaveBeenCalledTimes(1);
 });
+
+test('използва грамовете от подадения план, когато са налични', async () => {
+  setupDom();
+  const macros = {
+    plan: {
+      calories: 1900,
+      protein_percent: 30,
+      carbs_percent: 40,
+      fat_percent: 30,
+      protein_grams: 140,
+      carbs_grams: 190,
+      fat_grams: 63,
+      fiber_grams: 28
+    }
+  };
+  Object.assign(appState.todaysPlanMacros, { calories: 500, protein: 10, carbs: 20, fat: 5, fiber: 3 });
+  await populateDashboardMacros(macros);
+  const card = document.querySelector('macro-analytics-card');
+  const [payload] = card.setData.mock.calls[0];
+  expect(payload.plan).toMatchObject({
+    calories: 1900,
+    protein_grams: 140,
+    carbs_grams: 190,
+    fat_grams: 63,
+    fiber_grams: 28
+  });
+  expect(selectors.macroMetricsPreview.textContent).toContain('1900');
+});

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -446,7 +446,8 @@ export function validateMacroPayload({ plan, current }) {
 }
 
 export async function populateDashboardMacros(macros) {
-    renderMacroPreviewGrid(macros);
+    const flat = macros?.plan ?? macros;
+    renderMacroPreviewGrid(flat);
     let macroContainer = selectors.macroAnalyticsCardContainer;
     if (!macroContainer || !document.contains(macroContainer)) {
         macroContainer = document.createElement('div');
@@ -455,7 +456,7 @@ export async function populateDashboardMacros(macros) {
         selectors.analyticsCardsContainer?.appendChild(macroContainer);
         selectors.macroAnalyticsCardContainer = macroContainer;
     }
-    if (!macros) {
+    if (!flat) {
         macroContainer.innerHTML = '<div class="spinner-border" role="status"></div>';
         try {
             const res = await fetch(`${apiEndpoints.dashboard}?userId=${currentUserId}&recalcMacros=1`);
@@ -475,11 +476,11 @@ export async function populateDashboardMacros(macros) {
     }
     macroContainer.innerHTML = '';
     const plan = {
-        calories: todaysPlanMacros.calories,
-        protein_grams: todaysPlanMacros.protein,
-        carbs_grams: todaysPlanMacros.carbs,
-        fat_grams: todaysPlanMacros.fat,
-        fiber_grams: todaysPlanMacros.fiber
+        calories: flat?.calories ?? todaysPlanMacros.calories,
+        protein_grams: flat?.protein_grams ?? todaysPlanMacros.protein,
+        carbs_grams: flat?.carbs_grams ?? todaysPlanMacros.carbs,
+        fat_grams: flat?.fat_grams ?? todaysPlanMacros.fat,
+        fiber_grams: flat?.fiber_grams ?? todaysPlanMacros.fiber
     };
     const current = {
         calories: currentIntakeMacros.calories,


### PR DESCRIPTION
## Summary
- handle nested macro payloads in populateDashboardMacros
- prefer provided gram fields over todaysPlanMacros
- test direct gram mapping for macro analytics card

## Testing
- `npm run lint`
- `npm test -- js/__tests__/populateDashboardMacros.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892cfd7f1408326bbd9c86c17befdbf