### PR TITLE
Add product data consistency test and guide

### DIFF
--- a/docs/product_data_sync.md
+++ b/docs/product_data_sync.md
@@ -1,0 +1,21 @@
+# Синхронизация на продуктовите данни
+
+Файловете `kv/DIET_RESOURCES/product_measure.json` и `kv/DIET_RESOURCES/product_macros.json` трябва да съдържат един и същ набор от имена на продукти. Сравнението е без значение на регистъра.
+
+## Пример за добавяне
+1. Добавете името и мерките в `product_measure.json`.
+2. Добавете същото име и макросите в `product_macros.json`.
+3. Уверете се, че имената съвпадат точно:
+   ```json
+   { "name": "киноа", "measures": [...] }
+   { "name": "киноа", "calories": ... }
+   ```
+
+## Проверка
+Изпълнете:
+
+```
+npm run lint
+npm test -- js/__tests__/productDataConsistency.test.js
+```
+Тестът `productDataConsistency` ще сигнализира при липсващи или излишни имена.

--- a/js/__tests__/productDataConsistency.test.js
+++ b/js/__tests__/productDataConsistency.test.js
@@ -1,0 +1,22 @@
+import productMeasures from '../../kv/DIET_RESOURCES/product_measure.json' with { type: 'json' };
+import productMacros from '../../kv/DIET_RESOURCES/product_macros.json' with { type: 'json' };
+
+test('наборите от имена в product_measure.json и product_macros.json съвпадат', () => {
+  const measureNames = new Set((productMeasures || []).map(p => p.name.toLowerCase()));
+  const macroNames = new Set((productMacros || []).map(p => p.name.toLowerCase()));
+
+  const missingInMacros = [...measureNames].filter(n => !macroNames.has(n));
+  const missingInMeasures = [...macroNames].filter(n => !measureNames.has(n));
+
+  const messages = [];
+  if (missingInMacros.length) {
+    messages.push(`Липсват в product_macros.json: ${missingInMacros.join(', ')}`);
+  }
+  if (missingInMeasures.length) {
+    messages.push(`Липсват в product_measure.json: ${missingInMeasures.join(', ')}`);
+  }
+
+  if (messages.length) {
+    throw new Error(messages.join('\n'));
+  }
+});


### PR DESCRIPTION
## Summary
- add test to compare product names between `product_measure.json` and `product_macros.json`
- document how to keep the product files in sync

## Testing
- `npm run lint`
- `npm test -- js/__tests__/productDataConsistency.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689891fdba44832681348e4b564d17ee