### PR TITLE
Add generate plan button and test plan generation

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -269,6 +269,7 @@
       </form>
     </details>
     <button id="regeneratePlan">Генерирай нов план</button>
+    <button id="generatePlan">Създай план</button>
     <div id="regenProgress" class="hidden" aria-live="polite"></div>
     <button id="aiSummary">AI резюме</button>
     <div class="profile-nav-container">

--- a/js/__tests__/adminGeneratePlan.test.js
+++ b/js/__tests__/adminGeneratePlan.test.js
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+const startPlanGenerationMock = jest.fn();
+
+jest.unstable_mockModule('../config.js', () => ({
+  apiEndpoints: {
+    checkPlanPrerequisites: '/check',
+    regeneratePlan: '/regen',
+    planStatus: '/status'
+  }
+}));
+jest.unstable_mockModule('../planGeneration.js', () => ({
+  startPlanGeneration: startPlanGenerationMock
+}));
+
+let initEditClient;
+beforeEach(async () => {
+  jest.resetModules();
+  startPlanGenerationMock.mockReset();
+  startPlanGenerationMock.mockResolvedValue({ success: true });
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ json: async () => ({ ok: true }) })
+    .mockResolvedValueOnce({ json: async () => ({ success: true, planStatus: 'pending' }) });
+  global.alert = jest.fn();
+  document.body.innerHTML = `
+    <button id="generatePlan"></button>
+    <button id="regeneratePlan"></button>
+    <div id="regenProgress" class="hidden"></div>
+  `;
+  delete window.location;
+  window.location = new URL('http://example.com/');
+  ({ initEditClient } = await import('../editClient.js'));
+});
+
+test('активира "Създай план" и стартира генериране при липса на план', async () => {
+  await initEditClient('u1');
+  const btn = document.getElementById('generatePlan');
+  expect(btn.disabled).toBe(false);
+  btn.click();
+  await Promise.resolve();
+  expect(startPlanGenerationMock).toHaveBeenCalledWith({ userId: 'u1' });
+});

--- a/js/editClient.js
+++ b/js/editClient.js
@@ -579,6 +579,7 @@ export async function initEditClient(userId) {
   }
 
   const regenBtn = document.getElementById('regeneratePlan');
+  const generateBtn = document.getElementById('generatePlan');
   const regenProgress = document.getElementById('regenProgress');
 
   async function precheckPlan() {
@@ -610,6 +611,25 @@ export async function initEditClient(userId) {
     regenProgress,
     getUserId: () => userId
   });
+
+  if (generateBtn) {
+    try {
+      const resp = await fetch(`${apiEndpoints.planStatus}?userId=${userId}`);
+      const data = await resp.json().catch(() => ({}));
+      if (data.planStatus === 'ready') {
+        generateBtn.disabled = true;
+      } else {
+        setupPlanRegeneration({
+          regenBtn: generateBtn,
+          regenProgress,
+          getUserId: () => userId
+        });
+      }
+    } catch (err) {
+      console.error('planStatus check error:', err);
+      generateBtn.disabled = true;
+    }
+  }
 
   const aiSummaryBtn = document.getElementById('aiSummary');
   if (aiSummaryBtn) {


### PR DESCRIPTION
## Summary
- add "Създай план" button in admin panel
- initialize plan generation with status check for new button
- test that plan generation starts when plan is missing

## Testing
- `npm run lint`
- `npm test js/__tests__/adminGeneratePlan.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68942ac3a9308326ae27506d21594a2c