### PR TITLE
Scale 1–5 scores to 20% increments

### DIFF
--- a/js/__tests__/populateDashboardDetailedAnalytics.test.js
+++ b/js/__tests__/populateDashboardDetailedAnalytics.test.js
@@ -1,0 +1,66 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+test('преобразува стойности 1 и 4 в 20% и 80%', async () => {
+  document.body.innerHTML = `
+    <div id="analyticsCardsContainer"></div>
+    <div id="macroAnalyticsCardContainer"></div>
+    <div id="detailedAnalyticsContent"></div>
+    <div id="dashboardTextualAnalysis"></div>
+  `;
+  const selectors = {
+    analyticsCardsContainer: document.getElementById('analyticsCardsContainer'),
+    macroAnalyticsCardContainer: document.getElementById('macroAnalyticsCardContainer'),
+    detailedAnalyticsContent: document.getElementById('detailedAnalyticsContent'),
+    dashboardTextualAnalysis: document.getElementById('dashboardTextualAnalysis')
+  };
+  jest.unstable_mockModule('../uiElements.js', () => ({ selectors, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
+  jest.unstable_mockModule('../eventListeners.js', () => ({
+    ensureMacroAnalyticsElement: jest.fn(),
+    setupStaticEventListeners: jest.fn(),
+    setupDynamicEventListeners: jest.fn(),
+    initializeCollapsibleCards: jest.fn(),
+  }));
+  jest.unstable_mockModule('../extraMealForm.js', () => ({ openExtraMealModal: jest.fn() }));
+  jest.unstable_mockModule('../utils.js', () => ({
+    safeGet: (obj, path, def) => path.split('.').reduce((o, k) => (o && o[k] !== undefined ? o[k] : undefined), obj) ?? def,
+    safeParseFloat: (v) => parseFloat(v),
+    capitalizeFirstLetter: (s) => s,
+    escapeHtml: (s) => s,
+    applyProgressFill: jest.fn(),
+    getCssVar: jest.fn(),
+    formatDateBgShort: () => ''
+  }));
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: {
+      userName: 'Иван',
+      analytics: {
+        current: {},
+        streak: {},
+        detailed: [
+          { label: 'Mood', currentValueText: '1', currentValueNumeric: 1 },
+          { label: 'Energy', currentValueText: '4', currentValueNumeric: 4 }
+        ]
+      },
+      planData: {},
+      dailyLogs: [],
+      currentStatus: {},
+      initialData: {},
+      initialAnswers: {}
+    },
+    todaysMealCompletionStatus: {},
+    todaysExtraMeals: [],
+    todaysPlanMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
+    currentIntakeMacros: {},
+    planHasRecContent: false,
+    loadCurrentIntake: jest.fn(),
+    recalculateCurrentIntakeMacros: jest.fn(),
+    currentUserId: 'u1'
+  }));
+  const { populateUI } = await import('../populateUI.js');
+  await populateUI();
+  const bars = document.querySelectorAll('#analyticsCardsContainer .analytics-card .mini-progress-bar');
+  expect(bars[0].getAttribute('aria-valuenow')).toBe('20');
+  expect(bars[1].getAttribute('aria-valuenow')).toBe('80');
+});

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -304,7 +304,7 @@ function populateDashboardDetailedAnalytics(analyticsData) {
 
             if (!isNaN(metric.currentValueNumeric)) {
                 const value = Number(metric.currentValueNumeric);
-                const percent = value <= 5 ? ((value - 1) / 4) * 100 : Math.max(0, Math.min(100, value));
+                const percent = value <= 5 ? value * 20 : Math.max(0, Math.min(100, value));
                 progress.setAttribute('aria-valuenow', `${Math.round(percent)}`);
                 applyProgressFill(fill, percent);
             }

--- a/worker.js
+++ b/worker.js
@@ -3913,9 +3913,9 @@ async function calculateAnalyticsIndexes(userId, initialAnswers, finalPlan, logE
 
     const score1To5ToPercentage = (value, invert = false) => {
         const numValue = Number(value) || 0;
-        // Scale 1-5 to 0-100: (value - 1) * 25
-        // (1-1)*25=0, (2-1)*25=25, (3-1)*25=50, (4-1)*25=75, (5-1)*25=100
-        const score = Math.max(0, Math.min(100, (numValue - 1) * 25));
+        // Scale 1-5 to 0-100: value * 20
+        // 1→20, 2→40, 3→60, 4→80, 5→100
+        const score = Math.max(0, Math.min(100, numValue * 20));
         const finalScore = invert ? 100 - score : score;
         return Math.round(finalScore);
     };


### PR DESCRIPTION
## Summary
- Adjust 1–5 scoring conversion to multiply by 20 in worker logic
- Align dashboard detailed analytics percent calculation with new 20% steps
- Add unit test ensuring metrics 1 and 4 map to 20% and 80%

## Testing
- `npx eslint js/populateUI.js js/__tests__/populateDashboardDetailedAnalytics.test.js worker.js`
- `npm test js/__tests__/populateDashboardDetailedAnalytics.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68955841d3508326af4f4de9855afde9