### PR TITLE
refactor: parallelize user KV retrieval

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -4687,10 +4687,10 @@ async function handleListUserKvRequest(request, env) {
             }
         }
         const list = await env.USER_METADATA_KV.list({ prefix: `${userId}_`, limit, cursor });
-        const kv = {};
-        for (const { name } of list.keys) {
-            kv[name] = await env.USER_METADATA_KV.get(name);
-        }
+        const kvEntries = await Promise.all(
+            list.keys.map(async ({ name }) => [name, await env.USER_METADATA_KV.get(name)])
+        );
+        const kv = Object.fromEntries(kvEntries);
         return {
             success: true,
             kv,


### PR DESCRIPTION
## Summary
- fetch user KV values concurrently with `Promise.all`

## Testing
- `npm run lint`
- `npm test` *(fails: saveAiConfig sends updates payload with Authorization header)*

------
https://chatgpt.com/codex/tasks/task_e_68a71187e4ac832697e36418935c2d7d