### PR TITLE
Add fallback listing for clients when index missing

### DIFF
--- a/js/__tests__/allUserIds.test.js
+++ b/js/__tests__/allUserIds.test.js
@@ -43,6 +43,35 @@ test('handleListClientsRequest използва all_user_ids', async () => {
   ])
 })
 
+test('handleListClientsRequest пада назад към list при липсващ индекс', async () => {
+  const store = {
+    'u1_initial_answers': JSON.stringify({ name: 'Иван', submissionDate: '2024-01-02' }),
+    'u1_profile': JSON.stringify({ email: 'ivan@example.com' }),
+    'plan_status_u1': 'ready',
+    'u1_current_status': JSON.stringify({ adminTags: ['vip'], lastUpdated: '2024-01-10' })
+  }
+  const env = {
+    USER_METADATA_KV: {
+      get: jest.fn(async key => store[key] || null),
+      list: jest.fn(async () => ({ keys: [{ name: 'u1_initial_answers' }] }))
+    }
+  }
+  const res = await handleListClientsRequest({}, env)
+  expect(env.USER_METADATA_KV.list).toHaveBeenCalled()
+  expect(res.success).toBe(true)
+  expect(res.clients).toEqual([
+    {
+      userId: 'u1',
+      name: 'Иван',
+      email: 'ivan@example.com',
+      registrationDate: '2024-01-02',
+      status: 'ready',
+      tags: ['vip'],
+      lastUpdated: '2024-01-10'
+    }
+  ])
+})
+
 test('handleDeleteClientRequest премахва userId и ключове', async () => {
   const store = {
     all_user_ids: JSON.stringify(['u1', 'u2']),


### PR DESCRIPTION
## Summary
- gracefully list clients via KV.list when `all_user_ids` is missing
- test client listing fallback and ensure deletion test passes

## Testing
- `npm run lint`
- `npm test js/__tests__/allUserIds.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689e940a50408326a7835efdba268b9f