### PR TITLE
feat: allow skipping macro validation

### DIFF
--- a/js/__tests__/populateDashboardMacros.test.js
+++ b/js/__tests__/populateDashboardMacros.test.js
@@ -58,7 +58,7 @@ test('recalculates macros automatically and shows spinner while loading', async 
     { meal_name: 'Салата', macros: { calories: 200, protein: 5, carbs: 20, fat: 10, fiber: 5 } }
   ];
   appState.fullDashboardData.planData = { week1Menu: { [currentDayKey]: dayMenu } };
-  Object.assign(appState.todaysPlanMacros, macroUtils.calculatePlanMacros(dayMenu));
+  Object.assign(appState.todaysPlanMacros, macroUtils.calculatePlanMacros(dayMenu, true, true));
   Object.assign(appState.currentIntakeMacros, { calories: 100, protein: 10, carbs: 15, fat: 5, fiber: 2 });
 
   const originalFetch = global.fetch;
@@ -148,7 +148,7 @@ test('използва подадените планови макроси', asyn
     { meal_name: 'Омлет', macros: { calories: 300, protein: 20, carbs: 10, fat: 15, fiber: 2 } },
     { meal_name: 'Салата', macros: { calories: 200, protein: 5, carbs: 20, fat: 10, fiber: 5 } }
   ];
-  const summed = macroUtils.calculatePlanMacros(dayMenu);
+  const summed = macroUtils.calculatePlanMacros(dayMenu, true, true);
   Object.assign(appState.todaysPlanMacros, summed);
   Object.assign(appState.currentIntakeMacros, { calories: 150, protein: 12, carbs: 20, fat: 6, fiber: 3 });
   await populateDashboardMacros(macros);

--- a/js/app.js
+++ b/js/app.js
@@ -430,7 +430,7 @@ export async function loadDashboardData() {
             const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
             const currentDayKey = dayNames[new Date().getDay()];
             const dayMenu = fullDashboardData.planData?.week1Menu?.[currentDayKey] || [];
-            todaysPlanMacros = calculatePlanMacros(dayMenu);
+            todaysPlanMacros = calculatePlanMacros(dayMenu, true, true);
             loadCurrentIntake();
             chatHistory = []; // Reset chat history for test user on reload
 
@@ -498,7 +498,7 @@ export async function loadDashboardData() {
         const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
         const currentDayKey = dayNames[new Date().getDay()];
         const dayMenu = fullDashboardData.planData?.week1Menu?.[currentDayKey] || [];
-        todaysPlanMacros = calculatePlanMacros(dayMenu);
+        todaysPlanMacros = calculatePlanMacros(dayMenu, true, true);
         loadCurrentIntake();
         await populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
 

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -592,7 +592,7 @@ function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {
     if(selectors.dailyPlanTitle) selectors.dailyPlanTitle.textContent = `📅 Меню (${capitalizeFirstLetter(todayTitle)})`;
 
     const dailyPlanData = safeGet(week1Menu, currentDayKey, []);
-    Object.assign(todaysPlanMacros, calculatePlanMacros(dailyPlanData));
+    Object.assign(todaysPlanMacros, calculatePlanMacros(dailyPlanData, true, true));
 
     populateDashboardMacros();
 


### PR DESCRIPTION
## Summary
- add optional `skipValidation` flag across macro util helpers
- allow plan macros from `final_plan` to bypass validation
- adjust dashboard loading to pass skip flag

## Testing
- `npm run lint`
- `npm test js/__tests__/macroUtils.test.js js/__tests__/populateDashboardMacros.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ff2ccc8fc83268e7979527d7ca661