### PR TITLE
fix: export extra meal modal loader

### DIFF
--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -90,6 +90,21 @@ async function ensureProductMeasuresLoaded() {
 
 let extraMealFormLoaded = false;
 
+export async function openExtraMealModal() {
+    genericOpenModal('extraMealEntryModal');
+    if (extraMealFormLoaded || !selectors.extraMealFormContainer) return;
+    try {
+        const resp = await fetch('extra-meal-entry-form.html');
+        if (!resp.ok) throw new Error('Failed to load extra meal form');
+        selectors.extraMealFormContainer.innerHTML = await resp.text();
+        await initializeExtraMealFormLogic(selectors.extraMealFormContainer);
+        extraMealFormLoaded = true;
+    } catch (err) {
+        console.error('Неуспешно зареждане на формата за извънредно хранене', err);
+        showToast('Грешка при зареждане на формата.', true);
+    }
+}
+
 export function getQuantityDisplay(selectedRadio, quantityCustom) {
     const customVal = (quantityCustom || '').trim();
     if (selectedRadio) {


### PR DESCRIPTION
## Summary
- export `openExtraMealModal` in extra meal form module and load modal form dynamically

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68994dd42d2c8326928d67479e290694