### PR TITLE
Показване на текущи макро стойности

### DIFF
--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -24,7 +24,8 @@ beforeEach(async () => {
     removeMealMacros: jest.fn(),
     registerNutrientOverrides: jest.fn(),
     getNutrientOverride: jest.fn(() => null),
-    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] })
+    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] }),
+    calculateMacroPercents: jest.fn(() => ({ protein_percent: 0, carbs_percent: 0, fat_percent: 0 }))
   }));
   addExtraMealWithOverrideMock = jest.fn();
   appendExtraMealCardMock = jest.fn();

--- a/js/__tests__/loadProductMacrosInit.test.js
+++ b/js/__tests__/loadProductMacrosInit.test.js
@@ -4,7 +4,7 @@ import { jest } from '@jest/globals';
 test('initializeApp продължава при грешка в loadProductMacros', async () => {
   const loadProductMacros = jest.fn().mockRejectedValue(new Error('missing'));
 
-  jest.unstable_mockModule('../macroUtils.js', () => ({ loadProductMacros, calculateCurrentMacros: jest.fn(), calculatePlanMacros: jest.fn() }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({ loadProductMacros, calculateCurrentMacros: jest.fn(), calculatePlanMacros: jest.fn(), calculateMacroPercents: jest.fn(() => ({ protein_percent: 0, carbs_percent: 0, fat_percent: 0 })) }));
   jest.unstable_mockModule('../config.js', () => ({ isLocalDevelopment: false, apiEndpoints: {} }));
   jest.unstable_mockModule('../logger.js', () => ({ debugLog: jest.fn(), enableDebug: jest.fn() }));
   jest.unstable_mockModule('../utils.js', () => ({

--- a/js/__tests__/macroCardStandaloneEmbed.test.js
+++ b/js/__tests__/macroCardStandaloneEmbed.test.js
@@ -33,10 +33,12 @@ beforeEach(async () => {
     currentIntakeMacros: {},
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),
-    currentUserId: 'u1'
+    currentUserId: 'u1',
+    recalculateCurrentIntakeMacros: jest.fn(),
+    resetAppState: jest.fn()
   }));
   jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
-  jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn(), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn(), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn(), calculateMacroPercents: jest.fn(() => ({ protein_percent: 0, carbs_percent: 0, fat_percent: 0 })) }));
   const mod = await import('../populateUI.js');
   handleAccordionToggle = mod.handleAccordionToggle;
 });

