### PR TITLE
Синхронизация на макро цветовете между теми

### DIFF
--- a/css/base_styles.css
+++ b/css/base_styles.css
@@ -198,7 +198,8 @@ body.dark-theme {
   --macro-protein-color: #5BC0BE;
   --macro-fat-color: #FFD166;
   --macro-carbs-color: #FF6B6B;
-  --macro-ring-highlight: #1C1F2E;
+  --macro-fiber-color: #6FCF97;
+  --macro-ring-highlight: #ffffff;
   --macro-stroke-color: #444444;
 
   --toast-bg: rgba(37, 42, 65, 0.95); --toast-text: #F0F2F5;
@@ -284,7 +285,8 @@ body.vivid-theme {
   --macro-protein-color: #5BC0BE;
   --macro-fat-color: #FFD166;
   --macro-carbs-color: #FF6B6B;
-  --macro-ring-highlight: #1C1F2E;
+  --macro-fiber-color: #6FCF97;
+  --macro-ring-highlight: #ffffff;
   --macro-stroke-color: #444444;
 
   --toast-bg: rgba(37, 42, 65, 0.95); --toast-text: #F0F2F5;

--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -496,8 +496,7 @@ export class MacroAnalyticsCard extends HTMLElement {
         label: this.locale === 'en' ? 'Intake (g)' : 'Прием (гр)',
         data: [current.protein_grams, current.carbs_grams, current.fat_grams, current.fiber_grams],
         backgroundColor: macroColors,
-        borderColor: this.getCssVar('--card-bg'),
-        borderWidth: 4,
+        borderWidth: 0,
         borderRadius: 8,
         cutout: '65%',
         hoverOffset: 12


### PR DESCRIPTION
## Обобщение
- Премахната рамката на набора „Прием (гр)“ и зададена ширина 0 за чиста диаграма.
- Изравнени променливите за макро цветове и акцент на пръстена между светла и тъмна тема.

## Тестване
- `npm run lint`
- `npm test`
- Проверка на CSS променливи при смяна на тема чрез jsdom

------
https://chatgpt.com/codex/tasks/task_e_689327231a0083269810d996d6cc1fb7