### PR TITLE
refactor: reuse macro chart without destroying

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -200,10 +200,17 @@ function populateDashboardDetailedAnalytics(analyticsData) {
         console.warn("Detailed analytics elements for dashboard not found.");
         return;
     }
-    cardsContainer.innerHTML = '';
+
+    // Запазваме макро картата, за да не се рестартира анимацията
+    Array.from(cardsContainer.children).forEach(child => {
+        if (child !== macroContainer) child.remove();
+    });
     if (macroContainer) {
         macroContainer.classList.remove('loading');
-        cardsContainer.appendChild(macroContainer);
+        if (!cardsContainer.contains(macroContainer)) {
+            cardsContainer.appendChild(macroContainer);
+        }
+        ensureMacroAnalyticsElement();
         populateDashboardMacros(todaysPlanMacros);
     }
     textualAnalysisContainer.innerHTML = '';
@@ -507,7 +514,8 @@ export async function populateDashboardMacros(macros) {
     }
 
     renderMacroPreviewGrid(currentIntakeMacros);
-    macroContainer.innerHTML = '';
+    const existingSpinner = macroContainer.querySelector('.spinner-border');
+    if (existingSpinner) existingSpinner.remove();
     const plan = {
         calories: todaysPlanMacros.calories,
         protein_grams: todaysPlanMacros.protein,


### PR DESCRIPTION
## Summary
- prevent macro analytics card removal when refreshing analytics to keep animations intact
- reuse existing chart.js instance and update datasets instead of destroy
- remove spinner on macro data load and ensure macro card element is present before updates

## Testing
- `npx eslint js/populateUI.js js/macroAnalyticsCardComponent.js`
- `npm run test -- js/__tests__/populateDashboardMacros.test.js`
- `npm run test -- js/__tests__/macroAnalyticsCardComponent.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68977d9578e883268faccc2087f967c9