### PR TITLE
refactor: use scaleMacros for extra meal quantities

### DIFF
--- a/js/__tests__/extraMealAutofill.test.js
+++ b/js/__tests__/extraMealAutofill.test.js
@@ -2,6 +2,16 @@
 import { jest } from '@jest/globals';
 
 let initializeExtraMealFormLogic;
+const scaleMacrosImpl = (m, g) => {
+  const factor = g / 100;
+  return {
+    calories: (m.calories || 0) * factor,
+    protein: (m.protein || 0) * factor,
+    carbs: (m.carbs || 0) * factor,
+    fat: (m.fat || 0) * factor,
+    fiber: (m.fiber || 0) * factor,
+  };
+};
 
 beforeEach(async () => {
   jest.resetModules();
@@ -17,7 +27,8 @@ beforeEach(async () => {
     removeMealMacros: jest.fn(),
     registerNutrientOverrides: jest.fn(),
     getNutrientOverride: jest.fn(key => key === 'ябълка|x' ? { calories: 52, protein: 0.3, carbs: 14, fat: 0.2, fiber: 0 } : null),
-    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] })
+    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] }),
+    scaleMacros: jest.fn(scaleMacrosImpl)
   }));
   jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), appendExtraMealCard: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({
@@ -85,7 +96,8 @@ test('частично описание попълва макроси от пъ�
         { name: 'ябълка', calories: 52, protein: 0.3, carbs: 14, fat: 0.2, fiber: 0 },
         { name: 'ябълков сок', calories: 30, protein: 0.1, carbs: 7, fat: 0, fiber: 0 }
       ]
-    })
+    }),
+    scaleMacros: jest.fn(scaleMacrosImpl)
   }));
   jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), appendExtraMealCard: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({
@@ -147,7 +159,8 @@ test('попълва макроси при смяна на количество 
     removeMealMacros: jest.fn(),
     registerNutrientOverrides: jest.fn(),
     getNutrientOverride: jest.fn(key => key === 'ябълка|малко_количество' ? { calories: 26, protein: 0.15, carbs: 7, fat: 0.1, fiber: 1 } : null),
-    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] })
+    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] }),
+    scaleMacros: jest.fn(scaleMacrosImpl)
   }));
   jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), appendExtraMealCard: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({
@@ -210,7 +223,8 @@ test('попълва макроси при ръчно въведено коли�
     removeMealMacros: jest.fn(),
     registerNutrientOverrides: jest.fn(),
     getNutrientOverride: jest.fn(key => key === 'ябълка|120g' ? { calories: 60, protein: 0.3, carbs: 15, fat: 0.2, fiber: 2 } : null),
-    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] })
+    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] }),
+    scaleMacros: jest.fn(scaleMacrosImpl)
   }));
   jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), appendExtraMealCard: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({
@@ -280,7 +294,8 @@ test('грешка в описанието попълва макроси от н
         { name: 'ябълков сок', calories: 30, protein: 0.1, carbs: 7, fat: 0, fiber: 0 },
         { name: 'ябълка', calories: 52, protein: 0.3, carbs: 14, fat: 0.2, fiber: 0 }
       ]
-    })
+    }),
+    scaleMacros: jest.fn(scaleMacrosImpl)
   }));
   jest.unstable_mockModule('../populateUI.js', () => ({ addExtraMealWithOverride: jest.fn(), populateDashboardMacros: jest.fn(), appendExtraMealCard: jest.fn() }));
   jest.unstable_mockModule('../app.js', () => ({

--- a/js/__tests__/extraMealFetchMacros.test.js
+++ b/js/__tests__/extraMealFetchMacros.test.js
@@ -20,7 +20,8 @@ beforeEach(async () => {
     removeMealMacros: jest.fn(),
     registerNutrientOverrides: jest.fn(),
     getNutrientOverride: jest.fn(() => null),
-    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] })
+    loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] }),
+    scaleMacros: jest.fn()
   }));
   jest.unstable_mockModule('../populateUI.js', () => ({
     addExtraMealWithOverride: jest.fn(),

--- a/js/__tests__/extraMealForm.test.js
+++ b/js/__tests__/extraMealForm.test.js
@@ -1,6 +1,17 @@
 import { jest } from "@jest/globals";
 import { handleLogExtraMealRequest } from '../../worker.js';
 
+const scaleMacrosImpl = (m, g) => {
+  const factor = g / 100;
+  return {
+    calories: (m.calories || 0) * factor,
+    protein: (m.protein || 0) * factor,
+    carbs: (m.carbs || 0) * factor,
+    fat: (m.fat || 0) * factor,
+    fiber: (m.fiber || 0) * factor,
+  };
+};
+
 describe('handleLogExtraMealRequest', () => {
   test('returns success and stores data', async () => {
     const env = { USER_METADATA_KV: { get: jest.fn().mockResolvedValue(null), put: jest.fn() } };
@@ -40,6 +51,7 @@ describe('extraMealForm populateSummary', () => {
       registerNutrientOverrides: jest.fn(),
       getNutrientOverride: jest.fn(),
       loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] }),
+      scaleMacros: jest.fn(scaleMacrosImpl),
     }));
     jest.unstable_mockModule('../populateUI.js', () => ({
       addExtraMealWithOverride: jest.fn(),
@@ -131,6 +143,7 @@ describe('extraMealForm populateSummary', () => {
       registerNutrientOverrides: jest.fn((o) => Object.assign(overridesStore, o)),
       getNutrientOverride: jest.fn((k) => overridesStore[k]),
       loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] }),
+      scaleMacros: jest.fn(scaleMacrosImpl),
     }));
     jest.unstable_mockModule('../populateUI.js', () => ({
       addExtraMealWithOverride: jest.fn(),
@@ -194,7 +207,7 @@ describe('extraMealForm populateSummary', () => {
     desc.value = 'непозната храна';
     desc.dispatchEvent(new Event('input', { bubbles: true }));
 
-    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 350));
 
     document.getElementById('emNextStepBtn').click();
 
@@ -232,6 +245,7 @@ describe('quantity card selection', () => {
       registerNutrientOverrides: jest.fn(),
       getNutrientOverride: jest.fn(),
       loadProductMacros: jest.fn().mockResolvedValue({ overrides: {}, products: [] }),
+      scaleMacros: jest.fn(scaleMacrosImpl),
     }));
     jest.unstable_mockModule('../populateUI.js', () => ({
       addExtraMealWithOverride: jest.fn(),

--- a/js/__tests__/extraMealScaleMacros.test.js
+++ b/js/__tests__/extraMealScaleMacros.test.js
@@ -1,0 +1,85 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let initializeExtraMealFormLogic;
+const scaleMacrosMock = jest.fn(() => ({
+  calories: 104,
+  protein: 0.6,
+  carbs: 28,
+  fat: 0.4,
+  fiber: 0
+}));
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.unstable_mockModule('../uiHandlers.js', () => ({
+    showLoading: jest.fn(),
+    showToast: jest.fn(),
+    openModal: jest.fn(),
+    closeModal: jest.fn(),
+  }));
+  jest.unstable_mockModule('../config.js', () => ({ apiEndpoints: {} }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({
+    removeMealMacros: jest.fn(),
+    registerNutrientOverrides: jest.fn(),
+    getNutrientOverride: jest.fn(),
+    loadProductMacros: jest.fn().mockResolvedValue({
+      overrides: {},
+      products: [{ name: 'ябълка', calories: 52, protein: 0.3, carbs: 14, fat: 0.2, fiber: 0 }]
+    }),
+    scaleMacros: scaleMacrosMock,
+  }));
+  jest.unstable_mockModule('../populateUI.js', () => ({
+    addExtraMealWithOverride: jest.fn(),
+    appendExtraMealCard: jest.fn(),
+  }));
+  jest.unstable_mockModule('../app.js', () => ({
+    currentUserId: 'u1',
+    todaysExtraMeals: [],
+    currentIntakeMacros: {},
+    fullDashboardData: {},
+    loadCurrentIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn(),
+  }));
+  ({ initializeExtraMealFormLogic } = await import('../extraMealForm.js'));
+});
+
+test('computeQuantity използва scaleMacros за попълване на макроси', async () => {
+  document.body.innerHTML = `<div id="c">
+    <form id="extraMealEntryFormActual">
+      <div class="form-step"></div>
+      <div class="form-wizard-navigation">
+        <button id="emPrevStepBtn"></button>
+        <button id="emNextStepBtn"></button>
+        <button id="emSubmitBtn"></button>
+        <button id="emCancelBtn"></button>
+      </div>
+      <textarea id="foodDescription"></textarea>
+      <div id="foodSuggestionsDropdown"></div>
+      <select id="measureSelect"><option data-grams="100" selected>100g</option></select>
+      <input id="measureCount" value="2">
+      <input id="quantity">
+      <input name="calories">
+      <input name="protein">
+      <input name="carbs">
+      <input name="fat">
+      <input name="fiber">
+      <div class="form-step"></div>
+    </form>
+  </div>`;
+  const container = document.getElementById('c');
+  await initializeExtraMealFormLogic(container);
+  const desc = container.querySelector('#foodDescription');
+  desc.value = 'ябълка';
+  desc.dispatchEvent(new Event('input', { bubbles: true }));
+  const count = container.querySelector('#measureCount');
+  count.dispatchEvent(new Event('input', { bubbles: true }));
+  expect(scaleMacrosMock).toHaveBeenCalledWith(
+    expect.objectContaining({ name: 'ябълка' }),
+    200
+  );
+  expect(container.querySelector('input[name="calories"]').value).toBe('104.00');
+  expect(container.querySelector('input[name="protein"]').value).toBe('0.60');
+  expect(container.querySelector('input[name="carbs"]').value).toBe('28.00');
+  expect(container.querySelector('input[name="fat"]').value).toBe('0.40');
+});

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -4,7 +4,7 @@ import { showLoading, showToast, openModal as genericOpenModal, closeModal as ge
 import { apiEndpoints } from './config.js';
 import { currentUserId, todaysExtraMeals, currentIntakeMacros, loadCurrentIntake, updateMacrosAndAnalytics, fullDashboardData } from './app.js';
 import nutrientOverrides from '../kv/DIET_RESOURCES/nutrient_overrides.json' with { type: 'json' };
-import { removeMealMacros, registerNutrientOverrides, getNutrientOverride, loadProductMacros } from './macroUtils.js';
+import { removeMealMacros, registerNutrientOverrides, getNutrientOverride, loadProductMacros, scaleMacros } from './macroUtils.js';
 import {
     addExtraMealWithOverride,
     appendExtraMealCard
@@ -319,11 +319,8 @@ export async function initializeExtraMealFormLogic(formContainerElement) {
         if (description && total > 0) {
             const product = findClosestProduct(description); // напр. "яб" → "ябълка"
             if (product) {
-                const factor = total / 100;
-                MACRO_FIELDS.forEach(field => {
-                    const input = form.querySelector(`input[name="${field}"]`);
-                    if (input) input.value = ((product[field] ?? 0) * factor).toFixed(2);
-                });
+                const scaled = scaleMacros(product, total);
+                MACRO_FIELDS.forEach(f => form.querySelector(`input[name="${f}"]`).value = scaled[f].toFixed(2));
                 if (autoFillMsg) autoFillMsg.classList.remove('hidden');
             } else {
                 applyMacroOverrides(description, total);


### PR DESCRIPTION
## Summary
- reuse `scaleMacros` in `computeQuantity` for extra meal forms
- update tests and add coverage for scaled macro values

## Testing
- `npm run lint js/extraMealForm.js js/__tests__/extraMealScaleMacros.test.js`
- `npm test js/__tests__/extraMealAutofill.test.js js/__tests__/extraMealFetchMacros.test.js js/__tests__/extraMealForm.test.js js/__tests__/extraMealScaleMacros.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68982458f87c83268a6c9d3f50b0b9b0