--- a/js/__tests__/macroThreshold.test.js
+++ b/js/__tests__/macroThreshold.test.js
@@ -9,7 +9,13 @@ test('buildMacroCardUrl appends user threshold', async () => {
   }));
   jest.unstable_mockModule('../uiElements.js', () => ({ selectors: {}, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
   jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
-  jest.unstable_mockModule('../macroUtils.js', () => ({ getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({ getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn(), calculateMacroPercents: jest.fn(() => ({ protein_percent: 0, carbs_percent: 0, fat_percent: 0 })), calculatePlanMacros: jest.fn() }));
+  jest.unstable_mockModule('../eventListeners.js', () => ({
+    ensureMacroAnalyticsElement: jest.fn(),
+    setupStaticEventListeners: jest.fn(),
+    setupDynamicEventListeners: jest.fn(),
+    initializeCollapsibleCards: jest.fn(),
+  }));
   jest.unstable_mockModule('../app.js', () => ({
     fullDashboardData: {},
     todaysMealCompletionStatus: {},
@@ -18,7 +24,9 @@ test('buildMacroCardUrl appends user threshold', async () => {
     todaysExtraMeals: [],
     loadCurrentIntake: jest.fn(),
     currentUserId: 'u1',
-    todaysPlanMacros: { calories:0, protein:0, carbs:0, fat:0, fiber:0 }
+    todaysPlanMacros: { calories:0, protein:0, carbs:0, fat:0, fiber:0 },
+    recalculateCurrentIntakeMacros: jest.fn(),
+    resetAppState: jest.fn()
   }));
   jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
   const { setMacroExceedThreshold, buildMacroCardUrl } = await import('../populateUI.js');

--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 import { jest } from '@jest/globals';
-import { calculateCurrentMacros, addMealMacros, removeMealMacros, registerNutrientOverrides, getNutrientOverride, calculatePlanMacros, loadProductMacros, scaleMacros, formatPercent, normalizeMacros, __testExports } from '../macroUtils.js';
+import { calculateCurrentMacros, addMealMacros, removeMealMacros, registerNutrientOverrides, getNutrientOverride, calculatePlanMacros, loadProductMacros, scaleMacros, formatPercent, normalizeMacros, calculateMacroPercents, __testExports } from '../macroUtils.js';
 
 test('calculateCurrentMacros sums macros from completed meals and extras', () => {
   const planMenu = {
@@ -128,4 +128,11 @@ test('formatPercent форматира съотношения', () => {
 test('normalizeMacros приема _grams полета', () => {
   const result = normalizeMacros({ calories: 50, protein_grams: 10 });
   expect(result).toEqual({ calories: 50, protein: 10, carbs: 0, fat: 0, fiber: 0 });
+});
+
+test('calculateMacroPercents изчислява проценти спрямо калориите', () => {
+  const result = calculateMacroPercents({ calories: 200, protein: 10, carbs: 20, fat: 5 });
+  expect(result).toEqual({ protein_percent: 20, carbs_percent: 40, fat_percent: 23 });
+  const zero = calculateMacroPercents({ calories: 0, protein: 10, carbs: 10, fat: 5 });
+  expect(zero).toEqual({ protein_percent: 0, carbs_percent: 0, fat_percent: 0 });
 });

--- a/js/__tests__/populateDashboardMacros.importOnce.test.js
+++ b/js/__tests__/populateDashboardMacros.importOnce.test.js
@@ -37,11 +37,13 @@ test('динамичният импорт на macroAnalyticsCardComponent се 
     currentIntakeMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),
-    currentUserId: 'u1'
+    currentUserId: 'u1',
+    recalculateCurrentIntakeMacros: jest.fn(),
+    resetAppState: jest.fn()
   }));
   jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
   jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
-  jest.unstable_mockModule('../macroUtils.js', () => ({ getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({ getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn(), calculateMacroPercents: jest.fn(() => ({ protein_percent: 0, carbs_percent: 0, fat_percent: 0 })), calculatePlanMacros: jest.fn() }));
   jest.unstable_mockModule('../../utils/debug.js', () => ({ logMacroPayload: jest.fn() }));
   const eventListenersMock = {
     ensureMacroAnalyticsElement: jest.fn(() => {

--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -60,6 +60,7 @@ test('recalculates macros automatically and shows spinner while loading', async 
   ];
   appState.fullDashboardData.planData = { week1Menu: { [currentDayKey]: dayMenu } };
   Object.assign(appState.todaysPlanMacros, macroUtils.calculatePlanMacros(dayMenu));
+  Object.assign(appState.currentIntakeMacros, { calories: 100, protein: 10, carbs: 15, fat: 5, fiber: 2 });
 
   const originalFetch = global.fetch;
   let resolveFetch;
@@ -77,7 +78,7 @@ test('recalculates macros automatically and shows spinner while loading', async 
   await promise;
 
   expect(selectors.macroMetricsPreview.classList.contains('hidden')).toBe(false);
-  expect(selectors.macroMetricsPreview.textContent).toContain('500');
+  expect(selectors.macroMetricsPreview.textContent).toContain('100');
   expect(container.innerHTML).not.toContain('spinner-border');
   global.fetch = originalFetch;
   const card = container.querySelector('macro-analytics-card');
@@ -112,8 +113,9 @@ test('валидира и отхвърля некоректни макро да�
 test('calculatePlanMacros се извиква само веднъж при кеширани стойности', async () => {
   jest.resetModules();
   const calcMock = jest.fn().mockReturnValue({ calories: 100, protein: 10, carbs: 20, fat: 5, fiber: 3 });
-  jest.unstable_mockModule('../macroUtils.js', () => ({ loadProductMacros: jest.fn(), calculateCurrentMacros: jest.fn(), calculatePlanMacros: calcMock, getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), removeMealMacros: jest.fn(), scaleMacros: jest.fn(), registerNutrientOverrides: jest.fn() }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({ loadProductMacros: jest.fn(), calculateCurrentMacros: jest.fn(), calculatePlanMacros: calcMock, getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), removeMealMacros: jest.fn(), scaleMacros: jest.fn(), registerNutrientOverrides: jest.fn(), calculateMacroPercents: jest.fn(() => ({ protein_percent: 0, carbs_percent: 0, fat_percent: 0 })) }));
   const app = await import('../app.js');
+  Object.assign(app.currentIntakeMacros, { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 });
   const populate = await import('../populateUI.js');
   const { populateDashboardMacros } = populate;
   const { selectors } = await import('../uiElements.js');
@@ -147,6 +149,7 @@ test('игнорира подадения план и използва сума�
   ];
   const summed = macroUtils.calculatePlanMacros(dayMenu);
   Object.assign(appState.todaysPlanMacros, summed);
+  Object.assign(appState.currentIntakeMacros, { calories: 150, protein: 12, carbs: 20, fat: 6, fiber: 3 });
   await populateDashboardMacros(macros);
   const card = document.querySelector('macro-analytics-card');
   const [payload] = card.setData.mock.calls[0];
@@ -157,5 +160,5 @@ test('игнорира подадения план и използва сума�
     fat_grams: summed.fat,
     fiber_grams: summed.fiber
   });
-  expect(selectors.macroMetricsPreview.textContent).toContain(String(summed.calories));
+  expect(selectors.macroMetricsPreview.textContent).toContain('150');
 });

--- a/js/__tests__/renderPendingMacroChart.test.js
+++ b/js/__tests__/renderPendingMacroChart.test.js
@@ -36,11 +36,13 @@ describe('renderPendingMacroChart', () => {
       todaysExtraMeals: [],
       todaysPlanMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
       loadCurrentIntake: jest.fn(),
-      currentUserId: 'u1'
+      currentUserId: 'u1',
+      recalculateCurrentIntakeMacros: jest.fn(),
+      resetAppState: jest.fn()
     }));
     jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
     jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
-    jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn().mockReturnValue({ calories: 850, protein: 72, carbs: 70, fat: 28 }), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn() }));
+    jest.unstable_mockModule('../macroUtils.js', () => ({ calculatePlanMacros: jest.fn().mockReturnValue({ calories: 850, protein: 72, carbs: 70, fat: 28 }), getNutrientOverride: jest.fn(), addMealMacros: jest.fn(), scaleMacros: jest.fn(), calculateMacroPercents: jest.fn(() => ({ protein_percent: 0, carbs_percent: 0, fat_percent: 0 })) }));
     const eventListenersMock = {
       ensureMacroAnalyticsElement: jest.fn(() => {
         let el = document.querySelector('macro-analytics-card');

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -125,6 +125,24 @@ export function formatPercent(ratio, fractionDigits = 0) {
   return `${(val * 100).toFixed(fractionDigits)}%`;
 }
 
+/**
+ * Изчислява процентното съотношение на макросите спрямо общите калории.
+ * @param {{calories:number, protein:number, carbs:number, fat:number}} macros
+ * @returns {{protein_percent:number, carbs_percent:number, fat_percent:number}}
+ */
+export function calculateMacroPercents(macros = {}) {
+  const { calories = 0, protein = 0, carbs = 0, fat = 0 } = macros;
+  if (calories <= 0) {
+    return { protein_percent: 0, carbs_percent: 0, fat_percent: 0 };
+  }
+  const toPercent = (grams, kcalPerGram) => Math.round((grams * kcalPerGram / calories) * 100);
+  return {
+    protein_percent: toPercent(protein, 4),
+    carbs_percent: toPercent(carbs, 4),
+    fat_percent: toPercent(fat, 9)
+  };
+}
+
 function resolveMacros(meal, grams) {
   if (!meal) return { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
   let macros;

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -5,7 +5,7 @@ import { generateId, apiEndpoints, standaloneMacroUrl } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, loadCurrentIntake, recalculateCurrentIntakeMacros, currentUserId, todaysPlanMacros } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
 import { ensureChart } from './chartLoader.js';
-import { getNutrientOverride, scaleMacros, calculatePlanMacros } from './macroUtils.js';
+import { getNutrientOverride, scaleMacros, calculatePlanMacros, calculateMacroPercents } from './macroUtils.js';
 import { logMacroPayload } from '../utils/debug.js';
 import { ensureMacroAnalyticsElement } from './eventListeners.js';
 
@@ -415,11 +415,12 @@ function renderMacroPreviewGrid(macros) {
         return;
     }
     preview.classList.remove('hidden');
+    const percents = calculateMacroPercents(macros);
     const list = [
         { l: 'Калории', v: macros.calories, s: 'kcal', cls: 'calories' },
-        { l: 'Белтъчини', v: macros.protein_percent, s: '%' },
-        { l: 'Въглехидрати', v: macros.carbs_percent, s: '%' },
-        { l: 'Мазнини', v: macros.fat_percent, s: '%' }
+        { l: 'Белтъчини', v: macros.protein_percent ?? percents.protein_percent, s: '%' },
+        { l: 'Въглехидрати', v: macros.carbs_percent ?? percents.carbs_percent, s: '%' },
+        { l: 'Мазнини', v: macros.fat_percent ?? percents.fat_percent, s: '%' }
     ];
     const iconMap = {
         'Калории': 'bi-fire',
@@ -511,7 +512,7 @@ export async function populateDashboardMacros(macros) {
         return;
     }
 
-    renderMacroPreviewGrid(todaysPlanMacros);
+    renderMacroPreviewGrid(currentIntakeMacros);
     macroContainer.innerHTML = '';
     const plan = {
         calories: todaysPlanMacros.calories,


### PR DESCRIPTION
## Summary
- Показване на текущия макро прием в `macroMetricsPreview`
- Добавена функция за пресмятане на макро проценти спрямо калориите
- Актуализирани тестове и мокове за новата логика

## Testing
- `npm run lint`
- `npm test js/__tests__/populateDashboardMacros.test.js js/__tests__/macroThreshold.test.js js/__tests__/populateDashboardMacros.importOnce.test.js js/__tests__/renderPendingMacroChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6894294c10188326bff8ff1b8135853e