### PR TITLE
feat: use radial gradient for subtle glow

### DIFF
--- a/js/__tests__/subtleGlowGradient.test.js
+++ b/js/__tests__/subtleGlowGradient.test.js
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+import { subtleGlowPlugin } from '../chartLoader.js';
+
+test('subtleGlowPlugin създава радиален градиент с правилни параметри', () => {
+  const gradientMock = { addColorStop: jest.fn() };
+  const ctx = {
+    createRadialGradient: jest.fn(() => gradientMock),
+    beginPath: jest.fn(),
+    arc: jest.fn(),
+    stroke: jest.fn(),
+    closePath: jest.fn(),
+    fill: jest.fn(),
+    save: jest.fn(),
+    restore: jest.fn(),
+    lineWidth: 0,
+    strokeStyle: ''
+  };
+
+  const chart = {
+    ctx,
+    data: { datasets: [{ backgroundColor: '#ff0000' }] },
+    getSortedVisibleDatasetMetas: () => ([{
+      index: 0,
+      data: [{
+        x: 10,
+        y: 20,
+        outerRadius: 30,
+        innerRadius: 15,
+        startAngle: 0,
+        endAngle: Math.PI / 2
+      }]
+    }])
+  };
+
+  subtleGlowPlugin.afterDatasetsDraw(chart);
+
+  expect(ctx.createRadialGradient).toHaveBeenCalledWith(10, 20, 0, 10, 20, 40);
+  const innerStop = 30 / 40;
+  expect(gradientMock.addColorStop).toHaveBeenNthCalledWith(1, 0, '#ff0000');
+  expect(gradientMock.addColorStop).toHaveBeenNthCalledWith(2, innerStop, '#ff0000');
+  expect(gradientMock.addColorStop).toHaveBeenNthCalledWith(3, 1, 'transparent');
+});

--- a/js/chartLoader.js
+++ b/js/chartLoader.js
@@ -1,7 +1,8 @@
 let ChartLib;
 let subtleGlowRegistered = false;
+const GLOW_OFFSET = 10;
 
-const subtleGlowPlugin = {
+export const subtleGlowPlugin = {
   id: 'subtleGlow',
   afterDatasetsDraw(chart) {
     const { ctx } = chart;
@@ -28,6 +29,24 @@ const subtleGlowPlugin = {
         );
         ctx.closePath();
         ctx.fill();
+
+        const gradient = ctx.createRadialGradient(
+          element.x,
+          element.y,
+          0,
+          element.x,
+          element.y,
+          element.outerRadius + GLOW_OFFSET
+        );
+        const innerStop = element.outerRadius / (element.outerRadius + GLOW_OFFSET);
+        gradient.addColorStop(0, bg);
+        gradient.addColorStop(innerStop, bg);
+        gradient.addColorStop(1, 'transparent');
+        ctx.strokeStyle = gradient;
+        ctx.lineWidth = GLOW_OFFSET;
+        ctx.beginPath();
+        ctx.arc(element.x, element.y, element.outerRadius, element.startAngle, element.endAngle);
+        ctx.stroke();
       });
       ctx.restore();
     });


### PR DESCRIPTION
## Summary
- draw radial gradient glow from dataset center to outer radius
- cover subtleGlow plugin with unit test verifying gradient parameters

## Testing
- `npx eslint js/chartLoader.js js/__tests__/chartLoader.test.js js/__tests__/subtleGlowGradient.test.js`
- `npm run lint`
- `npm test js/__tests__/chartLoader.test.js js/__tests__/subtleGlowGradient.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68939a1666488326b5ff7d458dcef9b7