### PR TITLE
Remove plan modification button from admin panel

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -272,8 +272,6 @@
     <button id="generatePlan">Създай план</button>
     <div id="regenProgress" class="hidden" aria-live="polite"></div>
     <button id="aiSummary">AI резюме</button>
-    <button id="planModificationBtn">Промени план</button>
-    <div id="planModChatModalContainer"></div>
     <div class="profile-nav-container">
       <button id="profileCardNavToggle" class="profile-nav-toggle" aria-label="Показване на навигацията">
         <i class="fas fa-bars"></i>
@@ -522,7 +520,6 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="js/admin.js"></script>
-  <script type="module" src="js/planModChat.js"></script>
   <script type="module" src="js/adminColors.js"></script>
 </body>
 </html>

--- a/editclient.html
+++ b/editclient.html
@@ -61,7 +61,6 @@
             <div class="ms-auto d-flex align-items-center">
                 <button class="btn btn-danger me-2" id="global-cancel-btn">Отказ Всички</button>
                 <button class="btn btn-success me-3" id="global-save-btn">Запази Всички Промени</button>
-                <button class="btn btn-primary me-3" id="planModificationBtn"><i class="bi bi-chat-dots"></i> Промени план</button>
                 <div class="dropdown">
                     <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                         <i class="bi bi-tools"></i> Инструменти

--- a/js/admin.js
+++ b/js/admin.js
@@ -3,14 +3,11 @@ import { loadConfig, saveConfig } from './adminConfig.js';
 import { labelMap, statusMap } from './labelMap.js';
 import { fileToDataURL, fileToText, applyProgressFill } from './utils.js';
 import { loadTemplateInto } from './templateLoader.js';
-import { loadPartial } from './partialLoader.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
 import { loadMaintenanceFlag, setMaintenanceFlag } from './maintenanceMode.js';
 import { renderTemplate } from '../utils/templateRenderer.js';
 import { ensureChart } from './chartLoader.js';
 import { setupPlanRegeneration } from './planRegenerator.js';
-import { initializePlanModChatSelectors } from './uiElements.js';
-import { setupStaticEventListeners } from './eventListeners.js';
 import { setCurrentUserId as setAppCurrentUserId } from './app.js';
 
 let activeUserId = null;
@@ -41,7 +38,6 @@ const detailsSection = document.getElementById('clientDetails');
 const regenBtn = document.getElementById('regeneratePlan');
 const regenProgress = document.getElementById('regenProgress');
 const aiSummaryBtn = document.getElementById('aiSummary');
-const planModificationBtn = document.getElementById('planModificationBtn');
 const notesField = document.getElementById('adminNotes');
 const tagsField = document.getElementById('adminTags');
 const saveNotesBtn = document.getElementById('saveNotes');
@@ -114,13 +110,6 @@ const testAnalysisBtn = document.getElementById('testAnalysisModel');
 
 const modelOptionsList = document.getElementById('modelOptions');
 let availableModels = new Set(JSON.parse(localStorage.getItem('aiModelHistory') || '[]'));
-
-function togglePlanModificationBtn() {
-    if (!planModificationBtn) return;
-    const hasModal = !!document.getElementById('planModChatModal');
-    planModificationBtn.disabled = !hasModal;
-    planModificationBtn.classList.toggle('hidden', !hasModal);
-}
 
 function populateModelOptions() {
     if (!modelOptionsList) return;
@@ -1045,14 +1034,7 @@ async function showClient(userId) {
         adminProfileContainer.innerHTML = '';
         history.replaceState(null, '', `?userId=${encodeURIComponent(userId)}`);
         await loadTemplateInto('editclient.html', 'adminProfileContainer');
-        await loadPartial('planModChatModal.html', 'planModChatModalContainer');
-        try {
-            initializePlanModChatSelectors();
-            setupStaticEventListeners();
-        } catch (e) {
-            console.warn('initializePlanModChatSelectors warning', e);
-        }
-        togglePlanModificationBtn();
+        
         const mod = await import('./editClient.js');
         try {
             await mod.initEditClient(userId);
@@ -1956,7 +1938,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     generateEmailFieldsets();
     initEmailPreviews();
-    togglePlanModificationBtn();
 
     // Стартира асинхронните операции паралелно,
     // за да не блокират работата на интерфейса


### PR DESCRIPTION
## Summary
- remove plan modification button and modal container from admin page and template
- drop related imports and logic from admin.js

## Testing
- `npm run lint`
- `npm test js/__tests__/planModChat.test.js`
- `npm test js/__tests__/adminConfigRelated.test.js` *(fails: SyntaxError: The requested module './app.js' does not provide an export named 'setCurrentUserId')*

------
https://chatgpt.com/codex/tasks/task_e_68956bbb25bc8326900de8e55a2f7107