### PR TITLE
Expose precheck errors to the UI

### DIFF
--- a/backend/tests/regeneratePlan.test.js
+++ b/backend/tests/regeneratePlan.test.js
@@ -31,4 +31,20 @@ describe('POST /api/regeneratePlan', () => {
     expect(res.statusHint).toBe(400);
     expect(env.USER_METADATA_KV.put).not.toHaveBeenCalled();
   });
+
+  test('връща precheck при липсващи prerequisites', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        put: jest.fn(),
+        get: jest.fn(async key => null)
+      },
+      RESOURCES_KV: { get: jest.fn(async () => 'model') },
+      GEMINI_API_KEY: 'key'
+    };
+    const request = { json: async () => ({ userId: 'u1', reason: 'r' }) };
+    const res = await handleRegeneratePlanRequest(request, env, null, jest.fn());
+    expect(res.success).toBe(false);
+    expect(res.precheck).toEqual({ ok: false, message: 'Липсват първоначални отговори.' });
+    expect(res.statusHint).toBe(400);
+  });
 });

--- a/js/planGeneration.js
+++ b/js/planGeneration.js
@@ -18,6 +18,9 @@ export async function startPlanGeneration({ userId, reason = '', priorityGuidanc
   const data = await resp.json();
   if (!resp.ok) throw new Error(data.message || 'Request failed');
   if (!data.success) {
+    if (data.precheck?.message && typeof alert === 'function') {
+      alert(data.precheck.message);
+    }
     const err = new Error(data.precheck?.message || data.message || 'Грешка при стартиране на генерирането.');
     err.precheck = Boolean(data.precheck);
     throw err;

--- a/worker.js
+++ b/worker.js
@@ -1571,7 +1571,7 @@ async function handleRegeneratePlanRequest(request, env, ctx, planProcessor = pr
         const trimmedPriority = typeof priorityGuidance === 'string' ? priorityGuidance.trim() : '';
         const precheck = await validatePlanPrerequisites(env, userId);
         if (!precheck.ok) {
-            return { success: false, message: precheck.message, statusHint: 400 };
+            return { success: false, message: precheck.message, statusHint: 400, precheck };
         }
         if (trimmedPriority) {
             // Запис на приоритетни указания за потенциална модификация на плана


### PR DESCRIPTION
## Summary
- include `precheck` info in regenerate plan errors
- display precheck message in the UI when plan generation fails
- cover precheck error case with a unit test

## Testing
- `npm run lint`
- `npm test backend/tests/regeneratePlan.test.js js/__tests__/planGenerationParams.test.js js/__tests__/planRegenerator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893dc6ca578832699b4984f0e953ccb