### PR TITLE
feat: support admin context in plan modification chat

### DIFF
--- a/code.html
+++ b/code.html
@@ -1133,9 +1133,9 @@
 
     <!-- Коригирана JavaScript Връзка -->
     <script type="module">
-      import { loadTemplateInto } from './js/templateLoader.js';
+      import { loadPartial } from './js/partialLoader.js';
       import { initializeSelectors } from './js/uiElements.js';
-      loadTemplateInto('partials/planModChatModal.html', 'planModChatModalContainer').then(() => {
+      loadPartial('planModChatModal.html', 'planModChatModalContainer').then(() => {
         initializeSelectors();
       });
     </script>

--- a/js/__tests__/planModChat.test.js
+++ b/js/__tests__/planModChat.test.js
@@ -458,3 +458,79 @@ describe('openPlanModificationChat errors', () => {
     expect(showToastMock).toHaveBeenCalledWith('srv', true);
   });
 });
+
+describe('openPlanModificationChat context', () => {
+  let app;
+  beforeEach(async () => {
+    jest.resetModules();
+    const planModChatMessages = document.createElement('div');
+    const selectors = {
+      chatWidget: { classList: { contains: () => true } },
+      chatInput: null,
+      planModChatMessages,
+      planModChatInput: { value: 'hello', disabled: false, focus: jest.fn() },
+      planModChatSend: { disabled: false }
+    };
+    jest.unstable_mockModule('../uiElements.js', () => ({
+      selectors,
+      initializeSelectors: jest.fn(),
+      trackerInfoTexts: {},
+      detailedMetricInfoTexts: {},
+      loadInfoTexts: jest.fn(() => Promise.resolve())
+    }));
+    jest.unstable_mockModule('../uiHandlers.js', () => ({
+      toggleMenu: jest.fn(),
+      closeMenu: jest.fn(),
+      handleOutsideMenuClick: jest.fn(),
+      handleMenuKeydown: jest.fn(),
+      initializeTheme: jest.fn(),
+      applyTheme: jest.fn(),
+      toggleTheme: jest.fn(),
+      updateThemeButtonText: jest.fn(),
+      activateTab: jest.fn(),
+      handleTabKeydown: jest.fn(),
+      openModal: jest.fn(),
+      closeModal: jest.fn(),
+      openInstructionsModal: jest.fn(),
+      openInfoModalWithDetails: jest.fn(),
+      openMainIndexInfo: jest.fn(),
+      toggleDailyNote: jest.fn(),
+      showTrackerTooltip: jest.fn(),
+      hideTrackerTooltip: jest.fn(),
+      handleTrackerTooltipShow: jest.fn(),
+      handleTrackerTooltipHide: jest.fn(),
+      loadAndApplyColors: jest.fn(),
+      showLoading: jest.fn(),
+      showToast: jest.fn(),
+      updateTabsOverflowIndicator: jest.fn()
+    }));
+    jest.unstable_mockModule('../chat.js', () => ({
+      toggleChatWidget: jest.fn(),
+      closeChatWidget: jest.fn(),
+      clearChat: jest.fn(),
+      displayMessage: jest.fn(),
+      displayTypingIndicator: jest.fn(),
+      scrollToChatBottom: jest.fn(),
+      setAutomatedChatPending: jest.fn()
+    }));
+    jest.unstable_mockModule('../config.js', () => ({
+      isLocalDevelopment: false,
+      workerBaseUrl: '',
+      apiEndpoints: { getPlanModificationPrompt: '/prompt', chat: '/chat' },
+      generateId: jest.fn(),
+      standaloneMacroUrl: 'macroAnalyticsCardStandalone.html'
+    }));
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ prompt: 'p' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, reply: 'ok' }) });
+    app = await import('../app.js');
+  });
+
+  test('sends userIdOverride and context', async () => {
+    await app.openPlanModificationChat('uX', 'start', 'admin');
+    const payload = JSON.parse(global.fetch.mock.calls[1][1].body);
+    expect(payload.userId).toBe('uX');
+    expect(payload.context).toBe('admin');
+  });
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -3,6 +3,7 @@ import { loadConfig, saveConfig } from './adminConfig.js';
 import { labelMap, statusMap } from './labelMap.js';
 import { fileToDataURL, fileToText, applyProgressFill } from './utils.js';
 import { loadTemplateInto } from './templateLoader.js';
