### PR TITLE
Централизиран контрол на бутона за промяна на план

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -272,7 +272,7 @@
     <button id="generatePlan">Създай план</button>
     <div id="regenProgress" class="hidden" aria-live="polite"></div>
     <button id="aiSummary">AI резюме</button>
-    <button id="planModBtn">Промени план</button>
+    <button id="planModificationBtn">Промени план</button>
     <div class="profile-nav-container">
       <button id="profileCardNavToggle" class="profile-nav-toggle" aria-label="Показване на навигацията">
         <i class="fas fa-bars"></i>

--- a/editclient.html
+++ b/editclient.html
@@ -61,7 +61,7 @@
             <div class="ms-auto d-flex align-items-center">
                 <button class="btn btn-danger me-2" id="global-cancel-btn">Отказ Всички</button>
                 <button class="btn btn-success me-3" id="global-save-btn">Запази Всички Промени</button>
-                <button class="btn btn-primary me-3" id="planModBtn"><i class="bi bi-chat-dots"></i> Промени план</button>
+                <button class="btn btn-primary me-3" id="planModificationBtn"><i class="bi bi-chat-dots"></i> Промени план</button>
                 <div class="dropdown">
                     <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                         <i class="bi bi-tools"></i> Инструменти

--- a/js/admin.js
+++ b/js/admin.js
@@ -9,8 +9,8 @@ import { loadMaintenanceFlag, setMaintenanceFlag } from './maintenanceMode.js';
 import { renderTemplate } from '../utils/templateRenderer.js';
 import { ensureChart } from './chartLoader.js';
 import { setupPlanRegeneration } from './planRegenerator.js';
-import { openPlanModificationChat } from './planModChat.js';
 import { initializeSelectors } from './uiElements.js';
+import { setupStaticEventListeners } from './eventListeners.js';
 
 let activeUserId = null;
 let activeClientName = null;
@@ -1036,10 +1036,9 @@ async function showClient(userId) {
         history.replaceState(null, '', `?userId=${encodeURIComponent(userId)}`);
         await loadTemplateInto('editclient.html', 'adminProfileContainer');
         await loadPartial('planModChatModal.html', 'planModChatModalContainer');
-        const planModBtn = document.getElementById('planModBtn');
-        planModBtn?.addEventListener('click', () => openPlanModificationChat(userId, null, 'admin', activeClientName));
         try {
             initializeSelectors();
+            setupStaticEventListeners();
         } catch (e) {
             console.warn('initializeSelectors warning', e);
         }

--- a/js/initProfilePage.js
+++ b/js/initProfilePage.js
@@ -1,9 +1,8 @@
 import { loadTemplateInto } from './templateLoader.js';
 import { loadPartial } from './partialLoader.js';
 import { initClientProfile } from './clientProfile.js';
-import { openPlanModificationChat, clearPlanModChat, handlePlanModChatSend, handlePlanModChatInputKeypress } from './planModChat.js';
-import { selectors } from './uiElements.js';
-import { closeModal } from './uiHandlers.js';
+import { initializeSelectors } from './uiElements.js';
+import { setupStaticEventListeners } from './eventListeners.js';
 import { setCurrentUserId } from './app.js';
 
 function getUserId() {
@@ -15,26 +14,11 @@ async function initPage() {
   await loadTemplateInto('profileTemplate.html', 'profileContainer');
   await loadPartial('planModChatModal.html', 'planModChatModalContainer');
 
-  selectors.planModChatModal = document.getElementById('planModChatModal');
-  selectors.planModChatMessages = document.getElementById('planModChatMessages');
-  selectors.planModChatInput = document.getElementById('planModChatInput');
-  selectors.planModChatSend = document.getElementById('planModChatSend');
-  selectors.planModChatClose = document.getElementById('planModChatClose');
-  selectors.planModChatClear = document.getElementById('planModChatClear');
-  selectors.planModChatTitle = document.getElementById('planModChatTitle');
-  selectors.planModChatClient = document.getElementById('planModChatClient');
+  initializeSelectors();
+  setupStaticEventListeners();
 
-  const btn = document.getElementById('planModBtn');
-  if (btn) {
-    const userId = getUserId();
-    setCurrentUserId(userId);
-    btn.addEventListener('click', () => openPlanModificationChat(userId, null, 'admin'));
-  }
-
-  selectors.planModChatClose?.addEventListener('click', () => closeModal('planModChatModal'));
-  selectors.planModChatClear?.addEventListener('click', clearPlanModChat);
-  selectors.planModChatSend?.addEventListener('click', handlePlanModChatSend);
-  selectors.planModChatInput?.addEventListener('keypress', handlePlanModChatInputKeypress);
+  const userId = getUserId();
+  setCurrentUserId(userId);
 
   initClientProfile();
 }

--- a/profileTemplate.html
+++ b/profileTemplate.html
@@ -391,7 +391,7 @@
                     <p class="mb-0"><i class="fas fa-bullseye me-2"></i><strong>Основна цел:</strong> <span id="userGoalHeader">--</span></p>
                 </div>
                 <div class="mt-2 mt-md-0">
-                    <button class="btn btn-primary" id="planModBtn"><i class="bi bi-chat-dots"></i> Промени план</button>
+                    <button class="btn btn-primary" id="planModificationBtn"><i class="bi bi-chat-dots"></i> Промени план</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Обобщение
- Преименуван `planModBtn` на `planModificationBtn` в основните шаблони.
- Премахнати ръчни слушатели за бутона; използвани `initializeSelectors` и `setupStaticEventListeners` за автоматична обработка.
- Уверено зареждане на `planModChatModal.html` и инициализация на селекторите при профилни страници и админ изглед.

## Тестване
- `npm run lint`
- `npm test js/__tests__/planModChat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689554a06c608326938c58ecafe7ffd9