### PR TITLE
feat: add KV indexes for presets and contact requests

### DIFF
--- a/js/__tests__/aiPresets.test.js
+++ b/js/__tests__/aiPresets.test.js
@@ -21,6 +21,7 @@ test('save preset and retrieve it', async () => {
   const saveRes = await handleSaveAiPreset(reqSave, env);
   expect(saveRes.success).toBe(true);
   expect(kv._store['aiPreset_test']).toBe(JSON.stringify({ model_plan_generation: 'm1' }));
+  expect(JSON.parse(kv._store.aiPresets_index)).toContain('aiPreset_test');
 
   const listRes = await handleListAiPresets({}, env);
   expect(listRes.success).toBe(true);

--- a/js/__tests__/contactRequestsIndex.test.js
+++ b/js/__tests__/contactRequestsIndex.test.js
@@ -1,0 +1,68 @@
+import { jest } from '@jest/globals';
+import {
+  handleContactFormRequest,
+  handleGetContactRequestsRequest,
+  handleValidateIndexesRequest
+} from '../../worker.js';
+
+function createStore(initial = {}) {
+  const store = { ...initial };
+  return {
+    list: jest.fn(async ({ prefix } = {}) => ({
+      keys: Object.keys(store)
+        .filter(k => !prefix || k.startsWith(prefix))
+        .map(name => ({ name }))
+    })),
+    get: jest.fn(async key => store[key] || null),
+    put: jest.fn(async (key, value) => { store[key] = String(value); }),
+    _store: store
+  };
+}
+
+test('saves contact request and lists via index', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  const kv = createStore();
+  const env = {
+    CONTACT_REQUESTS_KV: kv,
+    RESOURCES_KV: { get: jest.fn().mockResolvedValue(null) },
+    USER_METADATA_KV: { get: jest.fn().mockResolvedValue(null), put: jest.fn() },
+    WORKER_ADMIN_TOKEN: 'secret',
+    MAIL_PHP_URL: 'https://php.example.com/mailer.php'
+  };
+  const reqSave = {
+    headers: { get: h => (h === 'CF-Connecting-IP' ? '1.1.1.1' : null) },
+    json: async () => ({ email: 'a@b.com', name: 'A', message: 'Hi' })
+  };
+  const saveRes = await handleContactFormRequest(reqSave, env);
+  expect(saveRes.success).toBe(true);
+  const idx = JSON.parse(kv._store.contactRequests_index);
+  expect(idx.length).toBe(1);
+
+  const reqList = { headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) } };
+  const listRes = await handleGetContactRequestsRequest(reqList, env);
+  expect(listRes.requests[0].email).toBe('a@b.com');
+});
+
+test('validateIndexes rebuilds indexes', async () => {
+  const resKv = createStore({ aiPreset_demo: '{}' });
+  const contactKv = createStore({ contact_1: '{}' });
+  const env = {
+    RESOURCES_KV: resKv,
+    CONTACT_REQUESTS_KV: contactKv,
+    WORKER_ADMIN_TOKEN: 'secret'
+  };
+  const req = { headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) } };
+  const res = await handleValidateIndexesRequest(req, env);
+  expect(res.success).toBe(true);
+  expect(JSON.parse(resKv._store.aiPresets_index)).toEqual(['aiPreset_demo']);
+  expect(JSON.parse(contactKv._store.contactRequests_index)).toEqual(['contact_1']);
+});
+
+afterEach(() => {
+  if (global.fetch && typeof global.fetch.mockRestore === 'function') {
+    global.fetch.mockRestore();
+  } else {
+    global.fetch = undefined;
+  }
+});
+


### PR DESCRIPTION
## Summary
- cache ai preset keys in `aiPresets_index` and read via KV
- track contact form entries with `contactRequests_index`
- admin endpoint `/api/validateIndexes` rebuilds both indexes

## Testing
- `sh scripts/test.sh js/__tests__/aiPresets.test.js js/__tests__/contactRequestsIndex.test.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d167e4bf8832689e128f6d37f2c2a