### PR TITLE
refactor: extract theme controls

### DIFF
--- a/js/themeControls.js
+++ b/js/themeControls.js
@@ -1,0 +1,75 @@
+// themeControls.js - Управление на смяната на темите
+// Изнесени функции от uiHandlers.js без зависимости към app.js
+
+import { selectors } from './uiElements.js';
+
+let systemThemeMediaQuery;
+const themes = ['light', 'dark', 'vivid'];
+
+function handleSystemThemeChange(e) {
+    const pref = localStorage.getItem('theme') || 'system';
+    if (pref === 'system') {
+        applyTheme(e.matches ? 'dark' : 'light');
+        updateThemeButtonText();
+    }
+}
+
+export function initializeTheme() {
+    const savedTheme = localStorage.getItem('theme') || 'system';
+    systemThemeMediaQuery = systemThemeMediaQuery || window.matchMedia('(prefers-color-scheme: dark)');
+    const systemTheme = systemThemeMediaQuery.matches ? 'dark' : 'light';
+    if (!systemThemeMediaQuery.onchange) {
+        systemThemeMediaQuery.addEventListener('change', handleSystemThemeChange);
+    }
+    let theme = savedTheme === 'system' ? systemTheme : savedTheme;
+    if (!themes.includes(theme)) theme = 'light';
+    applyTheme(theme);
+    updateThemeButtonText();
+}
+
+export function applyTheme(theme) {
+    document.body.classList.remove('light-theme', 'dark-theme', 'vivid-theme');
+    const cls = theme === 'dark' ? 'dark-theme' : theme === 'vivid' ? 'vivid-theme' : 'light-theme';
+    document.body.classList.add(cls);
+    document.dispatchEvent(new Event('themechange'));
+    document.dispatchEvent(new Event('progressChartThemeChange'));
+}
+
+export function toggleTheme() {
+    const current = document.body.classList.contains('dark-theme')
+        ? 'dark'
+        : document.body.classList.contains('vivid-theme')
+        ? 'vivid'
+        : 'light';
+    const idx = themes.indexOf(current);
+    const nextTheme = themes[(idx + 1) % themes.length];
+    localStorage.setItem('theme', nextTheme);
+    applyTheme(nextTheme);
+    updateThemeButtonText();
+}
+
+export function updateThemeButtonText() {
+    if (!selectors.themeToggleMenu) return;
+    const themeTextSpan = selectors.themeToggleMenu.querySelector('.theme-text');
+    const themeIconSpan = selectors.themeToggleMenu.querySelector('.menu-icon');
+    const current = document.body.classList.contains('dark-theme')
+        ? 'dark'
+        : document.body.classList.contains('vivid-theme')
+        ? 'vivid'
+        : 'light';
+    const nextTheme = themes[(themes.indexOf(current) + 1) % themes.length];
+    const labels = { light: 'Светла Тема', dark: 'Тъмна Тема', vivid: 'Ярка Тема' };
+    const icons = {
+        light: '<i class="bi bi-moon"></i>',
+        dark: '<i class="bi bi-palette-fill"></i>',
+        vivid: '<i class="bi bi-sun"></i>'
+    };
+    if (current === 'vivid') {
+        if (themeTextSpan) themeTextSpan.textContent = 'Цветна Тема';
+        if (themeIconSpan) themeIconSpan.innerHTML = '<i class="bi bi-palette"></i>';
+    } else {
+        if (themeTextSpan) themeTextSpan.textContent = labels[nextTheme];
+        if (themeIconSpan) themeIconSpan.innerHTML = icons[nextTheme];
+    }
+}
+

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -9,6 +9,9 @@ import {
 import { trackerInfoTexts, detailedMetricInfoTexts, mainIndexInfoTexts } from './uiElements.js';
 import { colorGroups } from './themeConfig.js';
 import { capitalizeFirstLetter, safeGet, escapeHtml } from './utils.js';
+import { toggleTheme, initializeTheme, applyTheme, updateThemeButtonText } from './themeControls.js';
+
+export { toggleTheme, initializeTheme, applyTheme, updateThemeButtonText };
 
 // Продължителност на анимацията при скриване/показване на модали
 const MODAL_TRANSITION_MS = 300;
@@ -58,77 +61,6 @@ export function handleOutsideMenuClick(event) {
 
 export function handleMenuKeydown(event) {
     if (event.key === 'Escape' && selectors.mainMenu?.classList.contains('menu-open')) closeMenu();
-}
-
-let systemThemeMediaQuery;
-
-function handleSystemThemeChange(e) {
-    const pref = localStorage.getItem('theme') || 'system';
-    if (pref === 'system') {
-        applyTheme(e.matches ? 'dark' : 'light');
-        updateThemeButtonText();
-    }
-}
-
-const themes = ['light', 'dark', 'vivid'];
-
-export function initializeTheme() {
-    const savedTheme = localStorage.getItem('theme') || 'system';
-    systemThemeMediaQuery = systemThemeMediaQuery || window.matchMedia('(prefers-color-scheme: dark)');
-    const systemTheme = systemThemeMediaQuery.matches ? 'dark' : 'light';
-    if (!systemThemeMediaQuery.onchange) {
-        systemThemeMediaQuery.addEventListener('change', handleSystemThemeChange);
-    }
-    let theme = savedTheme === 'system' ? systemTheme : savedTheme;
-    if (!themes.includes(theme)) theme = 'light';
-    applyTheme(theme);
-    updateThemeButtonText();
-}
-
-export function applyTheme(theme) {
-    document.body.classList.remove('light-theme', 'dark-theme', 'vivid-theme');
-    const cls = theme === 'dark' ? 'dark-theme' : theme === 'vivid' ? 'vivid-theme' : 'light-theme';
-    document.body.classList.add(cls);
-    document.dispatchEvent(new Event('themechange'));
-    document.dispatchEvent(new Event('progressChartThemeChange'));
-}
-
-export function toggleTheme() {
-    const current = document.body.classList.contains('dark-theme')
-        ? 'dark'
-        : document.body.classList.contains('vivid-theme')
-        ? 'vivid'
-        : 'light';
-    const idx = themes.indexOf(current);
-    const nextTheme = themes[(idx + 1) % themes.length];
-    localStorage.setItem('theme', nextTheme);
-    applyTheme(nextTheme);
-    updateThemeButtonText();
-}
-
-export function updateThemeButtonText() {
-    if (!selectors.themeToggleMenu) return;
-    const themeTextSpan = selectors.themeToggleMenu.querySelector('.theme-text');
-    const themeIconSpan = selectors.themeToggleMenu.querySelector('.menu-icon');
-    const current = document.body.classList.contains('dark-theme')
-        ? 'dark'
-        : document.body.classList.contains('vivid-theme')
-        ? 'vivid'
-        : 'light';
-    const nextTheme = themes[(themes.indexOf(current) + 1) % themes.length];
-    const labels = { light: 'Светла Тема', dark: 'Тъмна Тема', vivid: 'Ярка Тема' };
-    const icons = {
-        light: '<i class="bi bi-moon"></i>',
-        dark: '<i class="bi bi-palette-fill"></i>',
-        vivid: '<i class="bi bi-sun"></i>'
-    };
-    if (current === 'vivid') {
-        if (themeTextSpan) themeTextSpan.textContent = 'Цветна Тема';
-        if (themeIconSpan) themeIconSpan.innerHTML = '<i class="bi bi-palette"></i>';
-    } else {
-        if (themeTextSpan) themeTextSpan.textContent = labels[nextTheme];
-        if (themeIconSpan) themeIconSpan.innerHTML = icons[nextTheme];
-    }
 }
 
 export async function loadAndApplyColors() {

--- a/script.js
+++ b/script.js
@@ -8,7 +8,7 @@
 
 // --- ЧАСТ 1: ИНТЕГРИРАНИ МОДУЛИ (от отделните JS файлове) ---
 
-import { toggleTheme, initializeTheme } from './js/uiHandlers.js';
+import { toggleTheme, initializeTheme } from './js/themeControls.js';
 
 /**
  * @description Конфигурация и глобални променливи (от config.js)


### PR DESCRIPTION
## Summary
- move theme initialization and toggling into standalone `themeControls.js`
- import theme helpers in landing `script.js`
- re-export theme controls through `uiHandlers.js` for backward compatibility

## Testing
- `npm run lint`
- `node scripts/validateMacros.js`
- `sh scripts/test.sh js/__tests__/themeCycle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689fcaa768b88326ad97f51ffaa25558