### PR TITLE
feat: paginate user events

### DIFF
--- a/js/__tests__/userEvents.test.js
+++ b/js/__tests__/userEvents.test.js
@@ -1,24 +1,32 @@
 import { jest } from '@jest/globals';
-import { processPendingUserEvents } from '../../worker.js';
+
+await jest.unstable_mockModule('../../worker.js', async () => {
+  const original = await import('../../worker.js');
+  return { ...original, processSingleUserPlan: jest.fn().mockResolvedValue() };
+});
+
+const { processPendingUserEvents } = await import('../../worker.js');
 
   describe('processPendingUserEvents', () => {
     test('processes testResult event', async () => {
       const store = {
-        events_queue: JSON.stringify([{ key: 'event_testResult_u1_1', type: 'testResult', userId: 'u1' }]),
         event_testResult_u1_1: JSON.stringify({ type: 'testResult', userId: 'u1', createdTimestamp: 1, payload: { value: 5 } })
       };
       const env = {
         USER_METADATA_KV: {
           get: jest.fn(key => Promise.resolve(store[key])),
           put: jest.fn((key, val) => { store[key] = val; return Promise.resolve(); }),
-          delete: jest.fn(key => { delete store[key]; return Promise.resolve(); })
+          delete: jest.fn(key => { delete store[key]; return Promise.resolve(); }),
+          list: jest.fn(() => Promise.resolve({
+            keys: Object.keys(store).filter(k => k.startsWith('event_')).map(name => ({ name })),
+            list_complete: true
+          }))
         }
       };
       const ctx = { waitUntil: jest.fn() };
       await processPendingUserEvents(env, ctx, 5);
-      expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
+      expect(ctx.waitUntil).toHaveBeenCalled();
       expect(env.USER_METADATA_KV.put).toHaveBeenCalled();
       expect(env.USER_METADATA_KV.delete).toHaveBeenCalledWith('event_testResult_u1_1');
-      expect(JSON.parse(store.events_queue)).toHaveLength(0);
     });
   });


### PR DESCRIPTION
## Summary
- add pagination via limit and cursor when listing pending user events
- store last cursor and chain processing with `ctx.waitUntil`
- adjust tests for new paginated flow

## Testing
- `npm run lint worker.js js/__tests__/userEvents.test.js js/__tests__/planModRequest.test.js tests/queueIndex.spec.js`
- `NODE_OPTIONS=--max-old-space-size=8192 npm test js/__tests__/userEvents.test.js js/__tests__/planModRequest.test.js tests/queueIndex.spec.js` *(fails: Reached heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_689fc56475dc8326912847710633939d