### PR TITLE
Simplify plan regeneration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,8 +975,7 @@ curl -X POST /api/aiHelper \
 - `POST /api/testAiModel` – проверява връзката с конкретен AI модел.
 - `POST /api/submitQuestionnaire` – изпраща отговорите от началния въпросник.
 - `POST /api/regeneratePlan` – генерира изцяло нов план. Тяло на заявката:
-  `{ "userId": "u1", "reason": "по-балансиран режим", "priorityGuidance": "повече протеин" }`.
-  Полето `reason` е задължително и се използва като контекст при генерирането.
+  `{ "userId": "u1" }`.
 - `GET /api/analysisStatus` – връща текущия статус на персоналния анализ.
 - `GET /api/getInitialAnalysis` – връща първоначалния анализ.
 - `POST /api/analyzeImage` – анализира качено изображение и връща резултат. Изпращайте поле `image` с пълен `data:` URL. Ендпойнтът не изисква `WORKER_ADMIN_TOKEN`, освен ако изрично не сте го добавили като защита.

--- a/admin.html
+++ b/admin.html
@@ -269,17 +269,7 @@
       </form>
     </details>
     <button id="regeneratePlan">Генерирай нов план</button>
-    <div id="regenProgress" class="hidden">
-      <div class="progress">
-        <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 100%"></div>
-      </div>
-    </div>
-    <div id="regenLogModal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
-      <div class="modal-content">
-        <div class="modal-body" id="regenLogBody"></div>
-        <button id="regenLogClose" class="button button-secondary">Затвори</button>
-      </div>
-    </div>
+    <div id="regenProgress" class="hidden"></div>
     <button id="aiSummary">AI резюме</button>
     <div class="profile-nav-container">
       <button id="profileCardNavToggle" class="profile-nav-toggle" aria-label="Показване на навигацията">
@@ -525,17 +515,6 @@
     <a id="openTestQAnalysis" class="button button-small hidden" target="_blank">Отвори анализа</a>
   </details>
 
-  <div id="priorityGuidanceModal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
-    <div class="modal-content">
-      <button id="priorityGuidanceClose" class="close-button" aria-label="Затвори прозореца">&times;</button>
-      <label for="priorityGuidanceInput">Приоритетни указания</label>
-      <textarea id="priorityGuidanceInput" rows="4" placeholder="Опишете приоритетните указания"></textarea>
-      <div class="modal-actions">
-        <button id="priorityGuidanceConfirm" class="button">Потвърди</button>
-        <button id="priorityGuidanceCancel" class="button button-secondary">Отказ</button>
-      </div>
-    </div>
-  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -148,11 +148,6 @@
 }
 .modal-content .close-button:hover { color: var(--text-color-primary); }
 
