### PR TITLE
Align Macro Analytics Card container with standalone design

### DIFF
--- a/code.html
+++ b/code.html
@@ -523,7 +523,7 @@
                   </div>
                 </div>
                 <div id="analyticsCardsContainer" class="analytics-cards-grid">
-                  <div id="macroAnalyticsCardContainer" class="card analytics-card"></div>
+                  <div id="macroAnalyticsCardContainer"></div>
                 </div>
               </div>
             </div>

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -118,6 +118,22 @@ body.vivid-theme .index-card .index-value {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: var(--space-lg);
 }
+
+#macroAnalyticsCardContainer {
+  --card-bg: #2C314A;
+  --text-color-primary: #E0E0E0;
+  --text-color-secondary: #A0A5C0;
+  --macro-protein-color: #5BC0BE;
+  --macro-carbs-color: #FFD166;
+  --macro-fat-color: #FF6B6B;
+  --macro-fiber-color: #6FCF97;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+}
 .analytics-card {
   background: rgba(var(--card-bg-rgb), var(--card-bg-opacity));
   backdrop-filter: blur(var(--glass-blur));

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -452,7 +452,8 @@ export async function populateDashboardMacros(macros) {
     if (!macroContainer || !document.contains(macroContainer)) {
         macroContainer = document.createElement('div');
         macroContainer.id = 'macroAnalyticsCardContainer';
-        macroContainer.className = 'card analytics-card';
+        // Container should inherit styling from standalone macro card
+        macroContainer.className = '';
         selectors.analyticsCardsContainer?.appendChild(macroContainer);
         selectors.macroAnalyticsCardContainer = macroContainer;
     }


### PR DESCRIPTION
## Summary
- sync Macro Analytics card container styling with standalone variant
- ensure dynamic container creation inherits new style

## Testing
- `npm run lint`
- `npm test js/__tests__/populateDashboardMacros.test.js js/__tests__/populateDashboardMacros.missingComponent.test.js js/__tests__/populateDashboardMacros.importOnce.test.js js/__tests__/populateDashboardMacros.noSetData.test.js js/__tests__/renderPendingMacroChart.test.js`
- `npm test js/__tests__/populateUI.test.js` *(fails: FATAL ERROR: Reached heap limit)*


------
https://chatgpt.com/codex/tasks/task_e_6892d59451e083268e07bfb1c4bc3536