### PR TITLE
Премахнато изискване за mailer и добавени тестове за дефолтен fallback

### DIFF
--- a/js/__tests__/workerEmail.test.js
+++ b/js/__tests__/workerEmail.test.js
@@ -200,6 +200,23 @@ describe('handleSendTestEmailRequest', () => {
     expect(fetch).toHaveBeenCalledWith('https://php.example.com/mailer.php', expect.any(Object));
   });
 
+  test('falls back to default PHP endpoint when no mailer config', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+      clone: () => ({ text: async () => '{}' }),
+      headers: { get: () => 'application/json' }
+    });
+    const request = {
+      headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) },
+      json: async () => ({ recipient: 't@e.com', subject: 's', body: 'b' })
+    };
+    const env = { WORKER_ADMIN_TOKEN: 'secret' };
+    const res = await handleSendTestEmailRequest(request, env);
+    expect(res.success).toBe(true);
+    expect(fetch).toHaveBeenCalledWith('https://radilovk.github.io/bodybest/mailer/mail.php', expect.any(Object));
+  });
+
   test('forwards fromName to mailer', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,

--- a/worker.js
+++ b/worker.js
@@ -40,24 +40,6 @@ async function parseJsonSafe(resp, label = 'response') {
   }
 }
 
-// Минимална логика за изпращане на имейл чрез PHP
-async function sendEmail(to, subject, message, env = {}) {
-  const url = env.MAIL_PHP_URL;
-  if (!url) {
-    throw new Error('MAIL_PHP_URL is required');
-  }
-  const fromName = env.FROM_NAME || '';
-  const resp = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ to, subject, message, body: message, fromName })
-  });
-  if (!resp.ok) {
-    const text = await resp.text().catch(() => '');
-    throw new Error(`PHP mailer error ${resp.status}${text ? `: ${text}` : ''}`);
-  }
-}
-
 // Унифицирано изпращане на имейл
 async function sendEmailUniversal(to, subject, body, env = {}) {
   const endpoint = env.MAILER_ENDPOINT_URL || globalThis['process']?.env?.MAILER_ENDPOINT_URL;
@@ -74,10 +56,8 @@ async function sendEmailUniversal(to, subject, body, env = {}) {
     }
     return;
   }
-  const phpUrl = env.MAIL_PHP_URL || globalThis['process']?.env?.MAIL_PHP_URL;
-  if (!phpUrl) {
-    throw new Error('MAILER_ENDPOINT_URL или MAIL_PHP_URL не са настроени');
-  }
+  const { sendEmail, DEFAULT_MAIL_PHP_URL } = await import('./sendEmailWorker.js');
+  const phpUrl = env.MAIL_PHP_URL || globalThis['process']?.env?.MAIL_PHP_URL || DEFAULT_MAIL_PHP_URL;
   const phpEnv = {
     MAIL_PHP_URL: phpUrl,
     FROM_NAME: fromName
@@ -2666,10 +2646,6 @@ async function handleSendTestEmailRequest(request, env) {
         }
         if (typeof body !== 'string' || !body) {
             return { success: false, message: 'Missing field: body (use "body", "text" or "message")', statusHint: 400 };
-        }
-
-        if (!env.MAILER_ENDPOINT_URL && !env.MAIL_PHP_URL && !globalThis['process']?.env?.MAILER_ENDPOINT_URL && !globalThis['process']?.env?.MAIL_PHP_URL) {
-            return { success: false, message: 'MAILER_ENDPOINT_URL или MAIL_PHP_URL не са настроени', statusHint: 500 };
         }
 
         await sendEmailUniversal(recipient, subject, body, env);


### PR DESCRIPTION
## Резюме
- премахнато е условието в handleSendTestEmailRequest за задължителни MAILER_ENDPOINT_URL/MAIL_PHP_URL
- sendEmailUniversal вече пада обратно към sendEmailWorker.js с DEFAULT_MAIL_PHP_URL
- добавен е тест за изпращане на тестови имейл без конфигурирани променливи

## Тестване
- `npm run lint`
- `npm test js/__tests__/workerEmail.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68997e83372c832691f6cee32cb40864