### PR TITLE
Добавени радио опции за мерни единици в извънредния прием

### DIFF
--- a/extra-meal-entry-form.html
+++ b/extra-meal-entry-form.html
@@ -72,8 +72,7 @@
                     <span class="card-content"><span class="card-icon-wrapper"><span class="card-icon">➕</span></span><span class="card-text-wrapper"><span class="card-label">Уточни</span></span></span>
                 </label>
             </div>
-            <select id="measureSelect" class="hidden input-focus-animate" style="margin-top: var(--space-sm);" aria-label="Мерна единица"></select>
-            <input type="number" id="measureCount" class="hidden input-focus-animate" style="margin-top: var(--space-sm);" min="0" step="1" placeholder="Брой" aria-label="Брой мерни единици">
+            <div id="measureOptions" class="measure-radio-group"></div>
         </fieldset>
         <input type="text" id="quantityCustom" name="quantityCustom" class="input-focus-animate" style="margin-top: var(--space-sm);" placeholder="Напр. 100гр, 2 с.л., специфично количество" aria-label="Уточнение за количество">
         <input type="number" id="quantity" name="quantity" class="hidden input-focus-animate" min="0" step="0.01" inputmode="decimal" aria-hidden="true">

--- a/js/__tests__/extraMealAutofill.test.js
+++ b/js/__tests__/extraMealAutofill.test.js
@@ -122,8 +122,9 @@ test('частично описание попълва макроси от пъ�
       </div>
       <textarea id="foodDescription"></textarea>
       <div id="foodSuggestionsDropdown"></div>
-      <select id="measureSelect"><option data-grams="100" selected>100g</option></select>
-      <input id="measureCount" value="1">
+      <div id="measureOptions">
+        <label class="quantity-card-option"><input type="radio" name="measureOption" data-grams="100" checked><span class="card-content"></span></label>
+      </div>
       <input id="quantity">
       <input name="calories">
       <input name="protein">
@@ -137,9 +138,8 @@ test('частично описание попълва макроси от пъ�
   await initializeExtraMealFormLogic(container);
   const input = container.querySelector('#foodDescription');
   input.value = 'яб';
-  input.dispatchEvent(new Event('input', { bubbles: true }));
-  const count = container.querySelector('#measureCount');
-  count.dispatchEvent(new Event('input', { bubbles: true }));
+  const measureRadio = container.querySelector('#measureOptions input');
+  measureRadio.dispatchEvent(new Event('change', { bubbles: true }));
   expect(container.querySelector('input[name="calories"]').value).toBe('52.00');
   expect(container.querySelector('input[name="protein"]').value).toBe('0.30');
   expect(container.querySelector('input[name="carbs"]').value).toBe('14.00');
@@ -320,8 +320,9 @@ test('грешка в описанието попълва макроси от н
       </div>
       <textarea id="foodDescription"></textarea>
       <div id="foodSuggestionsDropdown"></div>
-      <select id="measureSelect"><option data-grams="100" selected>100g</option></select>
-      <input id="measureCount" value="1">
+      <div id="measureOptions">
+        <label class="quantity-card-option"><input type="radio" name="measureOption" data-grams="100" checked><span class="card-content"></span></label>
+      </div>
       <input id="quantity">
       <input name="calories">
       <input name="protein">
@@ -335,9 +336,8 @@ test('грешка в описанието попълва макроси от н
   await initializeExtraMealFormLogic(container);
   const input = container.querySelector('#foodDescription');
   input.value = 'ябалка';
-  input.dispatchEvent(new Event('input', { bubbles: true }));
-  const count = container.querySelector('#measureCount');
-  count.dispatchEvent(new Event('input', { bubbles: true }));
+  const measureRadio = container.querySelector('#measureOptions input');
+  measureRadio.dispatchEvent(new Event('change', { bubbles: true }));
   expect(container.querySelector('input[name="calories"]').value).toBe('52.00');
   expect(container.querySelector('input[name="protein"]').value).toBe('0.30');
   expect(container.querySelector('input[name="carbs"]').value).toBe('14.00');

--- a/js/__tests__/extraMealScaleMacros.test.js
+++ b/js/__tests__/extraMealScaleMacros.test.js
@@ -56,8 +56,9 @@ test('computeQuantity използва scaleMacros за попълване на 
       </div>
       <textarea id="foodDescription"></textarea>
       <div id="foodSuggestionsDropdown"></div>
-      <select id="measureSelect"><option data-grams="100" selected>100g</option></select>
-      <input id="measureCount" value="2">
+      <div id="measureOptions">
+        <label class="quantity-card-option"><input type="radio" name="measureOption" data-grams="200" checked><span class="card-content"></span></label>
+      </div>
       <input id="quantity">
       <input name="calories">
       <input name="protein">
@@ -71,9 +72,8 @@ test('computeQuantity използва scaleMacros за попълване на 
   await initializeExtraMealFormLogic(container);
   const desc = container.querySelector('#foodDescription');
   desc.value = 'ябълка';
-  desc.dispatchEvent(new Event('input', { bubbles: true }));
-  const count = container.querySelector('#measureCount');
-  count.dispatchEvent(new Event('input', { bubbles: true }));
+  const measureRadio = container.querySelector('#measureOptions input');
+  measureRadio.dispatchEvent(new Event('change', { bubbles: true }));
   expect(scaleMacrosMock).toHaveBeenCalledWith(
     expect.objectContaining({ name: 'ябълка' }),
     200


### PR DESCRIPTION
## Резюме
- заменен падащият списък за мерни единици с радио карти в `extra-meal-entry-form`
- актуализирана логика за избор на мерна единица и автоматично попълване на количество
- добавена опция "Друго" и обновени тестове за новото поведение

## Тестване
- `npm run lint`
- `npm test js/__tests__/extraMealAutofill.test.js js/__tests__/extraMealScaleMacros.test.js js/__tests__/extraMealForm.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6898acbe006c8326b10df6394b5ac4c5