### PR TITLE
fix: prevent overwriting daily macros

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -395,7 +395,9 @@ export function recalculateCurrentIntakeMacros() {
 
 export function updateMacrosAndAnalytics() {
     recalculateCurrentIntakeMacros();
-    populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
+    // Използваме вече кешираните дневни макроси,
+    // за да избегнем презаписване с глобални стойности
+    populateDashboardMacros();
     renderPendingMacroChart();
     refreshAnalytics();
 }


### PR DESCRIPTION
## Summary
- call `populateDashboardMacros()` with cached macros to keep daily plan values

## Testing
- `npm run lint`
- `npm test js/__tests__/populateDashboardMacros.noSetData.test.js js/__tests__/macroCardVisibilityAfterAnalytics.test.js js/__tests__/renderPendingMacroChart.test.js js/__tests__/extraMealFormSubmit.test.js js/__tests__/extraMealFetchMacros.test.js` *(fails: The requested module './app.js' does not provide an export named 'ensureFreshDailyIntake')*
- `npm test js/__tests__/extraMealFormSubmit.test.js`
- `npm test js/__tests__/extraMealFetchMacros.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897f064016c8326ac802dcfbb510b56