-#regenLogBody {
-  max-height: 300px;
-  overflow-y: auto;
-}
-
 .achievement-emoji {
   font-size: 4rem;
   text-align: center;

--- a/editclient.html
+++ b/editclient.html
@@ -82,17 +82,7 @@
         </div>
     </nav>
 
-    <div id="regenProgress" class="hidden">
-        <div class="progress">
-            <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 100%"></div>
-        </div>
-    </div>
-    <div id="regenLogModal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
-        <div class="modal-content">
-            <div class="modal-body" id="regenLogBody"></div>
-            <button id="regenLogClose" class="button button-secondary">Затвори</button>
-        </div>
-    </div>
+    <div id="regenProgress" class="hidden"></div>
 
     <div class="container-fluid mt-4">
         <div class="row">

--- a/js/__tests__/adminRegeneratePlan.test.js
+++ b/js/__tests__/adminRegeneratePlan.test.js
@@ -1,98 +1,43 @@
 /** @jest-environment jsdom */
 import { jest } from '@jest/globals';
 
+const startPlanGenerationMock = jest.fn();
+
 jest.unstable_mockModule('../clientProfile.js', () => ({ initClientProfile: jest.fn() }));
-jest.unstable_mockModule('../templateLoader.js', () => ({
-  loadTemplateInto: async () => {}
-}));
+jest.unstable_mockModule('../templateLoader.js', () => ({ loadTemplateInto: async () => {} }));
 jest.unstable_mockModule('../config.js', () => ({
-  apiEndpoints: { regeneratePlan: '/regen', checkPlanPrerequisites: '/check', planLog: '/log', updateKv: '/kv' }
+  apiEndpoints: { regeneratePlan: '/regen' }
+}));
+jest.unstable_mockModule('../planGeneration.js', () => ({
+  startPlanGeneration: startPlanGenerationMock
 }));
 
 let admin;
 
 beforeEach(async () => {
-  global.fetch = jest.fn();
   jest.resetModules();
-  jest.useFakeTimers();
+  startPlanGenerationMock.mockReset();
+  startPlanGenerationMock.mockResolvedValue({ success: true });
+  global.alert = jest.fn();
   document.body.innerHTML = `
     <ul id="clientsList"></ul>
     <span id="clientsCount"></span>
     <input id="clientSearch" />
     <select id="statusFilter"><option value="all">all</option></select>
     <button id="showStats"></button>
-    <div id="priorityGuidanceModal" aria-hidden="true">
-      <textarea id="priorityGuidanceInput"></textarea>
-      <button id="priorityGuidanceConfirm"></button>
-      <button id="priorityGuidanceCancel"></button>
-      <button id="priorityGuidanceClose"></button>
-    </div>
-    <div id="regenLogModal" aria-hidden="true">
-      <div class="modal-body" id="regenLogBody"></div>
-      <button id="regenLogClose"></button>
-    </div>
     <div id="regenProgress" class="hidden"></div>
   `;
   admin = await import('../admin.js');
 });
 
-afterEach(() => {
-  jest.clearAllTimers();
-  jest.useRealTimers();
-});
-
-test('показва бутон за нов план при статус "в процес"', async () => {
-  global.fetch.mockResolvedValue({ ok: true, json: async () => ({ success: true, ok: true }) });
+test('показва бутон и стартира нов план', async () => {
   admin.allClients.length = 0;
   admin.allClients.push({ userId: 'u1', name: 'Test', status: 'processing', tags: [] });
   await admin.renderClients();
   await Promise.resolve();
   const btn = document.querySelector('.regen-plan-btn');
   expect(btn).not.toBeNull();
-  expect(btn.textContent).toContain('Нов план');
-});
-
-test('не показва бутон при липсващи prerequisites', async () => {
-  global.fetch.mockResolvedValue({ ok: true, json: async () => ({ success: true, ok: false }) });
-  admin.allClients.length = 0;
-  admin.allClients.push({ userId: 'u1', name: 'Test', status: 'processing', tags: [] });
-  await admin.renderClients();
-  await Promise.resolve();
-  const btn = document.querySelector('.regen-plan-btn');
-  const msg = document.querySelector('.regen-missing-msg');
-  expect(btn).toBeNull();
-  expect(msg.textContent).toContain('липсват данни');
-});
-
-test('праща reason при клик върху бутона и управлява лог модала', async () => {
-  global.fetch.mockImplementation((url) => {
-    if (url.startsWith('/check')) {
-      return Promise.resolve({ ok: true, json: async () => ({ success: true, ok: true }) });
-    }
-    if (url === '/regen') {
-      return Promise.resolve({ ok: true, json: async () => ({ success: true }) });
-    }
-    if (url.startsWith('/log')) {
-      return Promise.resolve({ ok: true, json: async () => ({ success: true, logs: [], status: 'ready' }) });
-    }
-    return Promise.resolve({ ok: true, json: async () => ({ success: true }) });
-  });
-  admin.allClients.length = 0;
-  admin.allClients.push({ userId: 'u1', name: 'Test', status: 'processing', tags: [] });
-  await admin.renderClients();
-  await Promise.resolve();
-  const btn = document.querySelector('.regen-plan-btn');
   btn.click();
-  document.getElementById('priorityGuidanceConfirm').click();
   await Promise.resolve();
-  const modal = document.getElementById('regenLogModal');
-  expect(modal.classList.contains('visible')).toBe(true);
-  await jest.advanceTimersByTimeAsync(3000);
-  expect(modal.classList.contains('visible')).toBe(false);
-  expect(document.getElementById('regenLogBody').textContent).toBe('');
-  expect(fetch).toHaveBeenNthCalledWith(2, '/regen', expect.objectContaining({
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId: 'u1', reason: 'Админ регенерация', priorityGuidance: '' })
-  }));
+  expect(startPlanGenerationMock).toHaveBeenCalledWith({ userId: 'u1' });
 });

--- a/js/__tests__/planRegenerator.test.js
+++ b/js/__tests__/planRegenerator.test.js
@@ -4,7 +4,7 @@ import { jest } from '@jest/globals';
 const startPlanGenerationMock = jest.fn();
 
 jest.unstable_mockModule('../config.js', () => ({
-  apiEndpoints: { regeneratePlan: '/regen', planLog: '/log', updateKv: '/kv' }
+  apiEndpoints: { regeneratePlan: '/regen' }
 }));
 jest.unstable_mockModule('../planGeneration.js', () => ({
   startPlanGeneration: startPlanGenerationMock
@@ -14,147 +14,23 @@ let setupPlanRegeneration;
 
 beforeEach(async () => {
   jest.resetModules();
-  jest.useFakeTimers();
   startPlanGenerationMock.mockReset();
   startPlanGenerationMock.mockResolvedValue({ success: true });
-  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, logs: [], status: 'ready' }) });
+  global.alert = jest.fn();
   document.body.innerHTML = `
     <button id="regen"></button>
     <div id="regenProgress" class="hidden"></div>
-    <div id="regenLogModal" aria-hidden="true">
-      <div class="modal-body" id="regenLogBody"></div>
-      <button id="regenLogClose"></button>
-    </div>
-    <div id="priorityGuidanceModal" aria-hidden="true">
-      <textarea id="priorityGuidanceInput"></textarea>
-      <button id="priorityGuidanceConfirm"></button>
-      <button id="priorityGuidanceCancel"></button>
-      <button id="priorityGuidanceClose"></button>
-    </div>
   `;
   ({ setupPlanRegeneration } = await import('../planRegenerator.js'));
 });
 
