### PR TITLE
Изнесен showLoading в отделен модул

### DIFF
--- a/js/loading.js
+++ b/js/loading.js
@@ -1,0 +1,13 @@
+import { selectors } from './uiElements.js';
+
+export function showLoading(show, message = "Зареждане...") {
+    if (!selectors.loadingOverlay || !selectors.loadingOverlayText) return;
+    selectors.loadingOverlayText.textContent = message;
+    if (show) {
+        selectors.loadingOverlay.classList.remove('hidden');
+    } else {
+        setTimeout(() => {
+            selectors.loadingOverlay.classList.add('hidden');
+        }, 150);
+    }
+}

--- a/js/uiElements.js
+++ b/js/uiElements.js
@@ -1,5 +1,5 @@
 // uiElements.js - Селектори и UI текстове
-import { showLoading } from './uiHandlers.js'; // Needed for error in initializeSelectors
+import { showLoading } from './loading.js'; // Needed for error in initializeSelectors
 
 export const selectors = {};
 

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -9,6 +9,8 @@ import {
 import { trackerInfoTexts, detailedMetricInfoTexts, mainIndexInfoTexts } from './uiElements.js';
 import { colorGroups } from './themeConfig.js';
 import { capitalizeFirstLetter, safeGet, escapeHtml } from './utils.js';
+import { showLoading } from './loading.js';
+export { showLoading };
 
 // Продължителност на анимацията при скриване/показване на модали
 const MODAL_TRANSITION_MS = 300;
@@ -325,18 +327,6 @@ export function handleTrackerTooltipHide(event) {
     const targetLabel = event.target.closest('label[data-tooltip-key]');
     if (infoBtn || targetLabel) {
         hideTrackerTooltip();
-    }
-}
-
-export function showLoading(show, message = "Зареждане...") {
-    if (!selectors.loadingOverlay || !selectors.loadingOverlayText) return;
-    selectors.loadingOverlayText.textContent = message;
-    if (show) {
-        selectors.loadingOverlay.classList.remove('hidden');
-    } else {
-        setTimeout(() => {
-            selectors.loadingOverlay.classList.add('hidden');
-        }, 150);
     }
 }
 


### PR DESCRIPTION
## Summary
- преместен showLoading в нов файл `js/loading.js`
- `uiElements.js` и `uiHandlers.js` препратени към новия модул

## Testing
- `npm run lint -- js/loading.js js/uiElements.js js/uiHandlers.js`
- `npm test extraMeal` *(провалени тестове)*

------
https://chatgpt.com/codex/tasks/task_e_689fce3682ac8326b96e1e11110a2100