### PR TITLE
Add plan modification button with global listener

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -272,6 +272,7 @@
     <button id="generatePlan">Създай план</button>
     <div id="regenProgress" class="hidden" aria-live="polite"></div>
     <button id="aiSummary">AI резюме</button>
+    <button id="planModBtn">Промени план</button>
     <div class="profile-nav-container">
       <button id="profileCardNavToggle" class="profile-nav-toggle" aria-label="Показване на навигацията">
         <i class="fas fa-bars"></i>

--- a/js/admin.js
+++ b/js/admin.js
@@ -12,6 +12,9 @@ import { setupPlanRegeneration } from './planRegenerator.js';
 import { openPlanModificationChat } from './planModChat.js';
 import { initializeSelectors } from './uiElements.js';
 
+let activeUserId = null;
+let activeClientName = null;
+
 async function ensureLoggedIn() {
     if (localStorage.getItem('adminSession') === 'true') {
         return;
@@ -37,6 +40,7 @@ const detailsSection = document.getElementById('clientDetails');
 const regenBtn = document.getElementById('regeneratePlan');
 const regenProgress = document.getElementById('regenProgress');
 const aiSummaryBtn = document.getElementById('aiSummary');
+const planModBtn = document.getElementById('planModBtn');
 const notesField = document.getElementById('adminNotes');
 const tagsField = document.getElementById('adminTags');
 const saveNotesBtn = document.getElementById('saveNotes');
@@ -106,6 +110,7 @@ const analysisModelInput = document.getElementById('analysisModel');
 const analysisPromptInput = document.getElementById('analysisPrompt');
 const testAnalysisBtn = document.getElementById('testAnalysisModel');
 
+if (planModBtn) planModBtn.addEventListener('click', () => openPlanModificationChat(activeUserId, null, 'admin', activeClientName));
 
 const modelOptionsList = document.getElementById('modelOptions');
 let availableModels = new Set(JSON.parse(localStorage.getItem('aiModelHistory') || '[]'));
@@ -1038,11 +1043,6 @@ async function showClient(userId) {
         } catch (e) {
             console.warn('initializeSelectors warning', e);
         }
-        let planModClientName = userId;
-        const planModBtn = document.getElementById('planModBtn');
-        if (planModBtn) {
-            planModBtn.addEventListener('click', () => openPlanModificationChat(userId, null, 'admin', planModClientName));
-        }
         const mod = await import('./editClient.js');
         try {
             await mod.initEditClient(userId);
@@ -1118,7 +1118,8 @@ async function showClient(userId) {
             const clientInfo = allClients.find(c => c.userId === userId);
             const regDate = clientInfo?.registrationDate ? new Date(clientInfo.registrationDate).toLocaleDateString('bg-BG') : '';
             const name = clientInfo?.name || data.name || userId;
-            planModClientName = name;
+            activeUserId = userId;
+            activeClientName = name;
             clientNameHeading.textContent = regDate ? `${name} - ${regDate}` : name;
             if (profileName) profileName.value = data.name || '';
             if (profileEmail) profileEmail.value = data.email || '';


### PR DESCRIPTION
## Summary
- add "Промени план" button in admin profile section
- wire button to openPlanModificationChat using active user and client name

## Testing
- `npm run lint`
- `npm test js/__tests__/planModChat.test.js`
- `npm test` *(fails: The requested module './app.js' does not provide an export named 'recalculateCurrentIntakeMacros'; The requested module './app.js' does not provide an export named 'chatModelOverride')*


------
https://chatgpt.com/codex/tasks/task_e_68955008263c832684655c54cd677c3c