### PR TITLE
Динамично обновяване на прогрес баровете след лог

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -713,6 +713,7 @@ export async function handleSaveLog() { // Exported for eventListeners.js
             }
         }
         await refreshAnalytics(true);
+        updateAnalyticsSections(fullDashboardData.analytics);
         await populateUI();
         initializeAchievements(currentUserId);
         showToast(result.message || "Логът е запазен!", false);


### PR DESCRIPTION
## Резюме
- обновяване на секцията с индекси веднага след запис на дневен лог
- гарантиране, че прогрес баровете в основните и аналитичните карти се актуализират

## Тестове
- `npm run lint`
- `npm test js/__tests__/updateAnalyticsSections.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6896b18f2e4483268fe88e430e44afeb