### PR TITLE
feat: track plan regeneration logs

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -274,6 +274,7 @@
         <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 100%"></div>
       </div>
     </div>
+    <div id="regenLog" class="regen-log"></div>
     <button id="aiSummary">AI резюме</button>
     <div class="profile-nav-container">
       <button id="profileCardNavToggle" class="profile-nav-toggle" aria-label="Показване на навигацията">

--- a/editclient.html
+++ b/editclient.html
@@ -87,6 +87,7 @@
             <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 100%"></div>
         </div>
     </div>
+    <div id="regenLog" class="regen-log"></div>
 
     <div class="container-fluid mt-4">
         <div class="row">

--- a/js/__tests__/adminRegeneratePlan.test.js
+++ b/js/__tests__/adminRegeneratePlan.test.js
@@ -6,7 +6,7 @@ jest.unstable_mockModule('../templateLoader.js', () => ({
   loadTemplateInto: async () => {}
 }));
 jest.unstable_mockModule('../config.js', () => ({
-  apiEndpoints: { regeneratePlan: '/regen', checkPlanPrerequisites: '/check', planStatus: '/status' }
+  apiEndpoints: { regeneratePlan: '/regen', checkPlanPrerequisites: '/check', planLog: '/log', updateKv: '/kv' }
 }));
 
 let admin;
@@ -27,6 +27,8 @@ beforeEach(async () => {
       <button id="priorityGuidanceCancel"></button>
       <button id="priorityGuidanceClose"></button>
     </div>
+    <div id="regenLog"></div>
+    <div id="regenProgress" class="hidden"></div>
   `;
   admin = await import('../admin.js');
 });
@@ -61,7 +63,8 @@ test('праща reason при клик върху бутона', async () => {
   global.fetch
     .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, ok: true }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
-    .mockResolvedValue({ ok: true, json: async () => ({ success: true, planStatus: 'ready' }) });
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, logs: [], status: 'ready' }) })
+    .mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
   admin.allClients.length = 0;
   admin.allClients.push({ userId: 'u1', name: 'Test', status: 'processing', tags: [] });
   await admin.renderClients();

--- a/js/__tests__/planGenerationParams.test.js
+++ b/js/__tests__/planGenerationParams.test.js
@@ -3,7 +3,7 @@ import { jest } from '@jest/globals';
 const startPlanGenerationMock = jest.fn();
 
 jest.unstable_mockModule('../config.js', () => ({
-  apiEndpoints: { regeneratePlan: '/regen', planStatus: '/status' }
+  apiEndpoints: { regeneratePlan: '/regen', planLog: '/log', updateKv: '/kv' }
 }));
 jest.unstable_mockModule('../planGeneration.js', () => ({
   startPlanGeneration: startPlanGenerationMock
@@ -15,10 +15,11 @@ beforeEach(async () => {
   jest.resetModules();
   startPlanGenerationMock.mockReset();
   startPlanGenerationMock.mockResolvedValue({ success: true });
-  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, planStatus: 'ready' }) });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, logs: [], status: 'ready' }) });
   document.body.innerHTML = `
     <button id="regen"></button>
     <div id="regenProgress" class="hidden"></div>
+    <div id="regenLog"></div>
     <div id="priorityGuidanceModal" aria-hidden="true">
       <textarea id="priorityGuidanceInput"></textarea>
       <textarea id="regenReasonInput"></textarea>

--- a/js/__tests__/planLogEndpoint.test.js
+++ b/js/__tests__/planLogEndpoint.test.js
@@ -1,0 +1,21 @@
+import { jest } from '@jest/globals';
+import { handlePlanLogRequest } from '../../worker.js';
+
+const makeRequest = (userId) => ({ url: `https://x/api/planLog?userId=${userId}` });
+
+describe('handlePlanLogRequest', () => {
+  test('връща логове и грешка при статус error', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(async (key) => {
+          if (key === 'u1_plan_log') return JSON.stringify(['start', 'end']);
+          if (key === 'plan_status_u1') return 'error';
+          if (key === 'u1_processing_error') return 'fatal';
+          return null;
+        })
+      }
+    };
+    const res = await handlePlanLogRequest(makeRequest('u1'), env);
+    expect(res).toEqual({ success: true, logs: ['start', 'end'], status: 'error', error: 'fatal' });
+  });
+});

--- a/js/__tests__/planRegenerator.test.js
+++ b/js/__tests__/planRegenerator.test.js
@@ -4,7 +4,7 @@ import { jest } from '@jest/globals';
 const startPlanGenerationMock = jest.fn();
 
 jest.unstable_mockModule('../config.js', () => ({
-  apiEndpoints: { regeneratePlan: '/regen', planStatus: '/status' }
+  apiEndpoints: { regeneratePlan: '/regen', planLog: '/log', updateKv: '/kv' }
 }));
 jest.unstable_mockModule('../planGeneration.js', () => ({
   startPlanGeneration: startPlanGenerationMock
@@ -17,10 +17,11 @@ beforeEach(async () => {
   jest.useFakeTimers();
   startPlanGenerationMock.mockReset();
   startPlanGenerationMock.mockResolvedValue({ success: true });
-  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, planStatus: 'ready' }) });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, logs: [], status: 'ready' }) });
   document.body.innerHTML = `
     <button id="regen"></button>
     <div id="regenProgress" class="hidden"></div>
+    <div id="regenLog"></div>
     <div id="priorityGuidanceModal" aria-hidden="true">
       <textarea id="priorityGuidanceInput"></textarea>
       <button id="priorityGuidanceConfirm"></button>
@@ -102,6 +103,7 @@ test('изпраща reason и priorityGuidance при отделни полет
   document.body.innerHTML = `
     <button id="regen"></button>
     <div id="regenProgress" class="hidden"></div>
+    <div id="regenLog"></div>
     <div id="priorityGuidanceModal" aria-hidden="true">
       <textarea id="priorityGuidanceInput"></textarea>
       <textarea id="regenReasonInput"></textarea>

--- a/js/config.js
+++ b/js/config.js
@@ -21,6 +21,7 @@ export const apiEndpoints = {
     log: `${workerBaseUrl}/api/log`,
     chat: `${workerBaseUrl}/api/chat`,
     planStatus: `${workerBaseUrl}/api/planStatus`,
+    planLog: `${workerBaseUrl}/api/planLog`,
     logExtraMeal: `${workerBaseUrl}/api/log-extra-meal`,
     getProfile: `${workerBaseUrl}/api/getProfile`,
     updateProfile: `${workerBaseUrl}/api/updateProfile`,


### PR DESCRIPTION
## Summary
- log key steps during plan generation and expose them through `/api/planLog`
- show live plan regeneration log in admin UI and client editor
- cover plan log endpoint and regeneration UI behaviour with tests

## Testing
- `npm run lint`
- `npm test js/__tests__/planRegenerator.test.js js/__tests__/planGenerationParams.test.js js/__tests__/adminRegeneratePlan.test.js js/__tests__/planGenerationLogs.test.js js/__tests__/planLogEndpoint.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893c26a554483268371357b524b402a