### PR TITLE
Поддръжка на индекс за заявки за контакт

### DIFF
--- a/js/__tests__/contactRequestsIndex.test.js
+++ b/js/__tests__/contactRequestsIndex.test.js
@@ -39,7 +39,9 @@ test('saves contact request and lists via index', async () => {
   expect(idx.length).toBe(1);
 
   const reqList = { headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) } };
+  kv.list.mockClear();
   const listRes = await handleGetContactRequestsRequest(reqList, env);
+  expect(kv.list).not.toHaveBeenCalled();
   expect(listRes.requests[0].email).toBe('a@b.com');
 });
 


### PR DESCRIPTION
## Summary
- актуализиране на индекса `contactRequests_index` при нови заявки
- четене на заявки за контакт чрез индексирани ключове
- добавен `handleValidateIndexesRequest` за възстановяване на индекси

## Testing
- `npm run lint`
- `node scripts/validateMacros.js && sh ./scripts/test.sh js/__tests__/contactRequestsIndex.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689fcc84757c8326bd6a3b00a325707d