### PR TITLE
feat: централизирано обновяване на макроси

### DIFF
--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -44,7 +44,8 @@ beforeEach(async () => {
       currentIntakeMacros: currentIntakeMacrosRef,
       fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: { fiber_percent: 10, fiber_grams: 30 } } },
       planHasRecContent: false,
-      loadCurrentIntake: jest.fn()
+      loadCurrentIntake: jest.fn(),
+      updateMacrosAndAnalytics: jest.fn()
     };
   });
   global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });

--- a/js/__tests__/renderPendingMacroChart.test.js
+++ b/js/__tests__/renderPendingMacroChart.test.js
@@ -38,7 +38,8 @@ describe('renderPendingMacroChart', () => {
       loadCurrentIntake: jest.fn(),
       currentUserId: 'u1',
       recalculateCurrentIntakeMacros: jest.fn(),
-      resetAppState: jest.fn()
+      resetAppState: jest.fn(),
+      updateMacrosAndAnalytics: jest.fn()
     }));
     jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
     jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));

--- a/js/app.js
+++ b/js/app.js
@@ -11,7 +11,14 @@ import {
     openModal, closeModal,
     showLoading, showToast, updateTabsOverflowIndicator
 } from './uiHandlers.js';
-import { populateUI, populateProgressHistory, populateDashboardMacros, setMacroExceedThreshold, updateAnalyticsSections } from './populateUI.js';
+import {
+    populateUI,
+    populateProgressHistory,
+    populateDashboardMacros,
+    setMacroExceedThreshold,
+    updateAnalyticsSections,
+    renderPendingMacroChart
+} from './populateUI.js';
 // КОРЕКЦИЯ: Премахваме handleDelegatedClicks от импорта тук
 import { setupStaticEventListeners, setupDynamicEventListeners, initializeCollapsibleCards } from './eventListeners.js';
 import { loadProductMacros, calculateCurrentMacros, calculatePlanMacros } from './macroUtils.js';
@@ -365,6 +372,13 @@ export function recalculateCurrentIntakeMacros() {
     } catch (err) {
         console.error('Error recalculating current intake:', err);
     }
+}
+
+export function updateMacrosAndAnalytics() {
+    recalculateCurrentIntakeMacros();
+    populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
+    renderPendingMacroChart();
+    refreshAnalytics();
 }
 
 /**

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -13,19 +13,16 @@ import { apiEndpoints } from './config.js';
 import {
     macroChartInstance,
     progressChartInstance,
-    populateDashboardMacros,
-    renderPendingMacroChart,
     macroExceedThreshold
 } from './populateUI.js';
 import {
     handleSaveLog, handleFeedbackFormSubmit, // from app.js
     handleChatSend, handleChatInputKeypress, // from app.js / chat.js
     todaysMealCompletionStatus,
-    fullDashboardData, activeTooltip, currentUserId,
+    activeTooltip, currentUserId,
     setChatModelOverride, setChatPromptOverride,
-    recalculateCurrentIntakeMacros,
-    refreshAnalytics,
-    autoSaveCompletedMeals
+    autoSaveCompletedMeals,
+    updateMacrosAndAnalytics
 } from './app.js';
 import {
     openPlanModificationChat,
@@ -309,11 +306,7 @@ function handleDelegatedClicks(event) {
         if (day && index !== undefined) {
             const isCompleted = mealCard.classList.toggle('completed');
             todaysMealCompletionStatus[`${day}_${index}`] = isCompleted;
-            recalculateCurrentIntakeMacros();
-            populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
-            // Автоматично опресняване на макро-картата
-            renderPendingMacroChart();
-            refreshAnalytics();
+            updateMacrosAndAnalytics();
             autoSaveCompletedMeals();
             showToast(`Храненето е ${isCompleted ? 'отбелязано' : 'размаркирано'}.`, false, 2000);
         }

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -2,13 +2,11 @@
 import { selectors } from './uiElements.js';
 import { showLoading, showToast, openModal as genericOpenModal, closeModal as genericCloseModal } from './uiHandlers.js';
 import { apiEndpoints } from './config.js';
-import { currentUserId, todaysExtraMeals, currentIntakeMacros, fullDashboardData, loadCurrentIntake } from './app.js';
+import { currentUserId, todaysExtraMeals, currentIntakeMacros, loadCurrentIntake, updateMacrosAndAnalytics } from './app.js';
 import nutrientOverrides from '../kv/DIET_RESOURCES/nutrient_overrides.json' with { type: 'json' };
 import { removeMealMacros, registerNutrientOverrides, getNutrientOverride, loadProductMacros } from './macroUtils.js';
 import {
     addExtraMealWithOverride,
-    populateDashboardMacros,
-    renderPendingMacroChart,
     appendExtraMealCard
 } from './populateUI.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
@@ -470,8 +468,8 @@ export async function handleExtraMealFormSubmit(event) {
         };
         addExtraMealWithOverride(dataToSend.foodDescription, entry);
         appendExtraMealCard(dataToSend.foodDescription, dataToSend.quantityEstimate);
-        // Автоматично опресняване на макро-картата
-        renderPendingMacroChart();
+        // Синхронизираме макросите и аналитиката
+        updateMacrosAndAnalytics();
         genericCloseModal('extraMealEntryModal');
     } catch (error) {
         showToast(`Грешка: ${error.message}`, true);
@@ -485,9 +483,8 @@ export function deleteExtraMeal(index) {
     if (removed) {
         removeMealMacros(removed, currentIntakeMacros);
         loadCurrentIntake();
-        populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
-        // Автоматично опресняване на макро-картата
-        renderPendingMacroChart();
+        // Опресняваме макросите и аналитиката след изтриване
+        updateMacrosAndAnalytics();
         showToast('Храненето е изтрито.', false, 2000);
     }
 }

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -2,7 +2,7 @@
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
 import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressFill, getCssVar, formatDateBgShort } from './utils.js';
 import { generateId, apiEndpoints, standaloneMacroUrl } from './config.js';
-import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, loadCurrentIntake, recalculateCurrentIntakeMacros, currentUserId, todaysPlanMacros, refreshAnalytics } from './app.js';
+import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, loadCurrentIntake, currentUserId, todaysPlanMacros, updateMacrosAndAnalytics } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
 import { ensureChart } from './chartLoader.js';
 import { getNutrientOverride, scaleMacros, calculatePlanMacros, calculateMacroPercents } from './macroUtils.js';
@@ -407,11 +407,8 @@ export function addExtraMealWithOverride(name = '', macros = {}, grams) {
     const scaled = gramValue ? scaleMacros(base, gramValue) : base;
     const entry = gramValue ? { ...scaled, grams: gramValue } : scaled;
     todaysExtraMeals.push(entry);
-    // Обновяваме текущите макроси с новото хранене
-    recalculateCurrentIntakeMacros();
-    populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
-    renderPendingMacroChart();
-    refreshAnalytics();
+    // Обновяваме макросите и аналитиката след добавяне на хранене
+    updateMacrosAndAnalytics();
 }
 
 function renderMacroPreviewGrid(macros) {


### PR DESCRIPTION
## Summary
- добавена `updateMacrosAndAnalytics` за последователно преизчисляване и визуално/аналитично опресняване на макросите
- заменени разпръснати извиквания с новата функция в слушателите и формите за допълнително хранене
- актуализирани тестови двойници за новия API

## Testing
- `npm run lint`
- `npm test js/__tests__/extraMealFormSubmit.test.js js/__tests__/renderPendingMacroChart.test.js js/__tests__/populateDashboardMacros.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68976dcabe288326aed504efbaff73af