### PR TITLE
feat: centralize local date handling

### DIFF
--- a/js/__tests__/getLocalDate.test.js
+++ b/js/__tests__/getLocalDate.test.js
@@ -1,0 +1,13 @@
+import timezoneMock from 'timezone-mock';
+import { getLocalDate } from '../utils.js';
+
+afterEach(() => {
+  timezoneMock.unregister();
+});
+
+test('getLocalDate връща коректна дата в локална полунощ', () => {
+  timezoneMock.register('Europe/Sofia');
+  const fakeNow = new Date('2023-12-31T22:30:00Z'); // 2024-01-01 00:30 локално
+  expect(fakeNow.toISOString().split('T')[0]).toBe('2023-12-31');
+  expect(getLocalDate(fakeNow)).toBe('2024-01-01');
+});

--- a/js/__tests__/loadCurrentIntake.test.js
+++ b/js/__tests__/loadCurrentIntake.test.js
@@ -1,10 +1,11 @@
 /** @jest-environment jsdom */
 import { jest } from '@jest/globals';
+import { getLocalDate } from '../utils.js';
 
 test('loadCurrentIntake агрегира макросите от логовете', async () => {
   jest.resetModules();
   const app = await import('../app.js');
-  const todayStr = new Date().toISOString().split('T')[0];
+  const todayStr = getLocalDate();
   Object.assign(app.fullDashboardData, {
     planData: { week1Menu: {} },
     dailyLogs: [
@@ -50,7 +51,7 @@ test('loadCurrentIntake не презаписва подаденото съст�
 test('loadCurrentIntake нулира локалните данни при липса на дневен запис', async () => {
   jest.resetModules();
   const app = await import('../app.js');
-  const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+  const yesterday = getLocalDate(new Date(Date.now() - 86400000));
   Object.assign(app.fullDashboardData, {
     planData: { week1Menu: {} },
     dailyLogs: [{ date: yesterday, data: { extraMeals: [{ calories: 100 }] } }],

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -1,5 +1,6 @@
 /** @jest-environment jsdom */
 import { jest } from '@jest/globals';
+import { getLocalDate } from '../utils.js';
 
 let populateUI, populateModule;
 
@@ -87,6 +88,7 @@ beforeEach(async () => {
     currentIntakeMacros: {},
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),
+    resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
     currentUserId: 'u1'
   }));
@@ -141,6 +143,7 @@ test('обновява макро картата чрез setData', async () => 
     currentIntakeMacros: {},
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),
+    resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
     currentUserId: 'u1'
   }));
@@ -178,6 +181,7 @@ test('hides modules when values are zero, except engagement card', async () => {
     todaysExtraMeals: [],
     currentIntakeMacros: {},
     loadCurrentIntake: jest.fn(),
+    resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
     currentUserId: 'u1'
   }));
@@ -191,7 +195,7 @@ test('hides modules when values are zero, except engagement card', async () => {
 
 test('показва картата за историята на теглото при наследен формат', async () => {
   jest.resetModules();
-  const today = new Date().toISOString().split('T')[0];
+  const today = getLocalDate();
   const fullData = {
     userName: 'Иван',
     analytics: { current: {}, streak: {} },
@@ -215,6 +219,7 @@ test('показва картата за историята на теглото 
     currentIntakeMacros: {},
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),
+    resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
     currentUserId: 'u1'
   }));
@@ -251,6 +256,7 @@ test('populates daily plan with color bars and meal types', async () => {
     currentIntakeMacros: {},
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),
+    resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
     currentUserId: 'u1'
   }));
@@ -297,6 +303,7 @@ test('handles meal type variations', async () => {
     currentIntakeMacros: {},
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),
+    resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
     currentUserId: 'u1'
   }));
@@ -323,7 +330,7 @@ test('applies success color to completed meal bar', async () => {
         ]
       }
     },
-    dailyLogs: [{ date: new Date().toISOString().split('T')[0], data: { completedMealsStatus: { [mealStatusKey]: true } } }],
+    dailyLogs: [{ date: getLocalDate(), data: { completedMealsStatus: { [mealStatusKey]: true } } }],
     currentStatus: {},
     initialData: {},
     initialAnswers: {}
@@ -335,6 +342,7 @@ test('applies success color to completed meal bar', async () => {
     currentIntakeMacros: {},
     planHasRecContent: false,
     loadCurrentIntake: jest.fn(),
+    resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
     currentUserId: 'u1'
   }));
