### PR TITLE
fix: throttle admin query polling

### DIFF
--- a/js/__tests__/adminQueriesPolling.test.js
+++ b/js/__tests__/adminQueriesPolling.test.js
@@ -1,0 +1,110 @@
+import { jest } from '@jest/globals';
+import { selectors } from '../uiElements.js';
+import {
+  startAdminQueriesPolling,
+  stopAdminQueriesPolling,
+  setCurrentUserId,
+  checkAdminQueries
+} from '../app.js';
+import { toggleChatWidget } from '../chat.js';
+
+const originalFetch = global.fetch;
+const originalVisibilityDescriptor = Object.getOwnPropertyDescriptor(document, 'visibilityState');
+let visibilityState = 'visible';
+
+Object.defineProperty(document, 'visibilityState', {
+  configurable: true,
+  get: () => visibilityState
+});
+
+function setVisibility(state) {
+  visibilityState = state;
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+describe('admin query polling behaviour', () => {
+  beforeEach(() => {
+    localStorage.removeItem('adminQueryPollMinutes');
+    visibilityState = 'visible';
+    selectors.chatMessages = document.createElement('div');
+    selectors.chatWidget = document.createElement('div');
+    selectors.chatFab = document.createElement('button');
+    selectors.chatInput = document.createElement('input');
+    selectors.chatFab.appendChild(document.createElement('span')).classList.add('assistant-icon');
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, queries: [] })
+    });
+    setCurrentUserId('test-user');
+    stopAdminQueriesPolling();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    stopAdminQueriesPolling();
+    setCurrentUserId(null);
+    selectors.chatMessages = null;
+    selectors.chatWidget = null;
+    selectors.chatFab = null;
+    selectors.chatInput = null;
+    jest.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    if (originalVisibilityDescriptor) {
+      Object.defineProperty(document, 'visibilityState', originalVisibilityDescriptor);
+    } else {
+      delete document.visibilityState;
+    }
+    global.fetch = originalFetch;
+  });
+
+  test('по подразбиране проверява веднъж на час', () => {
+    const intervalSpy = jest.spyOn(global, 'setInterval');
+    startAdminQueriesPolling();
+    expect(intervalSpy).toHaveBeenCalledTimes(1);
+    const intervalValue = intervalSpy.mock.calls[0][1];
+    expect(intervalValue).toBe(60 * 60000);
+  });
+
+  test('спира, когато разделът е скрит, и възобновява с незабавна проверка', async () => {
+    const intervalSpy = jest.spyOn(global, 'setInterval');
+    const clearSpy = jest.spyOn(global, 'clearInterval');
+    startAdminQueriesPolling({ intervalMinutes: 60 });
+    expect(intervalSpy).toHaveBeenCalledTimes(1);
+
+    setVisibility('hidden');
+    expect(clearSpy).toHaveBeenCalled();
+
+    intervalSpy.mockClear();
+    global.fetch.mockClear();
+    setVisibility('visible');
+    expect(intervalSpy).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(global.fetch).toHaveBeenCalled();
+  });
+
+  test('отварянето на чата прави незабавна проверка', async () => {
+    global.fetch.mockClear();
+    selectors.chatWidget.classList.remove('visible');
+    toggleChatWidget();
+    await Promise.resolve();
+    expect(global.fetch).toHaveBeenCalled();
+  });
+
+  test('не изпраща повторна заявка преди да изтече интервалът без force', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00Z'));
+    await checkAdminQueries('test-user', { force: true });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    global.fetch.mockClear();
+    await checkAdminQueries('test-user');
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    jest.setSystemTime(new Date('2025-01-01T01:01:00Z'));
+    await checkAdminQueries('test-user');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+});

--- a/js/chat.js
+++ b/js/chat.js
@@ -1,7 +1,7 @@
 
 // chat.js - Логика за Чат
 import { selectors } from './uiElements.js';
-import { chatHistory, currentUserId, handleChatImageUpload } from './app.js'; // Access chatHistory and userId
+import { chatHistory, currentUserId, handleChatImageUpload, checkAdminQueries } from './app.js'; // Access chatHistory and userId
 import { apiEndpoints, initialBotMessage } from './config.js';
 import { escapeHtml } from './utils.js';
 
@@ -32,6 +32,9 @@ export function toggleChatWidget(skipInit = false) {
                  chatHistory.forEach(msg => displayMessage(msg.text, msg.sender, msg.isError));
             }
             scrollToChatBottom();
+        }
+        if (currentUserId) {
+            void checkAdminQueries(currentUserId, { force: true });
         }
     }
 }


### PR DESCRIPTION
## Summary
- добавих ограничение в `checkAdminQueries`, което пази последния timestamp и пропуска излишни заявки, освен ако изрично не бъде форсирано
- гарантирах незабавна проверка само при отваряне на чата, презареждане на таблото или връщане на раздела във фокус, и занулявам след спиране на таймера
- разширих тестовия пакет за администраторския polling с казус за часовия тротъл

## Testing
- npm run lint
- npm test *(fails: множество съществуващи тестове и няколко OOM прекъсвания в тази среда)*

------
https://chatgpt.com/codex/tasks/task_e_68d479885df4832685af27c4316f8b40