### PR TITLE
Handle grams when aggregating meal macros

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -27,20 +27,40 @@ test('calculateCurrentMacros sums macros from completed meals and extras', () =>
   expect(result).toEqual({ calories: 848, protein: 67, carbs: 48, fat: 42, fiber: 5 });
 });
 
-test('calculateCurrentMacros използва meal.macros и overrides', () => {
-  registerNutrientOverrides({
-    'override meal': { calories: 56, protein: 5, carbs: 5, fat: 2, fiber: 1 }
+  test('calculateCurrentMacros използва meal.macros и overrides', () => {
+    registerNutrientOverrides({
+      'override meal': { calories: 56, protein: 5, carbs: 5, fat: 2, fiber: 1 }
+    });
+    const planMenu = {
+      monday: [
+        { meal_name: 'Override Meal' },
+        { macros: { calories: 159, protein_grams: 10, carbs_grams: 20, fat_grams: 5, fiber_grams: 3 } }
+      ]
+    };
+    const completionStatus = { monday_0: true, monday_1: true };
+    const result = calculateCurrentMacros(planMenu, completionStatus, []);
+    expect(result).toEqual({ calories: 215, protein: 15, carbs: 25, fat: 7, fiber: 4 });
+    registerNutrientOverrides({});
   });
+
+test('calculateCurrentMacros скалира macros по grams', () => {
   const planMenu = {
     monday: [
-      { meal_name: 'Override Meal' },
-      { macros: { calories: 159, protein_grams: 10, carbs_grams: 20, fat_grams: 5, fiber_grams: 3 } }
+      {
+        macros: {
+          calories: 200,
+          protein_grams: 10,
+          carbs_grams: 20,
+          fat_grams: 10,
+          fiber_grams: 5
+        },
+        grams: 50
+      }
     ]
   };
-  const completionStatus = { monday_0: true, monday_1: true };
+  const completionStatus = { monday_0: true };
   const result = calculateCurrentMacros(planMenu, completionStatus, []);
-  expect(result).toEqual({ calories: 215, protein: 15, carbs: 25, fat: 7, fiber: 4 });
-  registerNutrientOverrides({});
+  expect(result).toEqual({ calories: 100, protein: 5, carbs: 10, fat: 5, fiber: 2.5 });
 });
 
 test('calculatePlanMacros sums macros for day menu', () => {

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -268,15 +268,20 @@ export function calculatePlanMacros(dayMenu = []) {
 export function calculateCurrentMacros(planMenu = {}, completionStatus = {}, extraMeals = []) {
   const acc = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
 
+  const prepareMeal = (meal) =>
+    meal && typeof meal.macros === 'object'
+      ? { ...mapGramFields(meal.macros), grams: meal.grams }
+      : mapGramFields(meal);
+
   Object.entries(planMenu).forEach(([day, meals]) => {
     (meals || []).forEach((meal, idx) => {
       const key = `${day}_${idx}`;
-      if (completionStatus[key]) addMealMacros(mapGramFields(meal?.macros || meal), acc);
+      if (completionStatus[key]) addMealMacros(prepareMeal(meal), acc);
     });
   });
 
   if (Array.isArray(extraMeals)) {
-    extraMeals.forEach((m) => addMealMacros(mapGramFields(m), acc));
+    extraMeals.forEach((m) => addMealMacros(prepareMeal(m), acc));
   }
 
   return acc;


### PR DESCRIPTION
## Summary
- include meal grams when meal.macros is provided in calculateCurrentMacros
- test that grams correctly scale macro totals

## Testing
- `npm run lint js/macroUtils.js js/__tests__/macroUtils.test.js`
- `npm test -- js/__tests__/macroUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689816ccae1c8326982f9cfdc0a90872