+import { loadPartial } from './partialLoader.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 import { loadMaintenanceFlag, setMaintenanceFlag } from './maintenanceMode.js';
 import { renderTemplate } from '../utils/templateRenderer.js';
@@ -1031,7 +1032,7 @@ async function showClient(userId) {
         adminProfileContainer.innerHTML = '';
         history.replaceState(null, '', `?userId=${encodeURIComponent(userId)}`);
         await loadTemplateInto('editclient.html', 'adminProfileContainer');
-        await loadTemplateInto('partials/planModChatModal.html', 'planModChatModalContainer');
+        await loadPartial('planModChatModal.html', 'planModChatModalContainer');
         try {
             initializeSelectors();
         } catch (e) {
@@ -1039,7 +1040,7 @@ async function showClient(userId) {
         }
         const planModBtn = document.getElementById('planModBtn');
         if (planModBtn) {
-            planModBtn.addEventListener('click', () => openPlanModificationChat(userId));
+            planModBtn.addEventListener('click', () => openPlanModificationChat(userId, null, 'admin'));
         }
         const mod = await import('./editClient.js');
         try {

--- a/js/partialLoader.js
+++ b/js/partialLoader.js
@@ -1,0 +1,5 @@
+import { loadTemplateInto } from './templateLoader.js';
+
+export function loadPartial(name, containerId) {
+  return loadTemplateInto(`partials/${name}`, containerId);
+}

--- a/js/planModChat.js
+++ b/js/planModChat.js
@@ -13,6 +13,7 @@ import {
 } from './app.js';
 
 export let planModChatHistory = [];
+export let planModChatContext = null;
 let isSending = false;
 
 const planModificationPrompt = 'Моля, опишете накратко желаните от вас промени в плана.';
@@ -20,6 +21,7 @@ const planModificationPrompt = 'Моля, опишете накратко жел
 export function clearPlanModChat() {
   if (selectors.planModChatMessages) selectors.planModChatMessages.innerHTML = '';
   planModChatHistory.length = 0;
+  planModChatContext = null;
 }
 
 export function displayPlanModChatMessage(text, sender = 'bot', isError = false) {
@@ -76,6 +78,7 @@ async function sendPlanModChatMessage({ messageText, userId }) {
       history: planModChatHistory.slice(-10),
       source: 'planModChat'
     };
+    if (planModChatContext) payload.context = planModChatContext;
     if (chatModelOverride) payload.model = chatModelOverride;
     if (chatPromptOverride) payload.promptOverride = chatPromptOverride;
     const response = await fetch(apiEndpoints.chat, {
@@ -125,13 +128,14 @@ export function handlePlanModChatInputKeypress(e) {
   }
 }
 
-export async function openPlanModificationChat(userIdOverride = null, initialMessage = null) {
+export async function openPlanModificationChat(userIdOverride = null, initialMessage = null, context = null) {
   const uid = userIdOverride || currentUserId;
   if (!uid) {
     showToast('Моля, влезте първо.', true);
     return;
   }
   clearPlanModChat();
+  planModChatContext = context;
   openModal('planModChatModal');
   if (selectors.planModChatInput) selectors.planModChatInput.disabled = true;
   if (selectors.planModChatSend) selectors.planModChatSend.disabled = true;


### PR DESCRIPTION
## Summary
- add reusable partial loader
- allow openPlanModificationChat to accept context and log admin sessions
- cover admin context with dedicated tests

## Testing
- `npm run lint`
- `npm test planModChat`


------
https://chatgpt.com/codex/tasks/task_e_6894d7d65eec832699ef166401fb8211