### PR TITLE
feat: handle priority guidance and regen reasons

### DIFF
--- a/backend/tests/regeneratePlan.test.js
+++ b/backend/tests/regeneratePlan.test.js
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals';
 import { handleRegeneratePlanRequest } from '../../worker.js';
 
 describe('POST /api/regeneratePlan', () => {
-  test('записва reason и го предава към процесора', async () => {
+  test('записва priorityGuidance и reason и ги предава към процесора', async () => {
     const env = {
       USER_METADATA_KV: {
         put: jest.fn(),
@@ -15,7 +15,8 @@ describe('POST /api/regeneratePlan', () => {
     const mockProcessor = jest.fn().mockResolvedValue();
     const request = { json: async () => ({ userId: 'u1', priorityGuidance: 'повече протеин', reason: 'нова цел' }) };
     const res = await handleRegeneratePlanRequest(request, env, ctx, mockProcessor);
-    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('pending_plan_mod_u1', 'нова цел');
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('pending_plan_mod_u1', 'повече протеин');
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('regen_reason_u1', 'нова цел');
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('plan_status_u1', 'processing', { metadata: { status: 'processing' } });
     expect(ctx.waitUntil).toHaveBeenCalled();
     expect(mockProcessor).toHaveBeenCalledWith('u1', env, 'повече протеин', 'нова цел');

--- a/js/__tests__/planRegenerator.test.js
+++ b/js/__tests__/planRegenerator.test.js
@@ -41,7 +41,7 @@ test('изпраща reason при потвърждение', async () => {
   expect(fetch).toHaveBeenCalledWith('/regen', expect.objectContaining({
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId: 'u1', reason: 'причина' })
+    body: JSON.stringify({ userId: 'u1', reason: 'причина', priorityGuidance: '' })
   }));
 });
 
@@ -80,6 +80,32 @@ test('изпраща заявка само за последно избран us
 
   expect(fetch).toHaveBeenCalledTimes(1);
   expect(fetch).toHaveBeenCalledWith('/regen', expect.objectContaining({
-    body: JSON.stringify({ userId: 'u2', reason: 'Админ регенерация' })
+    body: JSON.stringify({ userId: 'u2', reason: 'Админ регенерация', priorityGuidance: '' })
+  }));
+});
+
+test('изпраща reason и priorityGuidance при отделни полета', async () => {
+  document.body.innerHTML = `
+    <button id="regen"></button>
+    <div id="regenProgress" class="hidden"></div>
+    <div id="priorityGuidanceModal" aria-hidden="true">
+      <textarea id="priorityGuidanceInput"></textarea>
+      <textarea id="regenReasonInput"></textarea>
+      <button id="priorityGuidanceConfirm"></button>
+      <button id="priorityGuidanceCancel"></button>
+      <button id="priorityGuidanceClose"></button>
+    </div>
+  `;
+  ({ setupPlanRegeneration } = await import('../planRegenerator.js'));
+  const regenBtn = document.getElementById('regen');
+  const regenProgress = document.getElementById('regenProgress');
+  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
+  regenBtn.click();
+  document.getElementById('regenReasonInput').value = 'причина';
+  document.getElementById('priorityGuidanceInput').value = 'приоритет';
+  document.getElementById('priorityGuidanceConfirm').click();
+  await Promise.resolve();
+  expect(fetch).toHaveBeenCalledWith('/regen', expect.objectContaining({
+    body: JSON.stringify({ userId: 'u1', reason: 'причина', priorityGuidance: 'приоритет' })
   }));
 });

--- a/js/__tests__/regeneratePlan.test.js
+++ b/js/__tests__/regeneratePlan.test.js
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals';
 import { handleRegeneratePlanRequest } from '../../worker.js';
 
 describe('handleRegeneratePlanRequest', () => {
-  test('записва reason и стартира генерирането', async () => {
+  test('записва priorityGuidance и reason и стартира генерирането', async () => {
     const env = {
       USER_METADATA_KV: {
         put: jest.fn(),
@@ -15,7 +15,8 @@ describe('handleRegeneratePlanRequest', () => {
     const mockProcessor = jest.fn().mockResolvedValue();
     const request = { json: async () => ({ userId: 'u1', priorityGuidance: 'повече протеин', reason: 'нова цел' }) };
     const res = await handleRegeneratePlanRequest(request, env, ctx, mockProcessor);
-    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('pending_plan_mod_u1', 'нова цел');
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('pending_plan_mod_u1', 'повече протеин');
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('regen_reason_u1', 'нова цел');
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('plan_status_u1', 'processing', { metadata: { status: 'processing' } });
     expect(ctx.waitUntil).toHaveBeenCalled();
     expect(mockProcessor).toHaveBeenCalledWith('u1', env, 'повече протеин', 'нова цел');

--- a/js/planRegenerator.js
+++ b/js/planRegenerator.js
@@ -19,11 +19,12 @@ function closeModal(modal) {
 
 export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
   const modal = document.getElementById('priorityGuidanceModal');
-  const input = document.getElementById('priorityGuidanceInput');
+  const priorityInput = document.getElementById('priorityGuidanceInput');
+  const reasonInput = document.getElementById('regenReasonInput');
   const confirm = document.getElementById('priorityGuidanceConfirm');
   const cancel = document.getElementById('priorityGuidanceCancel');
   const closeBtn = document.getElementById('priorityGuidanceClose');
-  if (!regenBtn || !modal || !confirm || !input) return;
+  if (!regenBtn || !modal || !confirm || (!priorityInput && !reasonInput)) return;
 
   const hide = () => closeModal(modal);
 
@@ -31,7 +32,8 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
     activeUserId = getUserId?.();
     activeRegenBtn = regenBtn;
     activeRegenProgress = regenProgress;
-    input.value = '';
+    if (priorityInput) priorityInput.value = '';
+    if (reasonInput) reasonInput.value = '';
     openModal(modal);
   });
   cancel?.addEventListener('click', hide);
@@ -42,7 +44,8 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
     confirm.addEventListener('click', async () => {
       if (!activeUserId || !activeRegenBtn) return;
       hide();
-      const reason = input.value.trim();
+      const reason = (reasonInput ? reasonInput.value : priorityInput?.value || '').trim();
+      const priorityGuidance = reasonInput ? (priorityInput?.value.trim() || '') : '';
       if (activeRegenProgress) {
         activeRegenProgress.textContent = 'Генериране…';
         activeRegenProgress.classList.remove('hidden');
@@ -52,7 +55,7 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
         const resp = await fetch(apiEndpoints.regeneratePlan, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ userId: activeUserId, reason: reason || 'Админ регенерация' })
+          body: JSON.stringify({ userId: activeUserId, reason: reason || 'Админ регенерация', priorityGuidance })
         });
         if (!resp.ok) throw new Error('Request failed');
       } catch (err) {


### PR DESCRIPTION
## Summary
- send both regeneration reason and priority guidance from plan regenerator modal
- persist priority guidance and regeneration reason separately in worker and pass both to plan processor
- expand tests for new parameters

## Testing
- `npm run lint`
- `npm test js/__tests__/planRegenerator.test.js js/__tests__/regeneratePlan.test.js backend/tests/regeneratePlan.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689384f468688326a0e99096403b42a1