### PR TITLE
feat: track kv list usage and hourly telemetry

### DIFF
--- a/js/__tests__/kvListTelemetry.test.js
+++ b/js/__tests__/kvListTelemetry.test.js
@@ -1,0 +1,30 @@
+import { jest } from '@jest/globals';
+import { _withKvListCounting, _maybeSendKvListTelemetry } from '../../worker.js';
+
+describe('kv list telemetry', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('counts list calls and sends telemetry once per hour', async () => {
+    const env = {
+      TEST_KV: { list: async () => ({ keys: [] }) },
+      TELEMETRY_ENDPOINT: 'https://example.com/telemetry'
+    };
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: async () => ({}), text: async () => '' }));
+
+    const wrapped = _withKvListCounting(env);
+    await wrapped.TEST_KV.list();
+    await wrapped.TEST_KV.list();
+    await _maybeSendKvListTelemetry(wrapped);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.kv_list_count).toBe(2);
+
+    global.fetch.mockClear();
+    await _maybeSendKvListTelemetry(wrapped);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -68,6 +68,70 @@ async function sendEmailUniversal(to, subject, body, env = {}) {
   await sendEmail(to, subject, body, phpEnv);
 }
 
+// --- KV list telemetry instrumentation ---
+let kvListCount = 0;
+let kvListLastSent = 0;
+
+/**
+ * Обвива env и брои всяко извикване на `.list()` върху KV namespace.
+ * @param {Object} env
+ * @returns {Object} proxied env
+ */
+function withKvListCounting(env) {
+  return new Proxy(env, {
+    get(target, prop) {
+      const value = target[prop];
+      if (value && typeof value.list === 'function') {
+        return new Proxy(value, {
+          get(obj, key) {
+            if (key === 'list') {
+              return async (...args) => {
+                kvListCount++;
+                return obj.list(...args);
+              };
+            }
+            return obj[key];
+          }
+        });
+      }
+      return value;
+    }
+  });
+}
+
+/**
+ * Изпраща телеметрия за kv.list веднъж на час и ресетира брояча.
+ * @param {Object} env
+ */
+async function maybeSendKvListTelemetry(env) {
+  const now = Date.now();
+  if (now - kvListLastSent >= 60 * 60 * 1000) {
+    kvListLastSent = now;
+    const payload = {
+      ts: new Date(now).toISOString(),
+      kv_list_count: kvListCount
+    };
+    try {
+      if (env.TELEMETRY_ENDPOINT) {
+        await fetch(env.TELEMETRY_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+      } else {
+        console.log('[KV] Telemetry', payload);
+      }
+    } catch (err) {
+      console.error('[KV] Telemetry send failed', err);
+    }
+    const threshold = parseInt(env.KV_LIST_ALERT_THRESHOLD || '1000', 10);
+    if (kvListCount > threshold) {
+      console.warn(`[ALERT] kv.list count ${kvListCount} exceeds ${threshold}`);
+    }
+    kvListCount = 0;
+  }
+}
+
 const WELCOME_SUBJECT = 'Добре дошъл в MyBody!';
 const WELCOME_BODY_TEMPLATE = `<!DOCTYPE html>
 <html lang="bg">
@@ -388,6 +452,8 @@ export default {
      * @returns {Promise<Response>}
      */
     async fetch(request, env, ctx) {
+        env = withKvListCounting(env);
+        await maybeSendKvListTelemetry(env);
         const url = new URL(request.url);
         const path = url.pathname;
         const method = request.method;
@@ -593,6 +659,8 @@ export default {
 
     // ------------- START FUNCTION: scheduled -------------
     async scheduled(event, env, ctx) {
+        env = withKvListCounting(env);
+        await maybeSendKvListTelemetry(env);
         console.log(`[CRON] Trigger executing at: ${new Date(event.scheduledTime)}`);
         if (!env.USER_METADATA_KV) {
             console.error("[CRON] USER_METADATA_KV binding missing. Check configuration.");
@@ -4761,4 +4829,9 @@ async function handleUpdateKvRequest(request, env) {
     handleLogRequest,
     handlePlanLogRequest,
     setPlanStatus
- };
+};
+
+export {
+    withKvListCounting as _withKvListCounting,
+    maybeSendKvListTelemetry as _maybeSendKvListTelemetry
+};


### PR DESCRIPTION
## Summary
- instrument env KV namespaces to count `list` calls and ship hourly telemetry with optional alert
- monitor KV list usage in cron and fetch handlers
- cover KV telemetry logic with unit test

## Testing
- `npm run lint`
- `npm test` *(fails: extraMealAutofill.test.js, extraMealFormSubmit.test.js, populateDashboardMacros.missingComponent.test.js, populateDashboardMacros.noSetData.test.js, updateAnalyticsSections.test.js, extraMealCountMeasure.test.js, saveAiConfig.test.js, extraMealNutrientLookup.test.js, extraMealNameOverride.test.js, extraMealScaleMacros.test.js, loadCurrentIntake.test.js, populateDashboardDetailedAnalytics.test.js, loadProductMacrosInit.test.js, macroCardStandaloneEmbed.test.js, macroThreshold.test.js, registerEmail.test.js, passwordReset.test.js, planUserQueue.test.js, kvListTelemetry.test.js, macroAnalyticsCardInnerRing.test.js, submitQuestionnaireEmailFlag.test.js; many failing in existing suite)*
- `NODE_OPTIONS=--experimental-vm-modules npx jest js/__tests__/kvListTelemetry.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689d1de485508326b9d6169c620664b6