### PR TITLE
Refactor daily logs storage

### DIFF
--- a/data/macroPayloadDebug.json
+++ b/data/macroPayloadDebug.json
@@ -1,13 +1,17 @@
 {
-  "error": "Invalid macro payload structure",
-  "payload": {
-    "plan": {
-      "calories": 0,
-      "protein_grams": 0,
-      "carbs_grams": 0,
-      "fat_grams": 0,
-      "fiber_grams": 0
-    },
-    "current": {}
+  "plan": {
+    "calories": 0,
+    "protein_grams": 0,
+    "carbs_grams": 0,
+    "fat_grams": 0,
+    "fiber_grams": 0
+  },
+  "current": {
+    "calories": 1000,
+    "protein_grams": 0,
+    "carbs_grams": 0,
+    "fat_grams": 0,
+    "fiber_grams": 0
   }
+}  }
 }


### PR DESCRIPTION
## Summary
- store daily logs per day instead of array
- fetch log history via prefix listing sorted by date
- remove legacy daily summary

## Testing
- `npm run lint`
- `npm test` *(failing: populateUI.test.js and others due to missing exports)*

------
https://chatgpt.com/codex/tasks/task_e_6895413037a48326970841baf65ace74