### PR TITLE
Refactor admin clients layout for full width and horizontal list

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -224,7 +224,7 @@
   <div class="layout">
   <details class="sidebar card" id="clientsSection">
     <summary class="clients-summary">Клиенти</summary>
-    <div id="clientsControls" class="clients-controls">
+    <div id="clientsControls" class="clients-controls clients-row">
       <input id="clientSearch" list="clientSuggestions" placeholder="Търсене по име или имейл">
       <datalist id="clientSuggestions"></datalist>
       <select id="statusFilter">
@@ -243,7 +243,7 @@
       <button id="showStats">Покажи статистика</button>
     </div>
     <p id="clientsCount"></p>
-    <ul id="clientsList"></ul>
+    <ul id="clientsList" class="clients-row"></ul>
   </details>
 
   <main id="clientDetails" class="main-content card hidden">

--- a/css/admin.css
+++ b/css/admin.css
@@ -62,10 +62,38 @@ pre { background: var(--surface-background, #f5f5f5); padding: 10px; overflow: a
   display: flex;
   flex-wrap: wrap;
   gap: 20px;
+  width: 100%;
 }
 .sidebar {
   flex: 1 1 250px;
   max-width: 300px;
+}
+#clientsSection {
+  flex: 1 1 100%;
+  max-width: 100%;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+.clients-row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 8px;
+  width: 100%;
+}
+#clientsList {
+  flex: 1 1 100%;
+}
+#clientsControls {
+  flex: 1 1 100%;
+}
+#clientsList li,
+.client-card {
+  margin-bottom: 5px;
+  display: flex;
+  gap: 5px;
+  flex: 1 1 200px;
 }
 .main-content {
   flex: 3 1 400px;


### PR DESCRIPTION
## Summary
- Allow clients section to span full width and wrap content flexibly
- Arrange client controls in a top flex row and list clients horizontally

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893aede00688326a442ac5940102450