### PR TITLE
Автоматично запазване на дневния лог в края на деня

### DIFF
--- a/js/__tests__/scheduleEndOfDaySave.test.js
+++ b/js/__tests__/scheduleEndOfDaySave.test.js
@@ -1,0 +1,24 @@
+/** @jest-environment node */
+import { jest } from '@jest/globals';
+
+describe('scheduleEndOfDaySave', () => {
+  test('извиква autoSaveDailyLog при смяна на датата', async () => {
+    global.document = { addEventListener: jest.fn() };
+    global.window = { location: { hostname: 'localhost' } };
+    const { scheduleEndOfDaySave, calcMsToMidnight } = await import('../app.js');
+
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-04-10T23:59:50'));
+    const saveMock = jest.fn();
+    const firstDelay = calcMsToMidnight();
+
+    scheduleEndOfDaySave(saveMock);
+    jest.advanceTimersByTime(firstDelay);
+    await Promise.resolve();
+    expect(saveMock).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(24 * 60 * 60 * 1000);
+    await Promise.resolve();
+    expect(saveMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Резюме
- добавено е кеширане `lastSavedDailyLogSerialized` и помощни функции за пропускане на неизменени дневни логове
- автоматичният и ръчният запис сравняват последно записаните данни и пропускат заявката при липса на промяна
- кешът се нулира при `resetAppState`, за да се избегнат стари стойности

## Тестване
- `npm run lint -- js/app.js js/__tests__/scheduleEndOfDaySave.test.js`
- `sh ./scripts/test.sh js/__tests__/scheduleEndOfDaySave.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689fc3d09a008326b0c1c454fff8d7b2