### PR TITLE
Проверка на prerequisites преди регенериране на планове

### DIFF
--- a/backend/tests/checkPlanPrerequisites.test.js
+++ b/backend/tests/checkPlanPrerequisites.test.js
@@ -1,0 +1,25 @@
+import { jest } from '@jest/globals';
+import { handleCheckPlanPrerequisitesRequest } from '../../worker.js';
+
+test('връща ok при налични prerequisites', async () => {
+  const env = {
+    USER_METADATA_KV: { get: jest.fn(async key => (key === 'u1_initial_answers' ? '{"a":1}' : null)), put: jest.fn() },
+    RESOURCES_KV: { get: jest.fn(async () => '@cf/model') }
+  };
+  const request = { url: 'https://example.com/api/checkPlanPrerequisites?userId=u1' };
+  const res = await handleCheckPlanPrerequisitesRequest(request, env);
+  expect(res.success).toBe(true);
+  expect(res.ok).toBe(true);
+});
+
+test('връща грешка при липсващи отговори', async () => {
+  const env = {
+    USER_METADATA_KV: { get: jest.fn(async () => null), put: jest.fn() },
+    RESOURCES_KV: { get: jest.fn(async () => '@cf/model') }
+  };
+  const request = { url: 'https://example.com/api/checkPlanPrerequisites?userId=u1' };
+  const res = await handleCheckPlanPrerequisitesRequest(request, env);
+  expect(res.success).toBe(true);
+  expect(res.ok).toBe(false);
+  expect(res.message).toBe('Липсват първоначални отговори.');
+});

--- a/js/__tests__/adminRegeneratePlan.test.js
+++ b/js/__tests__/adminRegeneratePlan.test.js
@@ -6,7 +6,7 @@ jest.unstable_mockModule('../templateLoader.js', () => ({
   loadTemplateInto: async () => {}
 }));
 jest.unstable_mockModule('../config.js', () => ({
-  apiEndpoints: { regeneratePlan: '/regen' }
+  apiEndpoints: { regeneratePlan: '/regen', checkPlanPrerequisites: '/check', planStatus: '/status' }
 }));
 
 let admin;
@@ -14,35 +14,66 @@ let admin;
 beforeEach(async () => {
   global.fetch = jest.fn();
   jest.resetModules();
+  jest.useFakeTimers();
   document.body.innerHTML = `
     <ul id="clientsList"></ul>
     <span id="clientsCount"></span>
     <input id="clientSearch" />
     <select id="statusFilter"><option value="all">all</option></select>
     <button id="showStats"></button>
+    <div id="priorityGuidanceModal" aria-hidden="true">
+      <textarea id="priorityGuidanceInput"></textarea>
+      <button id="priorityGuidanceConfirm"></button>
+      <button id="priorityGuidanceCancel"></button>
+      <button id="priorityGuidanceClose"></button>
+    </div>
   `;
   admin = await import('../admin.js');
 });
 
