### PR TITLE
Implement KV resource caching with admin invalidation

### DIFF
--- a/tests/resourceCache.spec.ts
+++ b/tests/resourceCache.spec.ts
@@ -1,0 +1,36 @@
+import { jest } from '@jest/globals';
+import { getCachedResource, clearResourceCache } from '../worker.js';
+
+describe('resourceCache', () => {
+  beforeEach(() => {
+    clearResourceCache();
+  });
+
+  test('повторното четене не прави нов kv.get', async () => {
+    const kv = { get: jest.fn(() => Promise.resolve('value-1')) };
+
+    const first = await getCachedResource('prompt_chat', kv, 1000);
+    const second = await getCachedResource('prompt_chat', kv, 1000);
+
+    expect(first).toBe('value-1');
+    expect(second).toBe('value-1');
+    expect(kv.get).toHaveBeenCalledTimes(1);
+  });
+
+  test('изчистването на кеша форсира нов kv.get', async () => {
+    const kv = {
+      get: jest
+        .fn()
+        .mockResolvedValueOnce('initial')
+        .mockResolvedValueOnce('updated')
+    };
+
+    const first = await getCachedResource('model_chat', kv, 1000);
+    clearResourceCache('model_chat');
+    const second = await getCachedResource('model_chat', kv, 1000);
+
+    expect(first).toBe('initial');
+    expect(second).toBe('updated');
+    expect(kv.get).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- добавен модулен кеш за KV ресурси с helper `getCachedResource` и `clearResourceCache`
- използвани кеширани стойности за чат, dashboard и план-генериращи заявки и изчистване на кеша след админ промени
- добавен unit тест за кеша на ресурсите с мокнат KV

## Testing
- sh ./scripts/test.sh tests/resourceCache.spec.ts
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc8eb1567c8326ba4f01c4da8e95b1