### PR TITLE
Fix menu summary typing in chat context builder

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -3752,12 +3752,18 @@ function getChatContextKey(userId) {
     return `${userId}_chat_context`;
 }
 
+/**
+ * Строи резюме за менюто по дни на база генерирания план.
+ * @param {Record<string, Array<{meal_name?: string}> | undefined> | null} [week1Menu]
+ * @returns {Record<string, string>}
+ */
 function buildMenuSummaryByDay(week1Menu = {}) {
+    /** @type {Record<string, string>} */
     const summary = {};
     if (week1Menu && typeof week1Menu === 'object') {
         for (const [day, meals] of Object.entries(week1Menu)) {
             if (!day) continue;
-            const normalizedDay = day.toLowerCase();
+            const normalizedDay = String(day).toLowerCase();
             if (!Array.isArray(meals)) {
                 summary[normalizedDay] = 'няма планирани за днес';
                 continue;


### PR DESCRIPTION
## Summary
- annotate `buildMenuSummaryByDay` with explicit Record<string, string> typing and normalize day keys when building summaries

## Testing
- npm run lint
- npm test *(fails: multiple existing suites fail and repeated OOM during long-running suite execution)*

------
https://chatgpt.com/codex/tasks/task_e_68d1da226178832689e3cf9b4c7b2502