### PR TITLE
Добавена опция за изтриване на клиент

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -272,6 +272,7 @@
     <button id="generatePlan">Създай план</button>
     <div id="regenProgress" class="hidden" aria-live="polite"></div>
     <button id="aiSummary">AI резюме</button>
+    <button id="deleteClient" class="button button-danger">Изтрий профил</button>
     <div class="profile-nav-container">
       <button id="profileCardNavToggle" class="profile-nav-toggle" aria-label="Показване на навигацията">
         <i class="fas fa-bars"></i>

--- a/js/admin.js
+++ b/js/admin.js
@@ -37,6 +37,7 @@ const detailsSection = document.getElementById('clientDetails');
 const regenBtn = document.getElementById('regeneratePlan');
 const regenProgress = document.getElementById('regenProgress');
 const aiSummaryBtn = document.getElementById('aiSummary');
+const deleteClientBtn = document.getElementById('deleteClient');
 const notesField = document.getElementById('adminNotes');
 const tagsField = document.getElementById('adminTags');
 const saveNotesBtn = document.getElementById('saveNotes');
@@ -1231,6 +1232,31 @@ if (aiSummaryBtn) {
         const data = await resp.json();
         const summary = data.aiResponse?.result || data.aiResponse;
         alert(summary || 'Няма данни');
+    });
+}
+
+if (deleteClientBtn) {
+    deleteClientBtn.addEventListener('click', async () => {
+        if (!currentUserId) return;
+        if (!confirm('Сигурни ли сте, че искате да изтриете профила?')) return;
+        try {
+            const resp = await fetch(apiEndpoints.deleteClient, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ userId: currentUserId })
+            });
+            const data = await resp.json().catch(() => ({}));
+            if (!resp.ok || !data.success) {
+                alert(data.message || 'Грешка при изтриване.');
+                return;
+            }
+            alert('Профилът е изтрит.');
+            closeProfileBtn?.click();
+            await loadClients();
+        } catch (err) {
+            console.error('Error deleting client:', err);
+            alert('Грешка при изтриване на профила.');
+        }
     });
 }
 

--- a/js/config.js
+++ b/js/config.js
@@ -37,6 +37,7 @@ export const apiEndpoints = {
     generatePraise: `${workerBaseUrl}/api/generatePraise`,
     aiHelper: `${workerBaseUrl}/api/aiHelper`,
     listClients: `${workerBaseUrl}/api/listClients`,
+    deleteClient: `${workerBaseUrl}/api/deleteClient`,
     addAdminQuery: `${workerBaseUrl}/api/addAdminQuery`,
     getAdminQueries: `${workerBaseUrl}/api/getAdminQueries`,
     peekAdminQueries: `${workerBaseUrl}/api/peekAdminQueries`,

--- a/worker.js
+++ b/worker.js
@@ -530,6 +530,8 @@ export default {
                 }
             } else if (method === 'GET' && path === '/api/listClients') {
                 responseBody = await handleListClientsRequest(request, env);
+            } else if (method === 'POST' && path === '/api/deleteClient') {
+                responseBody = await handleDeleteClientRequest(request, env);
             } else if (method === 'POST' && path === '/api/addAdminQuery') {
                 responseBody = await handleAddAdminQueryRequest(request, env);
             } else if (method === 'GET' && path === '/api/getAdminQueries') {


### PR DESCRIPTION
## Обобщение
- добавен `apiEndpoints.deleteClient` за новия API път
- бутон **Изтрий профил** в `admin.html`
- обработчик в `js/admin.js` за потвърждение, изтриване и обновяване на списъка
- маршрутизаторът на `worker.js` обработва `POST /api/deleteClient`

## Тестове
- `npm run lint`
- `npm test` *(неуспешен – провал в `extraMealAutofill.test.js`, `extraMealFormSubmit.test.js`, `populateDashboardMacros.missingComponent.test.js`)*
- `npm test js/__tests__/allUserIds.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689fda07daa48326ac1fd1e9e59b1e55