### PR TITLE
Track AI token usage in KV metrics dashboard

### DIFF
--- a/js/kvUsage.js
+++ b/js/kvUsage.js
@@ -1,0 +1,274 @@
+const form = document.getElementById('kvUsageForm');
+const fromInput = document.getElementById('kvFromDate');
+const toInput = document.getElementById('kvToDate');
+const statusEl = document.getElementById('kvStatus');
+const totalsContainer = document.getElementById('kvSummaryTotals');
+const namespaceList = document.getElementById('kvNamespaceList');
+const methodList = document.getElementById('kvMethodList');
+const extraMetricsList = document.getElementById('kvExtraMetrics');
+const tableBody = document.querySelector('#kvUsageTable tbody');
+
+const intFormatter = new Intl.NumberFormat('bg-BG');
+const floatFormatter = new Intl.NumberFormat('bg-BG', { minimumFractionDigits: 0, maximumFractionDigits: 2 });
+
+init();
+
+function init() {
+  clearSummary();
+  setDefaultRange();
+  form?.addEventListener('submit', event => {
+    event.preventDefault();
+    void loadKvUsage();
+  });
+  void loadKvUsage();
+}
+
+function setDefaultRange() {
+  const today = new Date();
+  const to = formatDate(today);
+  const fromDate = new Date(today.getTime());
+  fromDate.setDate(fromDate.getDate() - 6);
+  fromInput.value = formatDate(fromDate);
+  toInput.value = to;
+}
+
+async function loadKvUsage() {
+  const from = fromInput.value;
+  const to = toInput.value;
+  if (!from || !to) {
+    statusEl.textContent = 'Моля изберете валиден период.';
+    return;
+  }
+  if (from > to) {
+    statusEl.textContent = 'Началната дата трябва да е преди крайната.';
+    return;
+  }
+
+  const params = new URLSearchParams({ from, to });
+  statusEl.textContent = 'Зареждане на KV статистика...';
+  try {
+    const response = await fetch(`/api/kvUsage?${params.toString()}`, {
+      headers: { 'Accept': 'application/json' }
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok || !payload.success) {
+      throw new Error(payload.message || `Сървърът върна ${response.status}`);
+    }
+
+    const handlers = Array.isArray(payload.handlers) ? payload.handlers : [];
+    const summary = payload.summary || {};
+    const datesCovered = Array.isArray(payload.dates) ? payload.dates : [];
+    const datesWithData = Array.isArray(payload.datesWithData) ? payload.datesWithData : [];
+
+    updateSummary(summary, payload.range, datesCovered, datesWithData, handlers);
+    renderTable(handlers);
+
+    const generatedAt = formatDateTime(summary.generatedAt);
+    const rangeText = payload.range
+      ? `${payload.range.from} – ${payload.range.to}`
+      : `${from} – ${to}`;
+    const coverageNote = datesWithData.length
+      ? `данни за ${datesWithData.length} от ${datesCovered.length || '-'} дни`
+      : 'няма данни за избрания период';
+    statusEl.textContent = `Период ${rangeText}; ${coverageNote}${generatedAt ? ` • обновено: ${generatedAt}` : ''}.`;
+  } catch (error) {
+    console.error('KV usage load failed:', error);
+    statusEl.textContent = `Грешка при зареждане: ${error.message}`;
+    clearSummary();
+    renderTable([]);
+  }
+}
+
+function updateSummary(summary, range, datesCovered, datesWithData, handlers) {
+  totalsContainer.innerHTML = '';
+
+  const totalRequests = Number(summary.totalRequests || 0);
+  const totalOperations = Number(summary.totalOperations || 0);
+  const avgPerRequest = totalRequests > 0 ? totalOperations / totalRequests : 0;
+  const daysInRange = Array.isArray(datesCovered) && datesCovered.length
+    ? datesCovered.length
+    : calculateRangeLength(range?.from, range?.to);
+  const extraMetrics = summary.extraMetrics || {};
+  const aiCalls = Number(extraMetrics['AI заявки'] || 0);
+  const aiTokens = Number(extraMetrics['AI токени - общо'] || 0);
+  const busiestRoute = handlers
+    .slice()
+    .sort((a, b) => Number(b.totalOperations || 0) - Number(a.totalOperations || 0))[0];
+
+  const summaryCards = [
+    createSummaryCard('Общо заявки', formatInt(totalRequests)),
+    createSummaryCard('KV операции', formatInt(totalOperations)),
+    createSummaryCard('Средно KV/заявка', formatFloat(avgPerRequest)),
+    createSummaryCard('Покрити дни', formatInt(daysInRange))
+  ];
+
+  if (busiestRoute?.handler) {
+    summaryCards.push(createSummaryCard('Най-натоварен маршрут', `${busiestRoute.handler} (${formatInt(busiestRoute.totalOperations || 0)} операции)`));
+  }
+  if (aiCalls > 0) {
+    summaryCards.push(createSummaryCard('AI заявки', formatInt(aiCalls)));
+  }
+  if (aiTokens > 0) {
+    summaryCards.push(createSummaryCard('AI токени (общо)', formatInt(aiTokens)));
+    if (aiCalls > 0) {
+      summaryCards.push(createSummaryCard('Средно токени/AI заявка', formatFloat(aiTokens / aiCalls)));
+    }
+  }
+
+  totalsContainer.innerHTML = summaryCards.join('');
+
+  renderNamespaceSummary(summary.namespaceTotals);
+  renderMethodSummary(summary.methodTotals);
+  renderExtraMetrics(summary.extraMetrics);
+}
+
+function renderNamespaceSummary(namespaceTotals) {
+  namespaceList.innerHTML = '';
+  const entries = Object.entries(namespaceTotals || {})
+    .sort((a, b) => Number(b[1]?.total || 0) - Number(a[1]?.total || 0));
+  if (!entries.length) {
+    namespaceList.innerHTML = '<li>Няма налични данни.</li>';
+    return;
+  }
+  for (const [name, metrics] of entries) {
+    const li = document.createElement('li');
+    li.textContent = `${name}: ${formatInt(metrics.total || 0)} (get ${formatInt(metrics.get || 0)}, put ${formatInt(metrics.put || 0)}, list ${formatInt(metrics.list || 0)}, delete ${formatInt(metrics.delete || 0)})`;
+    namespaceList.appendChild(li);
+  }
+}
+
+function renderMethodSummary(methodTotals) {
+  methodList.innerHTML = '';
+  const totals = methodTotals || {};
+  const entries = [
+    ['get', totals.get || 0],
+    ['put', totals.put || 0],
+    ['list', totals.list || 0],
+    ['delete', totals.delete || 0]
+  ].filter(([, value]) => value > 0);
+
+  if (!entries.length) {
+    methodList.innerHTML = '<li>Няма отчетени операции.</li>';
+    return;
+  }
+  for (const [method, value] of entries) {
+    const li = document.createElement('li');
+    li.textContent = `${method.toUpperCase()}: ${formatInt(value)}`;
+    methodList.appendChild(li);
+  }
+}
+
+function renderExtraMetrics(extraMetrics) {
+  extraMetricsList.innerHTML = '';
+  const entries = Object.entries(extraMetrics || {})
+    .filter(([, value]) => typeof value === 'number' && Number.isFinite(value) && value !== 0)
+    .sort((a, b) => Number(b[1]) - Number(a[1]));
+  if (!entries.length) {
+    extraMetricsList.innerHTML = '<li>Все още няма други измерители.</li>';
+    return;
+  }
+  for (const [metric, value] of entries) {
+    const li = document.createElement('li');
+    li.textContent = `${metric}: ${formatInt(value)}`;
+    extraMetricsList.appendChild(li);
+  }
+}
+
+function renderTable(handlers) {
+  tableBody.innerHTML = '';
+  if (!handlers.length) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 6;
+    cell.textContent = 'Няма данни за избрания период.';
+    row.appendChild(cell);
+    tableBody.appendChild(row);
+    return;
+  }
+
+  for (const handler of handlers) {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>${escapeHtml(handler.handler)}</td>
+      <td>${formatInt(handler.requests || 0)}</td>
+      <td>${formatInt(handler.totalOperations || 0)}</td>
+      <td>${formatFloat(handler.averagePerRequest || 0)}</td>
+      <td>${renderNamespaceCell(handler.byNamespace)}</td>
+      <td>${renderMethodCell(handler.byMethod)}</td>
+    `;
+    tableBody.appendChild(row);
+  }
+}
+
+function renderNamespaceCell(byNamespace) {
+  const entries = Object.entries(byNamespace || {})
+    .sort((a, b) => Number(b[1]?.total || 0) - Number(a[1]?.total || 0));
+  if (!entries.length) return '—';
+  return entries
+    .map(([name, metrics]) => `<div><span class="kv-tag">${escapeHtml(name)}</span> ${formatInt(metrics.total || 0)} (g:${formatInt(metrics.get || 0)} p:${formatInt(metrics.put || 0)} l:${formatInt(metrics.list || 0)} d:${formatInt(metrics.delete || 0)})</div>`)
+    .join('');
+}
+
+function renderMethodCell(byMethod = {}) {
+  const parts = [];
+  for (const method of ['get', 'put', 'list', 'delete']) {
+    const count = Number(byMethod[method] || 0);
+    if (count > 0) {
+      parts.push(`<span class="kv-tag">${escapeHtml(method.toUpperCase())}</span> ${formatInt(count)}`);
+    }
+  }
+  return parts.length ? parts.map(p => `<div>${p}</div>`).join('') : '—';
+}
+
+function clearSummary() {
+  totalsContainer.innerHTML = '';
+  namespaceList.innerHTML = '<li>Няма налични данни.</li>';
+  methodList.innerHTML = '<li>Няма отчетени операции.</li>';
+  extraMetricsList.innerHTML = '<li>Все още няма други измерители.</li>';
+}
+
+function createSummaryCard(title, value) {
+  return `
+    <div class="kv-summary-card">
+      <h3>${escapeHtml(title)}</h3>
+      <div class="kv-summary-value">${escapeHtml(value)}</div>
+    </div>
+  `;
+}
+
+function formatInt(value) {
+  return intFormatter.format(Math.round(Number(value) || 0));
+}
+
+function formatFloat(value) {
+  return floatFormatter.format(Number(value) || 0);
+}
+
+function formatDate(date) {
+  return date.toISOString().split('T')[0];
+}
+
+function formatDateTime(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString('bg-BG');
+}
+
+function calculateRangeLength(from, to) {
+  if (!from || !to) return 0;
+  const start = Date.parse(`${from}T00:00:00Z`);
+  const end = Date.parse(`${to}T00:00:00Z`);
+  if (Number.isNaN(start) || Number.isNaN(end) || end < start) return 0;
+  const diff = Math.floor((end - start) / (24 * 60 * 60 * 1000)) + 1;
+  return diff;
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/log.html
+++ b/log.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KV натоварване и лог на заявки</title>
+  <link rel="stylesheet" href="css/base_styles.css">
+  <link rel="stylesheet" href="css/components_styles.css">
+  <link rel="stylesheet" href="css/layout_styles.css">
+  <style>
+    body {
+      background: var(--surface-background);
+      color: var(--text-color-primary);
+      min-height: 100vh;
+    }
+    .kv-page {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: var(--space-xl) var(--space-lg) var(--space-3xl);
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-xl);
+    }
+    .kv-page h1 {
+      margin-bottom: var(--space-sm);
+      font-size: clamp(1.6rem, 2vw, 2rem);
+    }
+    .kv-page p.lead {
+      color: var(--text-color-muted);
+      margin-bottom: var(--space-lg);
+      max-width: 720px;
+    }
+    .kv-form {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-md);
+      align-items: flex-end;
+    }
+    .kv-form label {
+      display: flex;
+      flex-direction: column;
+      font-weight: 500;
+      color: var(--text-color-secondary);
+    }
+    .kv-form input[type="date"] {
+      padding: var(--space-sm) var(--space-md);
+      border-radius: var(--radius-md);
+      border: 1px solid var(--border-color-soft);
+      background: var(--surface-background);
+      color: inherit;
+      min-width: 180px;
+    }
+    .kv-status {
+      margin-top: var(--space-md);
+      color: var(--text-color-secondary);
+      font-size: 0.95rem;
+    }
+    .kv-summary-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: var(--space-lg);
+      margin-bottom: var(--space-lg);
+    }
+    .kv-summary-card {
+      background: rgba(var(--surface-background-rgb), 0.7);
+      border: 1px solid var(--border-color-soft);
+      border-radius: var(--radius-lg);
+      padding: var(--space-md);
+      box-shadow: var(--shadow-sm);
+    }
+    .kv-summary-card h3 {
+      margin: 0 0 var(--space-xs);
+      font-size: 0.95rem;
+      color: var(--text-color-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .kv-summary-value {
+      font-size: 1.6rem;
+      font-weight: 600;
+    }
+    .kv-summary-details {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: var(--space-lg);
+    }
+    .kv-summary-details h4 {
+      margin-bottom: var(--space-sm);
+      font-size: 1rem;
+    }
+    .kv-summary-details ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-xs);
+    }
+    .kv-summary-details li {
+      border-left: 3px solid var(--primary-color);
+      padding-left: var(--space-sm);
+      font-size: 0.95rem;
+    }
+    .table-wrapper {
+      overflow-x: auto;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: rgba(var(--surface-background-rgb), 0.65);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      border: 1px solid var(--border-color-soft);
+    }
+    thead {
+      background: color-mix(in srgb, var(--primary-color) 12%, var(--surface-background));
+    }
+    th, td {
+      padding: var(--space-sm) var(--space-md);
+      text-align: left;
+      border-bottom: 1px solid var(--border-color-soft);
+      vertical-align: top;
+    }
+    tbody tr:hover {
+      background: rgba(var(--primary-color-rgb, 28, 98, 209), 0.06);
+    }
+    .kv-suggestion-list {
+      list-style: disc;
+      padding-left: var(--space-xl);
+      color: var(--text-color-secondary);
+    }
+    .kv-tag {
+      display: inline-block;
+      background: color-mix(in srgb, var(--secondary-color) 25%, white);
+      color: var(--text-color-primary);
+      padding: 0.15rem 0.6rem;
+      border-radius: var(--radius-round);
+      font-size: 0.8rem;
+      margin-right: var(--space-xs);
+    }
+    @media (max-width: 768px) {
+      .kv-form {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      .kv-form label, .kv-form button {
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="kv-page">
+    <section class="card">
+      <h1>Натоварване на KV заявките</h1>
+      <p class="lead">Проследявайте кои бекенд маршрути генерират най-много KV операции и сравнявайте натоварването им по периоди. Данните са подредени по общ брой KV заявки, а резюмето включва и консумацията на AI токени, за да се откроят най-скъпите функции.</p>
+      <form id="kvUsageForm" class="kv-form">
+        <label for="kvFromDate">Начална дата
+          <input type="date" id="kvFromDate" name="from" required>
+        </label>
+        <label for="kvToDate">Крайна дата
+          <input type="date" id="kvToDate" name="to" required>
+        </label>
+        <button type="submit" class="button button-primary">Анализирай периода</button>
+      </form>
+      <p id="kvStatus" class="kv-status">Подгответе периода и натиснете „Анализирай периода“.</p>
+    </section>
+
+    <section class="card">
+      <h2>Резюме на натоварването</h2>
+      <div id="kvSummaryTotals" class="kv-summary-grid"></div>
+      <div class="kv-summary-details">
+        <div>
+          <h4>Разбивка по KV namespace</h4>
+          <ul id="kvNamespaceList"></ul>
+        </div>
+        <div>
+          <h4>Разбивка по тип операция</h4>
+          <ul id="kvMethodList"></ul>
+        </div>
+        <div>
+          <h4>Допълнителни метрики</h4>
+          <ul id="kvExtraMetrics"></ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Най-натоварени маршрути</h2>
+      <div class="table-wrapper">
+        <table id="kvUsageTable" aria-live="polite">
+          <thead>
+            <tr>
+              <th scope="col">Маршрут / функция</th>
+              <th scope="col">Брой заявки</th>
+              <th scope="col">KV операции общо</th>
+              <th scope="col">Средно на заявка</th>
+              <th scope="col">Namespace разпределение</th>
+              <th scope="col">Типове операции</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td colspan="6">Няма данни за избрания период.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Идеи за допълнително наблюдение</h2>
+      <ul class="kv-suggestion-list">
+        <li>Добавете прагове и аларми за AI токени, за да се сигнализира автоматично при очаквани надвишения.</li>
+        <li>Събирайте време за отговор на критичните маршрути – комбинация от KV заявки и латентност показва къде оптимизациите биха имали най-голям ефект.</li>
+        <li>Сравнявайте данните с броя активни потребители или с брой планирани задачи, за да нормализирате натоварването и да следите токените на потребител.</li>
+      </ul>
+    </section>
+  </main>
+  <script type="module" src="js/kvUsage.js"></script>
+</body>
+</html>

--- a/tests/kvUsageMetrics.test.js
+++ b/tests/kvUsageMetrics.test.js
@@ -1,0 +1,123 @@
+import { jest } from '@jest/globals';
+import { createKvMonitor, persistKvUsageMetrics, handleKvUsageMetricsRequest } from '../worker.js';
+
+describe('kv usage monitoring', () => {
+  test('createKvMonitor брои KV операциите и уважава runWithoutCounting', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(async () => null),
+        put: jest.fn(async () => undefined)
+      }
+    };
+
+    const monitor = createKvMonitor(env);
+    const wrapped = monitor.env;
+
+    await wrapped.USER_METADATA_KV.get('test-key');
+    await wrapped.USER_METADATA_KV.put('test-key', 'value');
+    await monitor.runWithoutCounting(() => wrapped.USER_METADATA_KV.get('skip-key'));
+
+    const snapshot = monitor.getSnapshot();
+    expect(snapshot.totalOperations).toBe(2);
+    expect(snapshot.byMethod.get).toBe(1);
+    expect(snapshot.byMethod.put).toBe(1);
+    expect(snapshot.byNamespace.USER_METADATA_KV.total).toBe(2);
+  });
+
+  test('persistKvUsageMetrics натрупва данните по дни', async () => {
+    const store = new Map();
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(async key => store.get(key) ?? null),
+        put: jest.fn(async (key, value) => {
+          store.set(key, value);
+        })
+      }
+    };
+
+    const counts = {
+      totalOperations: 3,
+      requests: 1,
+      byMethod: { total: 3, get: 2, put: 1 },
+      byNamespace: {
+        USER_METADATA_KV: { total: 3, get: 2, put: 1, list: 0, delete: 0 }
+      },
+      extraMetrics: { 'AI токени - общо': 40 }
+    };
+
+    const day = new Date('2024-04-20T10:00:00Z');
+    await persistKvUsageMetrics(env, 'GET /api/demo', counts, day, { includeZero: true });
+    await persistKvUsageMetrics(env, 'GET /api/demo', counts, day, { includeZero: true });
+
+    const stored = JSON.parse(store.get('kv_usage_2024-04-20'));
+    expect(stored.handlers['GET /api/demo'].totalOperations).toBe(6);
+    expect(stored.handlers['GET /api/demo'].byMethod.get).toBe(4);
+    expect(stored.handlers['GET /api/demo'].extraMetrics['AI токени - общо']).toBe(80);
+    expect(stored.handlers['GET /api/demo'].requests).toBe(2);
+  });
+
+  test('handleKvUsageMetricsRequest връща агрегирани стойности за периода', async () => {
+    const store = new Map();
+    store.set('kv_usage_2024-04-19', JSON.stringify({
+      date: '2024-04-19',
+      handlers: {
+        'GET /api/foo': {
+          handler: 'GET /api/foo',
+          requests: 2,
+          totalOperations: 8,
+          byMethod: { total: 8, get: 6, put: 2 },
+          byNamespace: {
+            USER_METADATA_KV: { total: 8, get: 6, put: 2, list: 0, delete: 0 }
+          },
+          extraMetrics: { 'AI токени - общо': 20 }
+        }
+      },
+      lastUpdated: '2024-04-19T12:00:00Z'
+    }));
+    store.set('kv_usage_2024-04-20', JSON.stringify({
+      date: '2024-04-20',
+      handlers: {
+        'GET /api/foo': {
+          handler: 'GET /api/foo',
+          requests: 1,
+          totalOperations: 5,
+          byMethod: { total: 5, get: 3, put: 2 },
+          byNamespace: {
+            USER_METADATA_KV: { total: 5, get: 3, put: 2, list: 0, delete: 0 }
+          },
+          extraMetrics: { 'AI токени - общо': 15 }
+        },
+        'GET /api/bar': {
+          handler: 'GET /api/bar',
+          requests: 1,
+          totalOperations: 2,
+          byMethod: { total: 2, get: 2 },
+          byNamespace: {
+            RESOURCES_KV: { total: 2, get: 2, put: 0, list: 0, delete: 0 }
+          },
+          extraMetrics: {}
+        }
+      },
+      lastUpdated: '2024-04-20T09:00:00Z'
+    }));
+
+    const env = {
+      USER_METADATA_KV: {
+        get: jest.fn(async key => store.get(key) ?? null)
+      }
+    };
+
+    const requestLike = { url: 'https://example.com/api/kvUsage?from=2024-04-19&to=2024-04-20' };
+    const result = await handleKvUsageMetricsRequest(requestLike, env);
+
+    expect(result.success).toBe(true);
+    expect(result.summary.totalOperations).toBe(15);
+    expect(result.summary.totalRequests).toBe(4);
+    expect(result.summary.namespaceTotals.USER_METADATA_KV.total).toBe(13);
+    expect(result.summary.namespaceTotals.RESOURCES_KV.total).toBe(2);
+    expect(result.summary.extraMetrics['AI токени - общо']).toBe(35);
+    expect(result.handlers[0].handler).toBe('GET /api/foo');
+    expect(result.handlers[0].totalOperations).toBe(13);
+    expect(result.handlers[0].averagePerRequest).toBeCloseTo(13 / 3);
+  });
+});


### PR DESCRIPTION
## Summary
- instrument AI provider helpers to извличат usage метрики и да ги добавят към KV мониторинга чрез новия `recordAiUsage`
- визуализирай натрупаните AI заявки и токени в `log.html` и резюмето на `kvUsage.js`
- разшири unit тестовете за KV агрегатора и `callModel`, за да покрият AI токените

## Testing
- npm run lint
- NODE_OPTIONS=--experimental-vm-modules npx --no-install jest --runInBand tests/kvUsageMetrics.test.js
- NODE_OPTIONS=--experimental-vm-modules npx --no-install jest --runInBand js/__tests__/callModel.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d33ab58dcc83268b92ce034c67d9db