### PR TITLE
Refine macro chart opacity and ring thickness

### DIFF
--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -511,7 +511,7 @@ export class MacroAnalyticsCard extends HTMLElement {
       {
         label: this.locale === 'en' ? 'Plan (g)' : 'План (гр)',
         data: [plan.protein_grams, plan.carbs_grams, plan.fat_grams, plan.fiber_grams],
-        backgroundColor: current ? macroColors.map((c) => `${c}40`) : macroColors,
+        backgroundColor: current ? macroColors.map((c) => `${c}BF`) : macroColors,
         borderWidth: 0,
         cutout: current ? '80%' : '65%',
         hoverOffset: 8
@@ -524,7 +524,7 @@ export class MacroAnalyticsCard extends HTMLElement {
         backgroundColor: macroColors,
         borderWidth: 0,
         borderRadius: 8,
-        cutout: '65%',
+        cutout: '75%',
         hoverOffset: 8
       });
     }


### PR DESCRIPTION
## Summary
- Reduce outer macro chart transparency to 25% for better visibility
- Thin inner ring of macro chart for a more delicate appearance

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e3bc6eb48326819bd5cb8ef52ab2