### PR TITLE
Prevent duplicate plan modification events

### DIFF
--- a/js/__tests__/planModRequest.test.js
+++ b/js/__tests__/planModRequest.test.js
@@ -5,7 +5,8 @@ import { processPendingUserEvents } from '../../worker.js';
     test('processes planMod event', async () => {
       const store = {
         events_queue: JSON.stringify([{ key: 'event_planMod_u1_1', type: 'planMod', userId: 'u1' }]),
-        event_planMod_u1_1: JSON.stringify({ type: 'planMod', userId: 'u1', createdTimestamp: 1, payload: {} })
+        event_planMod_u1_1: JSON.stringify({ type: 'planMod', userId: 'u1', createdTimestamp: 1, payload: {} }),
+        planMod_pending_u1: '1'
       };
       const env = {
         USER_METADATA_KV: {
@@ -18,8 +19,10 @@ import { processPendingUserEvents } from '../../worker.js';
       const count = await processPendingUserEvents(env, ctx, 5);
       expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
       expect(env.USER_METADATA_KV.delete).toHaveBeenCalledWith('event_planMod_u1_1');
+      expect(env.USER_METADATA_KV.delete).toHaveBeenCalledWith('planMod_pending_u1');
       expect(count).toBe(1);
       expect(JSON.parse(store.events_queue)).toHaveLength(0);
+      expect(store.planMod_pending_u1).toBeUndefined();
     });
 
     test('processes two planMod events for same user', async () => {
@@ -29,7 +32,8 @@ import { processPendingUserEvents } from '../../worker.js';
           { key: 'event_planMod_u1_2', type: 'planMod', userId: 'u1' }
         ]),
         event_planMod_u1_1: JSON.stringify({ type: 'planMod', userId: 'u1', createdTimestamp: 1, payload: { a: 1 } }),
-        event_planMod_u1_2: JSON.stringify({ type: 'planMod', userId: 'u1', createdTimestamp: 2, payload: { b: 2 } })
+        event_planMod_u1_2: JSON.stringify({ type: 'planMod', userId: 'u1', createdTimestamp: 2, payload: { b: 2 } }),
+        planMod_pending_u1: '1'
       };
       const env = {
         USER_METADATA_KV: {
@@ -42,8 +46,11 @@ import { processPendingUserEvents } from '../../worker.js';
       const count = await processPendingUserEvents(env, ctx, 5);
       expect(ctx.waitUntil).toHaveBeenCalledTimes(2);
       expect(env.USER_METADATA_KV.delete.mock.calls[0][0]).toBe('event_planMod_u1_1');
-      expect(env.USER_METADATA_KV.delete.mock.calls[1][0]).toBe('event_planMod_u1_2');
+      expect(env.USER_METADATA_KV.delete.mock.calls[1][0]).toBe('planMod_pending_u1');
+      expect(env.USER_METADATA_KV.delete.mock.calls[2][0]).toBe('event_planMod_u1_2');
+      expect(env.USER_METADATA_KV.delete.mock.calls[3][0]).toBe('planMod_pending_u1');
       expect(count).toBe(2);
       expect(JSON.parse(store.events_queue)).toHaveLength(0);
+      expect(store.planMod_pending_u1).toBeUndefined();
     });
   });


### PR DESCRIPTION
## Summary
- avoid duplicate plan modification requests by storing `planMod_pending_<userId>` flag
- drop pending flag after cron processes plan modification events
- cover new behaviour with unit tests

## Testing
- `npx eslint worker.js js/__tests__/createUserEvent.test.js js/__tests__/planModRequest.test.js js/__tests__/userEvents.test.js`
- `sh ./scripts/test.sh js/__tests__/createUserEvent.test.js js/__tests__/planModRequest.test.js js/__tests__/userEvents.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689d1a68743c8326bc98876889a72c72