### PR TITLE
Динамично обновяване на прогрес баровете

### DIFF
--- a/js/__tests__/updateAnalyticsSections.test.js
+++ b/js/__tests__/updateAnalyticsSections.test.js
@@ -1,0 +1,76 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+test('updateAnalyticsSections обновява прогрес баровете', async () => {
+  document.body.innerHTML = `
+    <div id="goalCard"><div id="goalProgressBar"></div><div id="goalProgressFill"></div><span id="goalProgressText"></span></div>
+    <div id="engagementCard"><div id="engagementProgressBar"></div><div id="engagementProgressFill"></div><span id="engagementProgressText"></span></div>
+    <div id="healthCard"><div id="healthProgressBar"></div><div id="healthProgressFill"></div><span id="healthProgressText"></span></div>
+    <div id="analyticsCardsContainer"></div>
+    <div id="macroAnalyticsCardContainer"></div>
+    <div id="detailedAnalyticsContent"></div>
+    <div id="dashboardTextualAnalysis"></div>
+  `;
+  const selectors = {
+    goalCard: document.getElementById('goalCard'),
+    goalProgressBar: document.getElementById('goalProgressBar'),
+    goalProgressFill: document.getElementById('goalProgressFill'),
+    goalProgressText: document.getElementById('goalProgressText'),
+    engagementCard: document.getElementById('engagementCard'),
+    engagementProgressBar: document.getElementById('engagementProgressBar'),
+    engagementProgressFill: document.getElementById('engagementProgressFill'),
+    engagementProgressText: document.getElementById('engagementProgressText'),
+    healthCard: document.getElementById('healthCard'),
+    healthProgressBar: document.getElementById('healthProgressBar'),
+    healthProgressFill: document.getElementById('healthProgressFill'),
+    healthProgressText: document.getElementById('healthProgressText'),
+    analyticsCardsContainer: document.getElementById('analyticsCardsContainer'),
+    macroAnalyticsCardContainer: document.getElementById('macroAnalyticsCardContainer'),
+    detailedAnalyticsContent: document.getElementById('detailedAnalyticsContent'),
+    dashboardTextualAnalysis: document.getElementById('dashboardTextualAnalysis')
+  };
+
+  jest.unstable_mockModule('../uiElements.js', () => ({ selectors, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
+  jest.unstable_mockModule('../eventListeners.js', () => ({ ensureMacroAnalyticsElement: jest.fn() }));
+
+  const applyProgressFill = jest.fn();
+  jest.unstable_mockModule('../utils.js', () => ({
+    safeGet: (obj, path, def) => path.split('.').reduce((o,k)=> (o && o[k] !== undefined ? o[k] : undefined), obj) ?? def,
+    safeParseFloat: v => parseFloat(v),
+    capitalizeFirstLetter: s => s,
+    escapeHtml: s => s,
+    applyProgressFill,
+    getCssVar: jest.fn(),
+    formatDateBgShort: () => ''
+  }));
+
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: { analytics: {}, initialAnswers: {}, initialData: {} },
+    todaysMealCompletionStatus: {},
+    currentIntakeMacros: {},
+    planHasRecContent: false,
+    todaysExtraMeals: [],
+    loadCurrentIntake: jest.fn(),
+    recalculateCurrentIntakeMacros: jest.fn(),
+    currentUserId: 'u1',
+    todaysPlanMacros: { calories:0, protein:0, carbs:0, fat:0, fiber:0 },
+    refreshAnalytics: jest.fn()
+  }));
+
+  const { updateAnalyticsSections } = await import('../populateUI.js');
+
+  const analytics = {
+    current: { goalProgress: 30, engagementScore: 50, overallHealthScore: 80 },
+    detailed: [],
+    textualAnalysis: ''
+  };
+  updateAnalyticsSections(analytics);
+
+  expect(applyProgressFill).toHaveBeenCalledWith(selectors.goalProgressFill, 30);
+  expect(selectors.goalProgressBar.getAttribute('aria-valuenow')).toBe('30');
+  expect(applyProgressFill).toHaveBeenCalledWith(selectors.engagementProgressFill, 50);
+  expect(selectors.engagementProgressBar.getAttribute('aria-valuenow')).toBe('50');
+  expect(applyProgressFill).toHaveBeenCalledWith(selectors.healthProgressFill, 80);
+  expect(selectors.healthProgressBar.getAttribute('aria-valuenow')).toBe('80');
+});

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -23,7 +23,8 @@ import {
     todaysMealCompletionStatus,
     fullDashboardData, activeTooltip, currentUserId,
     setChatModelOverride, setChatPromptOverride,
-    recalculateCurrentIntakeMacros
+    recalculateCurrentIntakeMacros,
+    refreshAnalytics
 } from './app.js';
 import {
     openPlanModificationChat,
@@ -311,6 +312,7 @@ function handleDelegatedClicks(event) {
             populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
             // Автоматично опресняване на макро-картата
             renderPendingMacroChart();
+            refreshAnalytics();
             showToast(`Храненето е ${isCompleted ? 'отбелязано' : 'размаркирано'}.`, false, 2000);
         }
         return;

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -2,7 +2,7 @@
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
 import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressFill, getCssVar, formatDateBgShort } from './utils.js';
 import { generateId, apiEndpoints, standaloneMacroUrl } from './config.js';
-import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, loadCurrentIntake, recalculateCurrentIntakeMacros, currentUserId, todaysPlanMacros } from './app.js';
+import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, loadCurrentIntake, recalculateCurrentIntakeMacros, currentUserId, todaysPlanMacros, refreshAnalytics } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
 import { ensureChart } from './chartLoader.js';
 import { getNutrientOverride, scaleMacros, calculatePlanMacros, calculateMacroPercents } from './macroUtils.js';
@@ -331,6 +331,13 @@ function populateDashboardDetailedAnalytics(analyticsData) {
     }
 }
 
+export function updateAnalyticsSections(analyticsData) {
+    if (!analyticsData) return;
+    fullDashboardData.analytics = analyticsData;
+    populateDashboardMainIndexes(analyticsData.current);
+    populateDashboardDetailedAnalytics(analyticsData);
+}
+
 export function renderPendingMacroChart() {
     const card = ensureMacroAnalyticsElement();
     if (!card) return;
@@ -404,6 +411,7 @@ export function addExtraMealWithOverride(name = '', macros = {}, grams) {
     recalculateCurrentIntakeMacros();
     populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
     renderPendingMacroChart();
+    refreshAnalytics();
 }
 
 function renderMacroPreviewGrid(macros) {


### PR DESCRIPTION
## Резюме
- добавена е `refreshAnalytics` функция за зареждане на нови анализи и актуализиране на прогрес баровете
- `updateAnalyticsSections` синхронизира `.main-indexes` и `analytics-card` при промяна на данни
- добавен тест `updateAnalyticsSections` за динамично обновяване

## Тестове
- `npm run lint`
- `npm test js/__tests__/updateAnalyticsSections.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6896a321388c8326a8b43bb423addae4