### PR TITLE
feat: highlight selected quantity card

### DIFF
--- a/css/extra_meal_form_styles.css
+++ b/css/extra_meal_form_styles.css
@@ -315,14 +315,17 @@
   white-space: normal;
 }
 
-#extraMealEntryModal .quantity-card-option:has(input[type="radio"]:checked) {
+#extraMealEntryModal .quantity-card-option:has(input[type="radio"]:checked),
+#extraMealEntryModal .quantity-card-option.selected {
   border-color: var(--primary-color);
   background-color: color-mix(in srgb, var(--primary-color) 10%, transparent);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-color) 50%, transparent);
 }
 
 #extraMealEntryModal .quantity-card-option:has(input[type="radio"]:checked) .card-label,
-#extraMealEntryModal .quantity-card-option:has(input[type="radio"]:checked) .card-icon {
+#extraMealEntryModal .quantity-card-option:has(input[type="radio"]:checked) .card-icon,
+#extraMealEntryModal .quantity-card-option.selected .card-label,
+#extraMealEntryModal .quantity-card-option.selected .card-icon {
   color: var(--primary-color);
   font-weight: 700;
 }
@@ -409,13 +412,16 @@ body.dark-theme #extraMealEntryModal .quantity-card-option:hover {
   border-color: var(--accent-color);
   background-color: color-mix(in srgb, var(--accent-color) 5%, transparent);
 }
-body.dark-theme #extraMealEntryModal .quantity-card-option:has(input[type="radio"]:checked) {
+body.dark-theme #extraMealEntryModal .quantity-card-option:has(input[type="radio"]:checked),
+body.dark-theme #extraMealEntryModal .quantity-card-option.selected {
   border-color: var(--primary-color);
   background-color: color-mix(in srgb, var(--primary-color) 15%, var(--input-bg) 85%);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-color) 60%, transparent);
 }
 body.dark-theme #extraMealEntryModal .quantity-card-option:has(input[type="radio"]:checked) .card-label,
-body.dark-theme #extraMealEntryModal .quantity-card-option:has(input[type="radio"]:checked) .card-icon {
+body.dark-theme #extraMealEntryModal .quantity-card-option:has(input[type="radio"]:checked) .card-icon,
+body.dark-theme #extraMealEntryModal .quantity-card-option.selected .card-label,
+body.dark-theme #extraMealEntryModal .quantity-card-option.selected .card-icon {
   color: var(--primary-color); /* За избрана карта, текстът и иконата стават в основния цвят на темата */
 }
 

--- a/js/__tests__/extraMealForm.test.js
+++ b/js/__tests__/extraMealForm.test.js
@@ -208,3 +208,71 @@ describe('extraMealForm populateSummary', () => {
     global.fetch = originalFetch;
   });
 });
+
+describe('quantity card selection', () => {
+  test('добавя selected клас към избраната карта', async () => {
+    jest.resetModules();
+    jest.unstable_mockModule('../uiHandlers.js', () => ({
+      showLoading: jest.fn(),
+      showToast: jest.fn(),
+      openModal: jest.fn(),
+      closeModal: jest.fn(),
+    }));
+    jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+    jest.unstable_mockModule('../app.js', () => ({
+      currentUserId: 'u1',
+      todaysExtraMeals: [],
+      currentIntakeMacros: {},
+      fullDashboardData: {},
+      loadCurrentIntake: jest.fn(),
+      updateMacrosAndAnalytics: jest.fn(),
+    }));
+    jest.unstable_mockModule('../macroUtils.js', () => ({
+      removeMealMacros: jest.fn(),
+      registerNutrientOverrides: jest.fn(),
+      getNutrientOverride: jest.fn(),
+      loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] }),
+    }));
+    jest.unstable_mockModule('../populateUI.js', () => ({
+      addExtraMealWithOverride: jest.fn(),
+      appendExtraMealCard: jest.fn(),
+    }));
+
+    const originalFetch = global.fetch;
+    global.fetch = undefined;
+    const { initializeExtraMealFormLogic } = await import('../extraMealForm.js');
+    global.fetch = originalFetch;
+
+    document.body.innerHTML = `
+      <form id="extraMealEntryFormActual">
+        <div class="form-step">
+          <label class="quantity-card-option"><input type="radio" name="quantityEstimateVisual" value="a"></label>
+          <label class="quantity-card-option"><input type="radio" name="quantityEstimateVisual" value="b"></label>
+        </div>
+        <div class="form-step" style="display:none"></div>
+        <div class="form-wizard-navigation">
+          <button id="emPrevStepBtn"></button>
+          <button id="emNextStepBtn"></button>
+          <button id="emSubmitBtn"></button>
+          <button id="emCancelBtn"></button>
+        </div>
+      </form>
+    `;
+
+    await initializeExtraMealFormLogic(document);
+
+    const radios = document.querySelectorAll('input[name="quantityEstimateVisual"]');
+    const first = radios[0];
+    const second = radios[1];
+
+    first.checked = true;
+    first.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(first.closest('.quantity-card-option').classList.contains('selected')).toBe(true);
+    expect(second.closest('.quantity-card-option').classList.contains('selected')).toBe(false);
+
+    second.checked = true;
+    second.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(second.closest('.quantity-card-option').classList.contains('selected')).toBe(true);
+    expect(first.closest('.quantity-card-option').classList.contains('selected')).toBe(false);
+  });
+});

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -501,6 +501,15 @@ export async function initializeExtraMealFormLogic(formContainerElement) {
             genericCloseModal(selectors.extraMealEntryModal.id);
         });
     }
+    quantityVisualRadios.forEach(radio => {
+        const label = radio.closest('.quantity-card-option');
+        if (radio.checked && label) label.classList.add('selected');
+        radio.addEventListener('change', function() {
+            form.querySelectorAll('.quantity-card-option').forEach(l => l.classList.remove('selected'));
+            const currentLabel = this.closest('.quantity-card-option');
+            if (this.checked && currentLabel) currentLabel.classList.add('selected');
+        });
+    });
     form.querySelectorAll('.icon-radio-label input[type="radio"]').forEach(radio => {
         const label = radio.closest('.icon-radio-label');
         if(radio.checked && label) label.classList.add('selected');


### PR DESCRIPTION
## Summary
- add JS handler to sync `selected` class on quantity cards
- include fallback CSS styles for `.quantity-card-option.selected`
- cover quantity card selection with unit test

## Testing
- `npm run lint`
- `npm test js/__tests__/extraMealForm.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689820fe469083268eee9512494a9f84