### PR TITLE
feat: expose missing prerequisites

### DIFF
--- a/backend/tests/checkPlanPrerequisites.test.js
+++ b/backend/tests/checkPlanPrerequisites.test.js
@@ -10,6 +10,7 @@ test('връща ok при налични prerequisites', async () => {
   const res = await handleCheckPlanPrerequisitesRequest(request, env);
   expect(res.success).toBe(true);
   expect(res.ok).toBe(true);
+  expect(res.missing).toEqual([]);
 });
 
 test('връща грешка при липсващи отговори', async () => {
@@ -21,5 +22,6 @@ test('връща грешка при липсващи отговори', async (
   const res = await handleCheckPlanPrerequisitesRequest(request, env);
   expect(res.success).toBe(true);
   expect(res.ok).toBe(false);
-  expect(res.message).toBe('Липсват първоначални отговори.');
+  expect(res.missing).toEqual(['първоначални отговори']);
+  expect(res.message).toBe('Липсват: първоначални отговори');
 });

--- a/js/__tests__/adminRegeneratePlan.test.js
+++ b/js/__tests__/adminRegeneratePlan.test.js
@@ -37,7 +37,7 @@ afterEach(() => {
 });
 
 test('показва бутон за нов план при статус "в процес"', async () => {
-  global.fetch.mockResolvedValue({ ok: true, json: async () => ({ success: true, ok: true }) });
+  global.fetch.mockResolvedValue({ ok: true, json: async () => ({ success: true, ok: true, missing: [] }) });
   admin.allClients.length = 0;
   admin.allClients.push({ userId: 'u1', name: 'Test', status: 'processing', tags: [] });
   await admin.renderClients();
@@ -47,19 +47,22 @@ test('показва бутон за нов план при статус "в п�
 });
 
 test('не показва бутон при липсващи prerequisites', async () => {
-  global.fetch.mockResolvedValue({ ok: true, json: async () => ({ success: true, ok: false }) });
+  global.fetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true, ok: false, missing: ['model_plan_generation'], message: 'Липсват: model_plan_generation' })
+  });
   admin.allClients.length = 0;
   admin.allClients.push({ userId: 'u1', name: 'Test', status: 'processing', tags: [] });
   await admin.renderClients();
   const btn = document.querySelector('.regen-plan-btn');
   const msg = document.querySelector('.regen-missing-msg');
   expect(btn).toBeNull();
-  expect(msg.textContent).toContain('липсват данни');
+  expect(msg.textContent).toBe('липсват: model_plan_generation');
 });
 
 test('праща reason при клик върху бутона', async () => {
   global.fetch
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, ok: true }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, ok: true, missing: [] }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
     .mockResolvedValue({ ok: true, json: async () => ({ success: true, planStatus: 'ready' }) });
   admin.allClients.length = 0;


### PR DESCRIPTION
## Summary
- collect all missing prerequisites and expose them via API
- surface missing items in admin UI and tests

## Testing
- `npm run lint`
- `npm test backend/tests/checkPlanPrerequisites.test.js js/__tests__/adminRegeneratePlan.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893967423648326bf73827c2136ad0f