### PR TITLE
Focus chat input after user ID initialization

### DIFF
--- a/js/assistantChat.js
+++ b/js/assistantChat.js
@@ -171,6 +171,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     userIdInput.value = savedId;
     userIdInput.disabled = true;
+    document.getElementById('chat-input').focus();
 
     const storedHistory = sessionStorage.getItem('chatHistory');
     if (storedHistory) {


### PR DESCRIPTION
## Summary
- focus chat input automatically once the user ID is populated

## Testing
- `npm run lint`
- `npm test` *(fails: Reached heap limit, JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a11f185798832686710dbfd22b11af