### PR TITLE
Handle regeneratePlan response

### DIFF
--- a/js/__tests__/planRegenerator.test.js
+++ b/js/__tests__/planRegenerator.test.js
@@ -52,6 +52,7 @@ test('деактивира и реактивира бутона', async () => {
   regenBtn.click();
   document.getElementById('priorityGuidanceConfirm').click();
   await Promise.resolve();
+  await Promise.resolve();
   expect(regenBtn.disabled).toBe(true);
   jest.advanceTimersByTime(3000);
   await Promise.resolve();

--- a/js/planRegenerator.js
+++ b/js/planRegenerator.js
@@ -57,7 +57,17 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ userId: activeUserId, reason: reason || 'Админ регенерация', priorityGuidance })
         });
+        const data = await resp.json();
         if (!resp.ok) throw new Error('Request failed');
+        if (!data.success) {
+          if (activeRegenProgress) {
+            activeRegenProgress.textContent = 'Грешка';
+            setTimeout(() => activeRegenProgress.classList.add('hidden'), 2000);
+          }
+          activeRegenBtn.disabled = false;
+          alert(data.message || 'Грешка при стартиране на генерирането.');
+          return;
+        }
       } catch (err) {
         console.error('regeneratePlan error:', err);
         if (activeRegenProgress) {


### PR DESCRIPTION
## Summary
- guard plan regeneration by parsing response JSON and halting on backend error
- stabilize regeneration tests with additional async wait

## Testing
- `npm run lint js/planRegenerator.js js/__tests__/planRegenerator.test.js`
- `npm test js/__tests__/planRegenerator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893879bcae88326bc8c0fa8fea3bfab