### PR TITLE
Fix extra meal log date parsing

### DIFF
--- a/tests/dailyLog.extraMeals.spec.ts
+++ b/tests/dailyLog.extraMeals.spec.ts
@@ -54,4 +54,24 @@ describe('dailyLog extra meals flow', () => {
     expect(dates).toContain('2024-06-02');
     expect(env.USER_METADATA_KV.list).not.toHaveBeenCalled();
   });
+
+  test('запазва локалната дата при mealTimeSpecific с часови пояс', async () => {
+    const env = createEnv();
+    const userId = 'user-offset';
+    const payload = {
+      userId,
+      foodDescription: 'кисело мляко',
+      quantityEstimate: 'средна порция',
+      mealTimeSpecific: '2024-06-02T00:30:00.000+03:00'
+    };
+
+    const response = await handleLogExtraMealRequest(createRequest(payload), env);
+    expect(response.success).toBe(true);
+    expect(response.savedDate).toBe('2024-06-02');
+
+    const logKey = `${userId}_log_2024-06-02`;
+    const stored = JSON.parse(env.__store.get(logKey));
+    expect(stored.extraMeals).toHaveLength(1);
+    expect(stored.extraMeals[0].consumedTimestamp).toBe(payload.mealTimeSpecific);
+  });
 });


### PR DESCRIPTION
## Summary
- добавих помощна функция за извличане на локалната дата без да се губи денят при ISO низове с часови пояси
- актуализирах handleLogExtraMealRequest да използва новата логика и да пада обратно към днешна дата при невалиден вход
- допълних покритието с тест за mealTimeSpecific със zoned ISO низ, гарантиращ запазване на датата и времевия печат

## Testing
- npm run lint
- npm test *(крашва заради out-of-memory; изпълнени са релевантните тестове отделно)*
- NODE_OPTIONS=--experimental-vm-modules npx --no-install jest --runTestsByPath --runInBand tests/dailyLog.extraMeals.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ccb8cfce90832682f40a97fc340b91