### PR TITLE
refactor: optimize daily log layout

### DIFF
--- a/code.html
+++ b/code.html
@@ -559,22 +559,23 @@
                 <div class="placeholder">Зареждане на тракера...</div>
               </div>
 
-              <button
-                id="add-note-btn"
-                class="button-secondary"
-                aria-label="Добавяне или скриване на бележка за деня"
-              ></button>
-              <textarea
-                id="daily-note"
-                class="hidden"
-                placeholder="Вашите бележки за деня..."
-                rows="3"
-                aria-label="Бележки за деня"
-              ></textarea>
+              <div class="daily-note-section">
+                <button
+                  id="add-note-btn"
+                  class="button-secondary"
+                  aria-label="Добавяне или скриване на бележка за деня"
+                ></button>
+                <textarea
+                  id="daily-note"
+                  class="hidden"
+                  placeholder="Вашите бележки за деня..."
+                  rows="3"
+                  aria-label="Бележки за деня"
+                ></textarea>
+              </div>
               <button
                 id="saveLogBtn"
                 class="button-primary"
-                style="margin-top: 1rem"
               >
                 Запази Дневник
               </button>

--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -565,14 +565,10 @@ body.vivid-theme .tracker .metric-rating .rating-value {
 }
 
 
-.tracker .daily-log-weight-metric {
-  border-bottom: 1px dashed var(--border-color-soft); 
-  padding-bottom: var(--space-lg); 
-}
 .tracker .daily-log-weight-metric .daily-log-weight-input-field {
-  flex-grow: 1; 
+  flex-grow: 1;
   max-width: 200px; /* Ограничена ширина */
-  padding: 0.6rem 0.8rem; 
+  padding: 0.6rem 0.8rem;
   font-size: 0.95rem;
 }
 
@@ -635,11 +631,17 @@ body.vivid-theme .tracker .metric-rating .rating-value {
     border-color: var(--toast-bg) transparent transparent transparent;
 }
 
-#openExtraMealModalBtn, #add-note-btn {
+#openExtraMealModalBtn {
     width: 100%;
     margin-bottom: var(--space-sm);
     justify-content: flex-start;
     padding-left: var(--space-md);
+}
+#add-note-btn {
+    width: 100%;
+    justify-content: flex-start;
+    padding-left: var(--space-md);
+    margin-bottom: var(--space-xs);
 }
 #openExtraMealModalBtn, #add-note-btn, #planModificationBtn {
     color: var(--card-bg);
@@ -648,7 +650,10 @@ body.vivid-theme .tracker .metric-rating .rating-value {
     margin-right: var(--space-sm);
     font-size: 1.1em;
 }
-#daily-note { margin-top: var(--space-md); margin-bottom: var(--space-xs); }
+.daily-note-section {
+    margin-top: var(--space-lg);
+}
+#daily-note { margin-top: var(--space-xs); margin-bottom: var(--space-xs); }
 #saveLogBtn {
     width: 100%;
     margin-top: var(--space-lg);


### PR DESCRIPTION
## Summary
- group daily note button and textarea within `daily-note-section`
- restyle daily note controls for cleaner spacing and mobile fit
- drop heavy divider on weight input to align with other metrics

## Testing
- `npm run lint`
- `npm test` *(fails: extraMealAutofill.test.js, extraMealFormSubmit.test.js, populateDashboardMacros.missingComponent.test.js, saveAiConfig.test.js, extraMealNutrientLookup.test.js, populateDashboardMacros.noSetData.test.js, updateAnalyticsSections.test.js, extraMealCountMeasure.test.js, loadCurrentIntake.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689ab66168348326890b428ad86a6adc