### PR TITLE
feat: fallback to name-only macro overrides

### DIFF
--- a/js/__tests__/extraMealNameOverride.test.js
+++ b/js/__tests__/extraMealNameOverride.test.js
@@ -1,0 +1,67 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let initializeExtraMealFormLogic;
+
+beforeEach(async () => {
+  jest.resetModules();
+  global.fetch = jest.fn().mockResolvedValue({ json: async () => [] });
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    showLoading: jest.fn(),
+    showToast: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+  const overrides = { 'ябълка': { calories: 60, protein: 1, carbs: 15, fat: 0.5, fiber: 3 } };
+  jest.unstable_mockModule('../macroUtils.js', () => ({
+    removeMealMacros: jest.fn(),
+    registerNutrientOverrides: jest.fn(),
+    getNutrientOverride: jest.fn(key => overrides[key]),
+    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] })
+  }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), appendExtraMealCard: jest.fn() }));
+  jest.unstable_mockModule('../app.js', () => ({
+    currentUserId: 'u1',
+    todaysExtraMeals: [],
+    todaysMealCompletionStatus: {},
+    currentIntakeMacros: {},
+    fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: { fiber_percent: 10, fiber_grams: 30 } } },
+    loadCurrentIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn()
+  }));
+  ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));
+});
+
+test('автопопълва макросите при override само по име', async () => {
+  document.body.innerHTML = `<div id="c">
+    <form id="extraMealEntryFormActual">
+      <div class="form-step"></div>
+      <div class="form-wizard-navigation">
+        <button id="emPrevStepBtn"></button>
+        <button id="emNextStepBtn"></button>
+        <button id="emSubmitBtn"></button>
+        <button id="emCancelBtn"></button>
+      </div>
+      <textarea id="foodDescription"></textarea>
+      <div id="foodSuggestionsDropdown"></div>
+      <input type="radio" name="quantityEstimateVisual" value="x" checked>
+      <input name="calories">
+      <input name="protein">
+      <input name="carbs">
+      <input name="fat">
+      <input name="fiber">
+      <div class="form-step"></div>
+    </form>
+  </div>`;
+  const container = document.getElementById('c');
+  await initializeExtraMealFormLogic(container);
+  const input = container.querySelector('#foodDescription');
+  input.value = 'Ябълка';
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  expect(container.querySelector('input[name="calories"]').value).toBe('60');
+  expect(container.querySelector('input[name="protein"]').value).toBe('1');
+  expect(container.querySelector('input[name="carbs"]').value).toBe('15');
+  expect(container.querySelector('input[name="fat"]').value).toBe('0.5');
+  expect(container.querySelector('input[name="fiber"]').value).toBe('3');
+});

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -296,17 +296,18 @@ export async function initializeExtraMealFormLogic(formContainerElement) {
     if (measureCountInput) measureCountInput.addEventListener('input', computeQuantity);
 
     function applyMacroOverrides(name, quantity = '') {
-        const macros = getNutrientOverride(buildCacheKey(name, quantity));
+        const key = buildCacheKey(name, quantity);
+        const macros =
+            getNutrientOverride(key) ||
+            getNutrientOverride(name.toLowerCase().trim());
         if (!macros) return;
-        let filled = false;
         MACRO_FIELDS.forEach(field => {
             const input = form.querySelector(`input[name="${field}"]`);
             if (input && !input.value) {
                 input.value = macros[field] ?? '';
-                filled = true;
             }
         });
-        if (filled && autoFillMsg) autoFillMsg.classList.remove('hidden');
+        if (autoFillMsg) autoFillMsg.classList.remove('hidden');
     }
 
     async function fetchAndApplyMacros(name, quantity = '') {


### PR DESCRIPTION
## Summary
- allow nutrient autofill to use name-only overrides
- always display autofill notice when overrides populate macros
- test autofill when only a name override exists

## Testing
- `npm run lint js/extraMealForm.js js/__tests__/extraMealNameOverride.test.js`
- `npm test js/__tests__/extraMealAutofill.test.js js/__tests__/extraMealNameOverride.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689812d541e08326b081a209811bf97d