### PR TITLE
Корекция на калориите за фибри в validateMacroCalories

### DIFF
--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -173,9 +173,16 @@ function resolveMacros(meal, grams) {
   return typeof grams === 'number' ? scaleMacros(macros, grams) : macros;
 }
 
+/**
+ * Проверява дали калориите съответстват на макросите.
+ * Фибрите се изваждат от въглехидратите за нетно съдържание и се
+ * оценяват по 2 kcal/грам.
+ * @param {{calories:number, protein:number, carbs:number, fat:number, fiber:number}} macros
+ * @param {number} [threshold=0.05] - Допустимото относително отклонение.
+ */
 function validateMacroCalories(macros = {}, threshold = 0.05) {
-  const { calories = 0, protein = 0, carbs = 0, fat = 0 } = macros;
-  const calc = protein * 4 + carbs * 4 + fat * 9;
+  const { calories = 0, protein = 0, carbs = 0, fat = 0, fiber = 0 } = macros;
+  const calc = protein * 4 + (carbs - fiber) * 4 + fat * 9 + fiber * 2;
   if (!calc) return;
   const diff = Math.abs(calc - calories);
   if (diff / calc > threshold) {


### PR DESCRIPTION
## Summary
- калкулацията в `validateMacroCalories` вече изважда фибрите от въглехидратите и ги отчита с 2 kcal/грам
- тестовете за макро калкулации включват примери с фибри и покриват коректен и грешен сценарий

## Testing
- `npm run lint js/macroUtils.js js/__tests__/macroUtils.test.js`
- `npm test js/__tests__/macroUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897e5f3f20483268c492d5f4e8556b4