### PR TITLE
Fix macros parameter usage in dashboard population

### DIFF
--- a/js/__tests__/macroCardVisibilityAfterAnalytics.test.js
+++ b/js/__tests__/macroCardVisibilityAfterAnalytics.test.js
@@ -52,7 +52,8 @@ test('макро картата остава видима след обновя�
     currentIntakeMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
     currentUserId: 'u1',
     todaysPlanMacros: { calories: 2000, protein: 150, carbs: 250, fat: 70, fiber: 30 },
-    updateMacrosAndAnalytics: jest.fn()
+    updateMacrosAndAnalytics: jest.fn(),
+    resetDailyIntake: jest.fn()
   }));
   jest.unstable_mockModule('../macroUtils.js', () => ({
     getNutrientOverride: jest.fn(),
@@ -64,7 +65,7 @@ test('макро картата остава видима след обновя�
 
   const { populateDashboardMacros, updateAnalyticsSections } = await import('../populateUI.js');
 
-  await populateDashboardMacros({ calories: 2000 });
+  await populateDashboardMacros();
   expect(selectors.macroAnalyticsCardContainer.querySelector('macro-analytics-card')).not.toBeNull();
 
   updateAnalyticsSections({ current: {}, detailed: [] });

--- a/js/__tests__/populateDashboardMacros.importOnce.test.js
+++ b/js/__tests__/populateDashboardMacros.importOnce.test.js
@@ -39,7 +39,9 @@ test('динамичният импорт на macroAnalyticsCardComponent се 
     loadCurrentIntake: jest.fn(),
     currentUserId: 'u1',
     recalculateCurrentIntakeMacros: jest.fn(),
-    resetAppState: jest.fn()
+    resetAppState: jest.fn(),
+    resetDailyIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn()
   }));
   jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
   jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));

--- a/js/__tests__/populateDashboardMacros.missingComponent.test.js
+++ b/js/__tests__/populateDashboardMacros.missingComponent.test.js
@@ -44,6 +44,8 @@ function setupMocks(selectors) {
     setChatPromptOverride: jest.fn(),
     recalculateCurrentIntakeMacros: jest.fn(),
     resetAppState: jest.fn(),
+    resetDailyIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn(),
     stopPlanStatusPolling: jest.fn(),
     stopAdminQueriesPolling: jest.fn()
   }));

--- a/js/__tests__/populateDashboardMacros.noSetData.test.js
+++ b/js/__tests__/populateDashboardMacros.noSetData.test.js
@@ -44,6 +44,8 @@ function setupMocks(selectors) {
     setChatPromptOverride: jest.fn(),
     recalculateCurrentIntakeMacros: jest.fn(),
     resetAppState: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn(),
+    resetDailyIntake: jest.fn(),
     stopPlanStatusPolling: jest.fn(),
     stopAdminQueriesPolling: jest.fn()
   }));

--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -95,7 +95,13 @@ test('recalculates macros automatically and shows spinner while loading', async 
   };
   const [payload] = card.setData.mock.calls[0];
   expect(payload).toMatchObject({
-    plan: expect.objectContaining({ calories: 500, protein_grams: 25, carbs_grams: 30, fat_grams: 25, fiber_grams: 7 }),
+    plan: expect.objectContaining({
+      calories: macros.calories,
+      protein_grams: macros.protein_grams,
+      carbs_grams: macros.carbs_grams,
+      fat_grams: macros.fat_grams,
+      fiber_grams: macros.fiber_grams
+    }),
     current: expectedCurrent
   });
 });
@@ -132,16 +138,14 @@ test('calculatePlanMacros се извиква само веднъж при ке�
   expect(calcMock).toHaveBeenCalledTimes(1);
 });
 
-test('игнорира подадения план и използва сумата от дневното меню', async () => {
+test('използва подадените планови макроси', async () => {
   setupDom();
   const macros = {
-    plan: {
-      calories: 1900,
-      protein_grams: 140,
-      carbs_grams: 190,
-      fat_grams: 63,
-      fiber_grams: 28
-    }
+    calories: 1900,
+    protein_grams: 140,
+    carbs_grams: 190,
+    fat_grams: 63,
+    fiber_grams: 28
   };
   const dayMenu = [
     { meal_name: 'Омлет', macros: { calories: 300, protein: 20, carbs: 10, fat: 15, fiber: 2 } },
@@ -154,11 +158,11 @@ test('игнорира подадения план и използва сума�
   const card = document.querySelector('macro-analytics-card');
   const [payload] = card.setData.mock.calls[0];
   expect(payload.plan).toMatchObject({
-    calories: summed.calories,
-    protein_grams: summed.protein,
-    carbs_grams: summed.carbs,
-    fat_grams: summed.fat,
-    fiber_grams: summed.fiber
+    calories: macros.calories,
+    protein_grams: macros.protein_grams,
+    carbs_grams: macros.carbs_grams,
+    fat_grams: macros.fat_grams,
+    fiber_grams: macros.fiber_grams
   });
   expect(selectors.macroMetricsPreview.textContent).toContain('150');
 });

--- a/js/__tests__/renderPendingMacroChart.test.js
+++ b/js/__tests__/renderPendingMacroChart.test.js
@@ -39,6 +39,7 @@ describe('renderPendingMacroChart', () => {
       currentUserId: 'u1',
       recalculateCurrentIntakeMacros: jest.fn(),
       resetAppState: jest.fn(),
+      resetDailyIntake: jest.fn(),
       updateMacrosAndAnalytics: jest.fn()
     }));
     jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
@@ -72,7 +73,7 @@ describe('renderPendingMacroChart', () => {
     renderPendingMacroChart();
     expect(ensureMacroAnalyticsElement).toHaveBeenCalledTimes(1);
     expect(card.setData).toHaveBeenCalledWith(
-      expect.objectContaining({ plan: expect.objectContaining({ protein_grams: 72 }) })
+      expect.objectContaining({ plan: expect.objectContaining({ protein_grams: macros.protein_grams }) })
     );
 
     appState.currentIntakeMacros.calories = 1500;


### PR DESCRIPTION
## Summary
- use `populateDashboardMacros` argument to update planned macros and fetch only when missing
- simplify internal calls to `populateDashboardMacros` without redundant arguments
- adjust tests for the new interface and behaviour

## Testing
- `npm run lint`
- `npm test js/__tests__/populateDashboardMacros.test.js js/__tests__/populateDashboardMacros.noSetData.test.js js/__tests__/populateDashboardMacros.missingComponent.test.js js/__tests__/populateDashboardMacros.importOnce.test.js js/__tests__/renderPendingMacroChart.test.js js/__tests__/macroCardVisibilityAfterAnalytics.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897de2661d0832693d20ae19f64bb4a