### PR TITLE
feat: cache ai preset index

### DIFF
--- a/js/__tests__/contactRequestsIndex.test.js
+++ b/js/__tests__/contactRequestsIndex.test.js
@@ -2,7 +2,8 @@ import { jest } from '@jest/globals';
 import {
   handleContactFormRequest,
   handleGetContactRequestsRequest,
-  handleValidateIndexesRequest
+  handleValidateIndexesRequest,
+  resetAiPresetIndexCache
 } from '../../worker.js';
 
 function createStore(initial = {}) {
@@ -18,6 +19,8 @@ function createStore(initial = {}) {
     _store: store
   };
 }
+
+beforeEach(() => resetAiPresetIndexCache());
 
 test('saves contact request and lists via index', async () => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true });
@@ -56,7 +59,7 @@ test('validateIndexes rebuilds indexes', async () => {
   const req = { headers: { get: h => (h === 'Authorization' ? 'Bearer secret' : null) } };
   const res = await handleValidateIndexesRequest(req, env);
   expect(res.success).toBe(true);
-  expect(JSON.parse(resKv._store.aiPresets_index)).toEqual(['aiPreset_demo']);
+  expect(JSON.parse(resKv._store.aiPreset_index)).toEqual(['demo']);
   expect(JSON.parse(contactKv._store.contactRequests_index)).toEqual(['contact_1']);
 });
 

