### PR TITLE
Use keydown for chat input submission

### DIFF
--- a/js/assistantChat.js
+++ b/js/assistantChat.js
@@ -190,8 +190,11 @@ document.addEventListener('DOMContentLoaded', () => {
         sendMessage();
         setTimeout(() => document.getElementById('chat-input').focus(), 0);
     });
-    document.getElementById('chat-input').addEventListener('keypress', e => {
-        if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
+    document.getElementById('chat-input').addEventListener('keydown', e => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            sendMessage();
+        }
     });
     document.getElementById('chat-clear').addEventListener('click', clearChat);
     document.getElementById('chat-upload').addEventListener('click', openImageDialog);


### PR DESCRIPTION
## Summary
- trigger assistant chat message sending on keydown instead of keypress

## Testing
- `npm run lint`
- `npm test` *(fails: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a11daac7a883268542f801af47c90a