### PR TITLE
feat: show logged extra meals on dashboard

### DIFF
--- a/js/__tests__/dashboardDataUnifiedLogs.test.js
+++ b/js/__tests__/dashboardDataUnifiedLogs.test.js
@@ -33,4 +33,29 @@ describe('handleDashboardDataRequest unified logs', () => {
     const expected = Math.round(((0) * 0.4) + (((2 / 5) * 100) * 0.4) + (((1 / 7) * 100) * 0.2));
     expect(res.analytics.current.engagementScore).toBe(expected);
   });
+
+  test('включва записи само с extraMeals', async () => {
+    const dateStr = '2024-01-01';
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(key => {
+          if (key === 'u1_initial_answers') return Promise.resolve(JSON.stringify({ name: 'U', weight: '70', height: '170', goal: 'lose' }));
+          if (key === 'u1_final_plan') return Promise.resolve(JSON.stringify({ caloriesMacros: { p: 1 }, week1Menu: {} }));
+          if (key === 'plan_status_u1') return Promise.resolve('ready');
+          if (key === 'u1_current_status') return Promise.resolve('{}');
+          if (key === 'u1_profile') return Promise.resolve('{}');
+          if (key === `u1_log_${dateStr}`) return Promise.resolve(JSON.stringify({ extraMeals: [{ foodDescription: 'Смути', quantityEstimate: '250 мл' }] }));
+          return Promise.resolve(null);
+        }),
+        put: jest.fn(),
+        list: jest.fn().mockResolvedValue({ keys: [{ name: `u1_log_${dateStr}` }] })
+      },
+      RESOURCES_KV: { get: jest.fn(() => Promise.resolve('{}')) }
+    };
+    const request = { url: 'https://example.com?userId=u1' };
+    const res = await handleDashboardDataRequest(request, env);
+    expect(res.dailyLogs).toHaveLength(1);
+    expect(res.dailyLogs[0].extraMeals).toHaveLength(1);
+    expect(res.dailyLogs[0].data).toEqual({});
+  });
 });

--- a/js/__tests__/populateUI.extraMeals.test.js
+++ b/js/__tests__/populateUI.extraMeals.test.js
@@ -1,0 +1,33 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+test('adds cards for todaysExtraMeals', async () => {
+  document.body.innerHTML = '<ul id="dailyMealList"></ul>';
+  const selectors = { dailyMealList: document.getElementById('dailyMealList') };
+  jest.unstable_mockModule('../uiElements.js', () => ({ selectors, trackerInfoTexts: {}, detailedMetricInfoTexts: {} }));
+  jest.unstable_mockModule('../eventListeners.js', () => ({
+    ensureMacroAnalyticsElement: jest.fn(),
+    setupStaticEventListeners: jest.fn(),
+    setupDynamicEventListeners: jest.fn(),
+    initializeCollapsibleCards: jest.fn(),
+  }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: { userName: 'Иван', analytics: {}, planData: {}, dailyLogs: [], currentStatus: {}, initialData: {}, initialAnswers: {} },
+    todaysMealCompletionStatus: {},
+    todaysExtraMeals: [{ foodDescription: 'Смути', quantityEstimate: '250 мл' }],
+    todaysPlanMacros: { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
+    currentIntakeMacros: {},
+    planHasRecContent: false,
+    loadCurrentIntake: jest.fn(),
+    resetDailyIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn(),
+    ensureFreshDailyIntake: jest.fn(),
+    currentUserId: 'u1',
+  }));
+  const { populateUI } = await import('../populateUI.js');
+  await populateUI();
+  const cards = document.querySelectorAll('#dailyMealList .extra-meal');
+  expect(cards).toHaveLength(1);
+  expect(cards[0].querySelector('.meal-name').textContent).toBe('Смути');
+});

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -90,6 +90,7 @@ beforeEach(async () => {
     loadCurrentIntake: jest.fn(),
     resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
+    ensureFreshDailyIntake: jest.fn(),
     currentUserId: 'u1'
   }));
   populateModule = await import('../populateUI.js');
@@ -145,6 +146,7 @@ test('обновява макро картата чрез setData', async () => 
     loadCurrentIntake: jest.fn(),
     resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
+    ensureFreshDailyIntake: jest.fn(),
     currentUserId: 'u1'
   }));
   jest.unstable_mockModule('../eventListeners.js', () => ({
@@ -183,6 +185,7 @@ test('hides modules when values are zero, except engagement card', async () => {
     loadCurrentIntake: jest.fn(),
     resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
+    ensureFreshDailyIntake: jest.fn(),
     currentUserId: 'u1'
   }));
   ({ populateUI } = await import('../populateUI.js'));
@@ -221,6 +224,7 @@ test('показва картата за историята на теглото 
     loadCurrentIntake: jest.fn(),
     resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
+    ensureFreshDailyIntake: jest.fn(),
     currentUserId: 'u1'
   }));
   ({ populateUI } = await import('../populateUI.js'));
