### PR TITLE
Парсване на количеството в извънредната форма

### DIFF
--- a/extra-meal-entry-form.html
+++ b/extra-meal-entry-form.html
@@ -73,6 +73,7 @@
             </div>
         </fieldset>
         <input type="text" id="quantityCustom" name="quantityCustom" class="input-focus-animate" style="margin-top: var(--space-sm);" placeholder="Напр. 100гр, 2 с.л., специфично количество" aria-label="Уточнение за количество">
+        <input type="number" id="quantity" name="quantity" class="hidden input-focus-animate" min="0" step="0.01" inputmode="decimal" aria-hidden="true">
 
         <div class="form-group" style="margin-top: var(--space-md);">
             <label for="mealTimeSelect">Кога го консумирахте?</label>

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -454,9 +454,18 @@ export async function handleExtraMealFormSubmit(event) {
     const form = event.target;
     const formData = new FormData(form);
 
-    const quantityField = formData.get('quantity');
+    const quantityCustomVal = (formData.get('quantityCustom') || '').trim();
+    let quantityField = (formData.get('quantity') || '').toString().trim();
+    if (!quantityField && quantityCustomVal) {
+        const match = quantityCustomVal.match(/[\d.,]+/);
+        if (match) {
+            quantityField = match[0].replace(',', '.');
+            formData.set('quantity', quantityField);
+        }
+    }
+
     let parsedQuantity;
-    if (quantityField !== null && quantityField !== undefined && quantityField !== '') {
+    if (quantityField) {
         parsedQuantity = Number(quantityField);
         if (!Number.isFinite(parsedQuantity) || parsedQuantity <= 0) {
             showToast('Количеството трябва да е положително число.', true);
@@ -465,7 +474,6 @@ export async function handleExtraMealFormSubmit(event) {
     }
 
     const selectedVisual = form.querySelector('input[name="quantityEstimateVisual"]:checked');
-    const quantityCustomVal = (formData.get('quantityCustom') || '').trim();
     if (!selectedVisual && !quantityCustomVal) {
         showToast('Моля, изберете количество или въведете стойност.', true);
         return;


### PR DESCRIPTION
## Резюме
- Добавено е скрито числово поле `quantity` в стъпка 2 на формата
- Логиката на `handleExtraMealFormSubmit` парсира стойност от `quantityCustom` и валидира резултата

## Тестове
- `npm run lint`
- `npm test js/__tests__/extraMealFormSubmit.test.js js/__tests__/extraMealForm.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897eb319c688326925b929ff20da7ed