### PR TITLE
Adjust chat context helper option defaults

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -3950,7 +3950,17 @@ function isChatContextFresh(context) {
     return Date.now() - updatedAt < ttl;
 }
 
-async function assembleChatContext(userId, env, { initialAnswers, finalPlan, currentStatus, logEntries, planStatus } = {}) {
+async function assembleChatContext(
+    userId,
+    env,
+    {
+        initialAnswers = undefined,
+        finalPlan = undefined,
+        currentStatus = undefined,
+        logEntries = undefined,
+        planStatus = undefined
+    } = {}
+) {
     const answers = initialAnswers || safeParseJson(await env.USER_METADATA_KV.get(`${userId}_initial_answers`), {});
     const plan = finalPlan || safeParseJson(await env.USER_METADATA_KV.get(`${userId}_final_plan`), {});
     if (!answers || Object.keys(answers).length === 0 || !plan || Object.keys(plan).length === 0) {
@@ -4034,7 +4044,7 @@ async function persistChatContext(userId, env, context) {
     }
 }
 
-async function refreshChatContextAfterLog(userId, env, dateStr, record = null, { weight } = {}) {
+async function refreshChatContextAfterLog(userId, env, dateStr, record = null, { weight = undefined } = {}) {
     if (!env?.USER_METADATA_KV || typeof env.USER_METADATA_KV.get !== 'function') {
         return;
     }


### PR DESCRIPTION
## Summary
- add explicit undefined defaults to the optional parameters destructured in `assembleChatContext`
- default the `weight` option in `refreshChatContextAfterLog` to avoid TS2525 complaints

## Testing
- npm run lint
- npm test *(fails in this environment: multiple existing suites abort with OOM or module resolution errors before finishing)*
- NODE_OPTIONS=--experimental-vm-modules npx jest tests/chatContext.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d1c482cf888326855641655a9b7c2b