### PR TITLE
Expose plan modification button in admin toolbar

### DIFF
--- a/editclient.html
+++ b/editclient.html
@@ -61,6 +61,7 @@
             <div class="ms-auto d-flex align-items-center">
                 <button class="btn btn-danger me-2" id="global-cancel-btn">Отказ Всички</button>
                 <button class="btn btn-success me-3" id="global-save-btn">Запази Всички Промени</button>
+                <button class="btn btn-primary me-3" id="planModBtn"><i class="bi bi-chat-dots"></i> Промени план</button>
                 <div class="dropdown">
                     <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                         <i class="bi bi-tools"></i> Инструменти
@@ -72,7 +73,6 @@
                         <li><hr class="dropdown-divider"></li>
                         <li><button class="dropdown-item" id="regeneratePlan" type="button"><i class="bi bi-arrow-repeat"></i> Генерирай нов план</button></li>
                         <li><button class="dropdown-item" id="aiSummary" type="button"><i class="bi bi-robot"></i> AI резюме</button></li>
-                        <li><button class="dropdown-item" id="planModBtn" type="button"><i class="bi bi-chat-dots"></i> Промени план</button></li>
                         <li><button class="dropdown-item" id="exportData" type="button"><i class="bi bi-download"></i> Експортирай всички данни</button></li>
                         <li><button class="dropdown-item" id="exportPlan" type="button"><i class="bi bi-file-earmark-code"></i> Експортирай плана JSON</button></li>
                         <li><button class="dropdown-item" id="exportCsv" type="button"><i class="bi bi-file-earmark-spreadsheet"></i> Експортирай дневниците CSV</button></li>


### PR DESCRIPTION
## Summary
- Move "Промени план" action from dropdown to main toolbar for easier access.

## Testing
- `npm run lint`
- `npm test` *(fails: missing exports in multiple test suites)*

------
https://chatgpt.com/codex/tasks/task_e_689542fc43808326a0c5290e6dfb3935