### PR TITLE
refactor: implement KV-based event queue

### DIFF
--- a/js/__tests__/userEvents.test.js
+++ b/js/__tests__/userEvents.test.js
@@ -4,8 +4,8 @@ import { processPendingUserEvents } from '../../worker.js';
   describe('processPendingUserEvents', () => {
     test('processes testResult event', async () => {
       const store = {
-        events_queue: JSON.stringify([{ key: 'event_testResult_u1_1', type: 'testResult', userId: 'u1' }]),
-        event_testResult_u1_1: JSON.stringify({ type: 'testResult', userId: 'u1', createdTimestamp: 1, payload: { value: 5 } })
+        events_queue: JSON.stringify([{ key: 'event_testResult_u1_1', type: 'testResult', userId: 'u1', createdTimestamp: 1 }]),
+        event_testResult_u1_1: JSON.stringify({ value: 5 })
       };
       const env = {
         USER_METADATA_KV: {

--- a/tests/queueIndex.spec.js
+++ b/tests/queueIndex.spec.js
@@ -27,8 +27,8 @@ describe('интегритет на индекси и опашки', () => {
 
     test('едновременен enqueue и dequeue поддържат опашката активна', async () => {
       const store = {
-        events_queue: JSON.stringify([{ key: 'event_test_u1', type: 'testResult', userId: 'u1' }]),
-        event_test_u1: JSON.stringify({ type: 'testResult', userId: 'u1', createdTimestamp: 1, payload: {} })
+        events_queue: JSON.stringify([{ key: 'event_test_u1', type: 'testResult', userId: 'u1', createdTimestamp: 1 }]),
+        event_test_u1: JSON.stringify({})
       };
       const env = {
         USER_METADATA_KV: {


### PR DESCRIPTION
## Summary
- add readQueue/writeQueue helpers for events_queue management
- switch createUserEvent to KV queue with duplicate planMod protection
- processPendingUserEvents consumes queue and clears processed payload keys

## Testing
- `npm run lint`
- `npm test -- js/__tests__/userEvents.test.js tests/queueIndex.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_689fa5ed62488326b30eeb231e93b916