### PR TITLE
test: verify extra meal card added

### DIFF
--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -86,3 +86,22 @@ test('изпраща макро стойности при попълнени п�
   );
   expect(appendExtraMealCardMock).toHaveBeenCalledWith(undefined, 'малко');
 });
+
+test('добавя DOM елемент при успешно изпращане', async () => {
+  document.body.innerHTML = `
+    <ul id="dailyMealList"></ul>
+    <form id="f">
+      <input type="radio" name="quantityEstimateVisual" value="малко" checked>
+    </form>`;
+  const selectors = (await import('../uiElements.js')).selectors;
+  selectors.dailyMealList = document.getElementById('dailyMealList');
+  appendExtraMealCardMock.mockImplementation(() => {
+    const li = document.createElement('li');
+    li.classList.add('meal-card');
+    selectors.dailyMealList.appendChild(li);
+  });
+  const form = document.getElementById('f');
+  const e = { preventDefault: jest.fn(), target: form };
+  await handleExtraMealFormSubmit(e);
+  expect(document.querySelectorAll('#dailyMealList li.meal-card')).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary
- add integration-style test for extra meal submission to ensure a meal card is appended to the list

## Testing
- `npm run lint`
- `npm test js/__tests__/extraMealFormSubmit.test.js js/__tests__/appendExtraMealCard.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689780d5d40083269eb16b1e09979025