### PR TITLE
Check for initial answers before generating plans

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -617,6 +617,12 @@ export default {
                 }
                 if (['pending', 'processing', 'error'].includes(status)) {
                     const userId = key.name.replace('plan_status_', '');
+                    const initialAnswers = await env.USER_METADATA_KV.get(`${userId}_initial_answers`);
+                    if (!initialAnswers) {
+                        await env.USER_METADATA_KV.put(key.name, 'pending_inputs', { metadata: { status: 'pending_inputs' } });
+                        console.log(`[CRON-PlanGen] Missing initial answers for ${userId}`);
+                        continue;
+                    }
                     await env.USER_METADATA_KV.put(key.name, 'processing', { metadata: { status: 'processing' } });
                     ctx.waitUntil(processSingleUserPlan(userId, env));
                     processedUsersForPlan++;


### PR DESCRIPTION
## Summary
- ensure `scheduled` skips plan generation when user initial answers are missing

## Testing
- `npm run lint`
- `npm test` *(fails: populateUI.test.js, workerEmail.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689421f600888326b1ee22f3b8c9c9e6