### PR TITLE
style: improve mobile tracker metric spacing

### DIFF
--- a/css/responsive_styles.css
+++ b/css/responsive_styles.css
@@ -123,8 +123,13 @@
   #planModChatSend svg { width: 18px; height: 18px; }
 
   .tracker .metric-rating {
-    flex-direction: column; 
-    align-items: flex-start; 
+    flex-direction: column;
+    align-items: flex-start;
+    margin-bottom: var(--space-xl);
+    gap: var(--space-xs);
+  }
+  .tracker .metric-rating:last-child {
+    margin-bottom: 0;
   }
   .tracker .metric-rating label {
     flex-basis: auto; 


### PR DESCRIPTION
## Summary
- refine tracker metric spacing on small screens

## Testing
- `npm run lint`
- `npm test -- js/__tests__/extraMealForm.test.js js/__tests__/planModChat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689aac8e077c8326a15cd9d6301c94cd