-test('показва бутон за нов план при статус "в процес"', () => {
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+test('показва бутон за нов план при статус "в процес"', async () => {
+  global.fetch.mockResolvedValue({ ok: true, json: async () => ({ success: true, ok: true }) });
   admin.allClients.length = 0;
   admin.allClients.push({ userId: 'u1', name: 'Test', status: 'processing', tags: [] });
-  admin.renderClients();
+  await admin.renderClients();
   const btn = document.querySelector('.regen-plan-btn');
   expect(btn).not.toBeNull();
   expect(btn.textContent).toContain('Нов план');
 });
 
-test('праща reason при клик върху бутона', async () => {
+test('не показва бутон при липсващи prerequisites', async () => {
+  global.fetch.mockResolvedValue({ ok: true, json: async () => ({ success: true, ok: false }) });
   admin.allClients.length = 0;
   admin.allClients.push({ userId: 'u1', name: 'Test', status: 'processing', tags: [] });
-  admin.renderClients();
+  await admin.renderClients();
   const btn = document.querySelector('.regen-plan-btn');
-  await btn.click();
+  const msg = document.querySelector('.regen-missing-msg');
+  expect(btn).toBeNull();
+  expect(msg.textContent).toContain('липсват данни');
+});
+
+test('праща reason при клик върху бутона', async () => {
+  global.fetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, ok: true }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+    .mockResolvedValue({ ok: true, json: async () => ({ success: true, planStatus: 'ready' }) });
+  admin.allClients.length = 0;
+  admin.allClients.push({ userId: 'u1', name: 'Test', status: 'processing', tags: [] });
+  await admin.renderClients();
+  const btn = document.querySelector('.regen-plan-btn');
+  btn.click();
+  document.getElementById('priorityGuidanceConfirm').click();
   await Promise.resolve();
-  expect(fetch).toHaveBeenCalledWith('/regen', expect.objectContaining({
+  jest.advanceTimersByTime(3000);
+  await Promise.resolve();
+  expect(fetch).toHaveBeenNthCalledWith(2, '/regen', expect.objectContaining({
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId: 'u1', reason: 'Админ регенерация' })
+    body: JSON.stringify({ userId: 'u1', reason: 'Админ регенерация', priorityGuidance: '' })
   }));
 });

--- a/js/__tests__/planRegenerator.test.js
+++ b/js/__tests__/planRegenerator.test.js
@@ -45,6 +45,18 @@ test('изпраща reason при потвърждение', async () => {
   }));
 });
 
+test('показва съобщение при липсващи prerequisites', async () => {
+  global.fetch.mockResolvedValueOnce({ ok: true, json: async () => ({ success: false, precheck: { message: 'Липсват данни' } }) });
+  const regenBtn = document.getElementById('regen');
+  const regenProgress = document.getElementById('regenProgress');
+  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
+  regenBtn.click();
+  document.getElementById('priorityGuidanceConfirm').click();
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(regenProgress.textContent).toBe('Липсват данни');
+});
+
 test('деактивира и реактивира бутона', async () => {
   const regenBtn = document.getElementById('regen');
   const regenProgress = document.getElementById('regenProgress');

--- a/js/config.js
+++ b/js/config.js
@@ -45,6 +45,7 @@ export const apiEndpoints = {
     getFeedbackMessages: `${workerBaseUrl}/api/getFeedbackMessages`,
     getPlanModificationPrompt: `${workerBaseUrl}/api/getPlanModificationPrompt`,
     regeneratePlan: `${workerBaseUrl}/api/regeneratePlan`,
+    checkPlanPrerequisites: `${workerBaseUrl}/api/checkPlanPrerequisites`,
     updateStatus: `${workerBaseUrl}/api/updateStatus`,
     getAiConfig: `${workerBaseUrl}/api/getAiConfig`,
     setAiConfig: `${workerBaseUrl}/api/setAiConfig`,

--- a/js/planRegenerator.js
+++ b/js/planRegenerator.js
@@ -60,12 +60,12 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
         const data = await resp.json();
         if (!resp.ok) throw new Error('Request failed');
         if (!data.success) {
+          const msg = data.precheck?.message || data.message || 'Грешка при стартиране на генерирането.';
           if (activeRegenProgress) {
-            activeRegenProgress.textContent = 'Грешка';
-            setTimeout(() => activeRegenProgress.classList.add('hidden'), 2000);
+            activeRegenProgress.textContent = msg;
+            setTimeout(() => activeRegenProgress.classList.add('hidden'), 4000);
           }
           activeRegenBtn.disabled = false;
-          alert(data.message || 'Грешка при стартиране на генерирането.');
           return;
         }
       } catch (err) {

--- a/worker.js
+++ b/worker.js
@@ -462,6 +462,8 @@ export default {
                 responseBody = await handleReAnalyzeQuestionnaireRequest(request, env, ctx);
             } else if (method === 'GET' && path === '/api/planStatus') {
                 responseBody = await handlePlanStatusRequest(request, env);
+            } else if (method === 'GET' && path === '/api/checkPlanPrerequisites') {
+                responseBody = await handleCheckPlanPrerequisitesRequest(request, env);
             } else if (method === 'GET' && path === '/api/analysisStatus') {
                 responseBody = await handleAnalysisStatusRequest(request, env);
             } else if (method === 'GET' && path === '/api/dashboardData') {
@@ -1508,6 +1510,23 @@ async function validatePlanPrerequisites(env, userId) {
     return { ok: true };
 }
 // ------------- END FUNCTION: validatePlanPrerequisites -------------
+
+// ------------- START FUNCTION: handleCheckPlanPrerequisitesRequest -------------
+async function handleCheckPlanPrerequisitesRequest(request, env) {
+    const url = new URL(request.url);
+    const userId = url.searchParams.get('userId');
+    if (!userId) {
+        return { success: false, message: 'Липсва ID на потребител.', statusHint: 400 };
+    }
+    try {
+        const precheck = await validatePlanPrerequisites(env, userId);
+        return { success: true, ...precheck };
+    } catch (error) {
+        console.error('Error in handleCheckPlanPrerequisitesRequest:', error.message, error.stack);
+        return { success: false, message: 'Грешка при проверка на prerequisites.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleCheckPlanPrerequisitesRequest -------------
 
 // ------------- START FUNCTION: handleRegeneratePlanRequest -------------
 async function handleRegeneratePlanRequest(request, env, ctx, planProcessor = processSingleUserPlan) {
@@ -4307,4 +4326,4 @@ async function processPendingUserEvents(env, ctx, maxToProcess = 5) {
 }
 // ------------- END BLOCK: UserEventHandlers -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRegeneratePlanRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleDashboardDataRequest, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleContactFormRequest, handleGetContactRequestsRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, sendAnalysisLinkEmail, sendContactEmail, getEmailConfig, calculateAnalyticsIndexes };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRegeneratePlanRequest, handleCheckPlanPrerequisitesRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleDashboardDataRequest, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleContactFormRequest, handleGetContactRequestsRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, sendAnalysisLinkEmail, sendContactEmail, getEmailConfig, calculateAnalyticsIndexes };


### PR DESCRIPTION
## Резюме
- Добавен е API `checkPlanPrerequisites` за валидиране на ключове преди регенерация.
- `renderClients` проверява prerequisites и показва съобщение при липса.
- `planRegenerator` показва конкретна причина при неуспешно стартиране.

## Тестване
- `npm run lint`
- `npm test js/__tests__/adminRegeneratePlan.test.js js/__tests__/planRegenerator.test.js backend/tests/regeneratePlan.test.js backend/tests/checkPlanPrerequisites.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6893900dbaa88326ad6c12b19cece5eb