### PR TITLE
Подобрено зареждане на дневния прием

### DIFF
--- a/js/__tests__/loadCurrentIntake.test.js
+++ b/js/__tests__/loadCurrentIntake.test.js
@@ -29,25 +29,19 @@ test('loadCurrentIntake агрегира макросите от логовет�
   });
 });
 
-test('loadCurrentIntake не презаписва подаденото състояние', async () => {
+test('loadCurrentIntake запазва данните когато е подаден само статус', async () => {
   jest.resetModules();
   const app = await import('../app.js');
   Object.assign(app.fullDashboardData, { planData: { week1Menu: {} } });
   app.todaysMealCompletionStatus.sample = true;
   app.todaysExtraMeals.length = 0;
-  app.todaysExtraMeals.push({ calories: 100, protein: 5, carbs: 10, fat: 2, fiber: 1 });
-  app.loadCurrentIntake(app.todaysMealCompletionStatus, app.todaysExtraMeals);
+  app.todaysExtraMeals.push({ calories: 100 });
+  app.loadCurrentIntake(app.todaysMealCompletionStatus, null);
   expect(app.todaysMealCompletionStatus).toEqual({ sample: true });
-  expect(app.currentIntakeMacros).toEqual({
-    calories: 100,
-    protein: 5,
-    carbs: 10,
-    fat: 2,
-    fiber: 1,
-  });
+  expect(app.todaysExtraMeals).toEqual([{ calories: 100 }]);
 });
 
-test('loadCurrentIntake нулира локалните данни при липса на дневен запис', async () => {
+test('loadCurrentIntake нулира данните при липса на дневен запис', async () => {
   jest.resetModules();
   const app = await import('../app.js');
   const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
@@ -58,6 +52,21 @@ test('loadCurrentIntake нулира локалните данни при лип
   app.todaysExtraMeals.push({ calories: 50 });
   app.todaysMealCompletionStatus.sample = true;
   app.loadCurrentIntake();
+  expect(app.todaysExtraMeals).toEqual([]);
+  expect(app.todaysMealCompletionStatus).toEqual({});
+});
+
+test('loadCurrentIntake нулира данните при смяна на деня дори при подадено състояние', async () => {
+  jest.resetModules();
+  const app = await import('../app.js');
+  const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+  Object.assign(app.fullDashboardData, {
+    planData: { week1Menu: {} },
+    dailyLogs: [{ date: yesterday, data: { extraMeals: [{ calories: 100 }] } }],
+  });
+  app.todaysExtraMeals.push({ calories: 50 });
+  app.todaysMealCompletionStatus.sample = true;
+  app.loadCurrentIntake(app.todaysMealCompletionStatus, app.todaysExtraMeals);
   expect(app.todaysExtraMeals).toEqual([]);
   expect(app.todaysMealCompletionStatus).toEqual({});
 });


### PR DESCRIPTION
## Summary
- добавена проверка за смяна на деня и JSDoc в `loadCurrentIntake`
- разширени тестове за поведение при непълен статус и смяна на деня

## Testing
- `npm run lint js/app.js js/__tests__/loadCurrentIntake.test.js`
- `npm test js/__tests__/loadCurrentIntake.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897de1a7e148326bf332867c91c948b