### PR TITLE
Persist rebuilt user index in handleListClientsRequest

### DIFF
--- a/js/__tests__/allUserIds.test.js
+++ b/js/__tests__/allUserIds.test.js
@@ -53,11 +53,17 @@ test('handleListClientsRequest пада назад към list при липсв
   const env = {
     USER_METADATA_KV: {
       get: jest.fn(async key => store[key] || null),
-      list: jest.fn(async () => ({ keys: [{ name: 'u1_initial_answers' }] }))
+      list: jest.fn(async () => ({ keys: [{ name: 'u1_initial_answers' }] })),
+      put: jest.fn(async (key, val) => { store[key] = val })
     }
   }
+  const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
   const res = await handleListClientsRequest({}, env)
   expect(env.USER_METADATA_KV.list).toHaveBeenCalled()
+  expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('all_user_ids', JSON.stringify(['u1']))
+  expect(JSON.parse(store.all_user_ids)).toEqual(['u1'])
+  expect(logSpy).toHaveBeenCalledWith('Rebuilt all_user_ids index with 1 entries')
+  logSpy.mockRestore()
   expect(res.success).toBe(true)
   expect(res.clients).toEqual([
     {

--- a/worker.js
+++ b/worker.js
@@ -2288,6 +2288,10 @@ async function handleListClientsRequest(request, env) {
                     .map(k => k.name)
                     .filter(n => n.endsWith('_initial_answers'))
                     .map(n => n.replace('_initial_answers', ''));
+                if (userIds.length > 0) {
+                    await env.USER_METADATA_KV.put('all_user_ids', JSON.stringify(userIds));
+                    console.log(`Rebuilt all_user_ids index with ${userIds.length} entries`);
+                }
             } catch (err) {
                 console.warn('Fallback listing failed in handleListClientsRequest:', err.message);
                 userIds = [];


### PR DESCRIPTION
## Summary
- Rebuild `all_user_ids` index when missing and persist the result
- Test that index rebuild stores IDs and logs restoration

## Testing
- `npm run lint`
- `npm test js/__tests__/allUserIds.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f5e52a2b0832681c37039c8e38055