### PR TITLE
Clamp admin query polling to 24h minimum

### DIFF
--- a/js/__tests__/adminQueriesPolling.test.js
+++ b/js/__tests__/adminQueriesPolling.test.js
@@ -68,6 +68,14 @@ describe('admin query polling behaviour', () => {
     expect(intervalValue).toBe(24 * 60 * 60000);
   });
 
+  test('не позволява интервал под 24 часа', () => {
+    const intervalSpy = jest.spyOn(global, 'setInterval');
+    startAdminQueriesPolling({ intervalMinutes: 0.5 });
+    expect(intervalSpy).toHaveBeenCalledTimes(1);
+    const intervalValue = intervalSpy.mock.calls[0][1];
+    expect(intervalValue).toBe(24 * 60 * 60000);
+  });
+
   test('спира, когато разделът е скрит, и възобновява с незабавна проверка', async () => {
     const intervalSpy = jest.spyOn(global, 'setInterval');
     const clearSpy = jest.spyOn(global, 'clearInterval');


### PR DESCRIPTION
## Summary
- clamp the admin query polling cadence to a 24-hour minimum and share explicit time constants
- normalize polling options so any value below the daily threshold is ignored in favour of the default interval
- cover the behaviour with a regression test to guard against future misconfiguration

## Testing
- npm run lint
- npm test *(fails: multiple existing suites error out with OOMs and unrelated assertion mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68d4917fd0b08326a8af023362ab2bcc