### PR TITLE
feat: track kv list telemetry

### DIFF
--- a/js/__tests__/kvListTelemetry.test.js
+++ b/js/__tests__/kvListTelemetry.test.js
@@ -21,7 +21,7 @@ describe('kv list telemetry', () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     const body = JSON.parse(global.fetch.mock.calls[0][1].body);
-    expect(body.kv_list_count).toBe(2);
+    expect(body.kv_list_counts.TEST_KV).toBe(2);
 
     global.fetch.mockClear();
     await _maybeSendKvListTelemetry(wrapped);


### PR DESCRIPTION
## Summary
- wrap KV namespaces to count list calls
- send counts to MONITORING_ENDPOINT every 15 minutes
- add tests for telemetry

## Testing
- `npm run lint`
- `npm test js/__tests__/kvListTelemetry.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689fd84d6488832691dc62a03b607301