### PR TITLE
feat: cache ai preset index

### DIFF
--- a/js/__tests__/aiPresets.test.js
+++ b/js/__tests__/aiPresets.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { handleSaveAiPreset, handleListAiPresets, handleGetAiPreset } from '../../worker.js';
+import { handleSaveAiPreset, handleListAiPresets, handleGetAiPreset, resetAiPresetIndexCache } from '../../worker.js';
 
 function createStore(initial = {}) {
   const store = { ...initial };
@@ -11,6 +11,8 @@ function createStore(initial = {}) {
   };
 }
 
+beforeEach(() => resetAiPresetIndexCache());
+
 test('save preset and retrieve it', async () => {
   const kv = createStore();
   const env = { RESOURCES_KV: kv, WORKER_ADMIN_TOKEN: 'secret' };
@@ -21,7 +23,7 @@ test('save preset and retrieve it', async () => {
   const saveRes = await handleSaveAiPreset(reqSave, env);
   expect(saveRes.success).toBe(true);
   expect(kv._store['aiPreset_test']).toBe(JSON.stringify({ model_plan_generation: 'm1' }));
-  expect(JSON.parse(kv._store.aiPresets_index)).toContain('aiPreset_test');
+  expect(JSON.parse(kv._store.aiPreset_index)).toContain('test');
 
   const listRes = await handleListAiPresets({}, env);
   expect(listRes.success).toBe(true);

--- a/js/__tests__/contactRequestsIndex.test.js
+++ b/js/__tests__/contactRequestsIndex.test.js
@@ -2,7 +2,8 @@ import { jest } from '@jest/globals';
 import {
   handleContactFormRequest,
   handleGetContactRequestsRequest,
-  handleValidateIndexesRequest
+  handleValidateIndexesRequest,
+  resetAiPresetIndexCache
 } from '../../worker.js';
 
 function createStore(initial = {}) {
@@ -18,6 +19,8 @@ function createStore(initial = {}) {
     _store: store
   };
 }
+
+beforeEach(() => resetAiPresetIndexCache());
 
 test('saves contact request and lists via index', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true });
@@ -56,7 +59,7 @@ test('validateIndexes rebuilds indexes', async () => {
   const req = { headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) } };
   const res = await handleValidateIndexesRequest(req, env);
   expect(res.success).toBe(true);
-  expect(JSON.parse(resKv._store.aiPresets_index)).toEqual(['aiPreset_demo']);
+  expect(JSON.parse(resKv._store.aiPreset_index)).toEqual(['demo']);
   expect(JSON.parse(contactKv._store.contactRequests_index)).toEqual(['contact_1']);
 });
 

--- a/tests/aiPresetIndex.spec.js
+++ b/tests/aiPresetIndex.spec.js
@@ -1,0 +1,54 @@
+import { jest } from '@jest/globals';
+import { handleSaveAiPreset, handleListAiPresets, resetAiPresetIndexCache } from '../worker.js';
+
+describe('ai preset index', () => {
+  beforeEach(() => resetAiPresetIndexCache());
+  test('handleSaveAiPreset добавя нов пресет в индекса', async () => {
+    const store = {};
+    const env = {
+      RESOURCES_KV: {
+        get: jest.fn(key => Promise.resolve(store[key])),
+        put: jest.fn((key, val) => { store[key] = val; return Promise.resolve(); }),
+        list: jest.fn(() => Promise.resolve({ keys: [] }))
+      },
+      WORKER_ADMIN_TOKEN: 't'
+    };
+    const request = {
+      headers: new Map([['Authorization', 'Bearer t']]),
+      json: async () => ({ name: 'p1', config: { a: 1 } })
+    };
+    await handleSaveAiPreset(request, env);
+    expect(JSON.parse(store.aiPreset_index)).toEqual(['p1']);
+    await handleSaveAiPreset(request, env);
+    expect(JSON.parse(store.aiPreset_index)).toEqual(['p1']);
+  });
+
+  test('handleListAiPresets използва индекса, когато е наличен', async () => {
+    const store = { aiPreset_index: JSON.stringify(['a']) };
+    const env = {
+      RESOURCES_KV: {
+        get: jest.fn(key => Promise.resolve(store[key])),
+        put: jest.fn((key, val) => { store[key] = val; return Promise.resolve(); }),
+        list: jest.fn(() => Promise.resolve({ keys: [] }))
+      }
+    };
+    const res = await handleListAiPresets({}, env);
+    expect(res.presets).toEqual(['a']);
+    expect(env.RESOURCES_KV.list).not.toHaveBeenCalled();
+  });
+
+  test('handleListAiPresets регенерира индекса при липса', async () => {
+    const store = {};
+    const env = {
+      RESOURCES_KV: {
+        get: jest.fn(key => Promise.resolve(store[key])),
+        put: jest.fn((key, val) => { store[key] = val; return Promise.resolve(); }),
+        list: jest.fn(() => Promise.resolve({ keys: [{ name: 'aiPreset_a' }, { name: 'aiPreset_b' }] }))
+      }
+    };
+    const res = await handleListAiPresets({}, env);
+    expect(res.presets).toEqual(['a', 'b']);
+    expect(JSON.parse(store.aiPreset_index)).toEqual(['a', 'b']);
+    expect(env.RESOURCES_KV.list).toHaveBeenCalledTimes(1);
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -290,6 +290,8 @@ const COMMAND_R_PLUS_SECRET_NAME = 'command-r-plus';
 const CF_AI_TOKEN_SECRET_NAME = 'CF_AI_TOKEN';
 const CF_ACCOUNT_ID_VAR_NAME = 'CF_ACCOUNT_ID';
 const WORKER_ADMIN_TOKEN_SECRET_NAME = 'WORKER_ADMIN_TOKEN';
+const AI_PRESET_INDEX_KEY = 'aiPreset_index';
+let aiPresetIndexCache = null;
 
 const GEMINI_API_URL_BASE = `https://generativelanguage.googleapis.com/v1beta/models/`;
 // Очаквани Bindings: RESOURCES_KV, USER_METADATA_KV
@@ -2530,8 +2532,21 @@ async function handleSetAiConfig(request, env) {
 // ------------- START FUNCTION: handleListAiPresets -------------
 async function handleListAiPresets(request, env) {
     try {
+        if (Array.isArray(aiPresetIndexCache) && aiPresetIndexCache.length) {
+            return { success: true, presets: aiPresetIndexCache };
+        }
+        const idxStr = await env.RESOURCES_KV.get(AI_PRESET_INDEX_KEY);
+        if (idxStr) {
+            const idx = safeParseJson(idxStr, []);
+            if (idx.length) {
+                aiPresetIndexCache = idx;
+                return { success: true, presets: idx };
+            }
+        }
         const { keys } = await env.RESOURCES_KV.list({ prefix: 'aiPreset_' });
         const presets = keys.map(k => k.name.replace(/^aiPreset_/, ''));
+        aiPresetIndexCache = presets;
+        await env.RESOURCES_KV.put(AI_PRESET_INDEX_KEY, JSON.stringify(presets));
         return { success: true, presets };
     } catch (error) {
         console.error('Error in handleListAiPresets:', error.message, error.stack);
@@ -2577,6 +2592,22 @@ async function handleSaveAiPreset(request, env) {
             return { success: false, message: 'Липсват данни.', statusHint: 400 };
         }
         await env.RESOURCES_KV.put(`aiPreset_${name}`, JSON.stringify(cfg));
+        try {
+            const idxStr = await env.RESOURCES_KV.get(AI_PRESET_INDEX_KEY);
+            const idx = idxStr ? safeParseJson(idxStr, []) : [];
+            if (!idx.includes(name)) {
+                idx.push(name);
+                await env.RESOURCES_KV.put(AI_PRESET_INDEX_KEY, JSON.stringify(idx));
+            }
+            aiPresetIndexCache = idx;
+        } catch (idxErr) {
+            console.error('Failed to update AI preset index:', idxErr.message);
+            if (Array.isArray(aiPresetIndexCache)) {
+                if (!aiPresetIndexCache.includes(name)) aiPresetIndexCache.push(name);
+            } else {
+                aiPresetIndexCache = [name];
+            }
+        }
         return { success: true };
     } catch (error) {
         console.error('Error in handleSaveAiPreset:', error.message, error.stack);
@@ -2692,8 +2723,9 @@ async function handleValidateIndexesRequest(request, env) {
             return { success: false, message: 'Невалиден токен.', statusHint: 403 };
         }
         const { keys: presetKeys } = await env.RESOURCES_KV.list({ prefix: 'aiPreset_' });
-        const presetIds = presetKeys.map(k => k.name);
-        await env.RESOURCES_KV.put('aiPresets_index', JSON.stringify(presetIds));
+        const presetIds = presetKeys.map(k => k.name.replace(/^aiPreset_/, ''));
+        aiPresetIndexCache = presetIds;
+        await env.RESOURCES_KV.put(AI_PRESET_INDEX_KEY, JSON.stringify(presetIds));
         const { keys: contactKeys } = await env.CONTACT_REQUESTS_KV.list({ prefix: 'contact_' });
         const contactIds = contactKeys.map(k => k.name);
         await env.CONTACT_REQUESTS_KV.put('contactRequests_index', JSON.stringify(contactIds));
@@ -4627,5 +4659,11 @@ async function handleUpdateKvRequest(request, env) {
     }
 }
 // ------------- END FUNCTION: handleUpdateKvRequest -------------
+
+// ------------- START FUNCTION: resetAiPresetIndexCache -------------
+function resetAiPresetIndexCache() {
+    aiPresetIndexCache = null;
+}
+// ------------- END FUNCTION: resetAiPresetIndexCache -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRegeneratePlanRequest, handleCheckPlanPrerequisitesRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleDashboardDataRequest, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleDeleteClientRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleContactFormRequest, handleGetContactRequestsRequest, handleValidateIndexesRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, sendAnalysisLinkEmail, sendContactEmail, getEmailConfig, getUserLogDates, calculateAnalyticsIndexes, handleListUserKvRequest, rebuildUserKvIndex, handleUpdateKvRequest, handleLogRequest, handlePlanLogRequest, setPlanStatus };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRegeneratePlanRequest, handleCheckPlanPrerequisitesRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleDashboardDataRequest, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleDeleteClientRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleContactFormRequest, handleGetContactRequestsRequest, handleValidateIndexesRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, sendAnalysisLinkEmail, sendContactEmail, getEmailConfig, getUserLogDates, calculateAnalyticsIndexes, handleListUserKvRequest, rebuildUserKvIndex, handleUpdateKvRequest, handleLogRequest, handlePlanLogRequest, setPlanStatus, resetAiPresetIndexCache };


### PR DESCRIPTION
## Summary
- cache `aiPreset_index` in-memory for faster access
- expose `resetAiPresetIndexCache` and update tests

## Testing
- `npm run lint`
- `npm test tests/aiPresetIndex.spec.js`
- `npm test js/__tests__/aiPresets.test.js`
- `npm test js/__tests__/contactRequestsIndex.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689fcf73e1d48326a9f2edb6f9362194