### PR TITLE
Използване на емоджи за медали вместо SVG икони

### DIFF
--- a/js/achievements.js
+++ b/js/achievements.js
@@ -4,12 +4,14 @@ import { openModal } from './uiHandlers.js';
 import { apiEndpoints } from './config.js';
 
 const medalIcons = [
+    '🥇',
+    '🥈',
+    '🥉',
     '🏅',
     '🏆',
-    '🔥',
-    '⭐',
-    '✅',
-    '😄'
+    '🎖️',
+    '🌟',
+    '✨'
 ];
 
 // Анимирано показване на иконка в модала за постижение
@@ -97,7 +99,7 @@ function renderAchievements(newIndex = -1) {
         const el = document.createElement('div');
         el.className = 'achievement-medal';
         if (index === newIndex) el.classList.add('new');
-        el.innerHTML = a.emoji || '<i class="bi bi-award"></i>';
+        el.innerHTML = a.emoji || '🏅';
         el.dataset.index = index;
         selectors.streakGrid.appendChild(el);
     });
@@ -128,7 +130,7 @@ export function handleAchievementClick(e) {
     const modalTitle = document.getElementById('achievementModalTitle');
     if (body) body.textContent = ach.message;
     if (modalTitle) modalTitle.textContent = ach.title;
-    showAchievementEmoji(ach.emoji || '<i class="bi bi-award"></i>');
+    showAchievementEmoji(ach.emoji || '🏅');
     openModal('achievementModal');
 }
 

--- a/worker.js
+++ b/worker.js
@@ -308,10 +308,14 @@ const RECENT_CHAT_MESSAGES_FOR_PRINCIPLES = 10;
 const AUTOMATED_FEEDBACK_TRIGGER_DAYS = 3; // След толкова дни предлагаме автоматичен чат
 const PRAISE_INTERVAL_DAYS = 3; // Интервал за нова похвала/значка
 const MEDAL_ICONS = [
-    '<i class="bi bi-award-fill"></i>',
-    '<i class="bi bi-trophy-fill"></i>',
-    '<i class="bi bi-fire"></i>',
-    '<i class="bi bi-stars"></i>'
+    '🥇',
+    '🥈',
+    '🥉',
+    '🏅',
+    '🏆',
+    '🎖️',
+    '🌟',
+    '✨'
 ];
 const AI_CONFIG_KEYS = [
     'model_plan_generation',


### PR DESCRIPTION
## Резюме
- обновен списък с медали в `achievements.js` с подробни емоджита
- премахнат fallback към SVG икони в UI и поддържащи функции
- `worker.js` използва същите емоджи за генерираните отличия

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a125fcd19c8326b974897d5ad699fd