### PR TITLE
feat: refine engagement score calculation

### DIFF
--- a/js/__tests__/engagementAnalytics.test.js
+++ b/js/__tests__/engagementAnalytics.test.js
@@ -1,0 +1,20 @@
+import { calculateAnalyticsIndexes } from '../../worker.js';
+
+const daysOrder = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
+
+describe('calculateAnalyticsIndexes engagement score', () => {
+  test('returns positive score when index data is logged', async () => {
+    const today = new Date();
+    const dayKey = daysOrder[today.getDay()];
+    const dateStr = today.toISOString().split('T')[0];
+
+    const finalPlan = { week1Menu: { [dayKey]: ['meal1'] } };
+    const logEntries = [{ date: dateStr, data: { mood: 3, energy: 4, completedMealsStatus: {} } }];
+    const env = { RESOURCES_KV: { get: async () => null } };
+
+    const result = await calculateAnalyticsIndexes('user', {}, finalPlan, logEntries, {}, env);
+    const expected = Math.round(((0) * 0.4) + (((2 / 5) * 100) * 0.4) + (((1 / 7) * 100) * 0.2));
+    expect(result.current.engagementScore).toBe(expected);
+  });
+});
+

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -154,7 +154,7 @@ test('обновява макро картата чрез setData', async () => 
   });
 });
 
-test('hides modules when values are zero', async () => {
+test('hides modules when values are zero, except engagement card', async () => {
   jest.resetModules();
   const zeroData = {
     fullDashboardData: {
@@ -179,7 +179,7 @@ test('hides modules when values are zero', async () => {
   ({ populateUI } = await import('../populateUI.js'));
   await populateUI();
   expect(document.getElementById('goalCard').classList.contains('hidden')).toBe(true);
-  expect(document.getElementById('engagementCard').classList.contains('hidden')).toBe(true);
+  expect(document.getElementById('engagementCard').classList.contains('hidden')).toBe(false);
   expect(document.getElementById('healthCard').classList.contains('hidden')).toBe(true);
   expect(document.getElementById('progressHistoryCard').classList.contains('hidden')).toBe(true);
 });

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -166,7 +166,7 @@ function populateDashboardMainIndexes(currentAnalytics) {
     }
 
     const engagementScore = safeParseFloat(safeGet(currentAnalytics, 'engagementScore'), null);
-    if (engagementScore === null || engagementScore <= 0) {
+    if (engagementScore === null || Number.isNaN(engagementScore) || engagementScore < 0) {
         hide(selectors.engagementCard);
     } else {
         show(selectors.engagementCard);

--- a/worker.js
+++ b/worker.js
@@ -3888,6 +3888,11 @@ async function calculateAnalyticsIndexes(userId, initialAnswers, finalPlan, logE
     let engagementScore = 0;
     let averageMealAdherence = 0;
     let logCompletionRate = 0;
+    let indexCompletionRate = 0;
+
+    let indexFieldsLogged = 0;
+    let indexFieldsExpected = 0;
+    const indexKeys = ['mood','energy','calmness','sleep','hydration'];
 
     let totalPlannedMealsInPeriod = 0;
     let totalCompletedMealsInPeriod = 0;
@@ -3926,6 +3931,16 @@ async function calculateAnalyticsIndexes(userId, initialAnswers, finalPlan, logE
                     }
                 });
             }
+
+            if (hasDataLoggedThisDay) {
+                indexFieldsExpected += indexKeys.length;
+                indexKeys.forEach((key) => {
+                    const val = logEntryForDay.data[key];
+                    if (val !== null && val !== undefined && String(val).trim() !== '') {
+                        indexFieldsLogged++;
+                    }
+                });
+            }
         }
         
         if (plannedMealsThisDay > 0) {
@@ -3939,8 +3954,9 @@ async function calculateAnalyticsIndexes(userId, initialAnswers, finalPlan, logE
     }
 
     averageMealAdherence = totalPlannedMealsInPeriod > 0 ? (totalCompletedMealsInPeriod / totalPlannedMealsInPeriod) * 100 : (daysWithAnyLogEntry > 0 ? 0 : 50); // if logs exist but no plan, 0%, else 50% default
+    indexCompletionRate = indexFieldsExpected > 0 ? (indexFieldsLogged / indexFieldsExpected) * 100 : 0;
     logCompletionRate = (daysWithAnyLogEntry / USER_ACTIVITY_LOG_LOOKBACK_DAYS_ANALYTICS) * 100;
-    engagementScore = capScore((averageMealAdherence * 0.7) + (logCompletionRate * 0.3));
+    engagementScore = capScore((averageMealAdherence * 0.4) + (indexCompletionRate * 0.4) + (logCompletionRate * 0.2));
 
     const avgMood = getAvgLog('mood', 3, logsToConsider, USER_ACTIVITY_LOG_LOOKBACK_DAYS_ANALYTICS);
     const avgEnergy = getAvgLog('energy', 3, logsToConsider, USER_ACTIVITY_LOG_LOOKBACK_DAYS_ANALYTICS);
@@ -4081,6 +4097,16 @@ async function calculateAnalyticsIndexes(userId, initialAnswers, finalPlan, logE
         currentValueNumeric: parseFloat(averageMealAdherence.toFixed(1)),
         currentValueText: `${Math.round(averageMealAdherence)}%`,
         infoTextKey: "meal_adherence_info",
+        periodDays: USER_ACTIVITY_LOG_LOOKBACK_DAYS_ANALYTICS
+    });
+
+    detailedAnalyticsMetrics.push({
+        key: "index_completion", label: "Попълване на Индекси",
+        initialValueText: "N/A",
+        expectedValueText: safeGetL(finalPlan, 'detailedTargets.index_completion_target_text', "> 80%"),
+        currentValueNumeric: parseFloat(indexCompletionRate.toFixed(1)),
+        currentValueText: `${Math.round(indexCompletionRate)}%`,
+        infoTextKey: "index_completion_info",
         periodDays: USER_ACTIVITY_LOG_LOOKBACK_DAYS_ANALYTICS
     });
 
@@ -4275,4 +4301,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRegeneratePlanRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleDashboardDataRequest, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleContactFormRequest, handleGetContactRequestsRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, sendAnalysisLinkEmail, sendContactEmail, getEmailConfig };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRegeneratePlanRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleDashboardDataRequest, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleContactFormRequest, handleGetContactRequestsRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, sendAnalysisLinkEmail, sendContactEmail, getEmailConfig, calculateAnalyticsIndexes };


### PR DESCRIPTION
## Summary
- compute engagement score from meal adherence, logged indices, and diary consistency
- expose index completion metric in analytics
- add targeted test for engagement calculation

## Testing
- `npm run lint`
- `npm test js/__tests__/engagementAnalytics.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892d6664d5083268b2c11d283637cd1