### PR TITLE
Cache empty log index with metadata

### DIFF
--- a/js/__tests__/dailyLog.test.js
+++ b/js/__tests__/dailyLog.test.js
@@ -87,9 +87,15 @@ describe('daily log', () => {
     };
     const dateStr = '2020-01-02';
     await handleLogRequest(makeRequest({ userId: 'u1', date: dateStr, data: { note: 'x' } }), env);
-    expect(JSON.parse(store['u1_logs_index'])).toEqual([dateStr]);
+    const createdIndex = JSON.parse(store['u1_logs_index']);
+    expect(createdIndex.dates).toEqual([dateStr]);
+    expect(typeof createdIndex.ts).toBe('number');
+    expect(createdIndex.version).toBe(1);
     await handleLogRequest(makeRequest({ userId: 'u1', date: dateStr, delete: true }), env);
     expect(store[`u1_log_${dateStr}`]).toBeUndefined();
-    expect(JSON.parse(store['u1_logs_index'])).toEqual([]);
+    const cleanedIndex = JSON.parse(store['u1_logs_index']);
+    expect(cleanedIndex.dates).toEqual([]);
+    expect(typeof cleanedIndex.ts).toBe('number');
+    expect(cleanedIndex.version).toBe(1);
   });
 });

--- a/tests/chatContext.spec.js
+++ b/tests/chatContext.spec.js
@@ -256,7 +256,10 @@ describe('chat context caching', () => {
 
     env.__store.set(`${userId}_log_${dateToDelete}`, JSON.stringify(deletedLogRecord));
     env.__store.set(`${userId}_log_${remainingDate}`, JSON.stringify(remainingLogRecord));
-    env.__store.set(`${userId}_logs_index`, JSON.stringify([remainingDate, dateToDelete]));
+    env.__store.set(
+      `${userId}_logs_index`,
+      JSON.stringify({ dates: [remainingDate, dateToDelete], ts: Date.now(), version: 1 })
+    );
     env.__store.set(`${userId}_chat_context`, JSON.stringify(existingContext));
 
     const response = await handleLogRequest(
@@ -274,7 +277,7 @@ describe('chat context caching', () => {
     expect(env.__store.has(`${userId}_log_${dateToDelete}`)).toBe(false);
 
     const updatedIndex = JSON.parse(env.__store.get(`${userId}_logs_index`));
-    expect(updatedIndex).not.toContain(dateToDelete);
+    expect(updatedIndex.dates).not.toContain(dateToDelete);
 
     const updatedContextStr = env.__store.get(`${userId}_chat_context`);
     expect(updatedContextStr).toBeTruthy();

--- a/tests/dailyLog.extraMeals.spec.ts
+++ b/tests/dailyLog.extraMeals.spec.ts
@@ -44,9 +44,11 @@ describe('dailyLog extra meals flow', () => {
     const indexKey = `${userId}_logs_index`;
     expect(env.__store.has(indexKey)).toBe(true);
     const storedIndex = JSON.parse(env.__store.get(indexKey));
-    expect(Array.isArray(storedIndex)).toBe(true);
-    expect(storedIndex).toContain('2024-06-02');
-    expect(storedIndex.length).toBe(1);
+    expect(Array.isArray(storedIndex.dates)).toBe(true);
+    expect(storedIndex.dates).toContain('2024-06-02');
+    expect(storedIndex.dates.length).toBe(1);
+    expect(typeof storedIndex.ts).toBe('number');
+    expect(storedIndex.version).toBe(1);
 
     env.USER_METADATA_KV.list.mockClear();
 


### PR DESCRIPTION
## Summary
- persist daily log index metadata with version and timestamp so empty results are cached and stale indexes rebuild safely
- reuse the same index helpers when adding or deleting logs to keep timestamps fresh
- adjust and extend Jest coverage to reflect the new structure and ensure an empty index skips additional KV.list calls

## Testing
- npm run lint
- npm test *(fails: existing suite exhausts memory and has unrelated broken specs)*
- NODE_OPTIONS="--experimental-vm-modules" npx jest --runInBand tests/getUserLogDates.spec.js
- NODE_OPTIONS="--experimental-vm-modules" npx jest --runInBand tests/dailyLog.extraMeals.spec.ts
- NODE_OPTIONS="--experimental-vm-modules" npx jest --runInBand js/__tests__/dailyLog.test.js
- NODE_OPTIONS="--experimental-vm-modules" npx jest --runInBand tests/chatContext.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d1d46dbe64832692aa50978e7fa8b8