### PR TITLE
Добавяне на описания към дневните показатели

### DIFF
--- a/js/__tests__/metricUtils.test.js
+++ b/js/__tests__/metricUtils.test.js
@@ -1,0 +1,19 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../uiElements.js', () => ({
+  trackerInfoTexts: {
+    energy: { levels: { 1: 'Много ниска', 2: 'Ниска', 3: 'Средна', 4: 'Висока', 5: 'Много висока' } }
+  }
+}));
+
+describe('getMetricDescription', () => {
+  test('връща описание за даден показател', async () => {
+    const { getMetricDescription } = await import('../metricUtils.js');
+    expect(getMetricDescription('energy', 4)).toBe('Висока');
+  });
+
+  test('връща fallback при липсващо описание', async () => {
+    const { getMetricDescription } = await import('../metricUtils.js');
+    expect(getMetricDescription('energy', 99)).toBe('Оценка 99 от 5');
+  });
+});

--- a/js/app.js
+++ b/js/app.js
@@ -3,6 +3,7 @@ import { isLocalDevelopment, apiEndpoints } from './config.js';
 import { debugLog, enableDebug } from './logger.js';
 import { safeParseFloat, escapeHtml, fileToDataURL, normalizeDailyLogs } from './utils.js';
 import { selectors, initializeSelectors, loadInfoTexts } from './uiElements.js';
+import { getMetricDescription } from './metricUtils.js';
 import {
     initializeTheme,
     loadAndApplyColors,
@@ -642,7 +643,10 @@ export async function handleSaveLog() { // Exported for eventListeners.js
     logPayload.data.note = selectors.dailyNote?.value.trim() || "";
     logPayload.data.completedMealsStatus = { ...todaysMealCompletionStatus };
     selectors.dailyTracker?.querySelectorAll('.metric-rating:not(.daily-log-weight-metric) input[type="hidden"]').forEach(input => {
-        logPayload.data[input.id.replace('-rating-input', '')] = parseInt(input.value);
+        const metricKey = input.id.replace('-rating-input', '');
+        const metricValue = parseInt(input.value);
+        logPayload.data[metricKey] = metricValue;
+        logPayload.data[`${metricKey}Description`] = getMetricDescription(metricKey, metricValue);
     });
 
     let hasDataToSave = !!logPayload.data.note ||

--- a/js/metricUtils.js
+++ b/js/metricUtils.js
@@ -1,0 +1,12 @@
+import { trackerInfoTexts } from './uiElements.js';
+
+/**
+ * Връща текстовото описание за даден показател и стойност.
+ * @param {string} key - Ключът на показателя (напр. 'energy').
+ * @param {number} value - Стойност 1-5.
+ * @returns {string} Описание на нивото или fallback текст.
+ */
+export function getMetricDescription(key, value) {
+    const desc = trackerInfoTexts[key]?.levels?.[value];
+    return desc || `Оценка ${value} от 5`;
+}


### PR DESCRIPTION
## Summary
- добавена е функция `getMetricDescription` за извличане на описанията на нивата от `trackerInfoTexts`
- дневният лог вече записва и текстово описание на всеки показател
- покритие с unit тест за новата функция

## Testing
- `npm run lint`
- `sh ./scripts/test.sh js/__tests__/metricUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68956600314c8326b73b19d40cd5eaee