### PR TITLE
Fuzzy match for extra meal products

### DIFF
--- a/js/__tests__/extraMealAutofill.test.js
+++ b/js/__tests__/extraMealAutofill.test.js
@@ -130,3 +130,71 @@ test('частично описание попълва макроси от пъ�
   expect(container.querySelector('input[name="protein"]').value).toBe('0.30');
   expect(container.querySelector('input[name="carbs"]').value).toBe('14.00');
 });
+
+test('грешка в описанието попълва макроси от най-близкия продукт', async () => {
+  jest.resetModules();
+  global.fetch = jest.fn().mockResolvedValue({ json: async () => [] });
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    showLoading: jest.fn(),
+    showToast: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({
+    removeMealMacros: jest.fn(),
+    registerNutrientOverrides: jest.fn(),
+    getNutrientOverride: jest.fn(),
+    loadProductMacros: jest.fn().mockResolvedValue({
+      overrides: {},
+      products: [
+        { name: 'ябълков сок', calories: 30, protein: 0.1, carbs: 7, fat: 0, fiber: 0 },
+        { name: 'ябълка', calories: 52, protein: 0.3, carbs: 14, fat: 0.2, fiber: 0 }
+      ]
+    })
+  }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), appendExtraMealCard: jest.fn() }));
+  jest.unstable_mockModule('../app.js', () => ({
+    currentUserId: 'u1',
+    todaysExtraMeals: [],
+    todaysMealCompletionStatus: {},
+    currentIntakeMacros: {},
+    fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: { fiber_percent: 10, fiber_grams: 30 } } },
+    loadCurrentIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn()
+  }));
+  ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));
+
+  document.body.innerHTML = `<div id="c">
+    <form id="extraMealEntryFormActual">
+      <div class="form-step"></div>
+      <div class="form-wizard-navigation">
+        <button id="emPrevStepBtn"></button>
+        <button id="emNextStepBtn"></button>
+        <button id="emSubmitBtn"></button>
+        <button id="emCancelBtn"></button>
+      </div>
+      <textarea id="foodDescription"></textarea>
+      <div id="foodSuggestionsDropdown"></div>
+      <select id="measureSelect"><option data-grams="100" selected>100g</option></select>
+      <input id="measureCount" value="1">
+      <input id="quantity">
+      <input name="calories">
+      <input name="protein">
+      <input name="carbs">
+      <input name="fat">
+      <input name="fiber">
+      <div class="form-step"></div>
+    </form>
+  </div>`;
+  const container = document.getElementById('c');
+  await initializeExtraMealFormLogic(container);
+  const input = container.querySelector('#foodDescription');
+  input.value = 'ябалка';
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  const count = container.querySelector('#measureCount');
+  count.dispatchEvent(new Event('input', { bubbles: true }));
+  expect(container.querySelector('input[name="calories"]').value).toBe('52.00');
+  expect(container.querySelector('input[name="protein"]').value).toBe('0.30');
+  expect(container.querySelector('input[name="carbs"]').value).toBe('14.00');
+});

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -287,17 +287,22 @@ export async function initializeExtraMealFormLogic(formContainerElement) {
 
     function findClosestProduct(desc = '') {
         const query = desc.toLowerCase();
+        if (!query) return null;
+
+        const direct = productList.filter(p => p.name.toLowerCase().includes(query));
+        if (direct.length) return direct[0]; // напр. "яб" → "ябълка"
+
         let best = null;
         let bestDist = Infinity;
         for (const p of productList) {
             const name = p.name.toLowerCase();
-            if (name.includes(query)) return p;
             const dist = levenshtein(name, query);
             if (dist < bestDist) {
                 bestDist = dist;
                 best = p;
             }
         }
+
         const threshold = Math.max(1, Math.floor(query.length * 0.3));
         return bestDist <= threshold ? best : null;
     }


### PR DESCRIPTION
## Summary
- Improve extra meal quantity auto-fill by using substring search with Levenshtein fallback
- Handle typos or partial product names (e.g. "яб" → "ябълка")
- Add tests for partial and fuzzy product matching

## Testing
- `npm run lint -- js/extraMealForm.js js/__tests__/extraMealAutofill.test.js`
- `npm test -- js/__tests__/extraMealAutofill.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6898195defc88326b61ff7157972c978