### PR TITLE
Check prerequisites before regenerating plan

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -269,7 +269,7 @@
       </form>
     </details>
     <button id="regeneratePlan">Генерирай нов план</button>
-    <div id="regenProgress" class="hidden"></div>
+    <div id="regenProgress" class="hidden" aria-live="polite"></div>
     <button id="aiSummary">AI резюме</button>
     <div class="profile-nav-container">
       <button id="profileCardNavToggle" class="profile-nav-toggle" aria-label="Показване на навигацията">

--- a/editclient.html
+++ b/editclient.html
@@ -82,7 +82,7 @@
         </div>
     </nav>
 
-    <div id="regenProgress" class="hidden"></div>
+    <div id="regenProgress" class="hidden" aria-live="polite"></div>
 
     <div class="container-fluid mt-4">
         <div class="row">

--- a/js/__tests__/editClient.precheck.test.js
+++ b/js/__tests__/editClient.precheck.test.js
@@ -1,0 +1,35 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../config.js', () => ({
+  apiEndpoints: { checkPlanPrerequisites: '/check', regeneratePlan: '/regen' }
+}));
+jest.unstable_mockModule('../planRegenerator.js', () => ({
+  setupPlanRegeneration: jest.fn()
+}));
+
+let initEditClient;
+beforeEach(async () => {
+  jest.resetModules();
+  global.fetch = jest.fn();
+  document.body.innerHTML = `
+    <button id="regeneratePlan"></button>
+    <div id="regenProgress" class="hidden"></div>
+  `;
+  // prevent auto-init via location search
+  delete window.location;
+  window.location = new URL('http://example.com/');
+  ({ initEditClient } = await import('../editClient.js'));
+});
+
+test('деактивира бутона при липсващи предпоставки', async () => {
+  fetch.mockResolvedValueOnce({
+    json: async () => ({ ok: false, message: 'Липсват първоначални отговори.' })
+  });
+  await initEditClient('u1');
+  const btn = document.getElementById('regeneratePlan');
+  const msg = document.getElementById('regenProgress');
+  expect(btn.disabled).toBe(true);
+  expect(msg.textContent).toBe('Липсват първоначални отговори.');
+  expect(msg.classList.contains('hidden')).toBe(false);
+});

--- a/js/__tests__/planRegenerator.test.js
+++ b/js/__tests__/planRegenerator.test.js
@@ -15,7 +15,7 @@ let setupPlanRegeneration;
 beforeEach(async () => {
   jest.resetModules();
   startPlanGenerationMock.mockReset();
-  startPlanGenerationMock.mockResolvedValue({ success: true });
+  startPlanGenerationMock.mockResolvedValue({ success: true, message: 'Готово' });
   global.alert = jest.fn();
   document.body.innerHTML = `
     <button id="regen"></button>
@@ -24,7 +24,7 @@ beforeEach(async () => {
   ({ setupPlanRegeneration } = await import('../planRegenerator.js'));
 });
 
-test('стартира нов план и управлява състоянието на бутона', async () => {
+test('стартира нов план, показва съобщение и управлява бутона', async () => {
   const regenBtn = document.getElementById('regen');
   const regenProgress = document.getElementById('regenProgress');
   setupPlanRegeneration({ regenBtn, regenProgress, getUserId: () => 'u1' });
@@ -32,5 +32,7 @@ test('стартира нов план и управлява състояние�
   expect(regenBtn.disabled).toBe(true);
   await Promise.resolve();
   expect(startPlanGenerationMock).toHaveBeenCalledWith({ userId: 'u1' });
+  expect(regenProgress.textContent).toBe('Готово');
+  expect(global.alert).toHaveBeenCalledWith('Готово');
   expect(regenBtn.disabled).toBe(false);
 });

--- a/js/editClient.js
+++ b/js/editClient.js
@@ -580,6 +580,31 @@ export async function initEditClient(userId) {
 
   const regenBtn = document.getElementById('regeneratePlan');
   const regenProgress = document.getElementById('regenProgress');
+
+  async function precheckPlan() {
+    if (!regenBtn) return;
+    try {
+      const resp = await fetch(`${apiEndpoints.checkPlanPrerequisites}?userId=${userId}`);
+      const data = await resp.json().catch(() => ({}));
+      if (!data.ok) {
+        regenBtn.disabled = true;
+        if (regenProgress) {
+          regenProgress.textContent = data.message || 'Липсват данни';
+          regenProgress.classList.remove('hidden');
+        }
+      } else {
+        regenBtn.disabled = false;
+        if (regenProgress) {
+          regenProgress.textContent = '';
+          regenProgress.classList.add('hidden');
+        }
+      }
+    } catch (err) {
+      console.error('precheckPlan error:', err);
+    }
+  }
+
+  await precheckPlan();
   setupPlanRegeneration({
     regenBtn,
     regenProgress,

--- a/js/planRegenerator.js
+++ b/js/planRegenerator.js
@@ -19,9 +19,10 @@ export function setupPlanRegeneration({ regenBtn, regenProgress, getUserId }) {
       regenProgress.classList.remove('hidden');
     }
     try {
-      await startPlanGeneration({ userId });
-      if (regenProgress) regenProgress.textContent = 'Готово';
-      alert('Планът е обновен.');
+      const result = await startPlanGeneration({ userId });
+      const msg = result?.message || 'Готово';
+      if (regenProgress) regenProgress.textContent = msg;
+      alert(msg);
     } catch (err) {
       console.error('regeneratePlan error:', err);
       if (regenProgress) regenProgress.textContent = 'Грешка';


### PR DESCRIPTION
## Summary
- Disable plan regeneration when prerequisites are missing in client editor
- Cover the new prerequisite check with a Jest test

## Testing
- `npm run lint`
- `npm test -- js/__tests__/editClient.precheck.test.js js/__tests__/planRegenerator.test.js js/__tests__/adminRegeneratePlan.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689420b37f44832693b700bad28b3957