### PR TITLE
refine glow ring sizing

### DIFF
--- a/js/__tests__/subtleGlowGradient.test.js
+++ b/js/__tests__/subtleGlowGradient.test.js
@@ -1,0 +1,53 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+import { subtleGlowPlugin, GLOW_OFFSET } from '../chartLoader.js';
+
+test('arc радиусът използва GLOW_OFFSET и вътрешният пръстен се коригира', () => {
+  const arc = jest.fn();
+  const ctx = {
+    save: jest.fn(),
+    restore: jest.fn(),
+    beginPath: jest.fn(),
+    closePath: jest.fn(),
+    fill: jest.fn(),
+    arc,
+    lineWidth: 0,
+    shadowColor: '',
+    shadowBlur: 0,
+    fillStyle: ''
+  };
+  const element = {
+    x: 10,
+    y: 20,
+    outerRadius: 50,
+    innerRadius: 30,
+    startAngle: 0,
+    endAngle: Math.PI
+  };
+  const chart = {
+    ctx,
+    getSortedVisibleDatasetMetas: () => [{ index: 0, data: [element] }],
+    data: { datasets: [{ backgroundColor: '#f00' }] }
+  };
+
+  subtleGlowPlugin.afterDatasetsDraw(chart);
+
+  expect(ctx.lineWidth).toBe(GLOW_OFFSET);
+  expect(arc).toHaveBeenNthCalledWith(
+    1,
+    element.x,
+    element.y,
+    element.outerRadius + GLOW_OFFSET,
+    element.startAngle,
+    element.endAngle
+  );
+  expect(arc).toHaveBeenNthCalledWith(
+    2,
+    element.x,
+    element.y,
+    element.innerRadius + 1,
+    element.endAngle,
+    element.startAngle,
+    true
+  );
+});

--- a/js/chartLoader.js
+++ b/js/chartLoader.js
@@ -1,7 +1,9 @@
 let ChartLib;
 let subtleGlowRegistered = false;
 
-const subtleGlowPlugin = {
+export const GLOW_OFFSET = 6;
+
+export const subtleGlowPlugin = {
   id: 'subtleGlow',
   afterDatasetsDraw(chart) {
     const { ctx } = chart;
@@ -13,14 +15,21 @@ const subtleGlowPlugin = {
           ? dataset.backgroundColor[i]
           : dataset.backgroundColor;
         ctx.shadowColor = bg;
-        ctx.shadowBlur = 8;
+        ctx.shadowBlur = 4;
+        ctx.lineWidth = GLOW_OFFSET;
         ctx.fillStyle = bg;
         ctx.beginPath();
-        ctx.arc(element.x, element.y, element.outerRadius, element.startAngle, element.endAngle);
         ctx.arc(
           element.x,
           element.y,
-          element.innerRadius,
+          element.outerRadius + GLOW_OFFSET,
+          element.startAngle,
+          element.endAngle
+        );
+        ctx.arc(
+          element.x,
+          element.y,
+          element.innerRadius + 1,
           element.endAngle,
           element.startAngle,
           true


### PR DESCRIPTION
## Summary
- reduce glow offset and shadow blur for subtler chart highlight
- tighten inner ring and apply consistent line width
- add tests verifying glow radius and inner ring correction

## Testing
- `npx eslint js/chartLoader.js js/__tests__/subtleGlowGradient.test.js`
- `npm test js/__tests__/subtleGlowGradient.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893a321a218832682c77e844ca48dd8