### PR TITLE
feat: add script to sync KV resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,12 @@ wrangler kv key put prompt_chat "$(cat templates/prompt_chat.txt)" --binding=RES
 wrangler kv key put recipe_data "$(cat data/recipes.json)" --binding=RESOURCES_KV
 ```
 
+За автоматично синхронизиране на всички файлове от директорията `kv/DIET_RESOURCES` към `RESOURCES_KV` използвайте:
+
+```bash
+npm run sync-kv
+```
+
 ### Required Worker Secrets
 
 Before deploying, configure the following secrets in Cloudflare (via the dashboard or `wrangler secret put`):

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "docs": "typedoc",
     "migrate-macros": "node scripts/migrate-final-plan-macros.js",
-    "deploy": "wrangler deploy && npm run migrate-macros"
+    "deploy": "wrangler deploy && npm run migrate-macros",
+    "sync-kv": "node scripts/sync-kv.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/sync-kv.js
+++ b/scripts/sync-kv.js
@@ -1,0 +1,30 @@
+import fs from 'fs'
+import path from 'path'
+import { spawnSync } from 'child_process'
+
+const dir = process.argv[2] || path.resolve('kv/DIET_RESOURCES')
+const binding = process.argv[3] || 'RESOURCES_KV'
+
+if (!fs.existsSync(dir)) {
+  console.error(`Directory not found: ${dir}`)
+  process.exit(1)
+}
+
+for (const file of fs.readdirSync(dir)) {
+  const filePath = path.join(dir, file)
+  if (fs.statSync(filePath).isFile()) {
+    const key = path.basename(file, path.extname(file))
+    const value = fs.readFileSync(filePath, 'utf8')
+    console.log(`Uploading ${key}...`)
+    const result = spawnSync('wrangler', ['kv', 'key', 'put', key, value, '--binding', binding], {
+      encoding: 'utf8',
+      stdio: 'inherit'
+    })
+    if (result.status !== 0) {
+      console.error(`Failed to upload ${key}`)
+      process.exit(result.status ?? 1)
+    }
+  }
+}
+
+console.log('KV sync complete.')


### PR DESCRIPTION
## Summary
- add sync-kv script to upload local KV resources
- expose script via npm and document usage

## Testing
- `npm run lint`
- `npm test backend/tests/checkPlanPrerequisites.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689796636df483269dff66b70440d243