### PR TITLE
Поддръжка на обединени дневници

### DIFF
--- a/js/__tests__/dashboardDataUnifiedLogs.test.js
+++ b/js/__tests__/dashboardDataUnifiedLogs.test.js
@@ -1,0 +1,36 @@
+import { jest } from '@jest/globals';
+import { handleDashboardDataRequest } from '../../worker.js';
+
+const daysOrder = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
+
+describe('handleDashboardDataRequest unified logs', () => {
+  test('използва обединения масив при липса на индивидуални ключове', async () => {
+    const today = new Date();
+    const dayKey = daysOrder[today.getDay()];
+    const dateStr = today.toISOString().split('T')[0];
+    const aggregated = JSON.stringify([{ date: dateStr, log: { mood: 3, energy: 4, completedMealsStatus: {} } }]);
+
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(key => {
+          if (key === 'u1_initial_answers') return Promise.resolve(JSON.stringify({ name: 'U', weight: '70', height: '170', goal: 'lose' }));
+          if (key === 'u1_final_plan') return Promise.resolve(JSON.stringify({ caloriesMacros: { p: 1 }, week1Menu: { [dayKey]: ['a','b','c','d','e'] } }));
+          if (key === 'plan_status_u1') return Promise.resolve('ready');
+          if (key === 'u1_current_status') return Promise.resolve('{}');
+          if (key === 'u1_profile') return Promise.resolve('{}');
+          if (key === 'u1_logs') return Promise.resolve(aggregated);
+          return Promise.resolve(null);
+        }),
+        put: jest.fn(),
+        list: jest.fn().mockResolvedValue({ keys: [] })
+      },
+      RESOURCES_KV: { get: jest.fn(async () => '{}') }
+    };
+
+    const request = { url: 'https://example.com?userId=u1' };
+    const res = await handleDashboardDataRequest(request, env);
+    expect(res.dailyLogs).toHaveLength(1);
+    const expected = Math.round(((0) * 0.4) + (((2 / 5) * 100) * 0.4) + (((1 / 7) * 100) * 0.2));
+    expect(res.analytics.current.engagementScore).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- чете `${userId}_logs` при липса на отделни `_log_` ключове и нормализира дневниците
- адаптира `calculateAnalyticsIndexes` да приема новия формат на логове
- добавя тест за метрики при обединен дневник

## Testing
- `npm run lint`
- `npm test js/__tests__/dashboardDataMacros.test.js js/__tests__/dailyLog.test.js js/__tests__/engagementAnalytics.test.js js/__tests__/dashboardDataUnifiedLogs.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68954f9e89f88326965fb61c309db98c