### PR TITLE
fix: position extra meal card

### DIFF
--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -388,8 +388,10 @@ export function appendExtraMealCard(name, quantity) {
     items.textContent = `Количество: ${quantity ?? ''}`;
     contentWrapper.appendChild(items);
 
-    const nextUncompleted = list.querySelector('li:not(.completed)');
-    list.insertBefore(extraLi, nextUncompleted || null);
+    // Поставяме картата след последното приключено хранене или най-отгоре при липса на такива
+    const completed = list.querySelectorAll('li.completed');
+    const anchor = completed.length ? completed[completed.length - 1].nextSibling : list.firstChild;
+    list.insertBefore(extraLi, anchor);
 }
 
 export function addExtraMealWithOverride(name = '', macros = {}, grams) {


### PR DESCRIPTION
## Summary
- place extra meal card after the last completed meal or at the top when none are completed

## Testing
- `npm run lint`
- `npm test js/__tests__/appendExtraMealCard.test.js`
- `npm test` *(fails: populateUI.test.js etc. - ensureFreshDailyIntake export missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897f2e54b1083268a3e5939af1d5b93