### PR TITLE
Align macro analytics current ring cutout

### DIFF
--- a/js/__tests__/macroAnalyticsCardInnerRing.test.js
+++ b/js/__tests__/macroAnalyticsCardInnerRing.test.js
@@ -19,6 +19,18 @@ beforeEach(async () => {
     observe() { this.cb([{ isIntersecting: true }]); }
     disconnect() {}
   };
+  const matchMediaMock = () => ({
+    matches: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  });
+  if (typeof window !== 'undefined') {
+    window.matchMedia = matchMediaMock;
+  }
+  global.matchMedia = matchMediaMock;
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => ({
@@ -32,7 +44,10 @@ beforeEach(async () => {
       intakeVsPlanLabel: 'Прием vs План'
     })
   });
-  jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: async () => ChartMock }));
+  jest.unstable_mockModule('../chartLoader.js', () => ({
+    ensureChart: async () => ChartMock,
+    registerSubtleGlow: jest.fn()
+  }));
   await import('../macroAnalyticsCardComponent.js');
 });
 

--- a/js/macroAnalyticsCardComponent.js
+++ b/js/macroAnalyticsCardComponent.js
@@ -559,6 +559,8 @@ export class MacroAnalyticsCard extends HTMLElement {
       ? [current.protein_grams, current.carbs_grams, current.fat_grams, current.fiber_grams]
       : null;
 
+    const currentDatasetCutout = '65%';
+
     if (this.chart) {
       const ds0 = this.chart.data.datasets[0];
       ds0.data = planData;
@@ -569,7 +571,7 @@ export class MacroAnalyticsCard extends HTMLElement {
           const ds1 = this.chart.data.datasets[1];
           ds1.data = currentData;
           ds1.backgroundColor = macroColors;
-          ds1.cutout = '75%';
+          ds1.cutout = currentDatasetCutout;
         } else {
           this.chart.data.datasets.push({
             label: this.locale === 'en' ? 'Intake (g)' : 'Прием (гр)',
@@ -577,7 +579,7 @@ export class MacroAnalyticsCard extends HTMLElement {
             backgroundColor: macroColors,
             borderWidth: 0,
             borderRadius: 8,
-            cutout: '75%',
+            cutout: currentDatasetCutout,
             hoverOffset: 8
           });
         }
@@ -607,7 +609,7 @@ export class MacroAnalyticsCard extends HTMLElement {
         backgroundColor: macroColors,
         borderWidth: 0,
         borderRadius: 8,
-        cutout: '75%',
+        cutout: currentDatasetCutout,
         hoverOffset: 8
       });
     }


### PR DESCRIPTION
## Summary
- align the current-intake doughnut layer to use a shared 65% cutout when creating or updating the macro analytics chart
- extend the inner ring test harness with the required matchMedia and registerSubtleGlow mocks to reflect the component’s runtime setup

## Testing
- npm run test:file js/__tests__/macroAnalyticsCardInnerRing.test.js *(fails: Node cannot execute scripts/test.sh)*
- sh ./scripts/test.sh js/__tests__/macroAnalyticsCardInnerRing.test.js


------
https://chatgpt.com/codex/tasks/task_e_68cca93b78908326b7749cde90768499