### PR TITLE
feat: handle missing macro data in charts

### DIFF
--- a/js/__tests__/editClient.test.js
+++ b/js/__tests__/editClient.test.js
@@ -38,3 +38,16 @@ test('initCharts uses Chart with parsed data', async () => {
   expect(macroConfig.data.datasets[0].data).toEqual([120, 200, 50, 30]);
   expect(ChartMock.mock.calls[1][1].type).toBe('line');
 });
+
+test('initCharts handles missing macros with placeholder', async () => {
+  document.body.innerHTML = '<div><canvas id="macro-chart"></canvas><canvas id="weight-chart"></canvas></div>';
+  const ChartMock = jest.fn().mockImplementation(() => ({ destroy: jest.fn() }));
+  global.Chart = ChartMock;
+  const { __testExports } = await import('../editClient.js');
+  const { initCharts } = __testExports;
+  await initCharts({ profileSummary: 'Текущо тегло 80 кг (промяна за 7 дни: -1 кг)' });
+  expect(ChartMock).toHaveBeenCalledTimes(1);
+  const placeholder = document.getElementById('macro-chart-placeholder');
+  expect(placeholder).not.toBeNull();
+  expect(placeholder.textContent).toBe('Няма налични макроси за визуализация.');
+});


### PR DESCRIPTION
## Summary
- guard initCharts and its call sites when caloriesMacros is missing
- show placeholder message for absent macro data in admin UI
- cover missing macro case with unit test

## Testing
- `npm run lint`
- `npm test js/__tests__/editClient.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893f89216d48326ae32ce4cb352daed