### PR TITLE
Синхронизация на допълнителните хранения с дневните логове

### DIFF
--- a/js/__tests__/extraMealForm.test.js
+++ b/js/__tests__/extraMealForm.test.js
@@ -31,6 +31,7 @@ describe('extraMealForm populateSummary', () => {
       currentUserId: 'u1',
       todaysExtraMeals: [],
       currentIntakeMacros: {},
+      fullDashboardData: {},
       loadCurrentIntake: jest.fn(),
       updateMacrosAndAnalytics: jest.fn(),
     }));
@@ -121,6 +122,7 @@ describe('extraMealForm populateSummary', () => {
       currentUserId: 'u1',
       todaysExtraMeals: [],
       currentIntakeMacros: {},
+      fullDashboardData: {},
       loadCurrentIntake: jest.fn(),
       updateMacrosAndAnalytics: jest.fn(),
     }));

--- a/js/app.js
+++ b/js/app.js
@@ -335,22 +335,20 @@ export function loadCurrentIntake(status = null, extraMeals = null) {
     try {
         currentIntakeMacros = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
 
-        // Ако не са подадени състояние и допълнителни хранения, зареждаме от дневника
-        if (!status || !extraMeals) {
-            const todayStr = new Date().toISOString().split('T')[0];
-            const todayLog = fullDashboardData?.dailyLogs?.find(l => l.date === todayStr)?.data;
-            if (!todayLog) {
-                todaysExtraMeals = [];
-                Object.keys(todaysMealCompletionStatus).forEach(k => delete todaysMealCompletionStatus[k]);
-                return;
-            }
+        const todayStr = new Date().toISOString().split('T')[0];
+        const todayLog = fullDashboardData?.dailyLogs?.find(l => l.date === todayStr)?.data;
+        if (todayLog) {
             const completed = todayLog.completedMealsStatus || {};
             Object.keys(todaysMealCompletionStatus).forEach(k => delete todaysMealCompletionStatus[k]);
             Object.assign(todaysMealCompletionStatus, completed);
             todaysExtraMeals = Array.isArray(todayLog.extraMeals) ? todayLog.extraMeals : [];
-            status = todaysMealCompletionStatus;
-            extraMeals = todaysExtraMeals;
+        } else if (!status || !extraMeals) {
+            todaysExtraMeals = [];
+            Object.keys(todaysMealCompletionStatus).forEach(k => delete todaysMealCompletionStatus[k]);
         }
+
+        status = status || todaysMealCompletionStatus;
+        extraMeals = extraMeals || todaysExtraMeals;
 
         currentIntakeMacros = calculateCurrentMacros(
             fullDashboardData.planData?.week1Menu || {},

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -2,7 +2,7 @@
 import { selectors } from './uiElements.js';
 import { showLoading, showToast, openModal as genericOpenModal, closeModal as genericCloseModal } from './uiHandlers.js';
 import { apiEndpoints } from './config.js';
-import { currentUserId, todaysExtraMeals, currentIntakeMacros, loadCurrentIntake, updateMacrosAndAnalytics } from './app.js';
+import { currentUserId, todaysExtraMeals, currentIntakeMacros, loadCurrentIntake, updateMacrosAndAnalytics, fullDashboardData } from './app.js';
 import nutrientOverrides from '../kv/DIET_RESOURCES/nutrient_overrides.json' with { type: 'json' };
 import { removeMealMacros, registerNutrientOverrides, getNutrientOverride, loadProductMacros } from './macroUtils.js';
 import {
@@ -556,6 +556,16 @@ export async function handleExtraMealFormSubmit(event) {
             fiber: dataToSend.fiber
         };
         addExtraMealWithOverride(dataToSend.foodDescription, entry);
+        // Актуализираме дневните логове с новото хранене
+        const todayStr = new Date().toISOString().split('T')[0];
+        if (!Array.isArray(fullDashboardData.dailyLogs)) fullDashboardData.dailyLogs = [];
+        let todayLog = fullDashboardData.dailyLogs.find(l => l.date === todayStr);
+        if (!todayLog) {
+            todayLog = { date: todayStr, data: { extraMeals: [] } };
+            fullDashboardData.dailyLogs.push(todayLog);
+        }
+        if (!Array.isArray(todayLog.data.extraMeals)) todayLog.data.extraMeals = [];
+        todayLog.data.extraMeals.push(entry);
         appendExtraMealCard(dataToSend.foodDescription, quantityDisplay);
         // Синхронизираме макросите и аналитиката
         updateMacrosAndAnalytics();


### PR DESCRIPTION
## Summary
- добавено обновяване на `fullDashboardData.dailyLogs` при запис на извънредно хранене
- `loadCurrentIntake` винаги взема актуални данни за допълнителните хранения от `dailyLogs`
- коригиран тестов модул `extraMealForm`

## Testing
- `npm run lint`
- `npm test js/__tests__/extraMeal*.test.js js/__tests__/loadCurrentIntake.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897cabb9a88832689342795c0cc1b66