### PR TITLE
Reduce admin notification polling frequency

### DIFF
--- a/js/__tests__/adminNotifications.test.js
+++ b/js/__tests__/adminNotifications.test.js
@@ -37,18 +37,21 @@ beforeEach(() => {
 });
 
 function setupFetchWithNotifications(clients, now) {
+  const notificationsPayload = clients.map(client => ({
+    userId: client.userId,
+    name: client.name,
+    queries: [{ message: 'q1', ts: Date.now() }],
+    replies: [],
+    feedback: [{ message: 'f1', timestamp: now }],
+    latestFeedbackTs: now
+  }));
+
   global.fetch = jest.fn(url => {
     if (url.includes('listClients')) {
       return Promise.resolve({ ok: true, json: async () => ({ success: true, clients }) });
     }
-    if (url.includes('peekAdminQueries')) {
-      return Promise.resolve({ ok: true, json: async () => ({ success: true, queries: [{ message: 'q1' }] }) });
-    }
-    if (url.includes('peekClientReplies')) {
-      return Promise.resolve({ ok: true, json: async () => ({ success: true, replies: [] }) });
-    }
-    if (url.includes('getFeedbackMessages')) {
-      return Promise.resolve({ ok: true, json: async () => ({ success: true, feedback: [{ message: 'f1', timestamp: now }] }) });
+    if (url.includes('peekAdminNotifications')) {
+      return Promise.resolve({ ok: true, json: async () => ({ success: true, clients: notificationsPayload }) });
     }
     if (url.includes('profileTemplate.html')) {
       return Promise.resolve({

--- a/js/config.js
+++ b/js/config.js
@@ -37,6 +37,7 @@ export const apiEndpoints = {
     generatePraise: `${workerBaseUrl}/api/generatePraise`,
     aiHelper: `${workerBaseUrl}/api/aiHelper`,
     listClients: `${workerBaseUrl}/api/listClients`,
+    peekAdminNotifications: `${workerBaseUrl}/api/peekAdminNotifications`,
     deleteClient: `${workerBaseUrl}/api/deleteClient`,
     addAdminQuery: `${workerBaseUrl}/api/addAdminQuery`,
     getAdminQueries: `${workerBaseUrl}/api/getAdminQueries`,


### PR DESCRIPTION
## Summary
- throttle the admin notification refresh timers to run once per hour instead of once per minute
- add a backend `/api/peekAdminNotifications` endpoint that aggregates unread queries, replies, and feedback for all clients
- update the admin UI to consume the aggregated snapshot with shared caching/backoff and refreshed tests

## Testing
- npm run lint
- NODE_OPTIONS="--experimental-vm-modules --max-old-space-size=4096" npx jest js/__tests__/adminNotifications.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d46abfde908326b9c92490ca36e799