### PR TITLE
Refactor regen log to modal

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -274,7 +274,12 @@
         <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 100%"></div>
       </div>
     </div>
-    <div id="regenLog" class="regen-log"></div>
+    <div id="regenLogModal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
+      <div class="modal-content">
+        <div class="modal-body" id="regenLogBody"></div>
+        <button id="regenLogClose" class="button button-secondary">Затвори</button>
+      </div>
+    </div>
     <button id="aiSummary">AI резюме</button>
     <div class="profile-nav-container">
       <button id="profileCardNavToggle" class="profile-nav-toggle" aria-label="Показване на навигацията">

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -147,6 +147,12 @@
   z-index: 10; 
 }
 .modal-content .close-button:hover { color: var(--text-color-primary); }
+
+#regenLogBody {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
 .achievement-emoji {
   font-size: 4rem;
   text-align: center;

--- a/editclient.html
+++ b/editclient.html
@@ -87,7 +87,12 @@
             <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 100%"></div>
         </div>
     </div>
-    <div id="regenLog" class="regen-log"></div>
+    <div id="regenLogModal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
+        <div class="modal-content">
+            <div class="modal-body" id="regenLogBody"></div>
+            <button id="regenLogClose" class="button button-secondary">Затвори</button>
+        </div>
+    </div>
 
     <div class="container-fluid mt-4">
         <div class="row">

--- a/js/__tests__/planGenerationParams.test.js
+++ b/js/__tests__/planGenerationParams.test.js
@@ -13,13 +13,17 @@ let regeneratePlan, setupPlanRegeneration;
 
 beforeEach(async () => {
   jest.resetModules();
+  jest.useFakeTimers();
   startPlanGenerationMock.mockReset();
   startPlanGenerationMock.mockResolvedValue({ success: true });
   global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, logs: [], status: 'ready' }) });
   document.body.innerHTML = `
     <button id="regen"></button>
     <div id="regenProgress" class="hidden"></div>
-    <div id="regenLog"></div>
+    <div id="regenLogModal" aria-hidden="true">
+      <div class="modal-body" id="regenLogBody"></div>
+      <button id="regenLogClose"></button>
+    </div>
     <div id="priorityGuidanceModal" aria-hidden="true">
       <textarea id="priorityGuidanceInput"></textarea>
       <textarea id="regenReasonInput"></textarea>
@@ -30,6 +34,10 @@ beforeEach(async () => {
   `;
   ({ regeneratePlan } = await import('../questionnaireCore.js'));
   ({ setupPlanRegeneration } = await import('../planRegenerator.js'));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 test('questionnaireCore и planRegenerator подават еднакви параметри', async () => {
@@ -45,6 +53,14 @@ test('questionnaireCore и planRegenerator подават еднакви пар�
   document.getElementById('priorityGuidanceInput').value = 'приоритет';
   document.getElementById('priorityGuidanceConfirm').click();
   await Promise.resolve();
+  const modal = document.getElementById('regenLogModal');
+  expect(modal.classList.contains('visible')).toBe(true);
+  jest.advanceTimersByTime(3000);
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(modal.classList.contains('visible')).toBe(false);
+  expect(document.getElementById('regenLogBody').textContent).toBe('');
   const secondCall = startPlanGenerationMock.mock.calls[1][0];
 
   expect(firstCall).toEqual(secondCall);

--- a/js/__tests__/planRegenerator.test.js
+++ b/js/__tests__/planRegenerator.test.js
@@ -21,7 +21,10 @@ beforeEach(async () => {
   document.body.innerHTML = `
     <button id="regen"></button>
     <div id="regenProgress" class="hidden"></div>
-    <div id="regenLog"></div>
+    <div id="regenLogModal" aria-hidden="true">
+      <div class="modal-body" id="regenLogBody"></div>
+      <button id="regenLogClose"></button>
+    </div>
     <div id="priorityGuidanceModal" aria-hidden="true">
       <textarea id="priorityGuidanceInput"></textarea>
       <button id="priorityGuidanceConfirm"></button>
@@ -76,6 +79,23 @@ test('деактивира и реактивира бутона', async () => {
   expect(regenBtn.disabled).toBe(false);
 });
 
+test('отваря и затваря лог модала', async () => {
+  const regenBtn = document.getElementById('regen');
+  const regenProgress = document.getElementById('regenProgress');
+  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
+  regenBtn.click();
+  document.getElementById('priorityGuidanceConfirm').click();
+  await Promise.resolve();
+  const modal = document.getElementById('regenLogModal');
+  expect(modal.classList.contains('visible')).toBe(true);
+  jest.advanceTimersByTime(3000);
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(modal.classList.contains('visible')).toBe(false);
+  expect(document.getElementById('regenLogBody').textContent).toBe('');
+});
+
 test('изпраща заявка само за последно избран userId', async () => {
   const regenBtn1 = document.getElementById('regen');
   const regenProgress1 = document.getElementById('regenProgress');
@@ -103,7 +123,10 @@ test('изпраща reason и priorityGuidance при отделни полет
   document.body.innerHTML = `
     <button id="regen"></button>
     <div id="regenProgress" class="hidden"></div>
-    <div id="regenLog"></div>
+    <div id="regenLogModal" aria-hidden="true">
+      <div class="modal-body" id="regenLogBody"></div>
+      <button id="regenLogClose"></button>
+    </div>
     <div id="priorityGuidanceModal" aria-hidden="true">
       <textarea id="priorityGuidanceInput"></textarea>
       <textarea id="regenReasonInput"></textarea>


### PR DESCRIPTION
## Summary
- replace regen log divs with accessible modal components
- show regeneration progress in modal with auto-scroll and cleanup
- extend tests to cover modal behavior

## Testing
- `npm run lint`
- `npm test -- js/__tests__/adminRegeneratePlan.test.js js/__tests__/planRegenerator.test.js js/__tests__/planGenerationParams.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893ca46621883269e8909bf29e6c4eb