### PR TITLE
Админ: динамична инициализация на плановия чат

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -40,7 +40,6 @@ const detailsSection = document.getElementById('clientDetails');
 const regenBtn = document.getElementById('regeneratePlan');
 const regenProgress = document.getElementById('regenProgress');
 const aiSummaryBtn = document.getElementById('aiSummary');
-const planModBtn = document.getElementById('planModBtn');
 const notesField = document.getElementById('adminNotes');
 const tagsField = document.getElementById('adminTags');
 const saveNotesBtn = document.getElementById('saveNotes');
@@ -110,7 +109,6 @@ const analysisModelInput = document.getElementById('analysisModel');
 const analysisPromptInput = document.getElementById('analysisPrompt');
 const testAnalysisBtn = document.getElementById('testAnalysisModel');
 
-if (planModBtn) planModBtn.addEventListener('click', () => openPlanModificationChat(activeUserId, null, 'admin', activeClientName));
 
 const modelOptionsList = document.getElementById('modelOptions');
 let availableModels = new Set(JSON.parse(localStorage.getItem('aiModelHistory') || '[]'));
@@ -1038,6 +1036,8 @@ async function showClient(userId) {
         history.replaceState(null, '', `?userId=${encodeURIComponent(userId)}`);
         await loadTemplateInto('editclient.html', 'adminProfileContainer');
         await loadPartial('planModChatModal.html', 'planModChatModalContainer');
+        const planModBtn = document.getElementById('planModBtn');
+        planModBtn?.addEventListener('click', () => openPlanModificationChat(userId, null, 'admin', activeClientName));
         try {
             initializeSelectors();
         } catch (e) {


### PR DESCRIPTION
## Резюме
- Зареждане и закачане на бутона за модификация на план след динамично зареждане на `editclient.html`.
- Предаване на актуалното име на клиента към чата за модификация.

## Тестване
- `npm run lint`
- `npm test` *(неуспешно: SyntaxError в няколко тестови файла)*

------
https://chatgpt.com/codex/tasks/task_e_68955372a30883269aee3dfcfd5ae11f