### PR TITLE
Handle missing prerequisites before plan regeneration

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1057,6 +1057,24 @@ async function showClient(userId) {
             detailsSection.classList.remove('hidden');
             resetTabs();
             openDetailsSections();
+            if (regenBtn) {
+                try {
+                    const resp = await fetch(`${apiEndpoints.checkPlanPrerequisites}?userId=${encodeURIComponent(userId)}`);
+                    const prereq = await resp.json().catch(() => ({}));
+                    if (resp.ok && prereq.success && prereq.ok) {
+                        regenBtn.disabled = false;
+                        regenProgress?.classList.add('hidden');
+                    } else {
+                        regenBtn.disabled = true;
+                        if (regenProgress) {
+                            regenProgress.textContent = (prereq.message || '').toLowerCase();
+                            regenProgress.classList.remove('hidden');
+                        }
+                    }
+                } catch {
+                    regenBtn.disabled = true;
+                }
+            }
             const clientInfo = allClients.find(c => c.userId === userId);
             const regDate = clientInfo?.registrationDate ? new Date(clientInfo.registrationDate).toLocaleDateString('bg-BG') : '';
             const name = clientInfo?.name || data.name || userId;


### PR DESCRIPTION
## Summary
- Check plan prerequisites when opening client view and disable regenerate button with message when requirements are missing
- Test regenerate-plan flow for missing email prerequisite

## Testing
- `npx eslint js/admin.js js/__tests__/adminRegeneratePlan.test.js`
- `sh ./scripts/test.sh js/__tests__/adminRegeneratePlan.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68939e830be88326b7c8261c610445b2