### PR TITLE
Поправка на количеството в картата за извънредно хранене

### DIFF
--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -87,6 +87,16 @@ test('изпраща макро стойности при попълнени п�
   expect(appendExtraMealCardMock).toHaveBeenCalledWith(undefined, 'малко');
 });
 
+test('предава въведено количество без избрана опция', async () => {
+  document.body.innerHTML = `<form id="f">
+    <input id="quantityCustom" name="quantityCustom" value="200 гр">
+  </form>`;
+  const form = document.getElementById('f');
+  const e = { preventDefault: jest.fn(), target: form };
+  await handleExtraMealFormSubmit(e);
+  expect(appendExtraMealCardMock).toHaveBeenCalledWith(undefined, '200 гр');
+});
+
 test('добавя DOM елемент при успешно изпращане', async () => {
   document.body.innerHTML = `
     <ul id="dailyMealList"></ul>


### PR DESCRIPTION
## Резюме
- показване на въведеното количество за извънредно хранене в meal-card
- тест за предаване на количество без избрана радио опция

## Тестване
- `npm run lint`
- `npm test js/__tests__/appendExtraMealCard.test.js js/__tests__/extraMealFormSubmit.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689786958d7c8326a9550c3b79bd00a8