### PR TITLE
fix: display extra meal macros in summary

### DIFF
--- a/js/__tests__/extraMealForm.test.js
+++ b/js/__tests__/extraMealForm.test.js
@@ -17,3 +17,92 @@ describe('handleLogExtraMealRequest', () => {
     expect(res.success).toBe(false);
   });
 });
+
+describe('extraMealForm populateSummary', () => {
+  test('renders macro values in summary', async () => {
+    jest.unstable_mockModule('../uiHandlers.js', () => ({
+      showLoading: jest.fn(),
+      showToast: jest.fn(),
+      openModal: jest.fn(),
+      closeModal: jest.fn(),
+    }));
+    jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+    jest.unstable_mockModule('../app.js', () => ({
+      currentUserId: 'u1',
+      todaysExtraMeals: [],
+      currentIntakeMacros: {},
+      loadCurrentIntake: jest.fn(),
+      updateMacrosAndAnalytics: jest.fn(),
+    }));
+    jest.unstable_mockModule('../macroUtils.js', () => ({
+      removeMealMacros: jest.fn(),
+      registerNutrientOverrides: jest.fn(),
+      getNutrientOverride: jest.fn(),
+      loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] }),
+    }));
+    jest.unstable_mockModule('../populateUI.js', () => ({
+      addExtraMealWithOverride: jest.fn(),
+      appendExtraMealCard: jest.fn(),
+    }));
+
+    const originalFetch = global.fetch;
+    global.fetch = undefined;
+    const { initializeExtraMealFormLogic } = await import('../extraMealForm.js');
+    global.fetch = originalFetch;
+
+    document.body.innerHTML = `
+      <form id="extraMealEntryFormActual">
+        <div class="form-step">
+          <input type="number" name="calories">
+          <input type="number" name="protein">
+          <input type="number" name="carbs">
+          <input type="number" name="fat">
+          <input type="number" name="fiber">
+        </div>
+        <div class="form-step" style="display:none">
+          <div id="extraMealSummary">
+            <span data-summary="foodDescription"></span>
+            <span data-summary="quantityEstimate"></span>
+            <span data-summary="mealTimeSelect"></span>
+            <span data-summary="reasonPrimary"></span>
+            <span data-summary="feelingAfter"></span>
+            <span data-summary="replacedPlanned"></span>
+            <span data-summary="calories"></span>
+            <span data-summary="protein"></span>
+            <span data-summary="carbs"></span>
+            <span data-summary="fat"></span>
+            <span data-summary="fiber"></span>
+          </div>
+        </div>
+        <div class="form-wizard-navigation">
+          <button id="emPrevStepBtn"></button>
+          <button id="emNextStepBtn"></button>
+          <button id="emSubmitBtn"></button>
+          <button id="emCancelBtn"></button>
+        </div>
+      </form>
+    `;
+
+    await initializeExtraMealFormLogic(document);
+
+    const setVal = (name, val) => {
+      const input = document.querySelector(`input[name="${name}"]`);
+      if (input) input.value = val;
+    };
+
+    setVal('calories', '100');
+    setVal('protein', '20');
+    setVal('carbs', '30');
+    setVal('fat', '10');
+    setVal('fiber', '5');
+
+    document.getElementById('emNextStepBtn').click();
+
+    const summary = document.getElementById('extraMealSummary');
+    expect(summary.querySelector('[data-summary="calories"]').textContent).toBe('100');
+    expect(summary.querySelector('[data-summary="protein"]').textContent).toBe('20');
+    expect(summary.querySelector('[data-summary="carbs"]').textContent).toBe('30');
+    expect(summary.querySelector('[data-summary="fat"]').textContent).toBe('10');
+    expect(summary.querySelector('[data-summary="fiber"]').textContent).toBe('5');
+  });
+});

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -136,10 +136,11 @@ export async function initializeExtraMealFormLogic(formContainerElement) {
         }
         summaryContainer.querySelector('[data-summary="replacedPlanned"]').textContent = replacedDisplay;
 
-        ['calories','protein','carbs','fat','fiber'].forEach(field => {
+        ['calories', 'protein', 'carbs', 'fat', 'fiber'].forEach(field => {
             const el = summaryContainer.querySelector(`[data-summary="${field}"]`);
             if (el) {
-                const val = getElValue(field);
+                const input = form.querySelector(`input[name="${field}"]`);
+                const val = input?.value || '';
                 el.textContent = val ? val : '-';
             }
         });


### PR DESCRIPTION
## Summary
- extract macro values from inputs by name instead of id
- add test covering macro rendering in extra meal summary

## Testing
- `npm run lint`
- `npm test js/__tests__/extraMealForm.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689780c4859c8326bea908edcedb83ce