### PR TITLE
Унифициране на goalCard с останалите index-card

### DIFF
--- a/code.html
+++ b/code.html
@@ -429,7 +429,7 @@
             <!-- Основни Индекси -->
             <div class="main-indexes">
               <div class="card index-card" id="goalCard">
-                <h4><i class="bi bi-bullseye"></i> <span id="goalProgressText" class="index-value">Изчисляване...</span></h4>
+                <h4><i class="bi bi-bullseye"></i> Цел <span id="goalProgressText" class="index-value">Изчисляване...</span></h4>
                 <div class="progress-bar-container">
                   <div
                     id="goalProgressBar"

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -159,14 +159,17 @@ function populateDashboardMainIndexes(currentAnalytics) {
             const goal = safeGet(fullDashboardData.initialAnswers, 'goal', '').toLowerCase();
             const startWeight = safeParseFloat(safeGet(fullDashboardData.initialData, 'weight'));
             const lossKgTarget = safeParseFloat(safeGet(fullDashboardData.initialAnswers, 'lossKg'));
-            let goalDesc = `${Math.round(goalProgressPercent)}%`;
+            let goalDesc = '';
             if (goal === 'отслабване' && !isNaN(startWeight) && !isNaN(lossKgTarget) && lossKgTarget > 0) {
-                 const targetWeight = startWeight - lossKgTarget;
-                 goalDesc = `Цел: ${targetWeight.toFixed(1)} кг | ${Math.round(goalProgressPercent)}%`;
+                const targetWeight = startWeight - lossKgTarget;
+                goalDesc = `Цел: ${targetWeight.toFixed(1)} кг`;
             } else if (goal) {
-                goalDesc = `${capitalizeFirstLetter(goal)} | ${Math.round(goalProgressPercent)}%`;
+                goalDesc = capitalizeFirstLetter(goal);
             }
-            selectors.goalProgressText.textContent = goalDesc;
+            if (selectors.goalCard && goalDesc) {
+                selectors.goalCard.setAttribute('title', goalDesc);
+            }
+            selectors.goalProgressText.textContent = `${Math.round(goalProgressPercent)}%`;
         }
     }
 


### PR DESCRIPTION
## Резюме
- Добавен статичен надпис "Цел" и изравнено позициониране на SVG и текст спрямо останалите index-card карти
- Поправено попълване на `goalProgressText` – показва само процент, а описанието се дава като tooltip

## Тестове
- `npm run lint`
- `npm test` *(неуспешно: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_689aa115f25c8326a1b196a0cb452552