### PR TITLE
Добавяне на attention анимация за асистентската икона

### DIFF
--- a/css/components_styles.css
+++ b/css/components_styles.css
@@ -347,6 +347,20 @@ body.dark-theme .chat-messages .message.bot { color: #e0e0e0; }
   height: 32px;
   animation: assistantPulse 2s infinite;
 }
+
+@keyframes assistantFloat {
+  0%,100% { transform: translateY(0); }
+  50%     { transform: translateY(-6px); }
+}
+@keyframes assistantGlow {
+  0%,100% { filter: drop-shadow(0 0 0 var(--secondary-color)); }
+  50%     { filter: drop-shadow(0 0 8px var(--secondary-color)); }
+}
+.assistant-icon.attention {
+  animation: assistantFloat 3s ease-in-out infinite,
+             assistantGlow 3s ease-in-out infinite,
+             assistantPulse 2s infinite;
+}
 @keyframes assistantWiggle {
   0%   { transform: rotate(0deg); }
   15%  { transform: rotate(-10deg); }
@@ -362,4 +376,5 @@ body.dark-theme .chat-messages .message.bot { color: #e0e0e0; }
 @media (prefers-reduced-motion: reduce) {
   #chat-fab .assistant-icon { animation: none; }
   .assistant-icon.wiggle { animation: none; }
+  .assistant-icon.attention { animation: none; }
 }

--- a/js/app.js
+++ b/js/app.js
@@ -86,6 +86,7 @@ async function checkAdminQueries(userId) {
             });
             if (!selectors.chatWidget?.classList.contains('visible')) {
                 if (selectors.chatFab) selectors.chatFab.classList.add('notification');
+                setAssistantAttention(true);
                 triggerAssistantWiggle();
                 setAutomatedChatPending(true);
             }
@@ -140,6 +141,12 @@ let lastSavedDailyLogSerialized = null; // Кеш на последно запи
 
 export { activeTooltip, setActiveTooltip };
 
+export function setAssistantAttention(active) {
+    const icon = selectors.chatFab?.querySelector('.assistant-icon');
+    if (!icon) return;
+    icon.classList.toggle('attention', active);
+}
+
 export function triggerAssistantWiggle() {
     const icon = selectors.chatFab?.querySelector('.assistant-icon');
     if (!icon) return;
@@ -149,6 +156,8 @@ export function triggerAssistantWiggle() {
     }
     icon.addEventListener('animationend', handleEnd, { once: true });
 }
+
+selectors.chatFab?.addEventListener('click', () => setAssistantAttention(false));
 
 // Функция за нулиране на глобалното състояние при изход
 export function resetAppState() {


### PR DESCRIPTION
## Обобщение
- Добавени са `assistantFloat` и `assistantGlow` keyframe анимации и новият клас `.assistant-icon.attention`.
- Разширена е media заявката за `prefers-reduced-motion`, за да спира анимациите на `.attention`.
- Въведена е функция `setAssistantAttention` и логика за активиране/деактивиране на класа при нови съобщения.

## Тестване
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a13501576c83268caab143c1a78bc4