### PR TITLE
fix: recalculate macros when adding extra meals

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -2,7 +2,7 @@
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
 import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressFill, getCssVar, formatDateBgShort } from './utils.js';
 import { generateId, apiEndpoints, standaloneMacroUrl } from './config.js';
-import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, loadCurrentIntake, currentUserId, todaysPlanMacros } from './app.js';
+import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, loadCurrentIntake, recalculateCurrentIntakeMacros, currentUserId, todaysPlanMacros } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
 import { ensureChart } from './chartLoader.js';
 import { getNutrientOverride, scaleMacros, calculatePlanMacros } from './macroUtils.js';
@@ -366,8 +366,10 @@ export function addExtraMealWithOverride(name = '', macros = {}, grams) {
     const scaled = gramValue ? scaleMacros(base, gramValue) : base;
     const entry = gramValue ? { ...scaled, grams: gramValue } : scaled;
     todaysExtraMeals.push(entry);
-    loadCurrentIntake();
+    // Обновяваме текущите макроси с новото хранене
+    recalculateCurrentIntakeMacros();
     populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
+    renderPendingMacroChart();
 }
 
 function renderMacroPreviewGrid(macros) {


### PR DESCRIPTION
## Summary
- recalc current intake macros when an extra meal is added
- refresh macro dashboard and pending chart after updating totals

## Testing
- `npm run lint js/populateUI.js`
- `npm test -- js/__tests__/extraMealFormSubmit.test.js js/__tests__/extraMealAutofill.test.js`
- `npm test -- js/__tests__/extraMealNutrientLookup.test.js` *(fails: fetch not called as expected)*

------
https://chatgpt.com/codex/tasks/task_e_689405d1fc7c832692c121547cda3de1