### PR TITLE
Добавен дефолтен MAIL_PHP_URL и fallback тестове

### DIFF
--- a/js/__tests__/emailSender.test.js
+++ b/js/__tests__/emailSender.test.js
@@ -39,6 +39,12 @@ test('uses MAIL_PHP_URL when endpoint missing', async () => {
   delete process.env.MAIL_PHP_URL;
 });
 
-test('throws when no mail endpoint configured', async () => {
-  await expect(sendEmailUniversal('n@a.bg', 'S', 'B')).rejects.toThrow('MAILER_ENDPOINT_URL или MAIL_PHP_URL не са настроени');
+test('falls back to default PHP endpoint when none configured', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  await sendEmailUniversal('n@a.bg', 'S', 'B');
+  expect(fetch).toHaveBeenCalledWith(
+    'https://radilovk.github.io/bodybest/mailer/mail.php',
+    expect.any(Object)
+  );
+  fetch.mockRestore();
 });

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -7,6 +7,7 @@
  */
 const WORKER_ADMIN_TOKEN_SECRET_NAME = 'WORKER_ADMIN_TOKEN';
 const MAIL_PHP_URL_VAR_NAME = 'MAIL_PHP_URL';
+export const DEFAULT_MAIL_PHP_URL = 'https://radilovk.github.io/bodybest/mailer/mail.php';
 
 async function recordUsage(env, identifier = '') {
   try {
@@ -53,10 +54,7 @@ async function checkRateLimit(env, identifier, limit = 3, windowMs = 60000) {
 }
 
 async function sendViaPhp(to, subject, message, env = {}) {
-  const url = env[MAIL_PHP_URL_VAR_NAME];
-  if (!url) {
-    throw new Error('MAIL_PHP_URL is required');
-  }
+  const url = env[MAIL_PHP_URL_VAR_NAME] || DEFAULT_MAIL_PHP_URL;
   const fromName = env.FROM_NAME || '';
   const resp = await fetch(url, {
     method: 'POST',

--- a/utils/emailSender.js
+++ b/utils/emailSender.js
@@ -28,11 +28,10 @@ export async function sendEmailUniversal(to, subject, body, env = {}) {
     return;
   }
 
-  const phpUrl = env.MAIL_PHP_URL || globalThis['process']?.env?.MAIL_PHP_URL;
-  if (!phpUrl) {
-    throw new Error('MAILER_ENDPOINT_URL или MAIL_PHP_URL не са настроени');
-  }
-  const { sendEmail } = await import('../sendEmailWorker.js');
+  const { sendEmail, DEFAULT_MAIL_PHP_URL } = await import('../sendEmailWorker.js');
+  const phpUrl = env.MAIL_PHP_URL ||
+    globalThis['process']?.env?.MAIL_PHP_URL ||
+    DEFAULT_MAIL_PHP_URL;
   const phpEnv = {
     MAIL_PHP_URL: phpUrl,
     FROM_NAME: fromName


### PR DESCRIPTION
## Обобщение
- fallback към `https://radilovk.github.io/bodybest/mailer/mail.php` когато липсват `MAILER_ENDPOINT_URL` и `MAIL_PHP_URL`
- worker-ът допуска извикване без `MAIL_PHP_URL` и използва същия дефолтен URL
- обновени тестове за `emailSender` и `workerEmail`

## Тестване
- `npm run lint`
- `npm test js/__tests__/emailSender.test.js js/__tests__/workerEmail.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689975628f20832682cf05f4d1064def