### PR TITLE
Подреждане на картите за допълнителни хранения

### DIFF
--- a/js/__tests__/appendExtraMealCard.test.js
+++ b/js/__tests__/appendExtraMealCard.test.js
@@ -1,0 +1,43 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+describe('appendExtraMealCard', () => {
+  test('вмъква картата преди първата невършена', async () => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <ul id="dailyMealList">
+        <li class="meal-card completed"></li>
+        <li class="meal-card"></li>
+        <li class="meal-card"></li>
+      </ul>
+    `;
+    const selectors = { dailyMealList: document.getElementById('dailyMealList') };
+    jest.unstable_mockModule('../uiElements.js', () => ({ selectors, trackerInfoTexts: {}, detailedMetricInfoTexts: {}, mainIndexInfoTexts: {}, initializeSelectors: jest.fn(), loadInfoTexts: jest.fn() }));
+    const { appendExtraMealCard } = await import('../populateUI.js');
+
+    appendExtraMealCard('Тест', '100');
+
+    const list = selectors.dailyMealList;
+    expect(list.children).toHaveLength(4);
+    expect(list.children[1].classList.contains('extra-meal')).toBe(true);
+  });
+
+  test('добавя картата накрая, ако всички са изпълнени', async () => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <ul id="dailyMealList">
+        <li class="meal-card completed"></li>
+        <li class="meal-card completed"></li>
+      </ul>
+    `;
+    const selectors = { dailyMealList: document.getElementById('dailyMealList') };
+    jest.unstable_mockModule('../uiElements.js', () => ({ selectors, trackerInfoTexts: {}, detailedMetricInfoTexts: {}, mainIndexInfoTexts: {}, initializeSelectors: jest.fn(), loadInfoTexts: jest.fn() }));
+    const { appendExtraMealCard } = await import('../populateUI.js');
+
+    appendExtraMealCard('Тест', '100');
+
+    const list = selectors.dailyMealList;
+    expect(list.children).toHaveLength(3);
+    expect(list.lastElementChild.classList.contains('extra-meal')).toBe(true);
+  });
+});

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -357,16 +357,16 @@ export function appendExtraMealCard(name, quantity) {
     const list = selectors.dailyMealList;
     if (!list) return;
 
-    const li = document.createElement('li');
-    li.classList.add('card', 'meal-card', 'soft-shadow', 'completed', 'extra-meal');
+    const extraLi = document.createElement('li');
+    extraLi.classList.add('card', 'meal-card', 'soft-shadow', 'completed', 'extra-meal');
 
     const colorBar = document.createElement('div');
     colorBar.className = 'meal-color-bar';
-    li.appendChild(colorBar);
+    extraLi.appendChild(colorBar);
 
     const contentWrapper = document.createElement('div');
     contentWrapper.className = 'meal-content-wrapper';
-    li.appendChild(contentWrapper);
+    extraLi.appendChild(contentWrapper);
 
     const title = document.createElement('h2');
     title.className = 'meal-name';
@@ -383,7 +383,8 @@ export function appendExtraMealCard(name, quantity) {
     items.textContent = `Количество: ${quantity ?? ''}`;
     contentWrapper.appendChild(items);
 
-    list.appendChild(li);
+    const nextUncompleted = list.querySelector('li:not(.completed)');
+    list.insertBefore(extraLi, nextUncompleted || null);
 }
 
 export function addExtraMealWithOverride(name = '', macros = {}, grams) {


### PR DESCRIPTION
## Summary
- Вмъкване на нова карта преди първото невършено хранене или в края при липса на такива
- Добавени Jest тестове за подреждане на допълнителни хранения

## Testing
- `npm run lint`
- `sh scripts/test.sh js/__tests__/appendExtraMealCard.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68940bbc39d483268f403fba9137efad