@@ -424,6 +432,7 @@ describe('progress bar width handling', () => {
       currentIntakeMacros: {},
       planHasRecContent: false,
       loadCurrentIntake: jest.fn(),
+      resetDailyIntake: jest.fn(),
       updateMacrosAndAnalytics: jest.fn(),
       currentUserId: 'u1'
     }));
@@ -455,6 +464,6 @@ test('ресет на макросите при смяна на деня', async
   expect(loadCurrentIntake).toHaveBeenCalled();
   expect(updateMacrosAndAnalytics).toHaveBeenCalled();
   expect(spy).not.toHaveBeenCalled();
-  expect(sessionStorage.getItem('lastDashboardDate')).toBe(new Date().toISOString().split('T')[0]);
+  expect(sessionStorage.getItem('lastDashboardDate')).toBe(getLocalDate());
   spy.mockRestore();
 });

--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,7 @@
 // app.js - Основен Файл на Приложението
 import { isLocalDevelopment, apiEndpoints } from './config.js';
 import { debugLog, enableDebug } from './logger.js';
-import { safeParseFloat, escapeHtml, fileToDataURL, normalizeDailyLogs } from './utils.js';
+import { safeParseFloat, escapeHtml, fileToDataURL, normalizeDailyLogs, getLocalDate } from './utils.js';
 import { selectors, initializeSelectors, loadInfoTexts } from './uiElements.js';
 import { getMetricDescription } from './metricUtils.js';
 import {
@@ -342,7 +342,7 @@ export function loadCurrentIntake(status = null, extraMeals = null) {
     try {
         currentIntakeMacros = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
 
-        const todayStr = new Date().toISOString().split('T')[0];
+        const todayStr = getLocalDate();
         const todayLog = fullDashboardData?.dailyLogs?.find(l => l.date === todayStr)?.data;
         if (todayLog) {
             const completed = todayLog.completedMealsStatus || {};
@@ -661,7 +661,7 @@ export async function autoSaveCompletedMeals() {
     if (!currentUserId) return;
     const payload = {
         userId: currentUserId,
-        date: new Date().toISOString().split('T')[0],
+        date: getLocalDate(),
         data: { completedMealsStatus: { ...todaysMealCompletionStatus } }
     };
     try {
@@ -691,7 +691,7 @@ export async function autoSaveCompletedMeals() {
 }
 
 export async function handleSaveLog() { // Exported for eventListeners.js
-    const logPayload = { userId: currentUserId, date: new Date().toISOString().split('T')[0], data: {} };
+    const logPayload = { userId: currentUserId, date: getLocalDate(), data: {} };
     const weightInputElement = document.getElementById('dailyLogWeightInput');
 
     if (weightInputElement) {

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -10,6 +10,7 @@ import {
     appendExtraMealCard
 } from './populateUI.js';
 import { sanitizeHTML } from './htmlSanitizer.js';
+import { getLocalDate } from './utils.js';
 
 const dynamicNutrientOverrides = { ...nutrientOverrides };
 registerNutrientOverrides(dynamicNutrientOverrides);
@@ -557,7 +558,7 @@ export async function handleExtraMealFormSubmit(event) {
         };
         addExtraMealWithOverride(dataToSend.foodDescription, entry);
         // Актуализираме дневните логове с новото хранене
-        const todayStr = new Date().toISOString().split('T')[0];
+        const todayStr = getLocalDate();
         if (!Array.isArray(fullDashboardData.dailyLogs)) fullDashboardData.dailyLogs = [];
         let todayLog = fullDashboardData.dailyLogs.find(l => l.date === todayStr);
         if (!todayLog) {

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -1,6 +1,6 @@
 // populateUI.js - Попълване на UI с данни
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
-import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressFill, getCssVar, formatDateBgShort } from './utils.js';
+import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressFill, getCssVar, formatDateBgShort, getLocalDate } from './utils.js';
 import { generateId, apiEndpoints, standaloneMacroUrl } from './config.js';
 import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, currentUserId, todaysPlanMacros, updateMacrosAndAnalytics, resetDailyIntake } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
@@ -109,7 +109,7 @@ export async function populateUI() {
     if (!data || Object.keys(data).length === 0) {
         showToast("Липсват данни за показване.", true); return;
     }
-    const todayDateStr = new Date().toISOString().split('T')[0];
+    const todayDateStr = getLocalDate();
     const lastDate = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('lastDashboardDate') : null;
     if (lastDate !== todayDateStr) {
         resetDailyIntake();
@@ -599,7 +599,7 @@ function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {
     }
 
     const today = new Date();
-    const todayDateStr = today.toISOString().split('T')[0];
+    const todayDateStr = getLocalDate(today);
     const dayNames = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
     const currentDayKey = dayNames[today.getDay()];
     const todayTitle = today.toLocaleDateString('bg-BG', { weekday: 'long', day: 'numeric', month: 'long' });
@@ -682,7 +682,7 @@ function populateDashboardLog(dailyLogs, currentStatus, initialData) {
     }
 
     const today = new Date();
-    const todayDateStr = today.toISOString().split('T')[0];
+    const todayDateStr = getLocalDate(today);
     if (selectors.dailyLogDate) selectors.dailyLogDate.textContent = `за ${today.toLocaleDateString('bg-BG', { day: '2-digit', month: '2-digit', year: 'numeric' })}`;
 
     const todaysLog = dailyLogs?.find(log => log.date === todayDateStr)?.data || {};

--- a/js/utils.js
+++ b/js/utils.js
@@ -49,6 +49,15 @@ export const escapeHtml = (text) => {
 };
 
 /**
+ * Връща датата във формат YYYY-MM-DD според локалната часова зона.
+ * @param {Date} [date=new Date()] - Дата за форматиране.
+ * @returns {string} Датата в локален формат.
+ */
+export function getLocalDate(date = new Date()) {
+    return date.toLocaleDateString('en-CA');
+}
+
+/**
  * Форматира дата в кратък български формат (напр. "1 ян").
  * @param {string|number|Date} date - Датата за форматиране.
  * @returns {string} Форматираната дата.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "globals": "^16.2.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0",
+        "timezone-mock": "^1.3.6",
         "typedoc": "^0.28.5",
         "vite": "^6.3.5"
       },
@@ -6280,6 +6281,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/timezone-mock": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/timezone-mock/-/timezone-mock-1.3.6.tgz",
+      "integrity": "sha512-YcloWmZfLD9Li5m2VcobkCDNVaLMx8ohAb/97l/wYS3m+0TIEK5PFNMZZfRcusc6sFjIfxu8qcJT0CNnOdpqmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "globals": "^16.2.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0",
+    "timezone-mock": "^1.3.6",
     "typedoc": "^0.28.5",
     "vite": "^6.3.5"
   },

--- a/scripts/update-compat-date.js
+++ b/scripts/update-compat-date.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
+import { getLocalDate } from '../js/utils.js';
 
-const today = new Date().toISOString().split('T')[0];
+const today = getLocalDate();
 
 let toml;
 try {

--- a/worker.js
+++ b/worker.js
@@ -1,4 +1,5 @@
 // Cloudflare Worker Script (index.js) - Версия 2.3
+import { getLocalDate } from './js/utils.js';
 // Добавен е режим за дебъг чрез HTTP заглавие `X-Debug: 1`
 // Също така са запазени всички функционалности от предходните версии
 // Включва:
@@ -1140,7 +1141,7 @@ async function handleLogRequest(request, env) {
             throw new Error("Липсва потребителско ID (userId).");
         }
 
-        const todayStr = new Date().toISOString().split('T')[0];
+        const todayStr = getLocalDate();
         const dateToLog = inputData.date || todayStr; // Позволява подаване на дата, иначе днешна
         const logKey = `${userId}_log_${dateToLog}`;
 
@@ -1394,10 +1395,10 @@ async function handleLogExtraMealRequest(request, env) {
                 logDateStr = mealDate.toISOString().split('T')[0];
             } catch (e) {
                 console.warn(`LOG_EXTRA_MEAL_WARN (${userId}): Invalid mealTimeSpecific format: ${inputData.mealTimeSpecific}. Defaulting to today.`);
-                logDateStr = new Date().toISOString().split('T')[0];
+                logDateStr = getLocalDate();
             }
         } else {
-            logDateStr = new Date().toISOString().split('T')[0];
+            logDateStr = getLocalDate();
         }
 
         const logKey = `${userId}_log_${logDateStr}`;


### PR DESCRIPTION
## Summary
- add `getLocalDate` helper for consistent YYYY-MM-DD in local timezone
- replace direct `toISOString().split('T')[0]` usage across modules
- cover `getLocalDate` with timezone-aware unit test

## Testing
- `npm run lint`
- `npm test js/__tests__/getLocalDate.test.js js/__tests__/loadCurrentIntake.test.js`
- `npm test js/__tests__/populateUI.test.js` *(hangs, manual stop)*

------
https://chatgpt.com/codex/tasks/task_e_6897e5ec0aec8326ae84a93585ca228c