### PR TITLE
Handle edit client init errors

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1040,7 +1040,12 @@ async function showClient(userId) {
         history.replaceState(null, '', `?userId=${encodeURIComponent(userId)}`);
         await loadTemplateInto('editclient.html', 'adminProfileContainer');
         const mod = await import('./editClient.js');
-        await mod.initEditClient(userId);
+        try {
+            await mod.initEditClient(userId);
+        } catch (err) {
+            console.error('initEditClient error', err);
+            alert('Липсва визуализация на плана.');
+        }
         setupProfileCardNav();
     }
     try {


### PR DESCRIPTION
## Summary
- ensure client view continues loading when edit initialization fails
- notify admins when plan visualization is unavailable

## Testing
- `npm run lint`
- `npm test -- js/__tests__/editClient.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893bac6c0e88326a45121eba7652ac5