### PR TITLE
Премахване на дублиран модал за приоритетни указания

### DIFF
--- a/editclient.html
+++ b/editclient.html
@@ -544,18 +544,6 @@
     </div>
     </div>
 
-    <div id="priorityGuidanceModal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
-        <div class="modal-content">
-            <button id="priorityGuidanceClose" class="close-button" aria-label="Затвори прозореца">&times;</button>
-            <label for="priorityGuidanceInput">Приоритетни указания</label>
-            <textarea id="priorityGuidanceInput" rows="4"></textarea>
-            <div class="modal-actions">
-                <button id="priorityGuidanceConfirm" class="button">Потвърди</button>
-                <button id="priorityGuidanceCancel" class="button button-secondary">Отказ</button>
-            </div>
-        </div>
-    </div>
-
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Chart.js for visualizations -->

--- a/js/editClient.js
+++ b/js/editClient.js
@@ -564,7 +564,13 @@ export async function initEditClient(userId) {
 
   const regenBtn = document.getElementById('regeneratePlan');
   const regenProgress = document.getElementById('regenProgress');
-  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => userId });
+  const priorityGuidanceInput = document.getElementById('priorityGuidanceInput');
+  setupPlanRegeneration({
+    regenBtn,
+    regenProgress,
+    getUserId: () => userId,
+    getPriorityGuidance: () => priorityGuidanceInput?.value.trim() || ''
+  });
 
   const aiSummaryBtn = document.getElementById('aiSummary');
   if (aiSummaryBtn) {

--- a/js/planRegenerator.js
+++ b/js/planRegenerator.js
@@ -5,6 +5,7 @@ let activeUserId;
 let activeRegenBtn;
 let activeRegenProgress;
 let confirmListenerAdded = false;
+let modalListenersAdded = false;
 let displayedLogs = 0;
 
 function openModal(modal) {
@@ -48,8 +49,12 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId, getP
     if (reasonInput) reasonInput.value = '';
     openModal(modal);
   });
-  cancel?.addEventListener('click', hide);
-  closeBtn?.addEventListener('click', hide);
+
+  if (!modalListenersAdded) {
+    modalListenersAdded = true;
+    cancel?.addEventListener('click', hide);
+    closeBtn?.addEventListener('click', hide);
+  }
 
   if (!confirmListenerAdded) {
     confirmListenerAdded = true;


### PR DESCRIPTION
## Резюме
- премахнат е локалният `priorityGuidanceModal` от `editclient.html`
- `editClient.js` и `planRegenerator.js` вече използват общия модал от `admin.html`
- добавени са предпазни флагове, за да се инициализира модалът само веднъж

## Тестване
- `npm run lint`
- `npm test js/__tests__/planRegenerator.test.js js/__tests__/adminRegeneratePlan.test.js js/__tests__/planGenerationParams.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893d86d9be883268cc515f4e81e0bb8