### PR TITLE
refactor: load plan mod chat modal as partial

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -520,6 +520,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="js/admin.js"></script>
+  <script type="module" src="js/planModChat.js"></script>
   <script type="module" src="js/adminColors.js"></script>
 </body>
 </html>

--- a/code.html
+++ b/code.html
@@ -1055,48 +1055,7 @@
       </div>
 
       <!-- Plan Modification Chat Modal -->
-      <div
-        id="planModChatModal"
-        class="modal"
-        role="dialog"
-        aria-labelledby="planModChatTitle"
-        aria-modal="true"
-        aria-hidden="true"
-      >
-        <div class="modal-content plan-mod-chat-content">
-          <div class="plan-mod-chat-header">
-            <h4 id="planModChatTitle"><img src="img/assisticon.png" class="icon assistant-icon" alt="" aria-hidden="true"> Промяна на план</h4>
-            <div class="chat-actions">
-              <button
-                id="planModChatClear"
-                class="plan-mod-chat-clear"
-                aria-label="Изчисти чата"
-              >
-                🗑
-              </button>
-              <button
-                id="planModChatClose"
-                class="plan-mod-chat-close"
-                aria-label="Затвори чата"
-              >
-                <svg class="icon"><use href="#icon-close"></use></svg>
-              </button>
-            </div>
-          </div>
-          <div id="planModChatMessages" class="plan-mod-chat-messages"></div>
-          <div class="plan-mod-chat-input-area">
-            <textarea
-              id="planModChatInput"
-              placeholder="Вашето съобщение..."
-              rows="2"
-              aria-label="Поле за въвеждане на съобщение"
-            ></textarea>
-            <button id="planModChatSend" aria-label="Изпрати съобщение">
-              <svg class="icon"><use href="#icon-send"></use></svg>
-            </button>
-          </div>
-        </div>
-      </div>
+      <div id="planModChatModalContainer"></div>
       <!-- ======================= END MODAL WINDOWS =========================== -->
 
       <!-- ======================================================================= -->
@@ -1173,6 +1132,13 @@
     <!-- End #appWrapper -->
 
     <!-- Коригирана JavaScript Връзка -->
+    <script type="module">
+      import { loadTemplateInto } from './js/templateLoader.js';
+      import { initializeSelectors } from './js/uiElements.js';
+      loadTemplateInto('partials/planModChatModal.html', 'planModChatModalContainer').then(() => {
+        initializeSelectors();
+      });
+    </script>
     <script type="module" src="js/app.js" defer></script>
     <script type="module" src="js/planModChat.js" defer></script>
   </body>

--- a/editclient.html
+++ b/editclient.html
@@ -72,6 +72,7 @@
                         <li><hr class="dropdown-divider"></li>
                         <li><button class="dropdown-item" id="regeneratePlan" type="button"><i class="bi bi-arrow-repeat"></i> Генерирай нов план</button></li>
                         <li><button class="dropdown-item" id="aiSummary" type="button"><i class="bi bi-robot"></i> AI резюме</button></li>
+                        <li><button class="dropdown-item" id="planModBtn" type="button"><i class="bi bi-chat-dots"></i> Промени план</button></li>
                         <li><button class="dropdown-item" id="exportData" type="button"><i class="bi bi-download"></i> Експортирай всички данни</button></li>
                         <li><button class="dropdown-item" id="exportPlan" type="button"><i class="bi bi-file-earmark-code"></i> Експортирай плана JSON</button></li>
                         <li><button class="dropdown-item" id="exportCsv" type="button"><i class="bi bi-file-earmark-spreadsheet"></i> Експортирай дневниците CSV</button></li>
@@ -534,10 +535,11 @@
     </div>
     </div>
 
+    <div id="planModChatModalContainer"></div>
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Chart.js for visualizations -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="module" src="js/editClient.js"></script>
-</body>
+  </body>
 </html>

--- a/js/admin.js
+++ b/js/admin.js
@@ -8,6 +8,8 @@ import { loadMaintenanceFlag, setMaintenanceFlag } from './maintenanceMode.js';
 import { renderTemplate } from '../utils/templateRenderer.js';
 import { ensureChart } from './chartLoader.js';
 import { setupPlanRegeneration } from './planRegenerator.js';
+import { openPlanModificationChat } from './planModChat.js';
+import { initializeSelectors } from './uiElements.js';
 
 async function ensureLoggedIn() {
     if (localStorage.getItem('adminSession') === 'true') {
@@ -1029,6 +1031,16 @@ async function showClient(userId) {
         adminProfileContainer.innerHTML = '';
         history.replaceState(null, '', `?userId=${encodeURIComponent(userId)}`);
         await loadTemplateInto('editclient.html', 'adminProfileContainer');
+        await loadTemplateInto('partials/planModChatModal.html', 'planModChatModalContainer');
+        try {
+            initializeSelectors();
+        } catch (e) {
+            console.warn('initializeSelectors warning', e);
+        }
+        const planModBtn = document.getElementById('planModBtn');
+        if (planModBtn) {
+            planModBtn.addEventListener('click', () => openPlanModificationChat(userId));
+        }
         const mod = await import('./editClient.js');
         try {
             await mod.initEditClient(userId);

--- a/partials/planModChatModal.html
+++ b/partials/planModChatModal.html
@@ -1,0 +1,42 @@
+<div
+  id="planModChatModal"
+  class="modal"
+  role="dialog"
+  aria-labelledby="planModChatTitle"
+  aria-modal="true"
+  aria-hidden="true"
+>
+  <div class="modal-content plan-mod-chat-content">
+    <div class="plan-mod-chat-header">
+      <h4 id="planModChatTitle"><img src="img/assisticon.png" class="icon assistant-icon" alt="" aria-hidden="true"> Промяна на план</h4>
+      <div class="chat-actions">
+        <button
+          id="planModChatClear"
+          class="plan-mod-chat-clear"
+          aria-label="Изчисти чата"
+        >
+          🗑
+        </button>
+        <button
+          id="planModChatClose"
+          class="plan-mod-chat-close"
+          aria-label="Затвори чата"
+        >
+          <svg class="icon"><use href="#icon-close"></use></svg>
+        </button>
+      </div>
+    </div>
+    <div id="planModChatMessages" class="plan-mod-chat-messages"></div>
+    <div class="plan-mod-chat-input-area">
+      <textarea
+        id="planModChatInput"
+        placeholder="Вашето съобщение..."
+        rows="2"
+        aria-label="Поле за въвеждане на съобщение"
+      ></textarea>
+      <button id="planModChatSend" aria-label="Изпрати съобщение">
+        <svg class="icon"><use href="#icon-send"></use></svg>
+      </button>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- extract Plan Modification Chat modal to `partials/planModChatModal.html`
- dynamically load modal in code and admin client views
- wire admin client button to open plan modification chat

## Testing
- `npm run lint`
- `npm test planModChat handleChatRequestPlanMod`


------
https://chatgpt.com/codex/tasks/task_e_6894d53098f48326b82a558e63cf49e3