### PR TITLE
Handle missing mail config and improve error feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,9 +298,9 @@ means the Node dependencies haven't been installed. Run `npm install` and then
 try again. Recent versions of the worker rely on the `MAILER_ENDPOINT_URL`
 environment variable instead of dynamic imports. If this variable is missing, the
 worker uses the helper from `sendEmailWorker.js` and posts directly to
-`MAIL_PHP_URL` (defaults to `https://radilovk.github.io/bodybest/mailer/mail.php`). A **500** error from
-`/api/sendTestEmail` usually indicates a problem with the PHP backend. Inspect
-the worker logs for details.
+`MAIL_PHP_URL`. A **500** error from `/api/sendTestEmail` usually indicates a problem
+with the PHP backend or липсваща конфигурация. GitHub Pages не изпълнява PHP и не
+може да се използва като пощенски бекенд.
 
 If TypeScript complains that it cannot find `Buffer` or the type definition file
 for **`node`**, make sure Node.js types are installed and enabled:
@@ -1136,7 +1136,7 @@ To send a test email задайте `WORKER_ADMIN_TOKEN`. Може да посо
 | Variable | Purpose |
 |----------|---------|
 | `MAILER_ENDPOINT_URL` | Endpoint called by `worker.js` when sending emails. If omitted, the worker posts to `sendEmailWorker.js`. The request payload includes both `message` and `body` fields for compatibility. |
-| `MAIL_PHP_URL` | Legacy PHP endpoint if you prefer your own backend. Defaults to `https://radilovk.github.io/bodybest/mailer/mail.php`. |
+| `MAIL_PHP_URL` | PHP endpoint if you prefer your own backend. Required when `MAILER_ENDPOINT_URL` is not set. Must point to работещ PHP сървър (GitHub Pages не се поддържа). |
 | `EMAIL_PASSWORD` | Password used by `mailer.js` when authenticating with the SMTP server. |
 | `FROM_EMAIL` | Sender address used by `mailer.js` and the PHP backend. |
 | `FROM_NAME` | Optional display name for the sender shown in outgoing emails. |

--- a/js/__tests__/emailSender.test.js
+++ b/js/__tests__/emailSender.test.js
@@ -38,3 +38,7 @@ test('uses MAIL_PHP_URL when endpoint missing', async () => {
   fetch.mockRestore();
   delete process.env.MAIL_PHP_URL;
 });
+
+test('throws when no mail endpoint configured', async () => {
+  await expect(sendEmailUniversal('n@a.bg', 'S', 'B')).rejects.toThrow('MAILER_ENDPOINT_URL или MAIL_PHP_URL не са настроени');
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -1645,7 +1645,7 @@ async function sendTestEmail() {
         alert('Имейлът е изпратен успешно.');
     } catch (err) {
         console.error('Error sending test email:', err);
-        alert('Грешка при изпращане.');
+        alert(err.message || 'Грешка при изпращане.');
     }
 }
 

--- a/worker.js
+++ b/worker.js
@@ -42,7 +42,10 @@ async function parseJsonSafe(resp, label = 'response') {
 
 // Минимална логика за изпращане на имейл чрез PHP
 async function sendEmail(to, subject, message, env = {}) {
-  const url = env.MAIL_PHP_URL || 'https://radilovk.github.io/bodybest/mailer/mail.php';
+  const url = env.MAIL_PHP_URL;
+  if (!url) {
+    throw new Error('MAIL_PHP_URL is required');
+  }
   const fromName = env.FROM_NAME || '';
   const resp = await fetch(url, {
     method: 'POST',
@@ -50,7 +53,8 @@ async function sendEmail(to, subject, message, env = {}) {
     body: JSON.stringify({ to, subject, message, body: message, fromName })
   });
   if (!resp.ok) {
-    throw new Error(`PHP mailer error ${resp.status}`);
+    const text = await resp.text().catch(() => '');
+    throw new Error(`PHP mailer error ${resp.status}${text ? `: ${text}` : ''}`);
   }
 }
 
@@ -65,12 +69,17 @@ async function sendEmailUniversal(to, subject, body, env = {}) {
       body: JSON.stringify({ to, subject, message: body, body, fromName })
     });
     if (!resp.ok) {
-      throw new Error(`Mailer responded with ${resp.status}`);
+      const text = await resp.text().catch(() => '');
+      throw new Error(`Mailer responded with ${resp.status}${text ? `: ${text}` : ''}`);
     }
     return;
   }
+  const phpUrl = env.MAIL_PHP_URL || globalThis['process']?.env?.MAIL_PHP_URL;
+  if (!phpUrl) {
+    throw new Error('MAILER_ENDPOINT_URL или MAIL_PHP_URL не са настроени');
+  }
   const phpEnv = {
-    MAIL_PHP_URL: env.MAIL_PHP_URL || globalThis['process']?.env?.MAIL_PHP_URL,
+    MAIL_PHP_URL: phpUrl,
     FROM_NAME: fromName
   };
   await sendEmail(to, subject, body, phpEnv);
@@ -2659,11 +2668,15 @@ async function handleSendTestEmailRequest(request, env) {
             return { success: false, message: 'Missing field: body (use "body", "text" or "message")', statusHint: 400 };
         }
 
+        if (!env.MAILER_ENDPOINT_URL && !env.MAIL_PHP_URL && !globalThis['process']?.env?.MAILER_ENDPOINT_URL && !globalThis['process']?.env?.MAIL_PHP_URL) {
+            return { success: false, message: 'MAILER_ENDPOINT_URL или MAIL_PHP_URL не са настроени', statusHint: 500 };
+        }
+
         await sendEmailUniversal(recipient, subject, body, env);
         return { success: true };
     } catch (error) {
         console.error('Error in handleSendTestEmailRequest:', error.message, error.stack);
-        return { success: false, message: 'Грешка при изпращане.', statusHint: 500 };
+        return { success: false, message: error.message || 'Грешка при изпращане.', statusHint: 500 };
     }
 }
 // ------------- END FUNCTION: handleSendTestEmailRequest -------------


### PR DESCRIPTION
## Summary
- require valid MAIL_PHP_URL or MAILER_ENDPOINT_URL and remove GitHub fallback
- expose detailed mailer errors in worker and admin UI
- document mandatory email configuration

## Testing
- `npm run lint`
- `npm test js/__tests__/emailSender.test.js js/__tests__/workerEmail.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68996b301e00832692ae25fb1bce79c3