### PR TITLE
Validate quantity in extra meal form

### DIFF
--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -405,10 +405,30 @@ export async function openExtraMealModal() {
     }
 }
 
+export async function fetchMacrosFromAi(_foodDescription, quantity) {
+    const qty = Number(quantity);
+    if (!Number.isFinite(qty) || qty <= 0) {
+        showToast('Количеството трябва да е положително число.', true);
+        throw new Error('Invalid quantity');
+    }
+    // TODO: Реална имплементация за извличане на макроси от AI
+    return {};
+}
+
 export async function handleExtraMealFormSubmit(event) {
     event.preventDefault();
     const form = event.target;
     const formData = new FormData(form);
+
+    const quantityField = formData.get('quantity');
+    let parsedQuantity;
+    if (quantityField !== null && quantityField !== undefined && quantityField !== '') {
+        parsedQuantity = Number(quantityField);
+        if (!Number.isFinite(parsedQuantity) || parsedQuantity <= 0) {
+            showToast('Количеството трябва да е положително число.', true);
+            return;
+        }
+    }
 
     const selectedVisual = form.querySelector('input[name="quantityEstimateVisual"]:checked');
     const quantityCustomVal = (formData.get('quantityCustom') || '').trim();
@@ -418,6 +438,7 @@ export async function handleExtraMealFormSubmit(event) {
     }
 
     const dataToSend = { userId: currentUserId, timestamp: new Date().toISOString() };
+    if (parsedQuantity !== undefined) dataToSend.quantity = parsedQuantity;
 
     let quantityDisplay = '';
     if (selectedVisual) {


### PR DESCRIPTION
## Summary
- validate positive quantity before submitting extra meal
- add stubbed fetchMacrosFromAi with quantity check
- cover negative quantity cases with new tests

## Testing
- `npm run lint`
- `npm test js/__tests__/extraMealFormSubmit.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689788f9142c83269cd3d86b92abdc06