### PR TITLE
Предпазна проверка за #appWrapper преди инициализация

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -293,6 +293,10 @@ export { planHasRecContent };
  * Извиква се при събитието DOMContentLoaded.
  */
 async function initializeApp() {
+    if (!document.getElementById('appWrapper')) {
+        debugLog('initializeApp пропуснат: липсва #appWrapper');
+        return;
+    }
     try {
         debugLog("initializeApp starting from app.js...");
         try {


### PR DESCRIPTION
## Обобщение
- добавена е ранна проверка за отсъстващ `#appWrapper` в `initializeApp`
- добавено е диагностично съобщение чрез `debugLog`

## Тестване
- `npm run lint`
- `npm test` *(нестигната памет: FATAL ERROR: Reached heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_689fd795495483269e4b3466098dbe02