--- a/tests/aiPresetIndex.spec.js
+++ b/tests/aiPresetIndex.spec.js
@@ -1,0 +1,71 @@
+import { jest } from '@jest/globals';
+import { handleSaveAiPreset, handleListAiPresets, handleDeleteAiPreset, resetAiPresetIndexCache } from '../worker.js';
+
+describe('ai preset index', () => {
+  beforeEach(() => resetAiPresetIndexCache());
+  test('handleSaveAiPreset добавя нов пресет в индекса', async () => {
+    const store = {};
+    const env = {
+      RESOURCES_KV: {
+        get: jest.fn(key => Promise.resolve(store[key])),
+        put: jest.fn((key, val) => { store[key] = val; return Promise.resolve(); }),
+        list: jest.fn(() => Promise.resolve({ keys: [] }))
+      },
+      WORKER_ADMIN_TOKEN: 't'
+    };
+    const request = {
+      headers: new Map([['Authorization', 'Bearer t']]),
+      json: async () => ({ name: 'p1', config: { a: 1 } })
+    };
+    await handleSaveAiPreset(request, env);
+    expect(JSON.parse(store.aiPreset_index)).toEqual(['p1']);
+    await handleSaveAiPreset(request, env);
+    expect(JSON.parse(store.aiPreset_index)).toEqual(['p1']);
+  });
+
+  test('handleListAiPresets използва индекса, когато е наличен', async () => {
+    const store = { aiPreset_index: JSON.stringify(['a']) };
+    const env = {
+      RESOURCES_KV: {
+        get: jest.fn(key => Promise.resolve(store[key])),
+        put: jest.fn((key, val) => { store[key] = val; return Promise.resolve(); }),
+        list: jest.fn(() => Promise.resolve({ keys: [] }))
+      }
+    };
+    const res = await handleListAiPresets({}, env);
+    expect(res.presets).toEqual(['a']);
+    expect(env.RESOURCES_KV.list).not.toHaveBeenCalled();
+  });
+
+  test('handleListAiPresets регенерира индекса при липса', async () => {
+    const store = {};
+    const env = {
+      RESOURCES_KV: {
+        get: jest.fn(key => Promise.resolve(store[key])),
+        put: jest.fn((key, val) => { store[key] = val; return Promise.resolve(); }),
+        list: jest.fn(() => Promise.resolve({ keys: [{ name: 'aiPreset_a' }, { name: 'aiPreset_b' }] }))
+      }
+    };
+    const res = await handleListAiPresets({}, env);
+    expect(res.presets).toEqual(['a', 'b']);
+    expect(JSON.parse(store.aiPreset_index)).toEqual(['a', 'b']);
+    expect(env.RESOURCES_KV.list).toHaveBeenCalledTimes(1);
+  });
+
+  test('handleDeleteAiPreset премахва пресет от индекса', async () => {
+    const store = { aiPreset_test: JSON.stringify({}), aiPreset_index: JSON.stringify(['test']) };
+    const env = {
+      RESOURCES_KV: {
+        get: jest.fn(key => Promise.resolve(store[key])),
+        put: jest.fn((key, val) => { store[key] = val; return Promise.resolve(); }),
+        delete: jest.fn(key => { delete store[key]; return Promise.resolve(); }),
+        list: jest.fn(() => Promise.resolve({ keys: [] }))
+      },
+      WORKER_ADMIN_TOKEN: 't'
+    };
+    const request = { headers: new Map([['Authorization', 'Bearer t']]), json: async () => ({ name: 'test' }) };
+    await handleDeleteAiPreset(request, env);
+    expect(store.aiPreset_test).toBeUndefined();
+    expect(JSON.parse(store.aiPreset_index)).toEqual([]);
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -290,6 +290,10 @@ const COMMAND_R_PLUS_SECRET_NAME = 'command-r-plus';
 const CF_AI_TOKEN_SECRET_NAME = 'CF_AI_TOKEN';
 const CF_ACCOUNT_ID_VAR_NAME = 'CF_ACCOUNT_ID';
 const WORKER_ADMIN_TOKEN_SECRET_NAME = 'WORKER_ADMIN_TOKEN';
+const AI_PRESET_INDEX_KEY = 'aiPreset_index';
+let aiPresetIndexCache = null;
+let aiPresetIndexCacheTime = 0;
+const AI_PRESET_INDEX_TTL_MS = 5 * 60 * 1000;
 
 const GEMINI_API_URL_BASE = `https://generativelanguage.googleapis.com/v1beta/models/`;
 // Очаквани Bindings: RESOURCES_KV, USER_METADATA_KV
@@ -548,6 +552,8 @@ export default {
                 responseBody = await handleGetAiPreset(request, env);
             } else if (method === 'POST' && path === '/api/saveAiPreset') {
                 responseBody = await handleSaveAiPreset(request, env);
+            } else if (method === 'POST' && path === '/api/deleteAiPreset') {
+                responseBody = await handleDeleteAiPreset(request, env);
             } else if (method === 'POST' && path === '/api/testAiModel') {
                 responseBody = await handleTestAiModelRequest(request, env);
             } else if (method === 'GET' && path === '/api/listContactRequests') {
@@ -2530,8 +2536,27 @@ async function handleSetAiConfig(request, env) {
 // ------------- START FUNCTION: handleListAiPresets -------------
 async function handleListAiPresets(request, env) {
     try {
+        const now = Date.now();
+        if (Array.isArray(aiPresetIndexCache) && aiPresetIndexCache.length && now - aiPresetIndexCacheTime < AI_PRESET_INDEX_TTL_MS) {
+            return { success: true, presets: aiPresetIndexCache };
+        }
+        const idxStr = await env.RESOURCES_KV.get(AI_PRESET_INDEX_KEY);
+        if (idxStr) {
+            const idx = safeParseJson(idxStr, []);
+            if (idx.length) {
+                aiPresetIndexCache = idx;
+                aiPresetIndexCacheTime = now;
+                return { success: true, presets: idx };
+            }
+        }
         const { keys } = await env.RESOURCES_KV.list({ prefix: 'aiPreset_' });
-        const presets = keys.map(k => k.name.replace(/^aiPreset_/, ''));
+        const presets = keys
+            .map(k => k.name)
+            .filter(name => name !== AI_PRESET_INDEX_KEY)
+            .map(name => name.replace(/^aiPreset_/, ''));
+        aiPresetIndexCache = presets;
+        aiPresetIndexCacheTime = now;
+        await env.RESOURCES_KV.put(AI_PRESET_INDEX_KEY, JSON.stringify(presets));
         return { success: true, presets };
     } catch (error) {
         console.error('Error in handleListAiPresets:', error.message, error.stack);
@@ -2577,6 +2602,24 @@ async function handleSaveAiPreset(request, env) {
             return { success: false, message: 'Липсват данни.', statusHint: 400 };
         }
         await env.RESOURCES_KV.put(`aiPreset_${name}`, JSON.stringify(cfg));
+        try {
+            const idxStr = await env.RESOURCES_KV.get(AI_PRESET_INDEX_KEY);
+            const idx = idxStr ? safeParseJson(idxStr, []) : [];
+            if (!idx.includes(name)) {
+                idx.push(name);
+                await env.RESOURCES_KV.put(AI_PRESET_INDEX_KEY, JSON.stringify(idx));
+            }
+            aiPresetIndexCache = idx;
+            aiPresetIndexCacheTime = Date.now();
+        } catch (idxErr) {
+            console.error('Failed to update AI preset index:', idxErr.message);
+            if (Array.isArray(aiPresetIndexCache)) {
+                if (!aiPresetIndexCache.includes(name)) aiPresetIndexCache.push(name);
+            } else {
+                aiPresetIndexCache = [name];
+            }
+            aiPresetIndexCacheTime = Date.now();
+        }
         return { success: true };
     } catch (error) {
         console.error('Error in handleSaveAiPreset:', error.message, error.stack);
@@ -2584,6 +2627,43 @@ async function handleSaveAiPreset(request, env) {
     }
 }
 // ------------- END FUNCTION: handleSaveAiPreset -------------
+
+// ------------- START FUNCTION: handleDeleteAiPreset -------------
+async function handleDeleteAiPreset(request, env) {
+    try {
+        const auth = request.headers.get('Authorization') || '';
+        const token = auth.replace(/^Bearer\s+/i, '').trim();
+        const expected = env[WORKER_ADMIN_TOKEN_SECRET_NAME];
+        if (expected && token !== expected) {
+            return { success: false, message: 'Невалиден токен.', statusHint: 403 };
+        }
+        const body = await request.json();
+        const name = body.name && String(body.name).trim();
+        if (!name) {
+            return { success: false, message: 'Липсва име.', statusHint: 400 };
+        }
+        await env.RESOURCES_KV.delete(`aiPreset_${name}`);
+        try {
+            const idxStr = await env.RESOURCES_KV.get(AI_PRESET_INDEX_KEY);
+            let idx = idxStr ? safeParseJson(idxStr, []) : [];
+            idx = idx.filter(n => n !== name);
+            await env.RESOURCES_KV.put(AI_PRESET_INDEX_KEY, JSON.stringify(idx));
+            aiPresetIndexCache = idx;
+            aiPresetIndexCacheTime = Date.now();
+        } catch (idxErr) {
+            console.error('Failed to update AI preset index:', idxErr.message);
+            if (Array.isArray(aiPresetIndexCache)) {
+                aiPresetIndexCache = aiPresetIndexCache.filter(n => n !== name);
+                aiPresetIndexCacheTime = Date.now();
+            }
+        }
+        return { success: true };
+    } catch (error) {
+        console.error('Error in handleDeleteAiPreset:', error.message, error.stack);
+        return { success: false, message: 'Грешка при изтриване на пресета.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleDeleteAiPreset -------------
 
 // ------------- START FUNCTION: handleTestAiModelRequest -------------
 async function handleTestAiModelRequest(request, env) {
@@ -2692,8 +2772,13 @@ async function handleValidateIndexesRequest(request, env) {
             return { success: false, message: 'Невалиден токен.', statusHint: 403 };
         }
         const { keys: presetKeys } = await env.RESOURCES_KV.list({ prefix: 'aiPreset_' });
-        const presetIds = presetKeys.map(k => k.name);
-        await env.RESOURCES_KV.put('aiPresets_index', JSON.stringify(presetIds));
+        const presetIds = presetKeys
+            .map(k => k.name)
+            .filter(name => name !== AI_PRESET_INDEX_KEY)
+            .map(name => name.replace(/^aiPreset_/, ''));
+        aiPresetIndexCache = presetIds;
+        aiPresetIndexCacheTime = Date.now();
+        await env.RESOURCES_KV.put(AI_PRESET_INDEX_KEY, JSON.stringify(presetIds));
         const { keys: contactKeys } = await env.CONTACT_REQUESTS_KV.list({ prefix: 'contact_' });
         const contactIds = contactKeys.map(k => k.name);
         await env.CONTACT_REQUESTS_KV.put('contactRequests_index', JSON.stringify(contactIds));
@@ -4627,5 +4712,12 @@ async function handleUpdateKvRequest(request, env) {
     }
 }
 // ------------- END FUNCTION: handleUpdateKvRequest -------------
+
+// ------------- START FUNCTION: resetAiPresetIndexCache -------------
+function resetAiPresetIndexCache() {
+    aiPresetIndexCache = null;
+    aiPresetIndexCacheTime = 0;
+}
+// ------------- END FUNCTION: resetAiPresetIndexCache -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRegeneratePlanRequest, handleCheckPlanPrerequisitesRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleDashboardDataRequest, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleDeleteClientRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleTestAiModelRequest, handleContactFormRequest, handleGetContactRequestsRequest, handleValidateIndexesRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, sendAnalysisLinkEmail, sendContactEmail, getEmailConfig, getUserLogDates, calculateAnalyticsIndexes, handleListUserKvRequest, rebuildUserKvIndex, handleUpdateKvRequest, handleLogRequest, handlePlanLogRequest, setPlanStatus };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRegeneratePlanRequest, handleCheckPlanPrerequisitesRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleDashboardDataRequest, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handleDeleteClientRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleDeleteAiPreset, handleTestAiModelRequest, handleContactFormRequest, handleGetContactRequestsRequest, handleValidateIndexesRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, sendAnalysisLinkEmail, sendContactEmail, getEmailConfig, getUserLogDates, calculateAnalyticsIndexes, handleListUserKvRequest, rebuildUserKvIndex, handleUpdateKvRequest, handleLogRequest, handlePlanLogRequest, setPlanStatus, resetAiPresetIndexCache };


### PR DESCRIPTION
## Summary
- cache `aiPreset_index` in-memory for faster access
- expose `resetAiPresetIndexCache` and update tests
- add preset deletion and cache TTL

## Testing
- `npm run lint`
- `npm test tests/aiPresetIndex.spec.js`
- `npm test js/__tests__/aiPresets.test.js`
- `npm test js/__tests__/contactRequestsIndex.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689fcf73e1d48326a9f2edb6f9362194