@@ -258,6 +262,7 @@ test('populates daily plan with color bars and meal types', async () => {
     loadCurrentIntake: jest.fn(),
     resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
+    ensureFreshDailyIntake: jest.fn(),
     currentUserId: 'u1'
   }));
   ({ populateUI } = await import('../populateUI.js'));
@@ -305,6 +310,7 @@ test('handles meal type variations', async () => {
     loadCurrentIntake: jest.fn(),
     resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
+    ensureFreshDailyIntake: jest.fn(),
     currentUserId: 'u1'
   }));
   ({ populateUI } = await import('../populateUI.js'));
@@ -344,6 +350,7 @@ test('applies success color to completed meal bar', async () => {
     loadCurrentIntake: jest.fn(),
     resetDailyIntake: jest.fn(),
     updateMacrosAndAnalytics: jest.fn(),
+    ensureFreshDailyIntake: jest.fn(),
     currentUserId: 'u1'
   }));
   ({ populateUI } = await import('../populateUI.js'));
@@ -390,6 +397,7 @@ test('clicking a meal card toggles completion status', async () => {
       planHasRecContent: false,
       loadCurrentIntake: jest.fn(),
       updateMacrosAndAnalytics: jest.fn(),
+      ensureFreshDailyIntake: jest.fn(),
       currentUserId: 'u1'
     };
   });
@@ -434,6 +442,7 @@ describe('progress bar width handling', () => {
       loadCurrentIntake: jest.fn(),
       resetDailyIntake: jest.fn(),
       updateMacrosAndAnalytics: jest.fn(),
+      ensureFreshDailyIntake: jest.fn(),
       currentUserId: 'u1'
     }));
     ({ populateUI } = await import('../populateUI.js'));

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -118,6 +118,9 @@ export async function populateUI() {
     try { await populateDashboardMacros(data.planData?.caloriesMacros); } catch(e) { console.error("Error in populateDashboardMacros:", e); }
     try { populateDashboardStreak(data.analytics?.streak); } catch(e) { console.error("Error in populateDashboardStreak:", e); }
     try { populateDashboardDailyPlan(data.planData?.week1Menu, data.dailyLogs, data.recipeData); } catch(e) { console.error("Error in populateDashboardDailyPlan:", e); }
+    todaysExtraMeals.forEach(m =>
+        appendExtraMealCard(m.foodDescription ?? 'Хранене', m.quantityEstimate ?? '')
+    );
     try { populateDashboardLog(data.dailyLogs, data.currentStatus, data.initialData); } catch(e) { console.error("Error in populateDashboardLog:", e); }
     try { populateProfileTab(data.userName, data.initialData, data.currentStatus, data.initialAnswers); } catch(e) { console.error("Error in populateProfileTab:", e); }
     try { populateWeekPlanTab(data.planData?.week1Menu); } catch(e) { console.error("Error in populateWeekPlanTab:", e); }

--- a/worker.js
+++ b/worker.js
@@ -1046,7 +1046,10 @@ async function handleDashboardDataRequest(request, env) {
                     totals: parsed.totals || null,
                     extraMeals: parsed.extraMeals || []
                 };
-            }).filter(entry => entry !== null && entry.data && Object.keys(entry.data).length > 0);
+            }).filter(entry => entry && (
+                (entry.data && Object.keys(entry.data).length > 0) ||
+                (entry.extraMeals && entry.extraMeals.length > 0)
+            ));
         } else {
             const allLogsStr = await env.USER_METADATA_KV.get(`${userId}_logs`);
             const allLogs = safeParseJson(allLogsStr, []);
@@ -1056,7 +1059,10 @@ async function handleDashboardDataRequest(request, env) {
                     data: l.data || l.log || {},
                     totals: l.totals || null,
                     extraMeals: l.extraMeals || []
-                })).filter(e => e.date && e.data && Object.keys(e.data).length > 0)
+                })).filter(e => e.date && (
+                    (e.data && Object.keys(e.data).length > 0) ||
+                    (e.extraMeals && e.extraMeals.length > 0)
+                ))
                     .sort((a, b) => new Date(b.date) - new Date(a.date))
                     .slice(0, USER_ACTIVITY_LOG_LIST_LIMIT);
             }


### PR DESCRIPTION
## Summary
- keep dashboard log entries when they only contain extra meals
- render cards for previously logged extra meals on UI load
- add focused tests for extra meal rendering

## Testing
- `npm run lint`
- `npm test js/__tests__/dashboardDataMacros.test.js js/__tests__/dashboardDataUnifiedLogs.test.js js/__tests__/populateUI.extraMeals.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6897f4f021e4832686e708f48466cbfd