### PR TITLE
feat(extra-meal): display logged meals

### DIFF
--- a/js/__tests__/extraMealAutofill.test.js
+++ b/js/__tests__/extraMealAutofill.test.js
@@ -13,7 +13,7 @@ beforeEach(async () => {
     closeModal: jest.fn()
   }));
   jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
-  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), renderPendingMacroChart: jest.fn() }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), renderPendingMacroChart: jest.fn(), appendExtraMealCard: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({
     currentUserId: 'u1',
     todaysExtraMeals: [],

--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -4,6 +4,7 @@ import { jest } from '@jest/globals';
 let handleExtraMealFormSubmit;
 let showToastMock;
 let addExtraMealWithOverrideMock;
+let appendExtraMealCardMock;
 let currentIntakeMacrosRef;
 
 beforeEach(async () => {
@@ -26,10 +27,12 @@ beforeEach(async () => {
     loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] })
   }));
   addExtraMealWithOverrideMock = jest.fn();
+  appendExtraMealCardMock = jest.fn();
   jest.unstable_mockModule('../populateUI.js', () => ({
     addExtraMealWithOverride: addExtraMealWithOverrideMock,
     populateDashboardMacros: jest.fn(),
-    renderPendingMacroChart: jest.fn()
+    renderPendingMacroChart: jest.fn(),
+    appendExtraMealCard: appendExtraMealCardMock
   }));
   jest.unstable_mockModule('../app.js', () => {
     currentIntakeMacrosRef = {};
@@ -79,4 +82,5 @@ test('изпраща макро стойности при попълнени п�
     undefined,
     { calories: 120, protein: 10, carbs: 15, fat: 5 }
   );
+  expect(appendExtraMealCardMock).toHaveBeenCalledWith(undefined, 'малко');
 });

--- a/js/__tests__/extraMealNutrientLookup.test.js
+++ b/js/__tests__/extraMealNutrientLookup.test.js
@@ -21,7 +21,7 @@ beforeEach(async () => {
     closeModal: jest.fn()
   }));
   jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
-  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), renderPendingMacroChart: jest.fn() }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), renderPendingMacroChart: jest.fn(), appendExtraMealCard: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({
     currentUserId: 'u1',
     todaysExtraMeals: [],
@@ -55,7 +55,7 @@ test('извиква nutrient lookup при непозната храна', asyn
     </form>
   </div>`;
   const container = document.getElementById('c');
-  initializeExtraMealFormLogic(container);
+  await initializeExtraMealFormLogic(container);
   const input = container.querySelector('#foodDescription');
   input.value = 'непозната храна';
   input.dispatchEvent(new Event('input', { bubbles: true }));

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -8,7 +8,8 @@ import { removeMealMacros, registerNutrientOverrides, getNutrientOverride, loadP
 import {
     addExtraMealWithOverride,
     populateDashboardMacros,
-    renderPendingMacroChart
+    renderPendingMacroChart,
+    appendExtraMealCard
 } from './populateUI.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 
@@ -468,6 +469,7 @@ export async function handleExtraMealFormSubmit(event) {
             fat: dataToSend.fat
         };
         addExtraMealWithOverride(dataToSend.foodDescription, entry);
+        appendExtraMealCard(dataToSend.foodDescription, dataToSend.quantityEstimate);
         // Автоматично опресняване на макро-картата
         renderPendingMacroChart();
         genericCloseModal('extraMealEntryModal');

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -353,6 +353,39 @@ export function renderPendingMacroChart() {
     card.setData(payload);
 }
 
+export function appendExtraMealCard(name, quantity) {
+    const list = selectors.dailyMealList;
+    if (!list) return;
+
+    const li = document.createElement('li');
+    li.classList.add('card', 'meal-card', 'soft-shadow', 'completed', 'extra-meal');
+
+    const colorBar = document.createElement('div');
+    colorBar.className = 'meal-color-bar';
+    li.appendChild(colorBar);
+
+    const contentWrapper = document.createElement('div');
+    contentWrapper.className = 'meal-content-wrapper';
+    li.appendChild(contentWrapper);
+
+    const title = document.createElement('h2');
+    title.className = 'meal-name';
+    title.textContent = name || 'Хранене';
+    const checkIcon = document.createElement('span');
+    checkIcon.className = 'check-icon';
+    checkIcon.setAttribute('aria-hidden', 'true');
+    checkIcon.innerHTML = '<svg class="icon"><use href="#icon-check"/></svg>';
+    title.appendChild(checkIcon);
+    contentWrapper.appendChild(title);
+
+    const items = document.createElement('div');
+    items.className = 'meal-items';
+    items.textContent = `Количество: ${quantity ?? ''}`;
+    contentWrapper.appendChild(items);
+
+    list.appendChild(li);
+}
+
 export function addExtraMealWithOverride(name = '', macros = {}, grams) {
     const hasMacros = macros && Object.keys(macros).length > 0;
     let gramValue = typeof grams === 'number' ? grams : undefined;


### PR DESCRIPTION
## Summary
- add appendExtraMealCard for rendering extra meals directly in the daily list
- invoke appendExtraMealCard after logging extra meal
- extend extra meal form tests to cover new card rendering

## Testing
- `npm run lint`
- `npm test js/__tests__/extraMealFormSubmit.test.js js/__tests__/extraMealAutofill.test.js js/__tests__/extraMealNutrientLookup.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6894097dd7b08326b640cc7bdb142c10