### PR TITLE
Добавяне на извънредни хранения в нормализираните дневни записи

### DIFF
--- a/js/__tests__/normalizeDailyLogs.test.js
+++ b/js/__tests__/normalizeDailyLogs.test.js
@@ -7,6 +7,7 @@ describe('normalizeDailyLogs', () => {
       date: '2024-01-01',
       weight: 80,
       completedMealsStatus: { breakfast: true },
+      extraMeals: [{ foodDescription: 'Смути' }],
       data: { note: 'hi' }
     }];
     const result = normalizeDailyLogs(input);
@@ -16,7 +17,8 @@ describe('normalizeDailyLogs', () => {
         data: {
           note: 'hi',
           weight: 80,
-          completedMealsStatus: { breakfast: true }
+          completedMealsStatus: { breakfast: true },
+          extraMeals: [{ foodDescription: 'Смути' }]
         }
       }
     ]);
@@ -28,7 +30,8 @@ describe('normalizeDailyLogs', () => {
       data: {
         note: 'ok',
         weight: 70,
-        completedMealsStatus: { lunch: false }
+        completedMealsStatus: { lunch: false },
+        extraMeals: [{ foodDescription: 'Сок' }]
       }
     }];
     expect(normalizeDailyLogs(input)).toEqual(input);

--- a/js/utils.js
+++ b/js/utils.js
@@ -276,7 +276,8 @@ export function normalizeDailyLogs(logs = []) {
         data: {
             ...log.data,
             weight: log.data?.weight ?? log.weight,
-            completedMealsStatus: log.data?.completedMealsStatus ?? log.completedMealsStatus
+            completedMealsStatus: log.data?.completedMealsStatus ?? log.completedMealsStatus,
+            extraMeals: log.data?.extraMeals ?? log.extraMeals
         }
     }));
 }


### PR DESCRIPTION
## Резюме
- Добавя `extraMeals` към резултата от `normalizeDailyLogs` за да се запазят извънредните хранения.
- Актуализира тестовете за `normalizeDailyLogs`, включвайки проверка за `extraMeals`.

## Тестове
- `npx eslint js/utils.js js/__tests__/normalizeDailyLogs.test.js`
- `npm test js/__tests__/normalizeDailyLogs.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689801c3f3f083268db76c88df8366f8