### PR TITLE
Автопопълване на макроси при промяна на количество

### DIFF
--- a/js/__tests__/extraMealAutofill.test.js
+++ b/js/__tests__/extraMealAutofill.test.js
@@ -45,11 +45,13 @@ test('автопопълва макросите при разпозната хр
       <textarea id="foodDescription"></textarea>
       <div id="foodSuggestionsDropdown"></div>
       <input type="radio" name="quantityEstimateVisual" value="x" checked>
-      <input name="calories">
-      <input name="protein">
-      <input name="carbs">
-      <input name="fat">
-      <input name="fiber">
+      <div class="macro-inputs-grid">
+        <input name="calories">
+        <input name="protein">
+        <input name="carbs">
+        <input name="fat">
+        <input name="fiber">
+      </div>
       <div class="form-step"></div>
     </form>
   </div>`;
@@ -129,6 +131,133 @@ test('частично описание попълва макроси от пъ�
   expect(container.querySelector('input[name="calories"]').value).toBe('52.00');
   expect(container.querySelector('input[name="protein"]').value).toBe('0.30');
   expect(container.querySelector('input[name="carbs"]').value).toBe('14.00');
+});
+
+test('попълва макроси при смяна на количество чрез радио бутон', async () => {
+  jest.resetModules();
+  global.fetch = jest.fn().mockResolvedValue({ json: async () => [] });
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    showLoading: jest.fn(),
+    showToast: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({
+    removeMealMacros: jest.fn(),
+    registerNutrientOverrides: jest.fn(),
+    getNutrientOverride: jest.fn(key => key === 'ябълка|малко_количество' ? { calories: 26, protein: 0.15, carbs: 7, fat: 0.1, fiber: 1 } : null),
+    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] })
+  }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), appendExtraMealCard: jest.fn() }));
+  jest.unstable_mockModule('../app.js', () => ({
+    currentUserId: 'u1',
+    todaysExtraMeals: [],
+    todaysMealCompletionStatus: {},
+    currentIntakeMacros: {},
+    fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: { fiber_percent: 10, fiber_grams: 30 } } },
+    loadCurrentIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn()
+  }));
+  ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));
+
+  document.body.innerHTML = `<div id="c">
+    <form id="extraMealEntryFormActual">
+      <div class="form-step"></div>
+      <div class="form-wizard-navigation">
+        <button id="emPrevStepBtn"></button>
+        <button id="emNextStepBtn"></button>
+        <button id="emSubmitBtn"></button>
+        <button id="emCancelBtn"></button>
+      </div>
+      <textarea id="foodDescription"></textarea>
+      <div id="foodSuggestionsDropdown"></div>
+      <input type="radio" name="quantityEstimateVisual" value="малко_количество">
+      <div class="macro-inputs-grid">
+        <input name="calories">
+        <input name="protein">
+        <input name="carbs">
+        <input name="fat">
+        <input name="fiber">
+      </div>
+      <div class="form-step"></div>
+    </form>
+  </div>`;
+  const container = document.getElementById('c');
+  await initializeExtraMealFormLogic(container);
+  const desc = container.querySelector('#foodDescription');
+  desc.value = 'ябълка';
+  desc.dispatchEvent(new Event('input', { bubbles: true }));
+
+  const smallRadio = container.querySelector('input[value="малко_количество"]');
+  smallRadio.checked = true;
+  smallRadio.dispatchEvent(new Event('change', { bubbles: true }));
+  expect(container.querySelector('input[name="calories"]').value).toBe('26');
+  expect(container.querySelector('#autoFillMsg').classList.contains('hidden')).toBe(false);
+});
+
+test('попълва макроси при ръчно въведено количество', async () => {
+  jest.resetModules();
+  global.fetch = jest.fn().mockResolvedValue({ json: async () => [] });
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    showLoading: jest.fn(),
+    showToast: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: jest.fn()
+  }));
+  jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({
+    removeMealMacros: jest.fn(),
+    registerNutrientOverrides: jest.fn(),
+    getNutrientOverride: jest.fn(key => key === 'ябълка|120g' ? { calories: 60, protein: 0.3, carbs: 15, fat: 0.2, fiber: 2 } : null),
+    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] })
+  }));
+  jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), appendExtraMealCard: jest.fn() }));
+  jest.unstable_mockModule('../app.js', () => ({
+    currentUserId: 'u1',
+    todaysExtraMeals: [],
+    todaysMealCompletionStatus: {},
+    currentIntakeMacros: {},
+    fullDashboardData: { planData: { week1Menu: {}, caloriesMacros: { fiber_percent: 10, fiber_grams: 30 } } },
+    loadCurrentIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn()
+  }));
+  ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));
+
+  document.body.innerHTML = `<div id="c">
+    <form id="extraMealEntryFormActual">
+      <div class="form-step"></div>
+      <div class="form-wizard-navigation">
+        <button id="emPrevStepBtn"></button>
+        <button id="emNextStepBtn"></button>
+        <button id="emSubmitBtn"></button>
+        <button id="emCancelBtn"></button>
+      </div>
+      <textarea id="foodDescription"></textarea>
+      <div id="foodSuggestionsDropdown"></div>
+      <input type="radio" name="quantityEstimateVisual" value="other_quantity_describe" checked>
+      <input id="quantityCustom">
+      <div class="macro-inputs-grid">
+        <input name="calories">
+        <input name="protein">
+        <input name="carbs">
+        <input name="fat">
+        <input name="fiber">
+      </div>
+      <div class="form-step"></div>
+    </form>
+  </div>`;
+  const container = document.getElementById('c');
+  await initializeExtraMealFormLogic(container);
+  const desc = container.querySelector('#foodDescription');
+  desc.value = 'ябълка';
+  desc.dispatchEvent(new Event('input', { bubbles: true }));
+
+  const custom = container.querySelector('#quantityCustom');
+  custom.value = '120g';
+  custom.dispatchEvent(new Event('input', { bubbles: true }));
+  expect(container.querySelector('input[name="calories"]').value).toBe('60');
+  expect(container.querySelector('#autoFillMsg').classList.contains('hidden')).toBe(false);
 });
 
 test('грешка в описанието попълва макроси от най-близкия продукт', async () => {

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -219,6 +219,7 @@ export async function initializeExtraMealFormLogic(formContainerElement) {
     const measureSelect = form.querySelector('#measureSelect');
     const measureCountInput = form.querySelector('#measureCount');
     const quantityHiddenInput = form.querySelector('#quantity');
+    const quantityCustomInput = form.querySelector('#quantityCustom');
     const mealTimeSpecificInput = form.querySelector('#mealTimeSpecific');
     const reasonRadioGroup = form.querySelectorAll('input[name="reasonPrimary"]');
     const reasonOtherText = form.querySelector('#reasonOtherText');
@@ -361,6 +362,29 @@ export async function initializeExtraMealFormLogic(formContainerElement) {
         } catch (e) {
             console.error('Nutrient lookup failed', e);
         }
+    }
+
+    function handleQuantityChange() {
+        const description = foodDescriptionInput?.value?.trim().toLowerCase();
+        const quantity = getCurrentQuantity();
+        if (autoFillMsg) autoFillMsg.classList.add('hidden');
+        computeQuantity();
+        if (description) {
+            applyMacroOverrides(description, quantity);
+            const overrideExists =
+                getNutrientOverride(buildCacheKey(description, quantity)) ||
+                getNutrientOverride(description.toLowerCase().trim());
+            if (!overrideExists) {
+                fetchAndApplyMacros(description, quantity);
+            }
+        }
+    }
+
+    if (quantityVisualRadios.length > 0) {
+        quantityVisualRadios.forEach(r => r.addEventListener('change', handleQuantityChange));
+    }
+    if (quantityCustomInput) {
+        quantityCustomInput.addEventListener('input', handleQuantityChange);
     }
 
     function showSuggestions(inputValue) {


### PR DESCRIPTION
## Summary
- свързване на radio бутоните и полето за ръчно количество с логиката за изчисляване на макроси
- обновяване на съобщението за автоматично попълване при промяна на количеството
- добавени тестове за автопопълване при избор на количество и при ръчно въведена стойност

## Testing
- `npm run lint`
- `npm test js/__tests__/extraMealAutofill.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689821566810832694feb2907b088954