### PR TITLE
refactor: remove unused app dependency from admin panel

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -8,7 +8,6 @@ import { loadMaintenanceFlag, setMaintenanceFlag } from './maintenanceMode.js';
 import { renderTemplate } from '../utils/templateRenderer.js';
 import { ensureChart } from './chartLoader.js';
 import { setupPlanRegeneration } from './planRegenerator.js';
-import { setCurrentUserId as setAppCurrentUserId } from './app.js';
 
 let activeUserId = null;
 let activeClientName = null;
@@ -247,7 +246,6 @@ let weightChart = null;
 let currentUserId = null;
 function setCurrentUserId(val) {
     currentUserId = val;
-    setAppCurrentUserId(val);
 }
 setupPlanRegeneration({
     regenBtn,


### PR DESCRIPTION
## Summary
- clean up admin panel imports by dropping unneeded `setCurrentUserId` from client app
- trim `setCurrentUserId` helper to maintain only local state

## Testing
- `npm run lint`
- `npm test js/__tests__/peekAdminQueries.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689571f789248326af65543d70402397