### PR TITLE
feat: allow nutrient overrides by name

### DIFF
--- a/js/__tests__/extraMealNameOverride.test.js
+++ b/js/__tests__/extraMealNameOverride.test.js
@@ -46,11 +46,13 @@ test('автопопълва макросите при override само по и
       <textarea id="foodDescription"></textarea>
       <div id="foodSuggestionsDropdown"></div>
       <input type="radio" name="quantityEstimateVisual" value="x" checked>
-      <input name="calories">
-      <input name="protein">
-      <input name="carbs">
-      <input name="fat">
-      <input name="fiber">
+      <div class="macro-inputs-grid">
+        <input name="calories">
+        <input name="protein">
+        <input name="carbs">
+        <input name="fat">
+        <input name="fiber">
+      </div>
       <div class="form-step"></div>
     </form>
   </div>`;
@@ -64,4 +66,7 @@ test('автопопълва макросите при override само по и
   expect(container.querySelector('input[name="carbs"]').value).toBe('15');
   expect(container.querySelector('input[name="fat"]').value).toBe('0.5');
   expect(container.querySelector('input[name="fiber"]').value).toBe('3');
+  const autoFillMsg = container.querySelector('#autoFillMsg');
+  expect(autoFillMsg).not.toBeNull();
+  expect(autoFillMsg.classList.contains('hidden')).toBe(false);
 });

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -321,7 +321,10 @@ export async function initializeExtraMealFormLogic(formContainerElement) {
                 if (autoFillMsg) autoFillMsg.classList.remove('hidden');
             } else {
                 applyMacroOverrides(description, total);
-                if (!getNutrientOverride(buildCacheKey(description, total))) {
+                const overrideExists =
+                    getNutrientOverride(buildCacheKey(description, total)) ||
+                    getNutrientOverride(description.toLowerCase().trim());
+                if (!overrideExists) {
                     fetchAndApplyMacros(description, total);
                 }
             }
@@ -418,7 +421,10 @@ export async function initializeExtraMealFormLogic(formContainerElement) {
             const quantity = getCurrentQuantity();
             if (autoFillMsg) autoFillMsg.classList.add('hidden');
             applyMacroOverrides(description, quantity);
-            if (description.length >= 3 && !getNutrientOverride(buildCacheKey(description, quantity))) {
+            const overrideExists =
+                getNutrientOverride(buildCacheKey(description, quantity)) ||
+                getNutrientOverride(description.toLowerCase().trim());
+            if (description.length >= 3 && !overrideExists) {
                 fetchAndApplyMacros(description, quantity);
             }
             let suggestedRadioValue = null;


### PR DESCRIPTION
## Summary
- avoid unnecessary macro lookups when override exists
- test override and auto fill message when only name matches

## Testing
- `npm run lint`
- `npm test js/__tests__/extraMealNameOverride.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689818f9a944832695aeae76a6bf57ac