### PR TITLE
Adjust admin query polling to daily interval

### DIFF
--- a/js/__tests__/adminQueriesPolling.test.js
+++ b/js/__tests__/adminQueriesPolling.test.js
@@ -60,12 +60,12 @@ describe('admin query polling behaviour', () => {
     global.fetch = originalFetch;
   });
 
-  test('по подразбиране проверява веднъж на час', () => {
+  test('по подразбиране проверява веднъж на 24 часа', () => {
     const intervalSpy = jest.spyOn(global, 'setInterval');
     startAdminQueriesPolling();
     expect(intervalSpy).toHaveBeenCalledTimes(1);
     const intervalValue = intervalSpy.mock.calls[0][1];
-    expect(intervalValue).toBe(60 * 60000);
+    expect(intervalValue).toBe(24 * 60 * 60000);
   });
 
   test('спира, когато разделът е скрит, и възобновява с незабавна проверка', async () => {
@@ -102,7 +102,7 @@ describe('admin query polling behaviour', () => {
     await checkAdminQueries('test-user');
     expect(global.fetch).not.toHaveBeenCalled();
 
-    jest.setSystemTime(new Date('2025-01-01T01:01:00Z'));
+    jest.setSystemTime(new Date('2025-01-02T00:01:00Z'));
     await checkAdminQueries('test-user');
     expect(global.fetch).toHaveBeenCalledTimes(1);
     jest.useRealTimers();

--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,7 @@
 // app.js - Основен Файл на Приложението
 import * as config from './config.js';
 const { isLocalDevelopment, apiEndpoints } = config;
-const ADMIN_QUERY_POLL_INTERVAL_MS_DEFAULT = 60 * 60000; // 1 час
+const ADMIN_QUERY_POLL_INTERVAL_MS_DEFAULT = 24 * 60 * 60000; // 24 часа
 import { debugLog, enableDebug } from './logger.js';
 import { safeParseFloat, escapeHtml, fileToDataURL, normalizeDailyLogs, getLocalDate } from './utils.js';
 import { selectors, initializeSelectors, loadInfoTexts } from './uiElements.js';


### PR DESCRIPTION
## Summary
- extend the default admin query polling interval from 1 hour to 24 hours in the dashboard logic
- update the admin query polling test expectations to match the new daily cadence

## Testing
- npm run lint
- npm test
- NODE_OPTIONS=--max-old-space-size=8192 npm test

------
https://chatgpt.com/codex/tasks/task_e_68d487df15b88326bd322039aa58ac40