### PR TITLE
Добавяне на ensureFreshDailyIntake и автоматично нулиране на дневния прием

### DIFF
--- a/js/__tests__/ensureFreshDailyIntake.test.js
+++ b/js/__tests__/ensureFreshDailyIntake.test.js
@@ -1,0 +1,18 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+import { getLocalDate } from '../utils.js';
+
+test('ensureFreshDailyIntake изчиства вчерашните extraMeals', async () => {
+  jest.resetModules();
+  const app = await import('../app.js');
+  const yesterday = getLocalDate(new Date(Date.now() - 86400000));
+  sessionStorage.setItem('lastDashboardDate', yesterday);
+  app.todaysExtraMeals.push({ calories: 100 });
+  app.todaysMealCompletionStatus.sample = true;
+
+  app.ensureFreshDailyIntake();
+
+  expect(app.todaysExtraMeals).toEqual([]);
+  expect(app.todaysMealCompletionStatus).toEqual({});
+  expect(sessionStorage.getItem('lastDashboardDate')).toBe(getLocalDate());
+});

--- a/js/__tests__/loadCurrentIntake.test.js
+++ b/js/__tests__/loadCurrentIntake.test.js
@@ -6,6 +6,7 @@ test('loadCurrentIntake агрегира макросите от логовет�
   jest.resetModules();
   const app = await import('../app.js');
   const todayStr = getLocalDate();
+  sessionStorage.setItem('lastDashboardDate', todayStr);
   Object.assign(app.fullDashboardData, {
     planData: { week1Menu: {} },
     dailyLogs: [
@@ -30,21 +31,23 @@ test('loadCurrentIntake агрегира макросите от логовет�
   });
 });
 
-test('loadCurrentIntake не презаписва подаденото състояние', async () => {
+test('loadCurrentIntake нулира подаденото състояние при липса на дневен запис', async () => {
   jest.resetModules();
   const app = await import('../app.js');
+  const todayStr = getLocalDate();
+  sessionStorage.setItem('lastDashboardDate', todayStr);
   Object.assign(app.fullDashboardData, { planData: { week1Menu: {} } });
   app.todaysMealCompletionStatus.sample = true;
-  app.todaysExtraMeals.length = 0;
   app.todaysExtraMeals.push({ calories: 100, protein: 5, carbs: 10, fat: 2, fiber: 1 });
   app.loadCurrentIntake(app.todaysMealCompletionStatus, app.todaysExtraMeals);
-  expect(app.todaysMealCompletionStatus).toEqual({ sample: true });
+  expect(app.todaysMealCompletionStatus).toEqual({});
+  expect(app.todaysExtraMeals).toEqual([]);
   expect(app.currentIntakeMacros).toEqual({
-    calories: 100,
-    protein: 5,
-    carbs: 10,
-    fat: 2,
-    fiber: 1,
+    calories: 0,
+    protein: 0,
+    carbs: 0,
+    fat: 0,
+    fiber: 0,
   });
 });
 
@@ -52,6 +55,7 @@ test('loadCurrentIntake нулира локалните данни при лип
   jest.resetModules();
   const app = await import('../app.js');
   const yesterday = getLocalDate(new Date(Date.now() - 86400000));
+  sessionStorage.setItem('lastDashboardDate', getLocalDate());
   Object.assign(app.fullDashboardData, {
     planData: { week1Menu: {} },
     dailyLogs: [{ date: yesterday, data: { extraMeals: [{ calories: 100 }] } }],
@@ -66,6 +70,7 @@ test('loadCurrentIntake нулира локалните данни при лип
 test('recalculateCurrentIntakeMacros преизчислява макросите', async () => {
   jest.resetModules();
   const app = await import('../app.js');
+  sessionStorage.setItem('lastDashboardDate', getLocalDate());
   Object.assign(app.fullDashboardData, { planData: { week1Menu: {} } });
   app.todaysMealCompletionStatus.sample = true;
   app.todaysExtraMeals.length = 0;

--- a/js/app.js
+++ b/js/app.js
@@ -168,6 +168,17 @@ export function resetDailyIntake() {
     currentIntakeMacros = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
 }
 
+export function ensureFreshDailyIntake() {
+    const todayDateStr = getLocalDate();
+    const lastDate = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('lastDashboardDate') : null;
+    if (lastDate !== todayDateStr) {
+        resetDailyIntake();
+        if (typeof sessionStorage !== 'undefined') {
+            sessionStorage.setItem('lastDashboardDate', todayDateStr);
+        }
+    }
+}
+
 // Функция за създаване на тестови данни
 
 function createTestData() {
@@ -340,6 +351,7 @@ async function initializeApp() {
 // ==========================================================================
 export function loadCurrentIntake(status = null, extraMeals = null) {
     try {
+        ensureFreshDailyIntake();
         currentIntakeMacros = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
 
         const todayStr = getLocalDate();
@@ -349,9 +361,10 @@ export function loadCurrentIntake(status = null, extraMeals = null) {
             Object.keys(todaysMealCompletionStatus).forEach(k => delete todaysMealCompletionStatus[k]);
             Object.assign(todaysMealCompletionStatus, completed);
             todaysExtraMeals = Array.isArray(todayLog.extraMeals) ? todayLog.extraMeals : [];
-        } else if (!status || !extraMeals) {
-            todaysExtraMeals = [];
-            Object.keys(todaysMealCompletionStatus).forEach(k => delete todaysMealCompletionStatus[k]);
+        } else {
+            resetDailyIntake();
+            status = null;
+            extraMeals = null;
         }
 
         status = status || todaysMealCompletionStatus;
@@ -369,6 +382,7 @@ export function loadCurrentIntake(status = null, extraMeals = null) {
 
 export function recalculateCurrentIntakeMacros() {
     try {
+        ensureFreshDailyIntake();
         currentIntakeMacros = calculateCurrentMacros(
             fullDashboardData.planData?.week1Menu || {},
             todaysMealCompletionStatus,

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -2,7 +2,7 @@
 import { selectors, trackerInfoTexts, detailedMetricInfoTexts } from './uiElements.js';
 import { safeGet, safeParseFloat, capitalizeFirstLetter, escapeHtml, applyProgressFill, getCssVar, formatDateBgShort, getLocalDate } from './utils.js';
 import { generateId, apiEndpoints, standaloneMacroUrl } from './config.js';
-import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, currentUserId, todaysPlanMacros, updateMacrosAndAnalytics, resetDailyIntake } from './app.js';
+import { fullDashboardData, todaysMealCompletionStatus, currentIntakeMacros, planHasRecContent, todaysExtraMeals, currentUserId, todaysPlanMacros, updateMacrosAndAnalytics, ensureFreshDailyIntake } from './app.js';
 import { showToast } from './uiHandlers.js'; // For populateDashboardDetailedAnalytics accordion
 import { ensureChart } from './chartLoader.js';
 import { getNutrientOverride, scaleMacros, calculatePlanMacros, calculateMacroPercents } from './macroUtils.js';
@@ -109,15 +109,8 @@ export async function populateUI() {
     if (!data || Object.keys(data).length === 0) {
         showToast("Липсват данни за показване.", true); return;
     }
-    const todayDateStr = getLocalDate();
-    const lastDate = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('lastDashboardDate') : null;
-    if (lastDate !== todayDateStr) {
-        resetDailyIntake();
-        updateMacrosAndAnalytics();
-        if (typeof sessionStorage !== 'undefined') {
-            sessionStorage.setItem('lastDashboardDate', todayDateStr);
-        }
-    }
+    ensureFreshDailyIntake();
+    updateMacrosAndAnalytics();
     try { populateUserInfo(data.userName); } catch(e) { console.error("Error in populateUserInfo:", e); }
     try { populateDashboardMainIndexes(data.analytics?.current); } catch(e) { console.error("Error in populateDashboardMainIndexes:", e); }
     try { populateDashboardDetailedAnalytics(data.analytics); } catch(e) { console.error("Error in populateDashboardDetailedAnalytics:", e); }


### PR DESCRIPTION
## Summary
- Добавена е `ensureFreshDailyIntake`, която нулира дневния прием при нов ден и обновява `sessionStorage`
- `loadCurrentIntake` и `recalculateCurrentIntakeMacros` вече я извикват и винаги изчистват данните при липсващ дневен лог
- `populateUI` използва новата проверка преди обновяване на макросите
- Добавен е unit тест за автоматично изчистване на вчерашни `extraMeals`

## Testing
- `npm run lint`
- `npm test -- js/__tests__/loadCurrentIntake.test.js js/__tests__/ensureFreshDailyIntake.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6897eac5fe8c83269fec38d3eba162f9