### PR TITLE
feat: add net carb flag to macro validation

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -110,6 +110,17 @@ test('validateMacroCalories не предупреждава при съвпад�
   warnSpy.mockRestore();
 });
 
+test('validateMacroCalories приема net carbs при carbsIncludeFiber=false', () => {
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  __testExports.validateMacroCalories(
+    { calories: 310, protein: 30, carbs: 20, fat: 10, fiber: 10 },
+    0.05,
+    false
+  );
+  expect(warnSpy).not.toHaveBeenCalled();
+  warnSpy.mockRestore();
+});
+
 test('getNutrientOverride кешира резултатите', () => {
   registerNutrientOverrides({ 'ябълка': { calories: 52, protein: 0.3, carbs: 14, fat: 0.2, fiber: 2.4 } });
   expect(__testExports.nutrientCache.size).toBe(0);

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -189,10 +189,12 @@ function resolveMacros(meal, grams) {
  * оценяват по 2 kcal/грам.
  * @param {{calories:number, protein:number, carbs:number, fat:number, fiber:number}} macros
  * @param {number} [threshold=0.05] - Допустимото относително отклонение.
+ * @param {boolean} [carbsIncludeFiber=true] - Ако въглехидратите включват фибри, изважда ги за нетно съдържание.
  */
-function validateMacroCalories(macros = {}, threshold = 0.05) {
+function validateMacroCalories(macros = {}, threshold = 0.05, carbsIncludeFiber = true) {
   const { calories = 0, protein = 0, carbs = 0, fat = 0, fiber = 0, alcohol = 0 } = macros;
-  const calc = protein * 4 + (carbs - fiber) * 4 + fat * 9 + fiber * 2 + alcohol * 7;
+  const netCarbs = carbsIncludeFiber ? carbs - fiber : carbs;
+  const calc = protein * 4 + netCarbs * 4 + fat * 9 + fiber * 2 + alcohol * 7;
   if (!calc) return;
   const diff = Math.abs(calc - calories);
   if (diff / calc > threshold) {
@@ -281,4 +283,4 @@ export function calculateCurrentMacros(planMenu = {}, completionStatus = {}, ext
 
   return acc;
 }
-export const __testExports = { macrosByIdOrName, nutrientCache, resolveMacros };
+export const __testExports = { macrosByIdOrName, nutrientCache, resolveMacros, validateMacroCalories };


### PR DESCRIPTION
## Summary
- add `carbsIncludeFiber` option to `validateMacroCalories`
- expose new helper in test exports
- cover net carb scenario in tests

## Testing
- `npm run lint`
- `node scripts/validateMacros.js`
- `sh ./scripts/test.sh js/__tests__/macroUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689816e25de0832685e60db7a98957b2