### PR TITLE
Handle missing daily log

### DIFF
--- a/js/__tests__/loadCurrentIntake.test.js
+++ b/js/__tests__/loadCurrentIntake.test.js
@@ -47,6 +47,21 @@ test('loadCurrentIntake не презаписва подаденото съст�
   });
 });
 
+test('loadCurrentIntake нулира локалните данни при липса на дневен запис', async () => {
+  jest.resetModules();
+  const app = await import('../app.js');
+  const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+  Object.assign(app.fullDashboardData, {
+    planData: { week1Menu: {} },
+    dailyLogs: [{ date: yesterday, data: { extraMeals: [{ calories: 100 }] } }],
+  });
+  app.todaysExtraMeals.push({ calories: 50 });
+  app.todaysMealCompletionStatus.sample = true;
+  app.loadCurrentIntake();
+  expect(app.todaysExtraMeals).toEqual([]);
+  expect(app.todaysMealCompletionStatus).toEqual({});
+});
+
 test('recalculateCurrentIntakeMacros преизчислява макросите', async () => {
   jest.resetModules();
   const app = await import('../app.js');

--- a/js/app.js
+++ b/js/app.js
@@ -331,7 +331,11 @@ export function loadCurrentIntake(status = null, extraMeals = null) {
         if (!status || !extraMeals) {
             const todayStr = new Date().toISOString().split('T')[0];
             const todayLog = fullDashboardData?.dailyLogs?.find(l => l.date === todayStr)?.data;
-            if (!todayLog) return;
+            if (!todayLog) {
+                todaysExtraMeals = [];
+                Object.keys(todaysMealCompletionStatus).forEach(k => delete todaysMealCompletionStatus[k]);
+                return;
+            }
             const completed = todayLog.completedMealsStatus || {};
             Object.keys(todaysMealCompletionStatus).forEach(k => delete todaysMealCompletionStatus[k]);
             Object.assign(todaysMealCompletionStatus, completed);


### PR DESCRIPTION
## Summary
- clear extra meals and meal status when no daily log is found
- add regression test for day change without log

## Testing
- `npx eslint js/app.js js/__tests__/loadCurrentIntake.test.js`
- `npm test js/__tests__/loadCurrentIntake.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68953d2a0e608326828c896edb9d0f7f