### PR TITLE
feat: recalc macro calories

### DIFF
--- a/docs/recalculateCaloriesExample.md
+++ b/docs/recalculateCaloriesExample.md
@@ -1,0 +1,13 @@
+# Пример: преизчисляване на калории
+
+Следният код показва как некоректно въведени калории се коригират спрямо макронутриентите.
+
+```js
+import { recalculateCalories } from '../js/macroUtils.js';
+
+const meal = { calories: 57, protein: 10, carbs: 20, fat: 10 };
+const corrected = recalculateCalories(meal);
+// corrected: { calories: 210, protein: 10, carbs: 20, fat: 10 }
+```
+
+Функцията пресмята калориите от протеин, въглехидрати, мазнини, фибри и алкохол и връща обект с актуализирани калории.

--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -123,6 +123,15 @@ test('validateMacroCalories предупреждава при голямо от�
   warnSpy.mockRestore();
 });
 
+test('validateMacroCalories коригира калориите при разминаване', () => {
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const macros = { calories: 57, protein: 10, carbs: 20, fat: 10 };
+  __testExports.validateMacroCalories(macros);
+  expect(macros.calories).toBe(210);
+  expect(warnSpy).toHaveBeenCalled();
+  warnSpy.mockRestore();
+});
+
 test('validateMacroCalories не предупреждава при съвпадение с фибри', () => {
   const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   addMealMacros({ calories: 350, protein: 30, carbs: 40, fat: 10, fiber: 10 }, { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 });

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -184,6 +184,20 @@ function resolveMacros(meal, grams) {
 }
 
 /**
+ * Преизчислява калориите от макронутриентите.
+ * Фибрите се изваждат от въглехидратите за нетно съдържание и се оценяват по 2 kcal/грам.
+ * @param {{calories:number, protein:number, carbs:number, fat:number, fiber:number, alcohol?:number}} macros
+ * @param {boolean} [carbsIncludeFiber=true] - Ако въглехидратите включват фибри, изважда ги за нетно съдържание.
+ * @returns {{calories:number, protein:number, carbs:number, fat:number, fiber:number, alcohol?:number}}
+ */
+export function recalculateCalories(macros = {}, carbsIncludeFiber = true) {
+  const { protein = 0, carbs = 0, fat = 0, fiber = 0, alcohol = 0 } = macros;
+  const netCarbs = carbsIncludeFiber ? carbs - fiber : carbs;
+  const calc = protein * 4 + netCarbs * 4 + fat * 9 + fiber * 2 + alcohol * 7;
+  return { ...macros, calories: calc };
+}
+
+/**
  * Проверява дали калориите съответстват на макросите.
  * Фибрите се изваждат от въглехидратите за нетно съдържание и се
  * оценяват по 2 kcal/грам.
@@ -201,6 +215,7 @@ function validateMacroCalories(macros = {}, threshold = 0.05, carbsIncludeFiber 
     console.warn(
       `[macroUtils] Calorie mismatch: expected ${calc.toFixed(2)}, received ${calories}`
     );
+    Object.assign(macros, recalculateCalories(macros, carbsIncludeFiber));
   }
 }
 
@@ -288,4 +303,10 @@ export function calculateCurrentMacros(planMenu = {}, completionStatus = {}, ext
 
   return acc;
 }
-export const __testExports = { macrosByIdOrName, nutrientCache, resolveMacros, validateMacroCalories };
+export const __testExports = {
+  macrosByIdOrName,
+  nutrientCache,
+  resolveMacros,
+  validateMacroCalories,
+  recalculateCalories
+};


### PR DESCRIPTION
## Summary
- add `recalculateCalories` to compute calories from macros
- use recalculation in `validateMacroCalories` to fix mismatched values
- document and test corrected calorie calculation

## Testing
- `npm run lint`
- `sh ./scripts/test.sh js/__tests__/macroUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6898188cf8708326857c8edf4a9fe740