-afterEach(() => {
-  jest.clearAllTimers();
-  jest.useRealTimers();
-});
-
-test('изпраща reason при потвърждение', async () => {
+test('стартира нов план и управлява състоянието на бутона', async () => {
   const regenBtn = document.getElementById('regen');
   const regenProgress = document.getElementById('regenProgress');
   setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
   regenBtn.click();
-  const input = document.getElementById('priorityGuidanceInput');
-  input.value = 'причина';
-  document.getElementById('priorityGuidanceConfirm').click();
-  await Promise.resolve();
-  expect(startPlanGenerationMock).toHaveBeenCalledWith({ userId: 'u1', reason: 'причина', priorityGuidance: '' });
-});
-
-test('показва съобщение при липсващи prerequisites', async () => {
-  startPlanGenerationMock.mockRejectedValueOnce(Object.assign(new Error('Липсват данни'), { precheck: true }));
-  const regenBtn = document.getElementById('regen');
-  const regenProgress = document.getElementById('regenProgress');
-  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
-  regenBtn.click();
-  document.getElementById('priorityGuidanceConfirm').click();
-  await Promise.resolve();
-  await Promise.resolve();
-  expect(regenProgress.textContent).toBe('Липсват данни');
-});
-
-test('деактивира и реактивира бутона', async () => {
-  const regenBtn = document.getElementById('regen');
-  const regenProgress = document.getElementById('regenProgress');
-  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
-  regenBtn.click();
-  document.getElementById('priorityGuidanceConfirm').click();
-  await Promise.resolve();
-  await Promise.resolve();
   expect(regenBtn.disabled).toBe(true);
-  jest.advanceTimersByTime(3000);
   await Promise.resolve();
-  await Promise.resolve();
+  expect(startPlanGenerationMock).toHaveBeenCalledWith({ userId: 'u1' });
   expect(regenBtn.disabled).toBe(false);
-});
-
-test('отваря и затваря лог модала', async () => {
-  const regenBtn = document.getElementById('regen');
-  const regenProgress = document.getElementById('regenProgress');
-  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
-  regenBtn.click();
-  document.getElementById('priorityGuidanceConfirm').click();
-  await Promise.resolve();
-  const modal = document.getElementById('regenLogModal');
-  expect(modal.classList.contains('visible')).toBe(true);
-  jest.advanceTimersByTime(3000);
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
-  expect(modal.classList.contains('visible')).toBe(false);
-  expect(document.getElementById('regenLogBody').textContent).toBe('');
-});
-
-test('изпраща заявка само за последно избран userId', async () => {
-  const regenBtn1 = document.getElementById('regen');
-  const regenProgress1 = document.getElementById('regenProgress');
-  const regenBtn2 = document.createElement('button');
-  regenBtn2.id = 'regen2';
-  document.body.appendChild(regenBtn2);
-  const regenProgress2 = document.createElement('div');
-  regenProgress2.id = 'regenProgress2';
-  regenProgress2.classList.add('hidden');
-  document.body.appendChild(regenProgress2);
-
-  setupPlanRegeneration({ regenBtn: regenBtn1, regenProgress: regenProgress1, getUserId: () => 'u1' });
-  setupPlanRegeneration({ regenBtn: regenBtn2, regenProgress: regenProgress2, getUserId: () => 'u2' });
-
-  regenBtn1.click();
-  regenBtn2.click();
-  document.getElementById('priorityGuidanceConfirm').click();
-  await Promise.resolve();
-
-  expect(startPlanGenerationMock).toHaveBeenCalledTimes(1);
-  expect(startPlanGenerationMock).toHaveBeenCalledWith({ userId: 'u2', reason: 'Админ регенерация', priorityGuidance: '' });
-});
-
-test('изпраща reason и priorityGuidance при отделни полета', async () => {
-  document.body.innerHTML = `
-    <button id="regen"></button>
-    <div id="regenProgress" class="hidden"></div>
-    <div id="regenLogModal" aria-hidden="true">
-      <div class="modal-body" id="regenLogBody"></div>
-      <button id="regenLogClose"></button>
-    </div>
-    <div id="priorityGuidanceModal" aria-hidden="true">
-      <textarea id="priorityGuidanceInput"></textarea>
-      <textarea id="regenReasonInput"></textarea>
-      <button id="priorityGuidanceConfirm"></button>
-      <button id="priorityGuidanceCancel"></button>
-      <button id="priorityGuidanceClose"></button>
-    </div>
-  `;
-  ({ setupPlanRegeneration } = await import('../planRegenerator.js'));
-  const regenBtn = document.getElementById('regen');
-  const regenProgress = document.getElementById('regenProgress');
-  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
-  regenBtn.click();
-  document.getElementById('regenReasonInput').value = 'причина';
-  document.getElementById('priorityGuidanceInput').value = 'приоритет';
-  document.getElementById('priorityGuidanceConfirm').click();
-  await Promise.resolve();
-  expect(startPlanGenerationMock).toHaveBeenCalledWith({ userId: 'u1', reason: 'причина', priorityGuidance: 'приоритет' });
-});
-
-test('предава priorityGuidance чрез getPriorityGuidance', async () => {
-  const regenBtn = document.getElementById('regen');
-  const regenProgress = document.getElementById('regenProgress');
-  const getPriorityGuidance = () => document.getElementById('priorityGuidanceInput').value.trim();
-  setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1', getPriorityGuidance });
-  regenBtn.click();
-  document.getElementById('priorityGuidanceInput').value = 'prio';
-  document.getElementById('priorityGuidanceConfirm').click();
-  await Promise.resolve();
-  expect(startPlanGenerationMock).toHaveBeenCalledWith({ userId: 'u1', reason: 'prio', priorityGuidance: 'prio' });
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -33,7 +33,6 @@ const tagFilterSelect = document.getElementById('tagFilter');
 const detailsSection = document.getElementById('clientDetails');
 const regenBtn = document.getElementById('regeneratePlan');
 const regenProgress = document.getElementById('regenProgress');
-const priorityGuidanceInput = document.getElementById('priorityGuidanceInput');
 const aiSummaryBtn = document.getElementById('aiSummary');
 const notesField = document.getElementById('adminNotes');
 const tagsField = document.getElementById('adminTags');
@@ -104,16 +103,6 @@ const analysisModelInput = document.getElementById('analysisModel');
 const analysisPromptInput = document.getElementById('analysisPrompt');
 const testAnalysisBtn = document.getElementById('testAnalysisModel');
 
-async function hasPlanPrerequisites(userId) {
-    try {
-        const resp = await fetch(`${apiEndpoints.checkPlanPrerequisites}?userId=${encodeURIComponent(userId)}`);
-        const data = await resp.json();
-        return resp.ok && data.success && data.ok;
-    } catch (err) {
-        console.error('prereq check error', err);
-        return false;
-    }
-}
 
 const modelOptionsList = document.getElementById('modelOptions');
 let availableModels = new Set(JSON.parse(localStorage.getItem('aiModelHistory') || '[]'));
@@ -258,8 +247,7 @@ function setCurrentUserId(val) {
 setupPlanRegeneration({
     regenBtn,
     regenProgress,
-    getUserId: () => currentUserId,
-    getPriorityGuidance: () => priorityGuidanceInput?.value.trim() || ''
+    getUserId: () => currentUserId
 });
 let profileNavObserver = null;
 let currentPlanData = null;
@@ -733,30 +721,21 @@ async function renderClients() {
             c.status === 'unknown' ||
             c.status === 'processing';
         if (needsPlan) {
-            const ok = await hasPlanPrerequisites(c.userId);
-            if (ok) {
-                const regen = document.createElement('button');
-                regen.className = 'regen-plan-btn button-small';
-                regen.textContent = 'Нов план';
-                regen.title = 'Генерирай нов план';
-                const progress = document.createElement('span');
-                progress.className = 'regen-progress hidden';
-                progress.setAttribute('aria-live', 'polite');
-                li.appendChild(regen);
-                li.appendChild(progress);
-                regen.addEventListener('click', e => e.stopPropagation());
-                setupPlanRegeneration({
-                    regenBtn: regen,
-                    regenProgress: progress,
-                    getUserId: () => c.userId,
-                    getPriorityGuidance: () => priorityGuidanceInput?.value.trim() || ''
-                });
-            } else {
-                const msg = document.createElement('span');
-                msg.className = 'regen-missing-msg';
-                msg.textContent = 'липсват данни за регенериране';
-                li.appendChild(msg);
-            }
+            const regen = document.createElement('button');
+            regen.className = 'regen-plan-btn button-small';
+            regen.textContent = 'Нов план';
+            regen.title = 'Генерирай нов план';
+            const progress = document.createElement('span');
+            progress.className = 'regen-progress hidden';
+            progress.setAttribute('aria-live', 'polite');
+            li.appendChild(regen);
+            li.appendChild(progress);
+            regen.addEventListener('click', e => e.stopPropagation());
+            setupPlanRegeneration({
+                regenBtn: regen,
+                regenProgress: progress,
+                getUserId: () => c.userId
+            });
         }
 
         clientsList?.appendChild(li);

--- a/js/editClient.js
+++ b/js/editClient.js
@@ -564,12 +564,10 @@ export async function initEditClient(userId) {
 
   const regenBtn = document.getElementById('regeneratePlan');
   const regenProgress = document.getElementById('regenProgress');
-  const priorityGuidanceInput = document.getElementById('priorityGuidanceInput');
   setupPlanRegeneration({
     regenBtn,
     regenProgress,
-    getUserId: () => userId,
-    getPriorityGuidance: () => priorityGuidanceInput?.value.trim() || ''
+    getUserId: () => userId
   });
 
   const aiSummaryBtn = document.getElementById('aiSummary');

--- a/js/planGeneration.js
+++ b/js/planGeneration.js
@@ -1,29 +1,20 @@
 import { apiEndpoints } from './config.js';
 
 /**
- * Стартира генериране на план.
+ * Стартира изцяло нов план без допълнителни проверки или приоритети.
  * @param {Object} params
  * @param {string} params.userId
- * @param {string} [params.reason]
- * @param {string} [params.priorityGuidance]
  * @returns {Promise<any>} резултатът от сървъра
  */
-export async function startPlanGeneration({ userId, reason = '', priorityGuidance = '' }) {
-  const payload = { userId, reason, priorityGuidance };
+export async function startPlanGeneration({ userId }) {
   const resp = await fetch(apiEndpoints.regeneratePlan, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload)
+    body: JSON.stringify({ userId })
   });
   const data = await resp.json();
-  if (!resp.ok) throw new Error(data.message || 'Request failed');
-  if (!data.success) {
-    if (data.precheck?.message && typeof alert === 'function') {
-      alert(data.precheck.message);
-    }
-    const err = new Error(data.precheck?.message || data.message || 'Грешка при стартиране на генерирането.');
-    err.precheck = Boolean(data.precheck);
-    throw err;
+  if (!resp.ok || !data.success) {
+    throw new Error(data.message || 'Грешка при стартиране на генерирането.');
   }
   return data;
 }

--- a/js/planRegenerator.js
+++ b/js/planRegenerator.js
@@ -1,144 +1,34 @@
-import { apiEndpoints } from './config.js';
 import { startPlanGeneration } from './planGeneration.js';
 
-let activeUserId;
-let activeRegenBtn;
-let activeRegenProgress;
-let confirmListenerAdded = false;
-let modalListenersAdded = false;
-let displayedLogs = 0;
+/**
+ * Настройва бутон за създаване на изцяло нов план.
+ * @param {Object} options
+ * @param {HTMLButtonElement} options.regenBtn
+ * @param {HTMLElement} [options.regenProgress] - елемент за съобщения
+ * @param {Function} options.getUserId - връща текущия userId
+ */
+export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
+  if (!regenBtn || typeof getUserId !== 'function') return;
 
-function openModal(modal) {
-  modal.classList.add('visible');
-  modal.setAttribute('aria-hidden', 'false');
-  const first = modal.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-  (first || modal).focus();
-}
-
-function closeModal(modal) {
-  modal.classList.remove('visible');
-  modal.setAttribute('aria-hidden', 'true');
-}
-
-const logModal = document.getElementById('regenLogModal');
-const logBody = document.getElementById('regenLogBody');
-const logClose = document.getElementById('regenLogClose');
-if (logClose && logModal && logBody) {
-  logClose.addEventListener('click', () => {
-    closeModal(logModal);
-    logBody.textContent = '';
+  regenBtn.addEventListener('click', async () => {
+    const userId = getUserId();
+    if (!userId) return;
+    regenBtn.disabled = true;
+    if (regenProgress) {
+      regenProgress.textContent = 'Генериране…';
+      regenProgress.classList.remove('hidden');
+    }
+    try {
+      await startPlanGeneration({ userId });
+      if (regenProgress) regenProgress.textContent = 'Готово';
+      alert('Планът е обновен.');
+    } catch (err) {
+      console.error('regeneratePlan error:', err);
+      if (regenProgress) regenProgress.textContent = 'Грешка';
+      alert('Грешка при генериране на плана.');
+    } finally {
+      regenBtn.disabled = false;
+      if (regenProgress) setTimeout(() => regenProgress.classList.add('hidden'), 2000);
+    }
   });
-}
-
-export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId, getPriorityGuidance }) {
-  const modal = document.getElementById('priorityGuidanceModal');
-  const priorityInput = document.getElementById('priorityGuidanceInput');
-  const reasonInput = document.getElementById('regenReasonInput');
-  const confirm = document.getElementById('priorityGuidanceConfirm');
-  const cancel = document.getElementById('priorityGuidanceCancel');
-  const closeBtn = document.getElementById('priorityGuidanceClose');
-  if (!regenBtn || !modal || !confirm || (!priorityInput && !reasonInput)) return;
-
-  const hide = () => closeModal(modal);
-
-  regenBtn.addEventListener('click', () => {
-    activeUserId = getUserId?.();
-    activeRegenBtn = regenBtn;
-    activeRegenProgress = regenProgress;
-    if (priorityInput) priorityInput.value = '';
-    if (reasonInput) reasonInput.value = '';
-    openModal(modal);
-  });
-
-  if (!modalListenersAdded) {
-    modalListenersAdded = true;
-    cancel?.addEventListener('click', hide);
-    closeBtn?.addEventListener('click', hide);
-  }
-
-  if (!confirmListenerAdded) {
-    confirmListenerAdded = true;
-    confirm.addEventListener('click', async () => {
-      if (!activeUserId || !activeRegenBtn) return;
-      hide();
-      const reason = (reasonInput ? reasonInput.value : priorityInput?.value || '').trim();
-      const priorityGuidance =
-        typeof getPriorityGuidance === 'function'
-          ? getPriorityGuidance() || ''
-          : reasonInput
-            ? priorityInput?.value.trim() || ''
-            : '';
-      if (activeRegenProgress) {
-        activeRegenProgress.textContent = 'Генериране…';
-        activeRegenProgress.classList.remove('hidden');
-      }
-      activeRegenBtn.disabled = true;
-      displayedLogs = 0;
-      if (logBody) logBody.textContent = '';
-      if (logModal) openModal(logModal);
-      try {
-        await startPlanGeneration({
-          userId: activeUserId,
-          reason: reason || 'Админ регенерация',
-          priorityGuidance
-        });
-      } catch (err) {
-        console.error('regeneratePlan error:', err);
-        if (activeRegenProgress) {
-          activeRegenProgress.textContent = err.message || 'Грешка';
-          setTimeout(() => activeRegenProgress.classList.add('hidden'), 4000);
-        }
-        activeRegenBtn.disabled = false;
-        if (!err.precheck) alert('Грешка при стартиране на генерирането.');
-        if (logModal) closeModal(logModal);
-        if (logBody) logBody.textContent = '';
-        return;
-      }
-
-      const userId = activeUserId;
-      const btn = activeRegenBtn;
-      const progress = activeRegenProgress;
-      const intervalId = setInterval(async () => {
-        try {
-          const resp = await fetch(`${apiEndpoints.planLog}?userId=${userId}`);
-          const data = await resp.json();
-          if (resp.ok && data.success) {
-            const logs = data.logs || [];
-            if (logBody) {
-              for (let i = displayedLogs; i < logs.length; i++) {
-                const div = document.createElement('div');
-                div.textContent = logs[i];
-                logBody.appendChild(div);
-              }
-              displayedLogs = logs.length;
-              logBody.scrollTop = logBody.scrollHeight;
-            }
-            if (data.status === 'ready' || data.status === 'error') {
-              clearInterval(intervalId);
-              if (progress) {
-                progress.textContent = data.status === 'ready' ? 'Готово' : 'Грешка';
-                setTimeout(() => progress.classList.add('hidden'), 2000);
-              }
-              btn.disabled = false;
-              if (data.status === 'ready') alert('Планът е обновен.');
-              else alert(`Грешка при генерирането: ${data.error || ''}`);
-              if (logModal) closeModal(logModal);
-              if (logBody) logBody.textContent = '';
-              try {
-                await fetch(apiEndpoints.updateKv, {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ key: `${userId}_plan_log`, value: '[]' })
-                });
-              } catch (e) {
-                console.error('clear plan log error:', e);
-              }
-            }
-          }
-        } catch (err) {
-          console.error('planLog polling error:', err);
-        }
-      }, 3000);
-    });
-  }
 }

--- a/js/questionnaireCore.js
+++ b/js/questionnaireCore.js
@@ -493,8 +493,8 @@ export function getResponses() {
   return state.responses;
 }
 
-export function regeneratePlan({ userId, reason = '', priorityGuidance = '' }) {
-  return startPlanGeneration({ userId, reason, priorityGuidance });
+export function regeneratePlan({ userId }) {
+  return startPlanGeneration({ userId });
 }
 
 export async function initQuestionnaire({ questionsUrl, submitUrl }) {


### PR DESCRIPTION
## Summary
- Simplify plan generation helper to accept only userId and remove prerequisite checks
- Strip UI modals and extra inputs, leaving a single-button flow for new plan creation
- Update admin and client views plus docs and tests for the minimal regeneration flow

## Testing
- `npm run lint`
- `sh ./scripts/test.sh js/__tests__/planRegenerator.test.js`
- `sh ./scripts/test.sh js/__tests__/planGenerationParams.test.js`
- `sh ./scripts/test.sh js/__tests__/adminRegeneratePlan.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893e2aff58c83269eb45642bbe54065