### PR TITLE
refactor: unify plan generation flow

### DIFF
--- a/js/__tests__/planGenerationParams.test.js
+++ b/js/__tests__/planGenerationParams.test.js
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+const startPlanGenerationMock = jest.fn();
+
+jest.unstable_mockModule('../config.js', () => ({
+  apiEndpoints: { regeneratePlan: '/regen', planStatus: '/status' }
+}));
+jest.unstable_mockModule('../planGeneration.js', () => ({
+  startPlanGeneration: startPlanGenerationMock
+}));
+
+let regeneratePlan, setupPlanRegeneration;
+
+beforeEach(async () => {
+  jest.resetModules();
+  startPlanGenerationMock.mockReset();
+  startPlanGenerationMock.mockResolvedValue({ success: true });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, planStatus: 'ready' }) });
+  document.body.innerHTML = `
+    <button id="regen"></button>
+    <div id="regenProgress" class="hidden"></div>
+    <div id="priorityGuidanceModal" aria-hidden="true">
+      <textarea id="priorityGuidanceInput"></textarea>
+      <textarea id="regenReasonInput"></textarea>
+      <button id="priorityGuidanceConfirm"></button>
+      <button id="priorityGuidanceCancel"></button>
+      <button id="priorityGuidanceClose"></button>
+    </div>
+  `;
+  ({ regeneratePlan } = await import('../questionnaireCore.js'));
+  ({ setupPlanRegeneration } = await import('../planRegenerator.js'));
+});
+
+test('questionnaireCore и planRegenerator подават еднакви параметри', async () => {
+  const params = { userId: 'u1', reason: 'причина', priorityGuidance: 'приоритет' };
+  await regeneratePlan(params);
+  const firstCall = startPlanGenerationMock.mock.calls[0][0];
+
+  const regenBtn = document.getElementById('regen');
+  const regenProgress = document.getElementById('regenProgress');
+  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
+  regenBtn.click();
+  document.getElementById('regenReasonInput').value = 'причина';
+  document.getElementById('priorityGuidanceInput').value = 'приоритет';
+  document.getElementById('priorityGuidanceConfirm').click();
+  await Promise.resolve();
+  const secondCall = startPlanGenerationMock.mock.calls[1][0];
+
+  expect(firstCall).toEqual(secondCall);
+});

--- a/js/planGeneration.js
+++ b/js/planGeneration.js
@@ -1,0 +1,25 @@
+import { apiEndpoints } from './config.js';
+
+/**
+ * Стартира генериране на план.
+ * @param {Object} params
+ * @param {string} params.userId
+ * @param {string} [params.reason]
+ * @param {string} [params.priorityGuidance]
+ * @returns {Promise<any>} резултатът от сървъра
+ */
+export async function startPlanGeneration({ userId, reason = '', priorityGuidance = '' }) {
+  const resp = await fetch(apiEndpoints.regeneratePlan, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, reason, priorityGuidance })
+  });
+  const data = await resp.json();
+  if (!resp.ok) throw new Error(data.message || 'Request failed');
+  if (!data.success) {
+    const err = new Error(data.precheck?.message || data.message || 'Грешка при стартиране на генерирането.');
+    err.precheck = Boolean(data.precheck);
+    throw err;
+  }
+  return data;
+}

--- a/js/planRegenerator.js
+++ b/js/planRegenerator.js
@@ -1,4 +1,5 @@
 import { apiEndpoints } from './config.js';
+import { startPlanGeneration } from './planGeneration.js';
 
 let activeUserId;
 let activeRegenBtn;
@@ -52,30 +53,19 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
       }
       activeRegenBtn.disabled = true;
       try {
-        const resp = await fetch(apiEndpoints.regeneratePlan, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ userId: activeUserId, reason: reason || 'Админ регенерация', priorityGuidance })
+        await startPlanGeneration({
+          userId: activeUserId,
+          reason: reason || 'Админ регенерация',
+          priorityGuidance
         });
-        const data = await resp.json();
-        if (!resp.ok) throw new Error('Request failed');
-        if (!data.success) {
-          const msg = data.precheck?.message || data.message || 'Грешка при стартиране на генерирането.';
-          if (activeRegenProgress) {
-            activeRegenProgress.textContent = msg;
-            setTimeout(() => activeRegenProgress.classList.add('hidden'), 4000);
-          }
-          activeRegenBtn.disabled = false;
-          return;
-        }
       } catch (err) {
         console.error('regeneratePlan error:', err);
         if (activeRegenProgress) {
-          activeRegenProgress.textContent = 'Грешка';
-          setTimeout(() => activeRegenProgress.classList.add('hidden'), 2000);
+          activeRegenProgress.textContent = err.message || 'Грешка';
+          setTimeout(() => activeRegenProgress.classList.add('hidden'), 4000);
         }
         activeRegenBtn.disabled = false;
-        alert('Грешка при стартиране на генерирането.');
+        if (!err.precheck) alert('Грешка при стартиране на генерирането.');
         return;
       }
 

--- a/js/questionnaireCore.js
+++ b/js/questionnaireCore.js
@@ -1,6 +1,7 @@
 import { setupRegistration } from './register.js';
 import { showMessage, hideMessage } from './messageUtils.js';
 import { updateStepProgress } from './stepProgress.js';
+import { startPlanGeneration } from './planGeneration.js';
 
 const state = {
   rawQuestions: [],
@@ -490,6 +491,10 @@ export async function submitResponses() {
 
 export function getResponses() {
   return state.responses;
+}
+
+export function regeneratePlan({ userId, reason = '', priorityGuidance = '' }) {
+  return startPlanGeneration({ userId, reason, priorityGuidance });
 }
 
 export async function initQuestionnaire({ questionsUrl, submitUrl }) {


### PR DESCRIPTION
## Summary
- extract `startPlanGeneration` helper for /api/regeneratePlan requests
- reuse the helper in questionnaire and admin regenerators
- add tests ensuring both modules send identical parameters

## Testing
- `npm run lint`
- `npm test js/__tests__/planRegenerator.test.js js/__tests__/planGenerationParams.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893be6412dc832694c5f50ec561baa6