### PR TITLE
Замяна на emoji икона за чат изчистване със SVG

### DIFF
--- a/code.html
+++ b/code.html
@@ -142,6 +142,20 @@
         />
       </symbol>
       <symbol
+        id="icon-trash"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M3 6h18M8 6V4h8v2m-6 4v8m-4-8v8m8-8v8M6 6v12a2 2 0 002 2h8a2 2 0 002-2V6"
+        />
+      </symbol>
+      <symbol
         id="icon-spinner"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
@@ -1090,7 +1104,7 @@
               class="chat-clear-btn"
               aria-label="Изчисти чата"
             >
-              🗑
+              <svg class="icon"><use href="#icon-trash"></use></svg>
             </button>
             <button
               id="chat-close"

--- a/partials/planModChatModal.html
+++ b/partials/planModChatModal.html
@@ -15,7 +15,7 @@
           class="plan-mod-chat-clear"
           aria-label="Изчисти чата"
         >
-          🗑
+          <svg class="icon"><use href="#icon-trash"></use></svg>
         </button>
         <button
           id="planModChatClose"


### PR DESCRIPTION
## Обобщение
- добавен SVG символ `icon-trash`
- заменени чат бутони за изчистване да използват SVG

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a125c20dbc8326a505a79ba889c071