### PR TITLE
Include priority guidance in plan generation

### DIFF
--- a/js/__tests__/planRegenerator.test.js
+++ b/js/__tests__/planRegenerator.test.js
@@ -146,3 +146,15 @@ test('изпраща reason и priorityGuidance при отделни полет
   await Promise.resolve();
   expect(startPlanGenerationMock).toHaveBeenCalledWith({ userId: 'u1', reason: 'причина', priorityGuidance: 'приоритет' });
 });
+
+test('предава priorityGuidance чрез getPriorityGuidance', async () => {
+  const regenBtn = document.getElementById('regen');
+  const regenProgress = document.getElementById('regenProgress');
+  const getPriorityGuidance = () => document.getElementById('priorityGuidanceInput').value.trim();
+  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1', getPriorityGuidance });
+  regenBtn.click();
+  document.getElementById('priorityGuidanceInput').value = 'prio';
+  document.getElementById('priorityGuidanceConfirm').click();
+  await Promise.resolve();
+  expect(startPlanGenerationMock).toHaveBeenCalledWith({ userId: 'u1', reason: 'prio', priorityGuidance: 'prio' });
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -33,6 +33,7 @@ const tagFilterSelect = document.getElementById('tagFilter');
 const detailsSection = document.getElementById('clientDetails');
 const regenBtn = document.getElementById('regeneratePlan');
 const regenProgress = document.getElementById('regenProgress');
+const priorityGuidanceInput = document.getElementById('priorityGuidanceInput');
 const aiSummaryBtn = document.getElementById('aiSummary');
 const notesField = document.getElementById('adminNotes');
 const tagsField = document.getElementById('adminTags');
@@ -254,7 +255,12 @@ let currentUserId = null;
 function setCurrentUserId(val) {
     currentUserId = val;
 }
-setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => currentUserId });
+setupPlanRegeneration({
+    regenBtn,
+    regenProgress,
+    getUserId: () => currentUserId,
+    getPriorityGuidance: () => priorityGuidanceInput?.value.trim() || ''
+});
 let profileNavObserver = null;
 let currentPlanData = null;
 let currentDashboardData = null;
@@ -739,7 +745,12 @@ async function renderClients() {
                 li.appendChild(regen);
                 li.appendChild(progress);
                 regen.addEventListener('click', e => e.stopPropagation());
-                setupPlanRegeneration({ regenBtn: regen, regenProgress: progress, getUserId: () => c.userId });
+                setupPlanRegeneration({
+                    regenBtn: regen,
+                    regenProgress: progress,
+                    getUserId: () => c.userId,
+                    getPriorityGuidance: () => priorityGuidanceInput?.value.trim() || ''
+                });
             } else {
                 const msg = document.createElement('span');
                 msg.className = 'regen-missing-msg';

--- a/js/planGeneration.js
+++ b/js/planGeneration.js
@@ -9,10 +9,11 @@ import { apiEndpoints } from './config.js';
  * @returns {Promise<any>} резултатът от сървъра
  */
 export async function startPlanGeneration({ userId, reason = '', priorityGuidance = '' }) {
+  const payload = { userId, reason, priorityGuidance };
   const resp = await fetch(apiEndpoints.regeneratePlan, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId, reason, priorityGuidance })
+    body: JSON.stringify(payload)
   });
   const data = await resp.json();
   if (!resp.ok) throw new Error(data.message || 'Request failed');

--- a/js/planRegenerator.js
+++ b/js/planRegenerator.js
@@ -29,7 +29,7 @@ if (logClose && logModal && logBody) {
   });
 }
 
-export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
+export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId, getPriorityGuidance }) {
   const modal = document.getElementById('priorityGuidanceModal');
   const priorityInput = document.getElementById('priorityGuidanceInput');
   const reasonInput = document.getElementById('regenReasonInput');
@@ -57,7 +57,12 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
       if (!activeUserId || !activeRegenBtn) return;
       hide();
       const reason = (reasonInput ? reasonInput.value : priorityInput?.value || '').trim();
-      const priorityGuidance = reasonInput ? (priorityInput?.value.trim() || '') : '';
+      const priorityGuidance =
+        typeof getPriorityGuidance === 'function'
+          ? getPriorityGuidance() || ''
+          : reasonInput
+            ? priorityInput?.value.trim() || ''
+            : '';
       if (activeRegenProgress) {
         activeRegenProgress.textContent = 'Генериране…';
         activeRegenProgress.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- propagate priority guidance from admin UI to plan generation
- ensure plan regeneration setup accepts external priority fetcher
- cover priority guidance flow with unit test

## Testing
- `npm run lint`
- `npm test js/__tests__/planRegenerator.test.js js/__tests__/planGenerationParams.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893d077673483269f843bb720058f00