### PR TITLE
Fix NotificationEntry typing for dynamic timestamp key

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -2687,7 +2687,7 @@ async function handleListClientsRequest(request, env) {
 }
 // ------------- END FUNCTION: handleListClientsRequest -------------
 
-/** @typedef {{ message?: string; timestamp?: string|number; ts?: string|number; rating?: number|null; type?: string; author?: string; date?: string|number; read?: boolean; resolvedTs?: number|null }} NotificationEntry */
+/** @typedef {{ message?: string; timestamp?: string|number; ts?: string|number; rating?: number|null; type?: string; author?: string; date?: string|number; read?: boolean; resolvedTs?: number|null; [key: string]: unknown }} NotificationEntry */
 // ------------- START FUNCTION: handlePeekAdminNotificationsRequest -------------
 async function handlePeekAdminNotificationsRequest(request, env) {
     try {


### PR DESCRIPTION
## Summary
- allow NotificationEntry to accept dynamic keys used during normalization

## Testing
- npm run lint
- NODE_OPTIONS=--max-old-space-size=8192 npm test *(fails: existing suites such as extraMealAutofill.test.js expect DOM population; command also exhausts heap memory)*

------
https://chatgpt.com/codex/tasks/task_e_68d4929573948326a2598b05a1d88b5d