### PR TITLE
feat: isolate plan mod chat selector setup

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -9,7 +9,7 @@ import { loadMaintenanceFlag, setMaintenanceFlag } from './maintenanceMode.js';
 import { renderTemplate } from '../utils/templateRenderer.js';
 import { ensureChart } from './chartLoader.js';
 import { setupPlanRegeneration } from './planRegenerator.js';
-import { initializeSelectors } from './uiElements.js';
+import { initializePlanModChatSelectors } from './uiElements.js';
 import { setupStaticEventListeners } from './eventListeners.js';
 import { setCurrentUserId as setAppCurrentUserId } from './app.js';
 
@@ -1047,10 +1047,10 @@ async function showClient(userId) {
         await loadTemplateInto('editclient.html', 'adminProfileContainer');
         await loadPartial('planModChatModal.html', 'planModChatModalContainer');
         try {
-            initializeSelectors();
+            initializePlanModChatSelectors();
             setupStaticEventListeners();
         } catch (e) {
-            console.warn('initializeSelectors warning', e);
+            console.warn('initializePlanModChatSelectors warning', e);
         }
         togglePlanModificationBtn();
         const mod = await import('./editClient.js');

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -106,6 +106,20 @@ export function initializeSelectors() {
     if (selectors.mainMenu) selectors.menuClose = selectors.mainMenu.querySelector('.menu-close');
 }
 
+export function initializePlanModChatSelectors() {
+    const ids = [
+        'planModChatModal',
+        'planModChatMessages',
+        'planModChatInput',
+        'planModChatSend',
+        'planModChatClose',
+        'planModChatClear'
+    ];
+    ids.forEach(id => {
+        selectors[id] = document.getElementById(id);
+    });
+}
+
 export let trackerInfoTexts = {};
 export let detailedMetricInfoTexts = {};
 export let mainIndexInfoTexts = {};


### PR DESCRIPTION
## Summary
- add `initializePlanModChatSelectors` for minimal modal selection
- use new selector init in admin flow

## Testing
- `npm run lint`
- `npm test js/__tests__/planModChat.test.js`
- `npm test js/__tests__/handleChatRequestPlanMod.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689568ad869c8326b99761fb88f82fd3