### PR TITLE
Move extra meal button to menu card and unify button colors

### DIFF
--- a/code.html
+++ b/code.html
@@ -535,6 +535,13 @@
               <ul id="dailyMealList" class="meal-list">
                 <li class="placeholder">Зареждане на храненията...</li>
               </ul>
+              <button
+                id="openExtraMealModalBtn"
+                class="button-secondary"
+                style="width: 100%"
+              >
+                <svg class="icon"><use href="#icon-utensils"></use></svg> Добави извънредно хранене
+              </button>
             </div>
             <!-- Край Меню -->
 
@@ -552,13 +559,6 @@
                 <div class="placeholder">Зареждане на тракера...</div>
               </div>
 
-              <button
-                id="openExtraMealModalBtn"
-                class="button-secondary"
-                style="margin-bottom: 0.5rem; width: 100%"
-              >
-                <svg class="icon"><use href="#icon-utensils"></use></svg> Добави извънредно хранене
-              </button>
               <button
                 id="add-note-btn"
                 class="button-secondary"

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -637,11 +637,14 @@ body.vivid-theme .tracker .metric-rating .rating-value {
 
 #openExtraMealModalBtn, #add-note-btn {
     width: 100%;
-    margin-bottom: var(--space-sm); 
-    justify-content: flex-start; 
-    padding-left: var(--space-md); 
+    margin-bottom: var(--space-sm);
+    justify-content: flex-start;
+    padding-left: var(--space-md);
 }
-#add-note-btn .menu-icon { 
+#openExtraMealModalBtn, #add-note-btn, #planModificationBtn {
+    color: var(--card-bg);
+}
+#add-note-btn .menu-icon {
     margin-right: var(--space-sm);
     font-size: 1.1em;
 }

--- a/profileTemplate.html
+++ b/profileTemplate.html
@@ -370,9 +370,12 @@
             margin-right: 10px;
             vertical-align: middle;
         }
-        
+
         @keyframes spin {
             to { transform: rotate(360deg); }
+        }
+        #planModificationBtn {
+            color: var(--card-bg);
         }
     </style>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">


### PR DESCRIPTION
## Summary
- Move 'Добави извънредно хранене' button to bottom of dailyMenu card
- Match text and icon color of extra meal, note and plan modification buttons to card background
- Apply same plan modification color rule in profile template

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError: The requested module './app.js' does not provide an export named 'ensureFreshDailyIntake', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689aa5231c848326a72db7652c76304e