### PR TITLE
Implement AI macro lookup with caching

### DIFF
--- a/js/__tests__/extraMealAutofill.test.js
+++ b/js/__tests__/extraMealAutofill.test.js
@@ -13,6 +13,12 @@ beforeEach(async () => {
     closeModal: jest.fn()
   }));
   jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({
+    removeMealMacros: jest.fn(),
+    registerNutrientOverrides: jest.fn(),
+    getNutrientOverride: jest.fn(key => key === 'ябълка|x' ? { calories: 52, protein: 0.3, carbs: 14, fat: 0.2, fiber: 0 } : null),
+    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] })
+  }));
   jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), renderPendingMacroChart: jest.fn(), appendExtraMealCard: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({
     currentUserId: 'u1',
@@ -20,7 +26,8 @@ beforeEach(async () => {
     todaysMealCompletionStatus: {},
     currentIntakeMacros: {},
     fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: { fiber_percent: 10, fiber_grams: 30 } } },
-    loadCurrentIntake: jest.fn()
+    loadCurrentIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn()
   }));
   ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));
 });

--- a/js/__tests__/extraMealFetchMacros.test.js
+++ b/js/__tests__/extraMealFetchMacros.test.js
@@ -1,0 +1,62 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let fetchMacrosFromAi;
+let showToastMock;
+
+beforeEach(async () => {
+  jest.resetModules();
+  showToastMock = jest.fn();
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => [] });
+
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    showLoading: jest.fn(),
+    showToast: showToastMock,
+    openModal: jest.fn(),
+    closeModal: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({
+    removeMealMacros: jest.fn(),
+    registerNutrientOverrides: jest.fn(),
+    getNutrientOverride: jest.fn(() => null),
+    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] })
+  }));
+  jest.unstable_mockModule('../populateUI.js', () => ({
+    addExtraMealWithOverride: jest.fn(),
+    populateDashboardMacros: jest.fn(),
+    renderPendingMacroChart: jest.fn(),
+    appendExtraMealCard: jest.fn()
+  }));
+  jest.unstable_mockModule('../app.js', () => ({
+    currentUserId: 'u1',
+    todaysExtraMeals: [],
+    todaysMealCompletionStatus: {},
+    currentIntakeMacros: {},
+    fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: { fiber_percent: 10, fiber_grams: 30 } } },
+    loadCurrentIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn()
+  }));
+
+  ({ fetchMacrosFromAi } = await import('../extraMealForm.js'));
+  fetch.mockClear();
+});
+
+test('успешно извличане се кешира', async () => {
+  fetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ calories: 100, protein: 10, carbs: 20, fat: 5, fiber: 3 })
+  });
+  const r1 = await fetchMacrosFromAi('банан', 100);
+  expect(r1.calories).toBe(100);
+  expect(fetch).toHaveBeenCalledTimes(1);
+  const r2 = await fetchMacrosFromAi('банан', 100);
+  expect(r2.calories).toBe(100);
+  expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+test('неуспешно извличане показва грешка', async () => {
+  fetch.mockResolvedValueOnce({ ok: false });
+  await expect(fetchMacrosFromAi('банан', 100)).rejects.toThrow('Nutrient lookup failed');
+  expect(showToastMock).toHaveBeenCalled();
+});

--- a/js/__tests__/extraMealNutrientLookup.test.js
+++ b/js/__tests__/extraMealNutrientLookup.test.js
@@ -28,7 +28,8 @@ beforeEach(async () => {
     todaysMealCompletionStatus: {},
     currentIntakeMacros: {},
     fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: { fiber_percent: 10, fiber_grams: 30 } } },
-    loadCurrentIntake: jest.fn()
+    loadCurrentIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn()
   }));
   ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));
 });


### PR DESCRIPTION
## Summary
- add real nutrient lookup via `/nutrient-lookup` with caching and validation
- cover fetchMacrosFromAi with unit tests for success and failure
- align existing tests with new app dependencies

## Testing
- `npm run lint`
- `npm test extraMeal`

------
https://chatgpt.com/codex/tasks/task_e_6897afe2272c83268c0f2b6507812742