### PR TITLE
feat: use active plan regeneration context

### DIFF
--- a/js/planRegenerator.js
+++ b/js/planRegenerator.js
@@ -1,5 +1,10 @@
 import { apiEndpoints } from './config.js';
 
+let activeUserId;
+let activeRegenBtn;
+let activeRegenProgress;
+let confirmListenerAdded = false;
+
 function openModal(modal) {
   modal.classList.add('visible');
   modal.setAttribute('aria-hidden', 'false');
@@ -23,66 +28,74 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
   const hide = () => closeModal(modal);
 
   regenBtn.addEventListener('click', () => {
+    activeUserId = getUserId?.();
+    activeRegenBtn = regenBtn;
+    activeRegenProgress = regenProgress;
     input.value = '';
     openModal(modal);
   });
   cancel?.addEventListener('click', hide);
   closeBtn?.addEventListener('click', hide);
 
-  confirm.addEventListener('click', async () => {
-    const userId = getUserId?.();
-    if (!userId) return;
-    hide();
-    const reason = input.value.trim();
-    if (regenProgress) {
-      regenProgress.textContent = 'Генериране…';
-      regenProgress.classList.remove('hidden');
-    }
-    regenBtn.disabled = true;
-    try {
-      const resp = await fetch(apiEndpoints.regeneratePlan, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId, reason: reason || 'Админ регенерация' })
-      });
-      if (!resp.ok) throw new Error('Request failed');
-    } catch (err) {
-      console.error('regeneratePlan error:', err);
-      if (regenProgress) {
-        regenProgress.textContent = 'Грешка';
-        setTimeout(() => regenProgress.classList.add('hidden'), 2000);
+  if (!confirmListenerAdded) {
+    confirmListenerAdded = true;
+    confirm.addEventListener('click', async () => {
+      if (!activeUserId || !activeRegenBtn) return;
+      hide();
+      const reason = input.value.trim();
+      if (activeRegenProgress) {
+        activeRegenProgress.textContent = 'Генериране…';
+        activeRegenProgress.classList.remove('hidden');
       }
-      regenBtn.disabled = false;
-      alert('Грешка при стартиране на генерирането.');
-      return;
-    }
-
-    const intervalId = setInterval(async () => {
+      activeRegenBtn.disabled = true;
       try {
-        const resp = await fetch(`${apiEndpoints.planStatus}?userId=${userId}`);
-        const data = await resp.json();
-        if (resp.ok && data.success) {
-          if (data.planStatus === 'ready') {
-            clearInterval(intervalId);
-            if (regenProgress) {
-              regenProgress.textContent = 'Готово';
-              setTimeout(() => regenProgress.classList.add('hidden'), 2000);
-            }
-            regenBtn.disabled = false;
-            alert('Планът е обновен.');
-          } else if (data.planStatus === 'error') {
-            clearInterval(intervalId);
-            if (regenProgress) {
-              regenProgress.textContent = 'Грешка';
-              setTimeout(() => regenProgress.classList.add('hidden'), 2000);
-            }
-            regenBtn.disabled = false;
-            alert(`Грешка при генерирането: ${data.error || ''}`);
-          }
-        }
+        const resp = await fetch(apiEndpoints.regeneratePlan, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId: activeUserId, reason: reason || 'Админ регенерация' })
+        });
+        if (!resp.ok) throw new Error('Request failed');
       } catch (err) {
-        console.error('planStatus polling error:', err);
+        console.error('regeneratePlan error:', err);
+        if (activeRegenProgress) {
+          activeRegenProgress.textContent = 'Грешка';
+          setTimeout(() => activeRegenProgress.classList.add('hidden'), 2000);
+        }
+        activeRegenBtn.disabled = false;
+        alert('Грешка при стартиране на генерирането.');
+        return;
       }
-    }, 3000);
-  });
+
+      const userId = activeUserId;
+      const btn = activeRegenBtn;
+      const progress = activeRegenProgress;
+      const intervalId = setInterval(async () => {
+        try {
+          const resp = await fetch(`${apiEndpoints.planStatus}?userId=${userId}`);
+          const data = await resp.json();
+          if (resp.ok && data.success) {
+            if (data.planStatus === 'ready') {
+              clearInterval(intervalId);
+              if (progress) {
+                progress.textContent = 'Готово';
+                setTimeout(() => progress.classList.add('hidden'), 2000);
+              }
+              btn.disabled = false;
+              alert('Планът е обновен.');
+            } else if (data.planStatus === 'error') {
+              clearInterval(intervalId);
+              if (progress) {
+                progress.textContent = 'Грешка';
+                setTimeout(() => progress.classList.add('hidden'), 2000);
+              }
+              btn.disabled = false;
+              alert(`Грешка при генерирането: ${data.error || ''}`);
+            }
+          }
+        } catch (err) {
+          console.error('planStatus polling error:', err);
+        }
+      }, 3000);
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- centralize plan regeneration to use active button/user context and a single confirm listener
- test that only the last chosen userId triggers regeneration request

## Testing
- `npx eslint js/planRegenerator.js js/__tests__/planRegenerator.test.js`
- `npm test js/__tests__/planRegenerator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892d1164cb08326a7095766b0d56549