### PR TITLE
Adjust tracker metric label spacing

### DIFF
--- a/css/responsive_styles.css
+++ b/css/responsive_styles.css
@@ -128,7 +128,7 @@
   }
   .tracker .metric-rating label {
     flex-basis: auto; 
-    margin-bottom: var(--space-sm); 
+    margin-bottom: var(--space-xs); 
   }
   .tracker .daily-log-weight-metric .daily-log-weight-input-field,
   .tracker .rating-squares {


### PR DESCRIPTION
## Summary
- reduce metric label margin in tracker for better spacing on small screens

## Testing
- `npm run lint`
- `npm test` *(fails: extraMealAutofill.test.js and others)*

------
https://chatgpt.com/codex/tasks/task_e_689aac96d6308326a836272ec87079b7