### PR TITLE
Избягване на дублиране на основната цел в анализите

### DIFF
--- a/reganalize/analyze.html
+++ b/reganalize/analyze.html
@@ -768,7 +768,12 @@
             
             document.getElementById('client-name').textContent = `${data.client.name},`;
             const { title = '', target = '' } = data.client.mainGoal || {};
-            let goalLine = title && target ? `${title} - ${target}` : (title || target);
+            let goalLine;
+            if (title && target) {
+                goalLine = title !== target ? `${title} - ${target}` : title;
+            } else {
+                goalLine = title || target;
+            }
             goalLine = goalLine.replace(/^[Оо]сновна цел[:\s-]*/, '').trim();
             document.getElementById('main-goal').textContent = goalLine;
             document.getElementById('obstacles-container').innerHTML = generateObstaclesHTML(data.topObstacles);


### PR DESCRIPTION
## Резюме
- предотвратено е дублиране на `title` и `target` при визуализация на основната цел в `renderAnalysis`

## Тестване
- `npm run lint`
- `npm test` *(част от тестовете се провалиха: extraMealForm, extraMealAutofill и др.)*
- ръчен Node пример, потвърждаващ че при еднакви `title` и `target` текстът се показва веднъж


------
https://chatgpt.com/codex/tasks/task_e_689a96f162788326beaadec00a7bd2b1