### PR TITLE
feat: add KV list monitoring

### DIFF
--- a/js/__tests__/kvListTelemetry.test.js
+++ b/js/__tests__/kvListTelemetry.test.js
@@ -7,10 +7,10 @@ describe('kv list telemetry', () => {
     global.fetch = originalFetch;
   });
 
-  test('counts list calls and sends telemetry once per hour', async () => {
+  test('counts list calls and sends telemetry every 15 minutes', async () => {
     const env = {
       TEST_KV: { list: async () => ({ keys: [] }) },
-      TELEMETRY_ENDPOINT: 'https://example.com/telemetry'
+      MONITORING_ENDPOINT: 'https://example.com/telemetry'
     };
     global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: async () => ({}), text: async () => '' }));
 


### PR DESCRIPTION
## Summary
- track each env.*.list call through kvListCounter
- send KV list metrics to monitoring endpoint every 15 minutes
- raise warning when hourly KV list rate exceeds threshold

## Testing
- `npm run lint -- worker.js js/__tests__/kvListTelemetry.test.js`
- `node scripts/validateMacros.js`
- `sh ./scripts/test.sh js/__tests__/kvListTelemetry.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689d25d4b2108326b495a7ff4d2fd176