### PR TITLE
Check pending plan modification flag before listing events

### DIFF
--- a/tests/createUserEvent.spec.ts
+++ b/tests/createUserEvent.spec.ts
@@ -1,0 +1,24 @@
+import { jest } from '@jest/globals';
+import { createUserEvent } from '../worker.js';
+
+describe('createUserEvent - pending план модификации', () => {
+  test('връща съобщение и пропуска list при активен pending флаг', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(async key => (key === 'pending_plan_mod_user-1' ? '{}' : null)),
+        list: jest.fn(async () => ({ keys: [] })),
+        put: jest.fn(),
+        delete: jest.fn()
+      }
+    };
+
+    const result = await createUserEvent('planMod', 'user-1', { причина: 'адаптация' }, env);
+
+    expect(result).toEqual({
+      success: false,
+      message: 'Вече има чакаща заявка за промяна на плана.'
+    });
+    expect(env.USER_METADATA_KV.list).not.toHaveBeenCalled();
+    expect(env.USER_METADATA_KV.get).toHaveBeenCalledWith('pending_plan_mod_user-1');
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -4347,6 +4347,15 @@ async function createUserEvent(eventType, userId, payload, env) {
 
     if (eventType === 'planMod') {
         try {
+            const pendingFlag = await env.USER_METADATA_KV.get(`pending_plan_mod_${userId}`);
+            if (pendingFlag) {
+                return { success: false, message: 'Вече има чакаща заявка за промяна на плана.' };
+            }
+        } catch (err) {
+            console.error(`EVENT_PENDING_FLAG_CHECK_ERROR (${userId}):`, err);
+        }
+
+        try {
             const existing = await env.USER_METADATA_KV.list({ prefix: `event_planMod_${userId}` });
             for (const { name } of existing.keys) {
                 const val = await env.USER_METADATA_KV.get(name);


### PR DESCRIPTION
## Summary
- prevent duplicate plan modification requests by short-circuiting when the pending flag exists
- keep the legacy KV list fallback only when the flag is absent to support older records
- cover the new flow with a unit test that ensures `kv.list` is not invoked when the pending flag is set

## Testing
- npm run lint
- NODE_OPTIONS="--experimental-vm-modules" npx --no-install jest --runInBand tests/createUserEvent.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc9dbdbca0832686ab538587d113d9