### PR TITLE
feat(kv): rebuild user index after update

### DIFF
--- a/js/__tests__/userKvEndpoints.test.js
+++ b/js/__tests__/userKvEndpoints.test.js
@@ -1,10 +1,6 @@
 /** @jest-environment node */
 import { jest } from '@jest/globals';
-import {
-  handleListUserKvRequest,
-  handleUpdateKvRequest,
-  rebuildUserKvIndex
-} from '../../worker.js';
+import * as worker from '../../worker.js';
 
 test('lists user KV entries with pagination', async () => {
   const list = jest.fn().mockResolvedValue({
@@ -19,7 +15,7 @@ test('lists user KV entries with pagination', async () => {
   const req = new Request(
     'https://example.com/api/listUserKv?userId=user1&cursor=abc&limit=2'
   );
-  const res = await handleListUserKvRequest(req, env);
+  const res = await worker.handleListUserKvRequest(req, env);
   expect(list).toHaveBeenCalledWith({
     prefix: 'user1_',
     cursor: 'abc',
@@ -40,21 +36,50 @@ test('returns cached index when available', async () => {
   );
   const env = { USER_METADATA_KV: { list, get, put: jest.fn() } };
   const req = new Request('https://example.com/api/listUserKv?userId=user1');
-  const res = await handleListUserKvRequest(req, env);
+  const res = await worker.handleListUserKvRequest(req, env);
   expect(list).not.toHaveBeenCalled();
   expect(res).toEqual({ success: true, kv: { user1_a: '1' }, listComplete: true, nextCursor: null });
 });
 
-test('updates KV entry', async () => {
+test('updates KV entry and rebuilds index', async () => {
   const put = jest.fn();
-  const env = { USER_METADATA_KV: { put } };
+  const list = jest
+    .fn()
+    .mockResolvedValue({ keys: [{ name: 'user1_c' }], list_complete: true });
+  const get = jest.fn().mockResolvedValue('3');
+  const env = { USER_METADATA_KV: { put, list, get } };
   const req = new Request('https://example.com/api/updateKv', {
     method: 'POST',
     body: JSON.stringify({ key: 'user1_c', value: '3' })
   });
-  const res = await handleUpdateKvRequest(req, env);
-  expect(put).toHaveBeenCalledWith('user1_c', '3');
+  const res = await worker.handleUpdateKvRequest(req, env);
+  expect(put).toHaveBeenNthCalledWith(1, 'user1_c', '3');
+  expect(put).toHaveBeenNthCalledWith(
+    2,
+    'user1_kv_index',
+    JSON.stringify({ user1_c: '3' })
+  );
   expect(res.success).toBe(true);
+});
+
+test('extracts userId from request body when key lacks prefix', async () => {
+  const put = jest.fn();
+  const list = jest
+    .fn()
+    .mockResolvedValue({ keys: [{ name: 'user3_kv_only' }], list_complete: true });
+  const get = jest.fn().mockResolvedValue('v');
+  const env = { USER_METADATA_KV: { put, list, get } };
+  const req = new Request('https://example.com/api/updateKv', {
+    method: 'POST',
+    body: JSON.stringify({ key: 'kv_only', value: 'v', userId: 'user3' })
+  });
+  await worker.handleUpdateKvRequest(req, env);
+  expect(put).toHaveBeenNthCalledWith(1, 'kv_only', 'v');
+  expect(put).toHaveBeenNthCalledWith(
+    2,
+    'user3_kv_index',
+    JSON.stringify({ user3_kv_only: 'v' })
+  );
 });
 
 test('rebuilds KV index for user', async () => {
@@ -65,7 +90,7 @@ test('rebuilds KV index for user', async () => {
   const get = jest.fn().mockResolvedValue('5');
   const put = jest.fn();
   const env = { USER_METADATA_KV: { list, get, put } };
-  await rebuildUserKvIndex('user2', env);
+  await worker.rebuildUserKvIndex('user2', env);
   expect(list).toHaveBeenCalledWith({ prefix: 'user2_' });
   expect(put).toHaveBeenCalledWith(
     'user2_kv_index',


### PR DESCRIPTION
## Summary
- rebuild user KV index after updating entries
- cover userKV endpoint with tests for index rebuild and safe userId extraction

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError: The requested module './app.js' does not provide an export named 'ensureFreshDailyIntake', etc.)*
- `sh ./scripts/test.sh js/__tests__/userKvEndpoints.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1e42dc2b48326b3aa06c1364b54f5