### PR TITLE
feat: include fiber in nutrient lookup

### DIFF
--- a/js/__tests__/extraMealAutofill.test.js
+++ b/js/__tests__/extraMealAutofill.test.js
@@ -60,4 +60,5 @@ test('автопопълва макросите при разпозната хр
   input.dispatchEvent(new Event('input', { bubbles: true }));
   expect(container.querySelector('input[name="calories"]').value).toBe('52');
   expect(container.querySelector('input[name="protein"]').value).toBe('0.3');
+  expect(container.querySelector('input[name="fiber"]').value).toBe('0');
 });

--- a/js/__tests__/extraMealFetchMacros.test.js
+++ b/js/__tests__/extraMealFetchMacros.test.js
@@ -49,9 +49,11 @@ test('успешно извличане се кешира', async () => {
   });
   const r1 = await fetchMacrosFromAi('банан', 100);
   expect(r1.calories).toBe(100);
+  expect(r1.fiber).toBe(3);
   expect(fetch).toHaveBeenCalledTimes(1);
   const r2 = await fetchMacrosFromAi('банан', 100);
   expect(r2.calories).toBe(100);
+  expect(r2.fiber).toBe(3);
   expect(fetch).toHaveBeenCalledTimes(1);
 });
 

--- a/js/__tests__/extraMealFormSubmit.test.js
+++ b/js/__tests__/extraMealFormSubmit.test.js
@@ -97,7 +97,7 @@ test('изпраща макро стойности при попълнени п�
   expect(body.fiber).toBe(3);
   expect(addExtraMealWithOverrideMock).toHaveBeenCalledWith(
     undefined,
-    { calories: 120, protein: 10, carbs: 15, fat: 5 }
+    { calories: 120, protein: 10, carbs: 15, fat: 5, fiber: 3 }
   );
   expect(appendExtraMealCardMock).toHaveBeenCalledWith(undefined, 'малко');
 });
@@ -145,6 +145,7 @@ test('извлича макроси от AI при празни полета', a
   const body = JSON.parse(fetch.mock.calls[0][1].body);
   expect(body.calories).toBe(50);
   expect(form.querySelector('#extraMealSummary [data-summary="protein"]').textContent).toBe('1');
+  expect(form.querySelector('#extraMealSummary [data-summary="fiber"]').textContent).toBe('2');
 });
 
 test('добавя DOM елемент при успешно изпращане', async () => {

--- a/js/__tests__/workerBackendCache.test.js
+++ b/js/__tests__/workerBackendCache.test.js
@@ -2,7 +2,7 @@
 import { jest } from '@jest/globals';
 
 test('nutrient lookup caches with TTL', async () => {
-  const mod = await import('../worker-backend.js');
+  const mod = await import('../../worker-backend.js');
   const put = jest.fn();
   const env = {
     USER_METADATA_KV: { get: jest.fn().mockResolvedValue(null), put },
@@ -11,7 +11,7 @@ test('nutrient lookup caches with TTL', async () => {
   const originalFetch = global.fetch;
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
-    json: async () => [{ calories: 1, protein_g: 1, carbohydrates_total_g: 1, fat_total_g: 1 }]
+    json: async () => [{ calories: 1, protein_g: 1, carbohydrates_total_g: 1, fat_total_g: 1, fiber_g: 1 }]
   });
   const req = new Request('https://example.com/nutrient-lookup', {
     method: 'POST',
@@ -19,5 +19,7 @@ test('nutrient lookup caches with TTL', async () => {
   });
   await mod.default.fetch(req, env);
   expect(put).toHaveBeenCalledWith(expect.stringContaining('nutrient_cache_'), expect.any(String), { expirationTtl: 86400 });
+  const saved = JSON.parse(put.mock.calls[0][1]);
+  expect(saved).toEqual({ calories: 1, protein: 1, carbs: 1, fat: 1, fiber: 1 });
   global.fetch = originalFetch;
 });

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -561,7 +561,8 @@ export async function handleExtraMealFormSubmit(event) {
             calories: dataToSend.calories,
             protein: dataToSend.protein,
             carbs: dataToSend.carbs,
-            fat: dataToSend.fat
+            fat: dataToSend.fat,
+            fiber: dataToSend.fiber
         };
         addExtraMealWithOverride(dataToSend.foodDescription, entry);
         appendExtraMealCard(dataToSend.foodDescription, quantityDisplay);

--- a/worker-backend.js
+++ b/worker-backend.js
@@ -171,7 +171,8 @@ async function lookupNutrients(query, env) {
             calories: Number(item.calories) || 0,
             protein: Number(item.protein_g) || 0,
             carbs: Number(item.carbohydrates_total_g || item.carbs_g) || 0,
-            fat: Number(item.fat_total_g || item.fat_g) || 0
+            fat: Number(item.fat_total_g || item.fat_g) || 0,
+            fiber: Number(item.fiber_g || item.fiber) || 0
           };
         }
       }
@@ -183,7 +184,7 @@ async function lookupNutrients(query, env) {
     try {
       const cfEndpoint = `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/ai/run/${env.MODEL}`;
       const messages = [
-        { role: 'system', content: 'Give nutrition data as JSON {calories, protein, carbs, fat} for the given food.' },
+        { role: 'system', content: 'Give nutrition data as JSON {calories, protein, carbs, fat, fiber} for the given food.' },
         { role: 'user', content: query }
       ];
       const resp = await fetch(cfEndpoint, {
@@ -204,14 +205,15 @@ async function lookupNutrients(query, env) {
           calories: Number(obj.calories) || 0,
           protein: Number(obj.protein) || 0,
           carbs: Number(obj.carbs) || 0,
-          fat: Number(obj.fat) || 0
+          fat: Number(obj.fat) || 0,
+          fiber: Number(obj.fiber) || 0
         };
       } catch {
-        return { calories: 0, protein: 0, carbs: 0, fat: 0 };
+        return { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
       }
     } catch (e) {
       console.error('AI nutrient lookup error', e);
     }
   }
-  return { calories: 0, protein: 0, carbs: 0, fat: 0 };
+  return { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
 }


### PR DESCRIPTION
## Summary
- extend nutrient lookup to return fiber and persist it in KV cache
- include fiber when submitting extra meals
- test fiber autopopulation and cache storage

## Testing
- `npm run lint`
- `npm test js/__tests__/workerBackendCache.test.js js/__tests__/extraMealAutofill.test.js js/__tests__/extraMealFetchMacros.test.js js/__tests__/extraMealForm.test.js js/__tests__/extraMealFormSubmit.test.js js/__tests__/extraMealNutrientLookup.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6897b2be72988326920a28efbf702166