### PR TITLE
Handle missing current data in macro analytics card

### DIFF
--- a/js/__tests__/macroAnalyticsCardComponent.test.js
+++ b/js/__tests__/macroAnalyticsCardComponent.test.js
@@ -130,6 +130,32 @@ test('класифицира over и under макросите', async () => {
   expect(fatDiv.classList.contains('under')).toBe(true);
 });
 
+test('при липсващ current макросите се нулират', async () => {
+  const card = document.createElement('macro-analytics-card');
+  document.body.appendChild(card);
+  const plan = {
+    calories: 2000,
+    protein_grams: 150,
+    protein_percent: 75,
+    carbs_grams: 250,
+    carbs_percent: 50,
+    fat_grams: 70,
+    fat_percent: 35
+  };
+  const current = {
+    calories: 1200,
+    protein_grams: 60,
+    carbs_grams: 100,
+    fat_grams: 40
+  };
+  card.setData({ plan, current });
+  const utils = within(card.shadowRoot);
+  await waitFor(() => utils.getByText('60 / 150г'));
+  card.setData({ plan });
+  expect(card.hasAttribute('current-data')).toBe(false);
+  await waitFor(() => utils.getByText('-- / 150г'));
+});
+
 test('data-endpoint и refresh-interval извикват fetch периодично', async () => {
   jest.useFakeTimers();
   const endpoint = '/macros';

--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -356,9 +356,7 @@ export class MacroAnalyticsCard extends HTMLElement {
       try {
         const res = await fetch(endpoint);
         const data = await res.json();
-        if (data.plan && data.current) {
-          this.setData(data);
-        }
+        this.setData({ plan: data.plan, current: data.current });
       } catch (e) {
         console.error('Failed to fetch macro data', e);
       }
@@ -369,7 +367,9 @@ export class MacroAnalyticsCard extends HTMLElement {
 
   setData({ plan, current }) {
     if (plan) this.setAttribute('plan-data', JSON.stringify(plan));
+    else this.removeAttribute('plan-data');
     if (current) this.setAttribute('current-data', JSON.stringify(current));
+    else this.removeAttribute('current-data');
   }
 
   getCssVar(name) {


### PR DESCRIPTION
## Summary
- ensure auto-refresh updates or clears macro data even when `current` is missing
- reset `plan-data` and `current-data` attributes when absent
- test missing current scenario to confirm macros reset

## Testing
- `npm run lint js/macroAnalyticsCardComponent.js js/__tests__/macroAnalyticsCardComponent.test.js`
- `npm test js/__tests__/macroAnalyticsCardComponent.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897d77a95008326a99c30b7631f89ec