### PR TITLE
Align macro analytics card container with standalone design

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -173,6 +173,19 @@ body.vivid-theme .index-card .index-value {
   width: 100%;
   border: 0;
 }
+
+#macroAnalyticsCardContainer {
+  --card-bg: #2C314A;
+  --card-bg-rgb: 44,49,74;
+  --card-bg-opacity: 1;
+  --text-color-primary: #E0E0E0;
+  --text-color-secondary: #A0A5C0;
+  --macro-protein-color: #5BC0BE;
+  --macro-carbs-color: #FFD166;
+  --macro-fat-color: #FF6B6B;
+  --macro-fiber-color: #6FCF97;
+  color: var(--text-color-primary);
+}
 .metric-current-text {
   margin-bottom: var(--space-sm);
   font-weight: 600;

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -202,7 +202,7 @@ function populateDashboardDetailedAnalytics(analyticsData) {
     }
     cardsContainer.innerHTML = '';
     if (macroContainer) {
-        macroContainer.classList.add('loading');
+        macroContainer.className = 'card analytics-card loading';
         macroContainer.innerHTML = `
             <h5></h5>
             <div class="chart-container">
@@ -474,6 +474,7 @@ export async function populateDashboardMacros(macros) {
         }
         return;
     }
+    macroContainer.classList.remove('loading', 'card', 'analytics-card');
     macroContainer.innerHTML = '';
     const plan = {
         calories: flat?.calories ?? todaysPlanMacros.calories,


### PR DESCRIPTION
## Summary
- style macro analytics container with same color palette as standalone card
- ensure skeleton state always has card styling
- drop wrapper classes after data load to avoid nested card visuals

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892d59451e083268e07bfb1c4bc3536