### PR TITLE
refactor: simplify plan regeneration

### DIFF
--- a/backend/tests/regeneratePlan.test.js
+++ b/backend/tests/regeneratePlan.test.js
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals';
 import { handleRegeneratePlanRequest } from '../../worker.js';
 
 describe('POST /api/regeneratePlan', () => {
-  test('записва priorityGuidance и reason и ги предава към процесора', async () => {
+  test('стартира генерирането само с userId', async () => {
     const env = {
       USER_METADATA_KV: {
         put: jest.fn(),
@@ -13,38 +13,40 @@ describe('POST /api/regeneratePlan', () => {
     };
     const ctx = { waitUntil: jest.fn() };
     const mockProcessor = jest.fn().mockResolvedValue();
-    const request = { json: async () => ({ userId: 'u1', priorityGuidance: 'повече протеин', reason: 'нова цел' }) };
+    const request = { json: async () => ({ userId: 'u1' }) };
     const res = await handleRegeneratePlanRequest(request, env, ctx, mockProcessor);
-    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('pending_plan_mod_u1', 'повече протеин');
-    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('regen_reason_u1', 'нова цел');
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('plan_status_u1', 'processing', { metadata: { status: 'processing' } });
+    expect(env.USER_METADATA_KV.put).not.toHaveBeenCalledWith('pending_plan_mod_u1', expect.anything());
+    expect(env.USER_METADATA_KV.put).not.toHaveBeenCalledWith('regen_reason_u1', expect.anything());
     expect(ctx.waitUntil).toHaveBeenCalled();
-    expect(mockProcessor).toHaveBeenCalledWith('u1', env, 'повече протеин', 'нова цел');
+    expect(mockProcessor).toHaveBeenCalledWith('u1', env);
+    expect(mockProcessor.mock.calls[0].length).toBe(2);
     expect(res.success).toBe(true);
   });
 
-  test('връща грешка при липсващ reason', async () => {
+  test('връща грешка при липсващ userId', async () => {
     const env = { USER_METADATA_KV: { put: jest.fn() } };
-    const request = { json: async () => ({ userId: 'u1', reason: '' }) };
+    const request = { json: async () => ({}) };
     const res = await handleRegeneratePlanRequest(request, env, null, jest.fn());
     expect(res.success).toBe(false);
     expect(res.statusHint).toBe(400);
     expect(env.USER_METADATA_KV.put).not.toHaveBeenCalled();
   });
 
-  test('връща precheck при липсващи prerequisites', async () => {
+  test('връща грешка при липсващи prerequisites', async () => {
     const env = {
       USER_METADATA_KV: {
         put: jest.fn(),
-        get: jest.fn(async key => null)
+        get: jest.fn(async () => null)
       },
       RESOURCES_KV: { get: jest.fn(async () => 'model') },
       GEMINI_API_KEY: 'key'
     };
-    const request = { json: async () => ({ userId: 'u1', reason: 'r' }) };
+    const request = { json: async () => ({ userId: 'u1' }) };
     const res = await handleRegeneratePlanRequest(request, env, null, jest.fn());
     expect(res.success).toBe(false);
-    expect(res.precheck).toEqual({ ok: false, message: 'Липсват първоначални отговори.' });
+    expect(res.message).toBe('Липсват първоначални отговори.');
+    expect(res.precheck).toBeUndefined();
     expect(res.statusHint).toBe(400);
   });
 });


### PR DESCRIPTION
## Summary
- simplify plan regeneration by only using userId
- update regeneration tests to match reduced payload

## Testing
- `npm run lint`
- `npm test backend/tests/regeneratePlan.test.js js/__tests__/regeneratePlan.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893ec38c3a88326961ea013e7d9891a