### PR TITLE
feat: handle missing subtleGlow plugin

### DIFF
--- a/js/__tests__/macroAnalyticsCardMissingPlugin.test.js
+++ b/js/__tests__/macroAnalyticsCardMissingPlugin.test.js
@@ -55,6 +55,6 @@ test('създава диаграма без plug-in когато Chart.register
   };
   card.setData({ plan });
   await waitFor(() => expect(card.chart).toBeTruthy());
-  expect(warnSpy).toHaveBeenCalled();
+  expect(warnSpy.mock.calls.some(([msg]) => msg.includes('subtleGlow'))).toBe(true);
   warnSpy.mockRestore();
 });

--- a/js/chartLoader.js
+++ b/js/chartLoader.js
@@ -76,6 +76,11 @@ export async function ensureChart() {
   return ChartLib;
 }
 
+/**
+ * Регистрира subtleGlow plug-in само веднъж.
+ * @param {any} Chart - инстанция на Chart.js (UMD).
+ * @returns {boolean} дали регистрацията е успешна.
+ */
 export function registerSubtleGlow(Chart) {
   if (subtleGlowRegistered) return true;
   if (!Chart || typeof Chart.register !== 'function') {

--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -300,7 +300,10 @@ export class MacroAnalyticsCard extends HTMLElement {
       this.showLoading();
       try {
         Chart = await ensureChart();
-        this.pluginRegistered = registerSubtleGlow(Chart);
+        const glowReady = registerSubtleGlow(Chart);
+        if (!glowReady) {
+          console.warn('subtleGlow plug-in не е наличен; диаграмата ще се рендерира без него.');
+        }
         this.renderChart();
       } catch (e) {
         console.error('Failed to load Chart.js', e);


### PR DESCRIPTION
## Summary
- warn and skip subtleGlow when Chart.js lacks `register`
- expose `registerSubtleGlow` helper in chart loader
- test chart rendering when plug-in is absent

## Testing
- `npm run lint`
- `npm test js/__tests__/macroAnalyticsCardComponent.test.js js/__tests__/macroAnalyticsCardMissingPlugin.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689390a334008326a03eaa1cf3373f75