### PR TITLE
Refactor plan regeneration modal handling

### DIFF
--- a/editclient.html
+++ b/editclient.html
@@ -538,18 +538,6 @@
     </div>
     </div>
 
-    <div id="priorityGuidanceModal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
-        <div class="modal-content">
-            <button id="priorityGuidanceClose" class="close-button" aria-label="Затвори прозореца">&times;</button>
-            <label for="priorityGuidanceInput">Приоритетни указания</label>
-            <textarea id="priorityGuidanceInput" rows="4"></textarea>
-            <div class="modal-actions">
-                <button id="priorityGuidanceConfirm" class="button">Потвърди</button>
-                <button id="priorityGuidanceCancel" class="button button-secondary">Отказ</button>
-            </div>
-        </div>
-    </div>
-
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Chart.js for visualizations -->

--- a/js/__tests__/planRegenerator.test.js
+++ b/js/__tests__/planRegenerator.test.js
@@ -32,11 +32,24 @@ afterEach(() => {
 test('изпраща reason при потвърждение', async () => {
   const regenBtn = document.getElementById('regen');
   const regenProgress = document.getElementById('regenProgress');
-  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
-  regenBtn.click();
+  const modal = document.getElementById('priorityGuidanceModal');
   const input = document.getElementById('priorityGuidanceInput');
+  const confirm = document.getElementById('priorityGuidanceConfirm');
+  const cancel = document.getElementById('priorityGuidanceCancel');
+  const closeBtn = document.getElementById('priorityGuidanceClose');
+  setupPlanRegeneration({
+    regenBtn,
+    regenProgress,
+    getUserId: () => 'u1',
+    modal,
+    input,
+    confirm,
+    cancel,
+    closeBtn
+  });
+  regenBtn.click();
   input.value = 'причина';
-  document.getElementById('priorityGuidanceConfirm').click();
+  confirm.click();
   await Promise.resolve();
   expect(fetch).toHaveBeenCalledWith('/regen', expect.objectContaining({
     method: 'POST',
@@ -48,9 +61,23 @@ test('изпраща reason при потвърждение', async () => {
 test('деактивира и реактивира бутона', async () => {
   const regenBtn = document.getElementById('regen');
   const regenProgress = document.getElementById('regenProgress');
-  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
+  const modal = document.getElementById('priorityGuidanceModal');
+  const input = document.getElementById('priorityGuidanceInput');
+  const confirm = document.getElementById('priorityGuidanceConfirm');
+  const cancel = document.getElementById('priorityGuidanceCancel');
+  const closeBtn = document.getElementById('priorityGuidanceClose');
+  setupPlanRegeneration({
+    regenBtn,
+    regenProgress,
+    getUserId: () => 'u1',
+    modal,
+    input,
+    confirm,
+    cancel,
+    closeBtn
+  });
   regenBtn.click();
-  document.getElementById('priorityGuidanceConfirm').click();
+  confirm.click();
   await Promise.resolve();
   expect(regenBtn.disabled).toBe(true);
   jest.advanceTimersByTime(3000);
@@ -69,13 +96,36 @@ test('изпраща заявка само за последно избран us
   regenProgress2.id = 'regenProgress2';
   regenProgress2.classList.add('hidden');
   document.body.appendChild(regenProgress2);
+  const modal = document.getElementById('priorityGuidanceModal');
+  const input = document.getElementById('priorityGuidanceInput');
+  const confirm = document.getElementById('priorityGuidanceConfirm');
+  const cancel = document.getElementById('priorityGuidanceCancel');
+  const closeBtn = document.getElementById('priorityGuidanceClose');
 
-  setupPlanRegeneration({ regenBtn: regenBtn1, regenProgress: regenProgress1, getUserId: () => 'u1' });
-  setupPlanRegeneration({ regenBtn: regenBtn2, regenProgress: regenProgress2, getUserId: () => 'u2' });
+  setupPlanRegeneration({
+    regenBtn: regenBtn1,
+    regenProgress: regenProgress1,
+    getUserId: () => 'u1',
+    modal,
+    input,
+    confirm,
+    cancel,
+    closeBtn
+  });
+  setupPlanRegeneration({
+    regenBtn: regenBtn2,
+    regenProgress: regenProgress2,
+    getUserId: () => 'u2',
+    modal,
+    input,
+    confirm,
+    cancel,
+    closeBtn
+  });
 
   regenBtn1.click();
   regenBtn2.click();
-  document.getElementById('priorityGuidanceConfirm').click();
+  confirm.click();
   await Promise.resolve();
 
   expect(fetch).toHaveBeenCalledTimes(1);

--- a/js/admin.js
+++ b/js/admin.js
@@ -33,6 +33,11 @@ const tagFilterSelect = document.getElementById('tagFilter');
 const detailsSection = document.getElementById('clientDetails');
 const regenBtn = document.getElementById('regeneratePlan');
 const regenProgress = document.getElementById('regenProgress');
+const priorityModal = document.getElementById('priorityGuidanceModal');
+const priorityInput = document.getElementById('priorityGuidanceInput');
+const priorityConfirm = document.getElementById('priorityGuidanceConfirm');
+const priorityCancel = document.getElementById('priorityGuidanceCancel');
+const priorityClose = document.getElementById('priorityGuidanceClose');
 const aiSummaryBtn = document.getElementById('aiSummary');
 const notesField = document.getElementById('adminNotes');
 const tagsField = document.getElementById('adminTags');
@@ -242,7 +247,16 @@ let currentUserId = null;
 function setCurrentUserId(val) {
     currentUserId = val;
 }
-setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => currentUserId });
+setupPlanRegeneration({
+    regenBtn,
+    regenProgress,
+    getUserId: () => currentUserId,
+    modal: priorityModal,
+    input: priorityInput,
+    confirm: priorityConfirm,
+    cancel: priorityCancel,
+    closeBtn: priorityClose
+});
 let profileNavObserver = null;
 let currentPlanData = null;
 let currentDashboardData = null;
@@ -726,7 +740,16 @@ function renderClients() {
             li.appendChild(regen);
             li.appendChild(progress);
             regen.addEventListener('click', e => e.stopPropagation());
-            setupPlanRegeneration({ regenBtn: regen, regenProgress: progress, getUserId: () => c.userId });
+            setupPlanRegeneration({
+                regenBtn: regen,
+                regenProgress: progress,
+                getUserId: () => c.userId,
+                modal: priorityModal,
+                input: priorityInput,
+                confirm: priorityConfirm,
+                cancel: priorityCancel,
+                closeBtn: priorityClose
+            });
         }
 
         clientsList?.appendChild(li);

--- a/js/editClient.js
+++ b/js/editClient.js
@@ -564,7 +564,21 @@ export async function initEditClient(userId) {
 
   const regenBtn = document.getElementById('regeneratePlan');
   const regenProgress = document.getElementById('regenProgress');
-  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => userId });
+  const priorityModal = document.getElementById('priorityGuidanceModal');
+  const priorityInput = document.getElementById('priorityGuidanceInput');
+  const priorityConfirm = document.getElementById('priorityGuidanceConfirm');
+  const priorityCancel = document.getElementById('priorityGuidanceCancel');
+  const priorityClose = document.getElementById('priorityGuidanceClose');
+  setupPlanRegeneration({
+    regenBtn,
+    regenProgress,
+    getUserId: () => userId,
+    modal: priorityModal,
+    input: priorityInput,
+    confirm: priorityConfirm,
+    cancel: priorityCancel,
+    closeBtn: priorityClose
+  });
 
   const aiSummaryBtn = document.getElementById('aiSummary');
   if (aiSummaryBtn) {

--- a/js/planRegenerator.js
+++ b/js/planRegenerator.js
@@ -3,7 +3,7 @@ import { apiEndpoints } from './config.js';
 let activeUserId;
 let activeRegenBtn;
 let activeRegenProgress;
-let confirmListenerAdded = false;
+let detachLast;
 
 function openModal(modal) {
   modal.classList.add('visible');
@@ -17,29 +17,39 @@ function closeModal(modal) {
   modal.setAttribute('aria-hidden', 'true');
 }
 
-export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
-  const modal = document.getElementById('priorityGuidanceModal');
-  const input = document.getElementById('priorityGuidanceInput');
-  const confirm = document.getElementById('priorityGuidanceConfirm');
-  const cancel = document.getElementById('priorityGuidanceCancel');
-  const closeBtn = document.getElementById('priorityGuidanceClose');
+export function setupPlanRegeneration({
+  regenBtn,
+  regenProgress,
+  getUserId,
+  modal,
+  input,
+  confirm,
+  cancel,
+  closeBtn
+}) {
   if (!regenBtn || !modal || !confirm || !input) return;
 
   const hide = () => closeModal(modal);
 
   regenBtn.addEventListener('click', () => {
+    detachLast?.();
     activeUserId = getUserId?.();
     activeRegenBtn = regenBtn;
     activeRegenProgress = regenProgress;
     input.value = '';
     openModal(modal);
-  });
-  cancel?.addEventListener('click', hide);
-  closeBtn?.addEventListener('click', hide);
 
-  if (!confirmListenerAdded) {
-    confirmListenerAdded = true;
-    confirm.addEventListener('click', async () => {
+    let onConfirm;
+    let onCancel;
+
+    const cleanup = () => {
+      confirm.removeEventListener('click', onConfirm);
+      cancel?.removeEventListener('click', onCancel);
+      closeBtn?.removeEventListener('click', onCancel);
+      if (detachLast === cleanup) detachLast = null;
+    };
+
+    onConfirm = async () => {
       if (!activeUserId || !activeRegenBtn) return;
       hide();
       const reason = input.value.trim();
@@ -63,6 +73,7 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
         }
         activeRegenBtn.disabled = false;
         alert('Грешка при стартиране на генерирането.');
+        cleanup();
         return;
       }
 
@@ -96,6 +107,18 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
           console.error('planStatus polling error:', err);
         }
       }, 3000);
-    });
-  }
+
+      cleanup();
+    };
+
+    onCancel = () => {
+      hide();
+      cleanup();
+    };
+
+    detachLast = cleanup;
+    confirm.addEventListener('click', onConfirm);
+    cancel?.addEventListener('click', onCancel);
+    closeBtn?.addEventListener('click', onCancel);
+  });
 }


### PR DESCRIPTION
## Summary
- remove extra priorityGuidance modal from editclient.html
- pass explicit modal elements to setupPlanRegeneration and drop global listener flag
- wire admin and client pages to the new modal API

## Testing
- `npm run lint`
- `npm test js/__tests__/planRegenerator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68937043dda88326997ae661ec0af410