### PR TITLE
Предотвратяване на загуба на фокус при чат бутона

### DIFF
--- a/js/assistantChat.js
+++ b/js/assistantChat.js
@@ -183,7 +183,13 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch { /* ignore parse errors */ }
     }
 
-    document.getElementById('chat-send').addEventListener('click', sendMessage);
+    const sendBtn = document.getElementById('chat-send');
+    sendBtn.addEventListener('mousedown', e => e.preventDefault());
+    sendBtn.addEventListener('click', e => {
+        e.preventDefault();
+        sendMessage();
+        setTimeout(() => document.getElementById('chat-input').focus(), 0);
+    });
     document.getElementById('chat-input').addEventListener('keypress', e => {
         if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
     });


### PR DESCRIPTION
## Обобщение
- Обвит обработчика на `chat-send` с `preventDefault`, за да се запази фокусът и да се избегнат нежелани ефекти

## Тестване
- `npm run lint`
- `npm test` *(неуспешен: FAIL js/__tests__/extraMealAutofill.test.js, възникна и `FATAL ERROR: Reached heap limit Allocation failed`)*
- `sh ./scripts/test.sh js/__tests__/planModChat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a11be99f048326bc6a0385801aa094