### PR TITLE
feat: автоматично запазване на завършените хранения

### DIFF
--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -24,7 +24,8 @@ import {
     fullDashboardData, activeTooltip, currentUserId,
     setChatModelOverride, setChatPromptOverride,
     recalculateCurrentIntakeMacros,
-    refreshAnalytics
+    refreshAnalytics,
+    autoSaveCompletedMeals
 } from './app.js';
 import {
     openPlanModificationChat,
@@ -313,6 +314,7 @@ function handleDelegatedClicks(event) {
             // Автоматично опресняване на макро-картата
             renderPendingMacroChart();
             refreshAnalytics();
+            autoSaveCompletedMeals();
             showToast(`Храненето е ${isCompleted ? 'отбелязано' : 'размаркирано'}.`, false, 2000);
         }
         return;


### PR DESCRIPTION
## Summary
- имплементирана autoSaveCompletedMeals за автоматично POST-ване на статуса на храненията и актуализиране на дневните логове
- извикване на autoSaveCompletedMeals след отбелязване на хранене за синхронизация с бекенда

## Testing
- `npm run lint`
- `npm test js/__tests__/loadCurrentIntake.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68976c2192bc8326acf3b908d285883f