### PR TITLE
Добавяне на контейнер за чат и условно показване на бутона за промяна на плана

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -273,6 +273,7 @@
     <div id="regenProgress" class="hidden" aria-live="polite"></div>
     <button id="aiSummary">AI резюме</button>
     <button id="planModificationBtn">Промени план</button>
+    <div id="planModChatModalContainer"></div>
     <div class="profile-nav-container">
       <button id="profileCardNavToggle" class="profile-nav-toggle" aria-label="Показване на навигацията">
         <i class="fas fa-bars"></i>

--- a/editclient.html
+++ b/editclient.html
@@ -535,7 +535,6 @@
     </div>
     </div>
 
-    <div id="planModChatModalContainer"></div>
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Chart.js for visualizations -->

--- a/js/admin.js
+++ b/js/admin.js
@@ -41,6 +41,7 @@ const detailsSection = document.getElementById('clientDetails');
 const regenBtn = document.getElementById('regeneratePlan');
 const regenProgress = document.getElementById('regenProgress');
 const aiSummaryBtn = document.getElementById('aiSummary');
+const planModificationBtn = document.getElementById('planModificationBtn');
 const notesField = document.getElementById('adminNotes');
 const tagsField = document.getElementById('adminTags');
 const saveNotesBtn = document.getElementById('saveNotes');
@@ -113,6 +114,13 @@ const testAnalysisBtn = document.getElementById('testAnalysisModel');
 
 const modelOptionsList = document.getElementById('modelOptions');
 let availableModels = new Set(JSON.parse(localStorage.getItem('aiModelHistory') || '[]'));
+
+function togglePlanModificationBtn() {
+    if (!planModificationBtn) return;
+    const hasModal = !!document.getElementById('planModChatModal');
+    planModificationBtn.disabled = !hasModal;
+    planModificationBtn.classList.toggle('hidden', !hasModal);
+}
 
 function populateModelOptions() {
     if (!modelOptionsList) return;
@@ -1044,6 +1052,7 @@ async function showClient(userId) {
         } catch (e) {
             console.warn('initializeSelectors warning', e);
         }
+        togglePlanModificationBtn();
         const mod = await import('./editClient.js');
         try {
             await mod.initEditClient(userId);
@@ -1947,6 +1956,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     generateEmailFieldsets();
     initEmailPreviews();
+    togglePlanModificationBtn();
 
     // Стартира асинхронните операции паралелно,
     // за да не блокират работата на интерфейса


### PR DESCRIPTION
## Summary
- добавен контейнер `planModChatModalContainer` в `admin.html`
- зареждане на `planModChatModal` и обновяване на селектори/слушатели при показване на клиент
- показване на бутона за промяна на плана само при успешно зареден модал

## Testing
- `npm run lint`
- `npm test js/__tests__/planModChat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689561712c1c832680edf2223a604a62