### PR TITLE
refactor: isolate tooltip state

### DIFF
--- a/js/__tests__/uiHandlersEscapeHtml.test.js
+++ b/js/__tests__/uiHandlersEscapeHtml.test.js
@@ -20,19 +20,13 @@ describe('uiHandlers escapeHtml usage', () => {
       loadInfoTexts: jest.fn(() => Promise.resolve())
     }));
 
-    jest.unstable_mockModule('../app.js', () => ({
-      fullDashboardData: { recipeData: { r1: { title: 'T <b>', body: 'B <i>\nline' } } },
+    jest.unstable_mockModule('../tooltipState.js', () => ({
       activeTooltip: null,
-      setActiveTooltip: jest.fn(),
-      todaysMealCompletionStatus: {},
-      todaysExtraMeals: [],
-      currentIntakeMacros: {},
-      planHasRecContent: false,
-      loadCurrentIntake: jest.fn()
+      setActiveTooltip: jest.fn()
     }));
 
     const { openInfoModalWithDetails } = await import('../uiHandlers.js');
-    openInfoModalWithDetails('r1', 'recipe');
+    openInfoModalWithDetails('r1', 'recipe', { recipeData: { r1: { title: 'T <b>', body: 'B <i>\nline' } } });
 
     expect(selectors.infoModalTitle.innerHTML).toBe('T &lt;b&gt;');
     expect(selectors.infoModalBody.innerHTML).toBe('B &lt;i&gt;<br>line');
@@ -56,15 +50,9 @@ describe('uiHandlers escapeHtml usage', () => {
       loadInfoTexts: jest.fn(() => Promise.resolve())
     }));
 
-    jest.unstable_mockModule('../app.js', () => ({
-      fullDashboardData: {},
+    jest.unstable_mockModule('../tooltipState.js', () => ({
       activeTooltip: null,
-      setActiveTooltip: jest.fn(),
-      todaysMealCompletionStatus: {},
-      todaysExtraMeals: [],
-      currentIntakeMacros: {},
-      planHasRecContent: false,
-      loadCurrentIntake: jest.fn()
+      setActiveTooltip: jest.fn()
     }));
 
     const { openMainIndexInfo } = await import('../uiHandlers.js');

--- a/js/app.js
+++ b/js/app.js
@@ -18,6 +18,7 @@ import {
     setMacroExceedThreshold,
     updateAnalyticsSections
 } from './populateUI.js';
+import { activeTooltip, setActiveTooltip } from './tooltipState.js';
 // КОРЕКЦИЯ: Премахваме handleDelegatedClicks от импорта тук
 import { setupStaticEventListeners, setupDynamicEventListeners, initializeCollapsibleCards } from './eventListeners.js';
 import { loadProductMacros, calculateCurrentMacros, calculatePlanMacros } from './macroUtils.js';
@@ -125,7 +126,6 @@ export let todaysMealCompletionStatus = {}; // Updated by populateUI and eventLi
 export let todaysExtraMeals = []; // Extra meals logged for today
 export let todaysPlanMacros = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 }; // Cached plan macros for today
 export let currentIntakeMacros = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 }; // Calculated current macro intake
-export let activeTooltip = null; // Managed by uiHandlers via setActiveTooltip
 export let chatModelOverride = null; // Optional model override for next chat message
 export let chatPromptOverride = null; // Optional prompt override for next chat message
 
@@ -138,7 +138,7 @@ let planStatusTimeout = null;
 let adminQueriesInterval = null; // Интервал за проверка на администраторски съобщения
 let lastSavedDailyLogSerialized = null; // Кеш на последно записания дневен лог
 
-export function setActiveTooltip(tooltip) { activeTooltip = tooltip; }
+export { activeTooltip, setActiveTooltip };
 
 export function triggerAssistantWiggle() {
     const icon = selectors.chatFab?.querySelector('.assistant-icon');
@@ -157,7 +157,7 @@ export function resetAppState() {
     chatHistory = [];
     todaysMealCompletionStatus = {};
     todaysPlanMacros = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
-    activeTooltip = null;
+    setActiveTooltip(null);
     chatPromptOverride = null;
     lastSavedDailyLogSerialized = null;
 }

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -22,7 +22,8 @@ import {
     activeTooltip, currentUserId,
     setChatModelOverride, setChatPromptOverride,
     autoSaveCompletedMeals,
-    updateMacrosAndAnalytics
+    updateMacrosAndAnalytics,
+    fullDashboardData
 } from './app.js';
 import {
     openPlanModificationChat,
@@ -272,7 +273,7 @@ function handleDelegatedClicks(event) {
             type = infoButton.dataset.type || 'colorVar';
             key = infoButton.dataset.key;
         }
-        if (type && key) openInfoModalWithDetails(key, type);
+        if (type && key) openInfoModalWithDetails(key, type, fullDashboardData);
         return;
     }
     const ratingSquare = target.closest('.rating-square');

--- a/js/tooltipState.js
+++ b/js/tooltipState.js
@@ -1,0 +1,2 @@
+export let activeTooltip = null;
+export function setActiveTooltip(val) { activeTooltip = val; }

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -1,11 +1,7 @@
 // uiHandlers.js - Управление на UI елементи (Меню, Тема, Табове, Модали, Tooltips и др.)
 import { selectors } from './uiElements.js';
 import { loadConfig } from './adminConfig.js';
-import {
-    fullDashboardData,
-    activeTooltip, // state from app.js that this module will modify
-    setActiveTooltip // function from app.js to update activeTooltip state
-} from './app.js';
+import { activeTooltip, setActiveTooltip } from './tooltipState.js';
 import { trackerInfoTexts, detailedMetricInfoTexts, mainIndexInfoTexts } from './uiElements.js';
 import { colorGroups } from './themeConfig.js';
 import { capitalizeFirstLetter, safeGet, escapeHtml } from './utils.js';
@@ -150,9 +146,9 @@ export function closeModal(modalId) {
     }, { once: true });
 }
 
-export function openInfoModalWithDetails(key, type) {
+export function openInfoModalWithDetails(key, type, dashboardData = {}) {
     let title = "Информация", body = "Няма налична информация.";
-    const currentFullDashboardData = fullDashboardData; // Accessing from app.js import
+    const currentFullDashboardData = dashboardData;
 
     if (type === 'recipe') {
         const recipe = safeGet(currentFullDashboardData, ['recipeData', key]);


### PR DESCRIPTION
## Summary
- extract tooltip state into js/tooltipState.js
- decouple uiHandlers from app by passing dashboard data to `openInfoModalWithDetails`
- update event listeners and tests accordingly

## Testing
- `npm run lint`
- `sh scripts/test.sh js/__tests__/uiHandlersEscapeHtml.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689fd9c677048326940c92c605f2ce12