### PR TITLE
Премахване на applyHeaderColor и коректен фон на мобилното меню

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,17 +21,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Мобилно меню
     if (mobileMenuBtn && nav) {
-        const applyHeaderColor = () => {
-            const bg = getComputedStyle(document.documentElement)
-                .getPropertyValue('--mobile-menu-bg') || '#ffffff';
-            nav.style.background = bg.trim();
-        };
         const closeNav = () => {
             body.classList.remove('nav-open');
             mobileMenuBtn.setAttribute('aria-expanded', 'false');
         };
         const toggleNav = () => {
-            applyHeaderColor();
             const open = body.classList.toggle('nav-open');
             mobileMenuBtn.setAttribute('aria-expanded', open);
         };

--- a/style.css
+++ b/style.css
@@ -108,7 +108,7 @@ header.scrolled { padding: 15px 0; background: var(--header-bg); backdrop-filter
 .logo-link { text-decoration: none; }
 .logo { width: 225px; height: auto; display: block; }
 nav { display: flex; align-items: center; }
-nav ul { display: flex; list-style: none; align-items: center; }
+nav ul { display: flex; list-style: none; align-items: center; background-color: inherit; }
 nav ul li { margin-left: 35px; }
 nav ul li a { font-family: 'Montserrat', sans-serif; font-weight: 600; color: var(--secondary-color); text-decoration: none; transition: var(--transition); position: relative; font-size: 1.1rem; }
 .dark-theme nav ul li a { color: var(--light-text); }


### PR DESCRIPTION
## Описание
- премахната е излишната функция `applyHeaderColor` и нейните извиквания
- `nav ul` наследява фона на контейнера чрез `background-color: inherit`

## Тестване
- `npm run lint`
- опит за Jest тест на наследяване на фона (неуспешен поради ограничена поддръжка на CSS в jsdom)


------
https://chatgpt.com/codex/tasks/task_e_689ffdcc47ec83269235f7b3deb117ab