### PR TITLE
Обновяване на URL на mailer

### DIFF
--- a/js/__tests__/emailSender.test.js
+++ b/js/__tests__/emailSender.test.js
@@ -43,7 +43,7 @@ test('falls back to default PHP endpoint when none configured', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true });
   await sendEmailUniversal('n@a.bg', 'S', 'B');
   expect(fetch).toHaveBeenCalledWith(
-    'https://radilovk.github.io/bodybest/mailer/mail.php',
+    'https://mybody.best/mailer/mail.php',
     expect.any(Object)
   );
   fetch.mockRestore();

--- a/js/__tests__/workerEmail.test.js
+++ b/js/__tests__/workerEmail.test.js
@@ -71,7 +71,7 @@ describe('handleSendEmailRequest and sendEmailUniversal', () => {
     const env = { WORKER_ADMIN_TOKEN: 'secret' };
     const res = await handleSendEmailRequest(req, env);
     expect(fetch).toHaveBeenCalledWith(
-      'https://radilovk.github.io/bodybest/mailer/mail.php',
+      'https://mybody.best/mailer/mail.php',
       expect.any(Object)
     );
     expect(res.status).toBe(200);

--- a/sendEmailWorker.js
+++ b/sendEmailWorker.js
@@ -7,7 +7,7 @@
  */
 const WORKER_ADMIN_TOKEN_SECRET_NAME = 'WORKER_ADMIN_TOKEN';
 const MAIL_PHP_URL_VAR_NAME = 'MAIL_PHP_URL';
-export const DEFAULT_MAIL_PHP_URL = 'https://radilovk.github.io/bodybest/mailer/mail.php';
+export const DEFAULT_MAIL_PHP_URL = 'https://mybody.best/mailer/mail.php';
 
 async function recordUsage(env, identifier = '') {
   try {


### PR DESCRIPTION
## Резюме
- смяна на `DEFAULT_MAIL_PHP_URL` към `https://mybody.best/mailer/mail.php`
- актуализиране на тестовете за email worker и универсалния изпращач

## Тестване
- `npm run lint`
- `npm test js/__tests__/workerEmail.test.js`
- `npm test js/__tests__/emailSender.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6899803e20c4832693c6f8153490d821