### PR TITLE
Cache analytics resources for analytics summary

### DIFF
--- a/js/__tests__/engagementAnalytics.test.js
+++ b/js/__tests__/engagementAnalytics.test.js
@@ -1,8 +1,12 @@
-import { calculateAnalyticsIndexes } from '../../worker.js';
+import { calculateAnalyticsIndexes, clearResourceCache } from '../../worker.js';
 
 const daysOrder = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
 
 describe('calculateAnalyticsIndexes engagement score', () => {
+  beforeEach(() => {
+    clearResourceCache();
+  });
+
   test('returns positive score when index data is logged', async () => {
     const today = new Date();
     const dayKey = daysOrder[today.getDay()];
@@ -15,6 +19,32 @@ describe('calculateAnalyticsIndexes engagement score', () => {
     const result = await calculateAnalyticsIndexes('user', {}, finalPlan, logEntries, {}, env);
     const expected = Math.round(((0) * 0.4) + (((2 / 5) * 100) * 0.4) + (((1 / 7) * 100) * 0.2));
     expect(result.current.engagementScore).toBe(expected);
+  });
+
+  test('reuses cached analytics prompt and model between calls', async () => {
+    const today = new Date();
+    const dayKey = daysOrder[today.getDay()];
+    const dateStr = today.toISOString().split('T')[0];
+
+    const finalPlan = { week1Menu: { [dayKey]: ['meal1'] } };
+    const logEntries = [{ date: dateStr, data: { mood: 3, energy: 4, completedMealsStatus: {} } }];
+
+    const getMock = jest.fn(async (key) => {
+      if (key === 'prompt_analytics_textual_summary') return 'Резюме: %%USER_GOAL%%';
+      if (key === 'model_plan_generation') return 'gpt-4o-mini';
+      return null;
+    });
+
+    const env = { RESOURCES_KV: { get: getMock } };
+
+    await calculateAnalyticsIndexes('user', {}, finalPlan, logEntries, {}, env);
+    await calculateAnalyticsIndexes('user', {}, finalPlan, logEntries, {}, env);
+
+    const promptCalls = getMock.mock.calls.filter(([key]) => key === 'prompt_analytics_textual_summary').length;
+    const modelCalls = getMock.mock.calls.filter(([key]) => key === 'model_plan_generation').length;
+
+    expect(promptCalls).toBe(1);
+    expect(modelCalls).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- cache the analytics summary prompt and plan model lookup through getCachedResource
- clear the analytics prompt cache together with plan model cache when AI config entries change
- extend the analytics tests to cover reuse of cached KV reads between consecutive calls

## Testing
- npm run lint *(passes with existing warnings)*
- npm test *(fails in this environment with OOM and pre-existing suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d77df21c8326896034612d379d38