### PR TITLE
feat: reset macros on day change

### DIFF
--- a/data/macroPayloadDebug.json
+++ b/data/macroPayloadDebug.json
@@ -1,1 +1,13 @@
-{}
+{
+  "error": "Invalid macro payload structure",
+  "payload": {
+    "plan": {
+      "calories": 0,
+      "protein_grams": 0,
+      "carbs_grams": 0,
+      "fat_grams": 0,
+      "fiber_grams": 0
+    },
+    "current": {}
+  }
+}

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 import { jest } from '@jest/globals';
 
-let populateUI;
+let populateUI, populateModule;
 
 beforeEach(async () => {
   jest.resetModules();
@@ -89,11 +89,13 @@ beforeEach(async () => {
     loadCurrentIntake: jest.fn(),
     currentUserId: 'u1'
   }));
-  ({ populateUI } = await import('../populateUI.js'));
+  populateModule = await import('../populateUI.js');
+  ({ populateUI } = populateModule);
 });
 
 afterEach(() => {
   document.body.innerHTML = '';
+  sessionStorage.clear();
 });
 
 test('populates dashboard sections', async () => {
@@ -434,4 +436,12 @@ describe('progress bar width handling', () => {
     expect(document.getElementById('engagementCard').classList.contains('hidden')).toBe(hidden);
     expect(document.getElementById('healthCard').classList.contains('hidden')).toBe(hidden);
   });
+});
+
+test('ресет на макросите при смяна на деня', async () => {
+  sessionStorage.setItem('lastDashboardDate', '2000-01-01');
+  const { loadCurrentIntake } = await import('../app.js');
+  await populateUI();
+  expect(loadCurrentIntake).toHaveBeenCalled();
+  expect(sessionStorage.getItem('lastDashboardDate')).toBe(new Date().toISOString().split('T')[0]);
 });

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -527,19 +527,28 @@ function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {
     }
 
     const today = new Date();
+    const todayDateStr = today.toISOString().split('T')[0];
     const dayNames = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
     const currentDayKey = dayNames[today.getDay()];
     const todayTitle = today.toLocaleDateString('bg-BG', { weekday: 'long', day: 'numeric', month: 'long' });
 
     if(selectors.dailyPlanTitle) selectors.dailyPlanTitle.textContent = `📅 Меню (${capitalizeFirstLetter(todayTitle)})`;
 
+    // Reset макросите ако денят се е сменил
+    const lastDate = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('lastDashboardDate') : null;
+    if (lastDate !== todayDateStr) {
+        loadCurrentIntake();
+        populateDashboardMacros(todaysPlanMacros);
+        if (typeof sessionStorage !== 'undefined') {
+            sessionStorage.setItem('lastDashboardDate', todayDateStr);
+        }
+    }
+
     const dailyPlanData = safeGet(week1Menu, currentDayKey, []);
     if (!dailyPlanData || dailyPlanData.length === 0) {
         listElement.innerHTML = '<li class="placeholder">Няма налично меню за днес.</li>'; return;
     }
     listElement.innerHTML = '';
-
-    const todayDateStr = today.toISOString().split('T')[0];
     const todaysLogFromServer = dailyLogs?.find(log => log.date === todayDateStr)?.data || {};
     const completedMealsFromServer = todaysLogFromServer.completedMealsStatus || {};
     // Accessing todaysMealCompletionStatus which is exported from app.js


### PR DESCRIPTION
## Summary
- reset dashboard macros when the calendar day changes
- cover day-change reset with targeted Jest test

## Testing
- `npm run lint`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runTestsByPath js/__tests__/populateUI.test.js -t "ресет" --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6893ecc6af288326835309fb896783c7