### PR TITLE
Include sendEmail worker in TypeScript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
   "include": [
     "worker.js",
     "worker-backend.js",
+    "sendEmailWorker.js",
     "mailer.js",
     "mailer.d.ts",
     "global.d.ts",


### PR DESCRIPTION
## Summary
- include `sendEmailWorker.js` in tsconfig so TypeScript picks it up
- verify default mailer URL export in `sendEmailWorker.js`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a7f96f6e8832684fec76009674548