### PR TITLE
sanitize achievement emojis

### DIFF
--- a/js/__tests__/achievementsSanitize.test.js
+++ b/js/__tests__/achievementsSanitize.test.js
@@ -1,0 +1,23 @@
+import { jest } from '@jest/globals';
+import { handleGetAchievementsRequest } from '../../worker.js';
+
+describe('handleGetAchievementsRequest emoji sanitization', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('replaces HTML in emoji with random medal and updates DB', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn().mockResolvedValue(JSON.stringify([{ title: 't', message: 'm', emoji: '<svg></svg>' }])),
+        put: jest.fn().mockResolvedValue(undefined)
+      }
+    };
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const request = { url: 'https://example.com?userId=u1' };
+    const res = await handleGetAchievementsRequest(request, env);
+    expect(res.success).toBe(true);
+    expect(res.achievements[0].emoji).toBe('🥇');
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_achievements', JSON.stringify([{ title: 't', message: 'm', emoji: '🥇' }]));
+  });
+});

--- a/js/achievements.js
+++ b/js/achievements.js
@@ -18,7 +18,8 @@ const medalIcons = [
 function showAchievementEmoji(iconHtml) {
     const emojiEl = document.getElementById('achievementModalEmoji');
     if (!emojiEl) return;
-    emojiEl.innerHTML = iconHtml;
+    // Използваме textContent, за да предотвратим инжектиране на HTML
+    emojiEl.textContent = iconHtml;
     emojiEl.setAttribute('aria-hidden', 'false');
     emojiEl.style.animation = 'none';
     // Trigger reflow to restart animation
@@ -56,7 +57,10 @@ export async function initializeAchievements(userId) {
     achievements = JSON.parse(localStorage.getItem(`achievements_${currentUserId}`) || '[]');
     let updated = false;
     achievements = achievements.map(a => {
-        if (!a.emoji) { a.emoji = medalIcons[Math.floor(Math.random() * medalIcons.length)]; updated = true; }
+        if (!a.emoji || /<.*>/.test(a.emoji)) {
+            a.emoji = medalIcons[Math.floor(Math.random() * medalIcons.length)];
+            updated = true;
+        }
         return a;
     });
     if (updated) saveAchievements();
@@ -66,7 +70,10 @@ export async function initializeAchievements(userId) {
             const data = await res.json();
             if (res.ok && data.success && Array.isArray(data.achievements)) {
                 achievements = data.achievements.map(a => {
-                    if (!a.emoji) { a.emoji = medalIcons[Math.floor(Math.random() * medalIcons.length)]; updated = true; }
+                    if (!a.emoji || /<.*>/.test(a.emoji)) {
+                        a.emoji = medalIcons[Math.floor(Math.random() * medalIcons.length)];
+                        updated = true;
+                    }
                     return a;
                 });
                 saveAchievements();
@@ -99,14 +106,17 @@ function renderAchievements(newIndex = -1) {
         const el = document.createElement('div');
         el.className = 'achievement-medal';
         if (index === newIndex) el.classList.add('new');
-        el.innerHTML = a.emoji || '🏅';
+        // Показваме само емоджита без HTML
+        el.textContent = a.emoji || '🏅';
         el.dataset.index = index;
         selectors.streakGrid.appendChild(el);
     });
 }
 
 export function createAchievement(title, message, emoji = null) {
-    const chosen = emoji || medalIcons[Math.floor(Math.random() * medalIcons.length)];
+    const chosen = emoji && !/<.*>/.test(emoji)
+        ? emoji
+        : medalIcons[Math.floor(Math.random() * medalIcons.length)];
     achievements.push({ date: Date.now(), title, message, emoji: chosen });
     if (achievements.length > 7) achievements.shift();
     saveAchievements();

--- a/worker.js
+++ b/worker.js
@@ -1774,7 +1774,10 @@ async function handleGetAchievementsRequest(request, env) {
         let achievements = safeParseJson(achStr, []);
         let updated = false;
         achievements = achievements.map(a => {
-            if (!a.emoji) { a.emoji = MEDAL_ICONS[Math.floor(Math.random() * MEDAL_ICONS.length)]; updated = true; }
+            if (!a.emoji || /<.*>/.test(a.emoji)) {
+                a.emoji = MEDAL_ICONS[Math.floor(Math.random() * MEDAL_ICONS.length)];
+                updated = true;
+            }
             return a;
         });
         if (updated) await env.USER_METADATA_KV.put(`${userId}_achievements`, JSON.stringify(achievements));
@@ -1795,7 +1798,16 @@ async function handleGeneratePraiseRequest(request, env) {
         const now = Date.now();
         const lastTsStr = await env.USER_METADATA_KV.get(`${userId}_last_praise_ts`);
         const achStr = await env.USER_METADATA_KV.get(`${userId}_achievements`);
-        const achievements = safeParseJson(achStr, []);
+        let achievements = safeParseJson(achStr, []);
+        let updated = false;
+        achievements = achievements.map(a => {
+            if (!a.emoji || /<.*>/.test(a.emoji)) {
+                a.emoji = MEDAL_ICONS[Math.floor(Math.random() * MEDAL_ICONS.length)];
+                updated = true;
+            }
+            return a;
+        });
+        if (updated) await env.USER_METADATA_KV.put(`${userId}_achievements`, JSON.stringify(achievements));
 
         if (!lastTsStr && achievements.length === 0) {
             const title = 'Първа стъпка';


### PR DESCRIPTION
## Summary
- sanitize achievement emoji values, replacing any HTML with random medal icon
- render medals using textContent to avoid HTML injection
- cover emoji sanitization with unit test

## Testing
- `npm run lint js/achievements.js worker.js js/__tests__/achievementsSanitize.test.js`
- `npm test js/__tests__/achievementsSanitize.test.js js/__tests__/generatePraise.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a12ff618a0832687721cef1249b7eb