### PR TITLE
Добавяне на индикатор за lookup в extraMealForm

### DIFF
--- a/css/extra_meal_form_styles.css
+++ b/css/extra_meal_form_styles.css
@@ -43,6 +43,14 @@
   margin-top: var(--space-sm);
 }
 
+/* --- Индикатор за зареждане при изчисление --- */
+#extraMealEntryModal .lookup-spinner {
+  width: 20px;
+  height: 20px;
+  margin-left: var(--space-xs);
+  vertical-align: middle;
+}
+
 /* --- Радио бутони с икони (за усещане) --- */
 #extraMealEntryModal .radio-group-icons {
   display: flex;

--- a/js/extraMealForm.js
+++ b/js/extraMealForm.js
@@ -262,6 +262,14 @@ export async function initializeExtraMealFormLogic(formContainerElement) {
     const quantityHiddenInput = form.querySelector('#quantity');
     const quantityCustomInput = form.querySelector('#quantityCustom');
     const quantityCountInput = form.querySelector('#quantityCountInput');
+    let quantityLookupLoading = false;
+    let quantityLookupSpinner;
+    if (quantityCustomInput) {
+        quantityLookupSpinner = document.createElement('svg');
+        quantityLookupSpinner.classList.add('icon', 'spinner', 'lookup-spinner', 'hidden');
+        quantityLookupSpinner.innerHTML = '<use href="#icon-spinner"></use>';
+        quantityCustomInput.insertAdjacentElement('afterend', quantityLookupSpinner);
+    }
     const reasonRadioGroup = form.querySelectorAll('input[name="reasonPrimary"]');
     const reasonOtherText = form.querySelector('#reasonOtherText');
     const replacedPlannedRadioGroup = form.querySelectorAll('input[name="replacedPlanned"]');
@@ -405,7 +413,9 @@ export async function initializeExtraMealFormLogic(formContainerElement) {
             lookupTimer = setTimeout(async () => {
                 const desc = foodDescriptionInput?.value?.trim();
                 const qty = quantityCustomInput.value.trim();
-                if (!desc || !qty) return;
+                if (!desc || !qty || quantityLookupLoading) return;
+                quantityLookupLoading = true;
+                quantityLookupSpinner?.classList.remove('hidden');
                 try {
                     const data = await nutrientLookup(desc, qty);
                     MACRO_FIELDS.forEach(f => {
@@ -415,6 +425,9 @@ export async function initializeExtraMealFormLogic(formContainerElement) {
                     if (autoFillMsg) autoFillMsg.classList.remove('hidden');
                 } catch (err) {
                     console.error('Невъзможно изчисление на макроси', err);
+                } finally {
+                    quantityLookupSpinner?.classList.add('hidden');
+                    quantityLookupLoading = false;
                 }
             }, 300);
         });


### PR DESCRIPTION
## Резюме
- Показване на спинър при nutrient lookup в полето quantityCustom
- Добавен стил `.lookup-spinner` за визуално съответствие

## Тестове
- `npm run lint`
- `npm test -- js/__tests__/extraMeal*.test.js` *(някои тестове се провалят, напр. `extraMealNutrientLookup.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_689a80da495c83268fb68276664977b2