### PR TITLE
Show real goal name on dashboard card

### DIFF
--- a/code.html
+++ b/code.html
@@ -429,7 +429,7 @@
             <!-- Основни Индекси -->
             <div class="main-indexes">
               <div class="card index-card" id="goalCard">
-                <h4><i class="bi bi-bullseye"></i> Цел <span id="goalProgressText" class="index-value">Изчисляване...</span></h4>
+                <h4><i class="bi bi-bullseye"></i> <span id="goalName">Цел</span> <span id="goalProgressText" class="index-value">Изчисляване...</span></h4>
                 <div class="progress-bar-container">
                   <div
                     id="goalProgressBar"

--- a/js/__tests__/populateUI.test.js
+++ b/js/__tests__/populateUI.test.js
@@ -10,7 +10,7 @@ beforeEach(async () => {
     <h1 id="headerTitle"></h1>
     <div id="goalCard"></div><div id="engagementCard"></div><div id="healthCard"></div>
     <div id="progressHistoryCard"></div>
-    <div id="goalProgressFill"></div><div id="goalProgressBar"></div><span id="goalProgressText"></span>
+    <span id="goalName"></span><div id="goalProgressFill"></div><div id="goalProgressBar"></div><span id="goalProgressText"></span>
     <div id="engagementProgressFill"></div><div id="engagementProgressBar"></div><span id="engagementProgressText"></span>
     <div id="healthProgressFill"></div><div id="healthProgressBar"></div><span id="healthProgressText"></span>
     <div id="streakGrid"></div>
@@ -27,6 +27,7 @@ beforeEach(async () => {
     progressHistoryCard: document.getElementById('progressHistoryCard'),
     goalProgressFill: document.getElementById('goalProgressFill'),
     goalProgressBar: document.getElementById('goalProgressBar'),
+    goalName: document.getElementById('goalName'),
     goalProgressText: document.getElementById('goalProgressText'),
     engagementProgressFill: document.getElementById('engagementProgressFill'),
     engagementProgressBar: document.getElementById('engagementProgressBar'),
@@ -79,8 +80,8 @@ beforeEach(async () => {
       planData: {},
       dailyLogs: [],
       currentStatus: {},
-      initialData: {},
-      initialAnswers: {}
+      initialData: { weight: 80 },
+      initialAnswers: { goal: 'отслабване', lossKg: 5 }
     },
     todaysMealCompletionStatus: {},
     todaysExtraMeals: [],
@@ -105,6 +106,7 @@ afterEach(() => {
 test('populates dashboard sections', async () => {
   await populateUI();
   expect(document.getElementById('headerTitle').textContent).toBe('Табло: Иван');
+  expect(document.getElementById('goalName').textContent).toBe('75.0 кг');
   expect(document.getElementById('goalProgressText').textContent).toBe('50%');
   expect(document.getElementById('engagementProgressText').textContent).toBe('80%');
   expect(document.getElementById('healthProgressText').textContent).toBe('70%');

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -155,20 +155,24 @@ function populateDashboardMainIndexes(currentAnalytics) {
             applyProgressFill(selectors.goalProgressFill, goalProgressPercent);
         }
         if (selectors.goalProgressBar) selectors.goalProgressBar.setAttribute('aria-valuenow', `${Math.round(goalProgressPercent)}`);
+        const goal = safeGet(fullDashboardData.initialAnswers, 'goal', '').toLowerCase();
+        const startWeight = safeParseFloat(safeGet(fullDashboardData.initialData, 'weight'));
+        const lossKgTarget = safeParseFloat(safeGet(fullDashboardData.initialAnswers, 'lossKg'));
+        let goalName = 'Цел';
+        let goalTitle = '';
+        if (goal === 'отслабване' && !isNaN(startWeight) && !isNaN(lossKgTarget) && lossKgTarget > 0) {
+            const targetWeight = startWeight - lossKgTarget;
+            goalName = `${targetWeight.toFixed(1)} кг`;
+            goalTitle = `Цел: ${goalName}`;
+        } else if (goal) {
+            goalName = capitalizeFirstLetter(goal);
+            goalTitle = goalName;
+        }
+        if (selectors.goalName) selectors.goalName.textContent = goalName;
+        if (selectors.goalCard && goalTitle) {
+            selectors.goalCard.setAttribute('title', goalTitle);
+        }
         if (selectors.goalProgressText) {
-            const goal = safeGet(fullDashboardData.initialAnswers, 'goal', '').toLowerCase();
-            const startWeight = safeParseFloat(safeGet(fullDashboardData.initialData, 'weight'));
-            const lossKgTarget = safeParseFloat(safeGet(fullDashboardData.initialAnswers, 'lossKg'));
-            let goalDesc = '';
-            if (goal === 'отслабване' && !isNaN(startWeight) && !isNaN(lossKgTarget) && lossKgTarget > 0) {
-                const targetWeight = startWeight - lossKgTarget;
-                goalDesc = `Цел: ${targetWeight.toFixed(1)} кг`;
-            } else if (goal) {
-                goalDesc = capitalizeFirstLetter(goal);
-            }
-            if (selectors.goalCard && goalDesc) {
-                selectors.goalCard.setAttribute('title', goalDesc);
-            }
             selectors.goalProgressText.textContent = `${Math.round(goalProgressPercent)}%`;
         }
     }

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -10,7 +10,7 @@ export function initializeSelectors() {
         menuOverlay: 'menu-overlay',
         themeToggleMenu: 'theme-toggle-menu', logoutButton: 'logoutButton', menuContactLink: 'menu-contact-link', menuPersonalizationLink: 'menu-personalization-link', menuFeedbackBtn: 'menu-feedback-btn',
         tabsContainer: '.tabs[role="tablist"]', tabButtons: '.tabs button[role="tab"]',
-        goalProgressBar: 'goalProgressBar', goalProgressFill: 'goalProgressFill', goalProgressText: 'goalProgressText',
+        goalName: 'goalName', goalProgressBar: 'goalProgressBar', goalProgressFill: 'goalProgressFill', goalProgressText: 'goalProgressText',
         engagementProgressBar: 'engagementProgressBar', engagementProgressFill: 'engagementProgressFill', engagementProgressText: 'engagementProgressText',
         healthProgressBar: 'healthProgressBar', healthProgressFill: 'healthProgressFill', healthProgressText: 'healthProgressText',
         goalCard: 'goalCard', engagementCard: 'engagementCard', healthCard: 'healthCard', streakCard: 'streakCard',


### PR DESCRIPTION
## Summary
- display actual goal name in dashboard goal card
- expose `goalName` selector and update goal info logic
- cover new goal name behavior in tests

## Testing
- `npm run lint`
- `npm test js/__tests__/populateUI.test.js` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_689aa83afd08832697b13f87d46e5863