### PR TITLE
Добавяне на SVG икона за секцията 'Поведенчески Стратегии и Нагласа'

### DIFF
--- a/code.html
+++ b/code.html
@@ -271,6 +271,16 @@
       <symbol id="icon-trophy" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 18.75h-9m9 0a3 3 0 013 3h-15a3 3 0 013-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 01-.982-3.172M9.497 14.25a7.454 7.454 0 00.981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 007.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 002.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 012.916.52 6.003 6.003 0 01-5.395 4.972m0 0a6.726 6.726 0 01-2.749 1.35m0 0a6.772 6.772 0 01-3.044 0"/>
       </symbol>
+      <symbol id="icon-brain" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 18V5" />
+        <path d="M15 13a4.17 4.17 0 0 1-3-4 4.17 4.17 0 0 1-3 4" />
+        <path d="M17.598 6.5A3 3 0 1 0 12 5a3 3 0 1 0-5.598 1.5" />
+        <path d="M17.997 5.125a4 4 0 0 1 2.526 5.77" />
+        <path d="M18 18a4 4 0 0 0 2-7.464" />
+        <path d="M19.967 17.483A4 4 0 1 1 12 18a4 4 0 1 1-7.967-.517" />
+        <path d="M6 18a4 4 0 0 1-2-7.464" />
+        <path d="M6.003 5.125a4 4 0 0 0-2.526 5.77" />
+      </symbol>
     </svg>
     <!-- ======================= END SVG ICONS DEFINITION ====================== -->
 
@@ -774,7 +784,7 @@
               </div>
             </div>
             <div class="recommendation-section">
-              <h3><i class="bi bi-brain" aria-hidden="true"></i> Поведенчески Стратегии и Нагласа</h3>
+              <h3><svg class="icon"><use href="#icon-brain"></use></svg> Поведенчески Стратегии и Нагласа</h3>
               <div id="recStrategiesContent" class="accordion-group">
                 <div class="card placeholder">
                   <p>Зареждане на стратегии...</p>


### PR DESCRIPTION
## Резюме
- добавен е SVG символ `icon-brain`
- заглавието на секцията "Поведенчески Стратегии и Нагласа" вече използва новата икона

## Тестване
- `npm run lint`
- `NODE_OPTIONS=--max_old_space_size=4096 npm test` *(част от тестовете се провалят: extraMealAutofill.test.js, extraMealFormSubmit.test.js и др.; наблюдаван е OOM)*

------
https://chatgpt.com/codex/tasks/task_e_68a20b770d64832685275832eab48b4a