### PR TITLE
feat(worker): log refused origins and allow all

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -481,9 +481,11 @@ export default {
                 .concat(defaultAllowedOrigins)
         ));
         const requestOrigin = request.headers.get('Origin');
-        const originToSend = requestOrigin === null
-            ? 'null'
-            : allowedOrigins.includes(requestOrigin) ? requestOrigin : allowedOrigins[0];
+        const originAllowed = requestOrigin && allowedOrigins.includes(requestOrigin);
+        if (requestOrigin && !originAllowed) {
+            console.warn(`Refused origin ${requestOrigin}`);
+        }
+        const originToSend = originAllowed ? requestOrigin : '*';
         const corsHeaders = {
             'Access-Control-Allow-Origin': originToSend,
             'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',


### PR DESCRIPTION
## Summary
- log and fall back to `*` when request origin is not allowed

## Testing
- `npm run lint worker.js`
- `sh ./scripts/test.sh js/__tests__/maintenanceWorker.test.js js/__tests__/aiConfig.test.js`
- `npx --yes wrangler deploy --dry-run`
- `npx --yes wrangler tail --format=json` *(fails: requires OAuth login)*

------
https://chatgpt.com/codex/tasks/task_e_689d2f51b91c83268e34b7448f8e245a