### PR TITLE
docs: add kv request overview page

### DIFF
--- a/docs/kv-request-overview.html
+++ b/docs/kv-request-overview.html
@@ -1,0 +1,1030 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+  <meta charset="UTF-8">
+  <title>Матрица на KV заявките към бекенда</title>
+  <link rel="stylesheet" href="../css/base_styles.css">
+  <link rel="stylesheet" href="../css/components_styles.css">
+  <style>
+    body {
+      font-family: var(--font-primary, 'Inter', sans-serif);
+      background: #f6f9fc;
+      color: #16213e;
+      line-height: 1.65;
+      padding: 2.5rem clamp(1rem, 4vw, 4rem);
+    }
+    h1, h2, h3 {
+      color: #0b1f51;
+      margin-top: 0;
+    }
+    h1 {
+      text-align: center;
+      margin-bottom: 1rem;
+    }
+    nav {
+      background: #fff;
+      border-radius: 18px;
+      box-shadow: 0 18px 44px rgba(14, 32, 79, 0.12);
+      padding: clamp(1rem, 3vw, 2rem);
+      margin-bottom: 2.5rem;
+    }
+    nav ul {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.75rem;
+      padding: 0;
+      list-style: none;
+      margin: 0;
+    }
+    nav a {
+      display: block;
+      padding: 0.75rem 1rem;
+      border-radius: 12px;
+      background: rgba(59, 130, 246, 0.1);
+      color: #1d4ed8;
+      font-weight: 600;
+      text-decoration: none;
+      transition: all 0.2s ease;
+    }
+    nav a:hover {
+      background: #2563eb;
+      color: #fff;
+      transform: translateY(-1px);
+    }
+    .card {
+      background: #fff;
+      border-radius: 20px;
+      box-shadow: 0 20px 48px rgba(15, 23, 42, 0.14);
+      padding: clamp(1.25rem, 3vw, 2.25rem);
+      margin-bottom: 2.75rem;
+      border-left: 6px solid rgba(37, 99, 235, 0.18);
+    }
+    .lead {
+      font-size: 1.05rem;
+      margin-bottom: 1.25rem;
+    }
+    .note {
+      background: rgba(16, 185, 129, 0.12);
+      border-left: 4px solid rgba(16, 185, 129, 0.55);
+      border-radius: 14px;
+      padding: 1rem 1.25rem;
+      margin: 1.25rem 0;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1.5rem;
+      font-size: 0.95rem;
+    }
+    th, td {
+      border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+      padding: 0.85rem 0.75rem;
+      vertical-align: top;
+    }
+    th {
+      background: rgba(37, 99, 235, 0.12);
+      color: #1d4ed8;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      font-size: 0.8rem;
+    }
+    tr:last-child td {
+      border-bottom: none;
+    }
+    .endpoint {
+      font-weight: 700;
+      color: #0f172a;
+    }
+    .role-user { color: #0f766e; font-weight: 600; }
+    .role-admin { color: #9333ea; font-weight: 600; }
+    .role-shared { color: #be123c; font-weight: 600; }
+    .kv-list {
+      margin: 0.35rem 0 0;
+      padding-left: 1rem;
+      list-style: disc;
+    }
+    .kv-list li {
+      margin-bottom: 0.3rem;
+    }
+    .frequency {
+      font-weight: 600;
+      color: #475569;
+    }
+    .logic-ok { color: #0f766e; font-weight: 600; }
+    .logic-watch { color: #f59e0b; font-weight: 600; }
+    .logic-risk { color: #dc2626; font-weight: 600; }
+    details {
+      background: rgba(15, 23, 42, 0.03);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 16px;
+      padding: 0.75rem 1rem;
+      margin: 1.25rem 0 0;
+    }
+    summary {
+      font-weight: 700;
+      cursor: pointer;
+      color: #0f172a;
+    }
+    .scenario-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: clamp(1rem, 3vw, 1.5rem);
+      margin-top: 1.5rem;
+    }
+    .scenario {
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 16px 36px rgba(15, 23, 42, 0.12);
+      padding: 1rem 1.25rem;
+      border-left: 4px solid rgba(148, 163, 184, 0.4);
+    }
+    .scenario h4 { margin-top: 0; }
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      background: rgba(37, 99, 235, 0.12);
+      color: #1d4ed8;
+      border-radius: 999px;
+      padding: 0.25rem 0.9rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+    }
+    code {
+      background: rgba(15, 23, 42, 0.08);
+      border-radius: 6px;
+      padding: 0.12rem 0.35rem;
+      font-size: 0.9rem;
+    }
+    footer {
+      text-align: center;
+      margin-top: 2.5rem;
+      color: #64748b;
+      font-size: 0.9rem;
+    }
+    @media (max-width: 900px) {
+      table, thead, tbody, th, td, tr { display: block; }
+      thead { display: none; }
+      tr { margin-bottom: 1.5rem; padding: 1rem; border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 14px; background: #fff; box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08); }
+      td { border: none; padding: 0.4rem 0; }
+      td::before { content: attr(data-label); display: block; font-weight: 700; color: #1d4ed8; margin-bottom: 0.25rem; text-transform: uppercase; letter-spacing: 0.03em; font-size: 0.78rem; }
+    }
+  </style>
+</head>
+<body>
+  <h1>Матрица на KV заявките към бекенда</h1>
+  <p class="lead">Документът описва всяка заявка към Cloudflare KV, кои екрани я задействат и колко често се случва. Целта е екипът да вижда бързо къде се извършват четене и запис в KV и дали има повтаряеми операции, които могат да се оптимизират.</p>
+  <div class="note">Всички примери са извлечени директно от продукционните UI модули и Cloudflare Worker-а. За всяка заявка са посочени свързаните функции, KV ключове и кратка оценка дали честотата е логична или е сигнал за допълнителен одит.</div>
+
+  <nav aria-label="Навигация по секции">
+    <ul>
+      <li><a href="#namespaces">1. KV namespace-и</a></li>
+      <li><a href="#user-flows">2. Потребителски заявки</a></li>
+      <li><a href="#admin-flows">3. Администраторски заявки</a></li>
+      <li><a href="#shared-flows">4. Общи и AI операции</a></li>
+      <li><a href="#automation">5. Автоматизации и cron</a></li>
+      <li><a href="#scenarios">6. Натоварени сценарии</a></li>
+      <li><a href="#ideas">7. Идеи за оптимизация</a></li>
+    </ul>
+  </nav>
+
+  <section id="namespaces" class="card">
+    <h2>1. KV namespace-и и тяхната роля</h2>
+    <p><span class="tag">USER_METADATA_KV</span> – съдържа потребителски акаунти, планове, дневници, чат контекст и админ индекси. Всяко записване е обвързано с <code>userId</code> и се използва в клиентските и администраторските екрани. <span class="tag">RESOURCES_KV</span> – съхранява статични ресурси (prompt-и, флагове, базови планове) и контролира поведението на AI функциите.</p>
+    <details>
+      <summary>Най-често използвани ключове</summary>
+      <ul class="kv-list">
+        <li><code>credential_{userId}</code>, <code>email_to_uuid_{email}</code> – регистрация и логин.</li>
+        <li><code>{userId}_initial_answers</code>, <code>{userId}_final_plan</code>, <code>plan_status_{userId}</code> – ядро на плана.</li>
+        <li><code>{userId}_logs_index</code>, <code>{userId}_log_{date}</code> – дневници и аналитика.</li>
+        <li><code>{userId}_chat_history</code>, <code>{userId}_kv_index</code> – кеш за чат/админ преглед.</li>
+        <li><code>prompt_*</code>, <code>model_*</code> в RESOURCES_KV – управление на AI моделите и шаблоните.</li>
+      </ul>
+    </details>
+  </section>
+  <section id="user-flows" class="card">
+    <h2>2. Потребителски KV заявки</h2>
+    <p>Всички редове по-долу се задействат от стандартния клиентски интерфейс (<code>register.js</code>, <code>questionnaireCore.js</code>, <code>app.js</code>, <code>assistantChat.js</code>, <code>profile-edit.js</code>). Колоната „Примерен тригер“ показва кратка ситуация за ориентиране.</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Заявка</th>
+          <th>Роля</th>
+          <th>Примерен тригер</th>
+          <th>KV операции</th>
+          <th>Честота</th>
+          <th>Логика</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/register</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Формата за регистрация (<code>setupRegistration()</code>)【F:js/register.js†L5-L57】</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>USER_METADATA_KV.get(email_to_uuid_{email})</code> – проверка за съществуващ акаунт.【F:worker.js†L893-L914】</li>
+              <li><code>put(credential_{userId})</code>, <code>put(email_to_uuid_{email})</code>, <code>put(plan_status_{userId})</code>.【F:worker.js†L915-L921】【F:worker.js†L4558-L4563】</li>
+              <li><code>get/put(all_user_ids)</code> – поддържа индекс за админа.【F:worker.js†L923-L932】</li>
+              <li>Чете <code>RESOURCES_KV.get('send_welcome_email')</code> за флаг за имейл.【F:worker.js†L934-L939】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Еднократно при регистрация. Повтаря се само ако има грешка и потребителят опита отново.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span> – проверката в KV предотвратява дублиране на акаунти.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/registerDemo</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Демо регистрация от маркетинг страница</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Наследява регистрационните операции.</li>
+              <li><code>get(email_to_uuid_{email})</code> + <code>put(plan_status_{userId}, 'demo')</code>.【F:worker.js†L946-L956】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Редки кампании; същия обем като реалните регистрации.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span> – отделен статус позволява сегментиране в админ панела.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/login</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Форма за вход (<code>login.js</code>)</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get(email_to_uuid_{email})</code>, <code>get(credential_{userId})</code> – валидира данни.【F:worker.js†L969-L988】</li>
+              <li><code>get(plan_status_{userId})</code>, <code>get({userId}_initial_answers)</code> – определя пренасочване.【F:worker.js†L998-L1004】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">На всяко логване. Няма кеш и е по 2 KV четения.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span> – необходима проверка преди достъп до таблото.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/submitQuestionnaire</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Изпращане на стартовия въпросник (<code>questionnaireCore.js</code>)</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get(email_to_uuid_{email})</code> – осигурява връзка към акаунта.【F:worker.js†L1067-L1072】</li>
+              <li><code>put({userId}_initial_answers)</code>, <code>put(plan_status_{userId}, 'pending')</code>, <code>put({userId}_last_significant_update_ts)</code>.【F:worker.js†L1073-L1081】</li>
+              <li>Стартира анализ който записва <code>{userId}_analysis</code>/<code>_analysis_status</code>.【F:worker.js†L1093-L1108】【F:worker.js†L2309-L2332】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Еднократно на клиент, но може да се повтори при промени.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span> – записите са минималният набор за стартиране на плана.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/submitDemoQuestionnaire</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Демо вариант на въпросника</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Съхранява <code>{userId}_initial_answers</code> и задава <code>_analysis_status</code> на <code>pending</code>.【F:worker.js†L1120-L1133】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">В нисък обем – само за тестови акаунти.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span> – огледално на реалния процес.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/planStatus</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Екран „Планът се подготвя“ (poll в <code>pending.js</code>)</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get(plan_status_{userId})</code> и условно <code>get({userId}_processing_error)</code>.【F:worker.js†L1166-L1177】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">На всеки 15 s докато планът не стане готов.</td>
+          <td data-label="Логика"><span class="logic-watch">Watch</span> – при дълги опашки генерира много четения.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/planLog</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">История „Какво се случва с плана“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Комбинира <code>get({userId}_plan_log)</code>, <code>get(plan_status_{userId})</code>, <code>get({userId}_processing_error)</code>.【F:worker.js†L1189-L1200】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Рядко – само при нужда от прозрачност.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/analysisStatus</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Страница „Анализът се генерира“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get({userId}_analysis_status)</code> и <code>get({userId}_analysis)</code> при готов анализ.【F:worker.js†L1183-L1204】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Подобно на плановия статус – периодичен poll.</td>
+          <td data-label="Логика"><span class="logic-watch">Watch</span> – обмислете WebSocket/SSE за по-рядко четене.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/dashboardData</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Зареждане на клиентското табло (<code>app.js</code>)</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Пакет от <code>get()</code>: <code>{userId}_initial_answers</code>, <code>_final_plan</code>, <code>plan_status</code>, <code>_current_status</code>, <code>_ai_update_pending_ack</code>, <code>_last_significant_update_ts</code>, <code>_last_feedback_chat_ts</code>, <code>_profile</code>.【F:worker.js†L1199-L1231】</li>
+              <li>Чете дневници чрез индекс <code>{userId}_logs_index</code> и <code>{userId}_log_{date}</code>.【F:worker.js†L1234-L1260】</li>
+              <li>При липси записва fallback данни и флагове.【F:worker.js†L1297-L1334】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">1× при зареждане + ръчно опресняване.</td>
+          <td data-label="Логика"><span class="logic-watch">Watch</span> – 8+ KV четения; кеширане на <code>_kv_index</code> би намалило latency.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/log</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Формуляр „Добави дневник“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Създава/изтрива <code>{userId}_log_{date}</code>, поддържа <code>{userId}_logs_index</code>.【F:worker.js†L1341-L1436】</li>
+              <li>Обновява <code>{userId}_lastActive</code> и <code>{userId}_current_status</code>.【F:worker.js†L1438-L1471】</li>
+              <li>Опционално синхронизира чат контекст в <code>{userId}_chat_history</code>.【F:worker.js†L1546-L1600】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">По веднъж на дневник (средно 1–2 пъти/ден).</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/log-extra-meal</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">„Добави извънредно хранене“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get({userId}_initial_answers)</code> за макроси и <code>put({userId}_log_{date})</code> с новата порция.【F:worker.js†L1755-L1807】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Същата като дневника.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/updateStatus</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Слайдери за настроение/енергия</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Чете <code>{userId}_current_status</code> и го презаписва със свежи стойности.【F:worker.js†L1508-L1536】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">По няколко пъти дневно (1 KV get + 1 put).</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/chat</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Виртуален асистент (<code>assistantChat.js</code>)</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Лоудва <code>{userId}_initial_answers</code>, <code>{userId}_final_plan</code>, <code>{userId}_chat_history</code>, <code>{userId}_current_status</code> и последни логове.【F:worker.js†L1538-L1591】</li>
+              <li>Запазва нова история <code>{userId}_chat_history</code> и контекст кеш <code>{userId}_chat_ctx</code>.【F:worker.js†L1629-L1680】【F:worker.js†L1729-L1743】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Всяко чат съобщение (5+ KV четения + 1–2 записа).</td>
+          <td data-label="Логика"><span class="logic-watch">Watch</span> – препоръчително е кеширане чрез <code>{userId}_kv_index</code>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/uploadTestResult</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Форма „Добави лабораторен резултат“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Записва <code>{userId}_latest_test_result</code> и добавя събитие <code>event_testResult_{ts}</code>.【F:worker.js†L2397-L2411】【F:worker.js†L5691-L5693】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Редки – при качване на резултати.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/uploadIrisDiag</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Попълване на ирис диагностика</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Съхранява <code>{userId}_latest_iris_diag</code> и събитие <code>event_irisDiag_{ts}</code>.【F:worker.js†L2414-L2430】【F:worker.js†L5695-L5700】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Много рядко.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/getProfile</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Екран „Моят профил“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get({userId}_profile)</code>, <code>get({userId}_initial_answers)</code> – подготвя формите.【F:worker.js†L1818-L1844】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">При всяко отваряне на профила.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/updateProfile</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Запис на редактиран профил (<code>profile-edit.js</code>)</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Обновява <code>{userId}_profile</code>, <code>{userId}_initial_answers</code> и <code>plan_status_{userId}</code> при значими промени.【F:worker.js†L1839-L1879】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Спорадично – при промени от клиента.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/updatePlanData</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Автоматично синхронизиране след AI обновление</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Презаписва <code>{userId}_final_plan</code>, <code>{userId}_analysis_macros</code> и флага <code>{userId}_ai_update_pending_ack</code>.【F:worker.js†L1958-L1990】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Само когато админ/AI генерира нов план.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/requestPasswordReset</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Форма „Забравена парола“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get(email_to_uuid_{email})</code> и <code>put(pwreset_{token})</code> (TTL 1h).【F:worker.js†L1984-L2004】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Спорадично.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/performPasswordReset</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Стъпка 2 от възстановяването</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get(pwreset_{token})</code>, <code>get(credential_{userId})</code>, <code>put(credential_{userId})</code>, <code>delete(pwreset_{token})</code>.【F:worker.js†L2007-L2033】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Огледално на заявката за ресет.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/acknowledgeAiUpdate</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Бутона „Разбрах“ след AI обновление</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Изтрива <code>{userId}_ai_update_pending_ack</code>.【F:worker.js†L2035-L2045】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">1× на обновление.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/recordFeedbackChat</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Затваряне на прозореца за обратна връзка</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>put({userId}_last_feedback_chat_ts)</code> със стойност <code>Date.now()</code>.【F:worker.js†L2054-L2065】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Рядко.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/submitFeedback</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Форма за отзиви в таблото</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Създава <code>feedback_{userId}_{ts}</code> и актуализира <code>{userId}_feedback_messages</code>.【F:worker.js†L2068-L2099】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Всяко изпращане на отзив.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/getAchievements</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Раздел „Постижения“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get({userId}_achievements)</code> и <code>get({userId}_logs)</code> (агрегирани).【F:worker.js†L2104-L2148】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">При визуализация.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/generatePraise</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Натискане на бутона за мотивация</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Прочита ключовете за план и статус и обновява <code>{userId}_last_praise_ts</code> и <code>{userId}_achievements</code>.【F:worker.js†L2129-L2261】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Макс веднъж дневно (UI блокира).</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/getInitialAnalysis</td>
+          <td class="role-user" data-label="Роля">Потребител</td>
+          <td data-label="Примерен тригер">Страница с анализа</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get({userId}_analysis)</code> – без допълнителни ключове.【F:worker.js†L2346-L2360】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">По заявка.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/contact</td>
+          <td class="role-user" data-label="Роля">Посетител/Потребител</td>
+          <td data-label="Примерен тригер">Контактна форма</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Записва <code>contactRequest_{timestamp}</code> в <code>CONTACT_REQUESTS_KV</code>.【F:worker.js†L3180-L3222】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">В зависимост от маркетинга.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  <section id="admin-flows" class="card">
+    <h2>3. Администраторски KV заявки</h2>
+    <p>Тези операции се активират през <code>admin.js</code>, <code>editClient.js</code>, <code>planGeneration.js</code> и помощните екрани. Обемът им е по-нисък, но имат по-широки последици.</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Заявка</th>
+          <th>Роля</th>
+          <th>Примерен тригер</th>
+          <th>KV операции</th>
+          <th>Честота</th>
+          <th>Логика</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/reAnalyzeQuestionnaire</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Бутон „Повтори анализа“ в админ панела</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get({userId}_initial_answers)</code>, <code>put({userId}_analysis_status, 'pending')</code> и стартиране на нов анализ.【F:worker.js†L2362-L2395】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Редки корекции.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/regeneratePlan</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">„Генерирай план“ в таба за клиент</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Стартира <code>processSingleUserPlan</code> → обновява <code>{userId}_final_plan</code>, <code>plan_status_{userId}</code>, <code>{userId}_processing_error</code>, <code>{userId}_ai_update_pending_ack</code> и логовете.【F:worker.js†L1931-L1990】【F:worker.js†L3398-L3659】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">По-рядко, но с много KV операции.</td>
+          <td data-label="Логика"><span class="logic-watch">Watch</span> – следете да не остава <code>plan_status</code> в „processing“.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/checkPlanPrerequisites</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Отваряне на клиент преди генериране</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Чете <code>{userId}_initial_answers</code>, <code>plan_status_{userId}</code>, <code>{userId}_final_plan</code>, <code>{userId}_current_status</code>.【F:worker.js†L1914-L1956】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Винаги преди нов план.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/listClients</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Списък с клиенти в админ панела</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Чете <code>all_user_ids</code>; ако липсва – прави <code>kv.list</code> и обновява индекса. За всеки клиент зарежда <code>{userId}_initial_answers</code>, <code>{userId}_profile</code>, <code>plan_status_{userId}</code>, <code>{userId}_current_status</code>.【F:worker.js†L2640-L2668】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">На всяко зареждане на списъка.</td>
+          <td data-label="Логика"><span class="logic-watch">Watch</span> – rely на индекса, за да се избегне скъпото <code>kv.list</code>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/peekAdminNotifications</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Банер „Нови заявки“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Чете <code>{userId}_admin_queries</code>, <code>{userId}_client_replies</code>, <code>{userId}_feedback_messages</code> при нужда.【F:worker.js†L2692-L2732】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">На всеки ~60 s (poll).</td>
+          <td data-label="Логика"><span class="logic-watch">Watch</span> – добра идея е кеш с <code>{userId}_kv_index</code>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/deleteClient</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Бутон „Изтрий клиент“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Изтрива масово ключове (<code>credential_*</code>, <code>email_to_uuid_*</code>, <code>{userId}_profile</code>, <code>{userId}_initial_answers</code>, <code>plan_status_{userId}</code>, <code>{userId}_current_status</code> и др.) и обновява <code>all_user_ids</code>.【F:worker.js†L2818-L2853】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Много рядко.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/addAdminQuery</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Админът пише въпрос до клиента</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Добавя елемент в <code>{userId}_admin_queries</code> и поддържа индекс <code>{userId}_admin_queries_index</code>.【F:worker.js†L2856-L2871】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Няколко пъти седмично.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/getAdminQueries</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Раздел „Въпроси към клиента“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Зарежда <code>{userId}_admin_queries</code>; при <code>peek</code> връща само броя нови записи.【F:worker.js†L2873-L2904】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">При преглед + периодични peek заявки.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/addClientReply</td>
+          <td class="role-admin" data-label="Роля">Потребител/Админ канал</td>
+          <td data-label="Примерен тригер">Клиентът отговаря през интерфейса</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Добавя в <code>{userId}_client_replies</code> и индекса <code>{userId}_client_replies_index</code>.【F:worker.js†L2894-L2925】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">При всяко съобщение.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/getClientReplies</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Преглед на входящи отговори</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Чете <code>{userId}_client_replies</code>; <code>peek</code> връща само новите броеве.【F:worker.js†L2911-L2935】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">При отваряне и при известия.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/getFeedbackMessages</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Раздел „Отзиви“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Зарежда <code>{userId}_feedback_messages</code>.【F:worker.js†L2932-L2946】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">По заявка.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/getPlanModificationPrompt</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Старт на AI подсказка за модификация</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Чете ключовете на клиента плюс <code>RESOURCES_KV</code> шаблони за план модификация.【F:worker.js†L2948-L3018】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">При подготовка за корекции.</td>
+          <td data-label="Логика"><span class="logic-watch">Watch</span> – много KV четения, но еднократно на сесия.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/listUserKv</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">„Покажи всички KV ключове“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Използва <code>{userId}_kv_index</code>; при липса прави <code>kv.list</code> и индивидуални <code>get</code>, след което кешира индекса.【F:worker.js†L5751-L5793】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">По заявка; тежко при много ключове.</td>
+          <td data-label="Логика"><span class="logic-watch">Watch</span> – избягвайте без нужда.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/updateKv</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Ръчно редактиране на ключ през секцията „KV данни“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Позволява директно <code>put</code>/<code>delete</code> върху ключ; опционално опреснява <code>{userId}_kv_index</code>.【F:worker.js†L5798-L5828】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Само при поддръжка.</td>
+          <td data-label="Логика"><span class="logic-risk">Risk</span> – препоръчителни guardrails.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/listContactRequests</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">CRM таб „Контакти“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Изброява ключове в <code>CONTACT_REQUESTS_KV</code> и кешира индекс за по-бърз достъп.【F:worker.js†L3231-L3277】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Зависи от маркетинга.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  <section id="shared-flows" class="card">
+    <h2>4. Общи, AI и конфигурационни KV заявки</h2>
+    <p>Тук попадат операции, които се ползват от админ панела, автоматизации и чат функции.</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Заявка</th>
+          <th>Роля</th>
+          <th>Примерен тригер</th>
+          <th>KV операции</th>
+          <th>Честота</th>
+          <th>Логика</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/aiHelper</td>
+          <td class="role-shared" data-label="Роля">Админ + Автоматизация</td>
+          <td data-label="Примерен тригер">AI помощник в админ панела</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Чете <code>RESOURCES_KV</code> за промптове (<code>prompt_ai_helper</code>, <code>model_ai_helper</code>) и събира контекст от user ключове.【F:worker.js†L2431-L2478】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Според нуждата на екипа.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/analyzeImage</td>
+          <td class="role-shared" data-label="Роля">Админ + Клиент чрез чат</td>
+          <td data-label="Примерен тригер">Качване на снимка за анализ</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Чете <code>RESOURCES_KV</code> за <code>model_image_analysis</code>/<code>prompt_image_analysis</code> и записва резултата в <code>{userId}_image_analysis_logs</code>.【F:worker.js†L2470-L2605】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Редки.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/testAiModel</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Секция „AI модели“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Чете <code>RESOURCES_KV</code> шаблони и записва обратна връзка в <code>ai_model_tests</code>.【F:worker.js†L3158-L3178】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">При настройка на нов модел.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/getAiConfig</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Зареждане на таба „AI конфигурация“</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Чете <code>RESOURCES_KV</code> ключове <code>model_*</code>, <code>prompt_*</code>, <code>send_welcome_email</code>.【F:worker.js†L2971-L2997】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">При всяко отваряне.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/setAiConfig</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Запис на конфигурация</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Записва <code>RESOURCES_KV.put(model_...)</code>, <code>put(prompt_...)</code>, <code>put(send_welcome_email)</code>.【F:worker.js†L2987-L3024】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Рядко.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/listAiPresets</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Меню за AI шаблони</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Извлича <code>RESOURCES_KV.list({ prefix: 'ai_preset_' })</code> и зарежда всеки preset с <code>get</code>.【F:worker.js†L3026-L3069】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">При отваряне на секцията.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/getAiPreset</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Избор на preset</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>RESOURCES_KV.get(ai_preset_{name})</code>.【F:worker.js†L3058-L3076】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Често по време на настройка.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/saveAiPreset</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Запис/обновяване на preset</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>RESOURCES_KV.put(ai_preset_{name})</code> и обновяване на индекс <code>ai_presets_index</code>.【F:worker.js†L3078-L3120】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Спорадично.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/deleteAiPreset</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Изтриване на preset</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>RESOURCES_KV.delete(ai_preset_{name})</code> и актуализация на индекса.【F:worker.js†L3121-L3156】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Рядко.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">GET /api/getMaintenanceMode</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Отваряне на панела за поддръжка</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Чете <code>RESOURCES_KV.get('maintenance_mode')</code>.【F:worker.js†L3339-L3354】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Рядко.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/setMaintenanceMode</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Активиране/деактивиране на режим поддръжка</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>RESOURCES_KV.put('maintenance_mode')</code> и обновяване на кеширани стойности.【F:worker.js†L3359-L3391】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Много рядко.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Заявка">POST /api/sendTestEmail</td>
+          <td class="role-admin" data-label="Роля">Администратор</td>
+          <td data-label="Примерен тригер">Тест на SMTP</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Опционално чете <code>RESOURCES_KV</code> за шаблони; не записва нови ключове.【F:worker.js†L3283-L3337】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Само при диагностика.</td>
+          <td data-label="Логика"><span class="logic-ok">OK</span>.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  <section id="automation" class="card">
+    <h2>5. Автоматизации и cron задачи</h2>
+    <p>Cloudflare Worker-ът изпълнява периодични задачи, които също четат и записват в KV. Таблицата показва какво се пипа без намеса на потребител.</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Процес</th>
+          <th>KV операции</th>
+          <th>Честота</th>
+          <th>Бележка</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="endpoint" data-label="Процес">Cron: генериране на план</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get('pending_plan_users')</code>, <code>put('pending_plan_users')</code> – опашка.【F:worker.js†L738-L776】</li>
+              <li><code>get({userId}_initial_answers)</code>, <code>put(plan_status_{userId}, ...)</code>.【F:worker.js†L770-L782】</li>
+              <li>Пише дневни метрики <code>cron_metrics_{date}</code>.【F:worker.js†L826-L858】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">На всеки cron тик (15 мин).</td>
+          <td data-label="Бележка">Поддържа опашката кратка; следете метриките.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Процес">Cron: обновяване на принципи</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>get('ready_plan_users')</code>, <code>put('ready_plan_users')</code>.【F:worker.js†L791-L820】</li>
+              <li>Чете <code>{userId}_lastActive</code>, <code>{userId}_last_significant_update_ts</code> и при нужда вика <code>handlePrincipleAdjustment</code> (която актуализира плана).【F:worker.js†L802-L820】【F:worker.js†L3703-L3878】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Също на cron интервал.</td>
+          <td data-label="Бележка">Прескача неактивни клиенти, за да пази ресурси.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Процес">Cron: потребителски събития</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li><code>list('event_*')</code>, <code>get(event_...)</code>, <code>delete(event_...)</code>.【F:worker.js†L5714-L5744】</li>
+              <li><code>put({userId}_latest_test_result)</code>, <code>put({userId}_latest_iris_diag)</code> при събития.【F:worker.js†L5691-L5700】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">На всеки cron run; обработва до 5 събития наведнъж.</td>
+          <td data-label="Бележка">Гарантира, че качените тестове и модификации стартират <code>processSingleUserPlan</code>.</td>
+        </tr>
+        <tr>
+          <td class="endpoint" data-label="Процес">KV list telemetry</td>
+          <td data-label="KV операции">
+            <ul class="kv-list">
+              <li>Обвива всички <code>ns.list</code> повиквания и брои колко пъти са извикани; изпраща JSON към мониторинг API. 【F:worker.js†L5843-L5878】</li>
+            </ul>
+          </td>
+          <td class="frequency" data-label="Честота">Изпраща данни максимум на 15 мин.</td>
+          <td data-label="Бележка">Използвайте отчетите, за да видите кои екрани злоупотребяват с <code>kv.list</code>.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  <section id="scenarios" class="card">
+    <h2>6. Натоварени сценарии (кой вдига най-много заявки)</h2>
+    <p>На база на UI потоците и cron логиката, ето три ключови сценария, в които KV натоварването е осезаемо. Броят на заявките е приблизителен и помага да насочим оптимизациите.</p>
+    <div class="scenario-grid">
+      <div class="scenario">
+        <h4>А. Нов клиент &rarr; първи план</h4>
+        <ul class="kv-list">
+          <li><strong>Регистрация + логин:</strong> 4 get/put (акаунт и статус).【F:worker.js†L893-L921】</li>
+          <li><strong>Въпросник:</strong> ~3 записа + задействан анализ.【F:worker.js†L1073-L1108】</li>
+          <li><strong>Очакване на план:</strong> <code>planStatus</code> poll &times; N (напр. 8 пъти за 2 мин).【F:worker.js†L1166-L1177】</li>
+          <li><strong>Първо зареждане на табло:</strong> 8+ четения за план, логове и статус.【F:worker.js†L1199-L1260】</li>
+        </ul>
+        <p class="frequency">Най-натоварени ключове: <code>plan_status_{userId}</code>, <code>{userId}_final_plan</code>.</p>
+      </div>
+      <div class="scenario">
+        <h4>Б. Активен клиент (дневник + чат)</h4>
+        <ul class="kv-list">
+          <li><strong>Дневник:</strong> 2–3 операции (<code>{userId}_log_{date}</code>, индекс, статус).【F:worker.js†L1341-L1471】</li>
+          <li><strong>Извънредно хранене:</strong> още 1 put върху дневника.【F:worker.js†L1755-L1807】</li>
+          <li><strong>Чат с асистента:</strong> 5+ четения + 2 записа за всяко съобщение.【F:worker.js†L1538-L1680】【F:worker.js†L1729-L1743】</li>
+          <li><strong>Похвала/постижения:</strong> периодични четения и записи в <code>{userId}_achievements</code>.【F:worker.js†L2104-L2261】</li>
+        </ul>
+        <p class="frequency">Най-чести заявки: <code>{userId}_log_*</code>, <code>{userId}_chat_history</code>, <code>{userId}_current_status</code>.</p>
+      </div>
+      <div class="scenario">
+        <h4>В. Администратор подготвя нов план</h4>
+        <ul class="kv-list">
+          <li><strong>Списък клиенти:</strong> до 4 get-а на клиент + евентуален <code>kv.list</code>.【F:worker.js†L2640-L2668】</li>
+          <li><strong>Преглед на клиента:</strong> <code>getAdminQueries</code>, <code>getClientReplies</code>, <code>getFeedbackMessages</code>.【F:worker.js†L2873-L2946】</li>
+          <li><strong>Проверка на предпоставки:</strong> 4 ключа за статус и входни данни.【F:worker.js†L1914-L1956】</li>
+          <li><strong>RegeneratePlan:</strong> десетки записи/четения (план, лога, статус, pending).【F:worker.js†L3398-L3659】</li>
+        </ul>
+        <p class="frequency">Най-натоварващ: <code>processSingleUserPlan</code> цикълът и свързаните му ключове.</p>
+      </div>
+    </div>
+  </section>
+  <section id="ideas" class="card">
+    <h2>7. Идеи за оптимизация и подобрения</h2>
+    <ul class="kv-list">
+      <li><strong>Кеширане на план статус</strong> – <code>planStatus</code> и <code>analysisStatus</code> правят десетки четения при дълго чакане. Можем да върнем <code>retryAfter</code> стойност и да намалим честотата на poll след първите 3 заявки.【F:worker.js†L1166-L1204】</li>
+      <li><strong>Автоматично обновяване на <code>{userId}_kv_index</code></strong> – след всяко успешно зареждане на таблото да се обновява индексът, така админът ще избягва скъпото <code>kv.list</code>.【F:worker.js†L1199-L1260】【F:worker.js†L5751-L5793】</li>
+      <li><strong>Батч за чат контекста</strong> – при chat заявките да се кешира компактен snapshot в <code>{userId}_chat_ctx</code> и да се използва при следващите съобщения, вместо повторни 5+ четения.【F:worker.js†L1538-L1680】</li>
+      <li><strong>Guardrails за <code>/api/updateKv</code></strong> – добавете списък с разрешени префикси и журнал на измененията, за да няма случайно изтриване на критични ключове.【F:worker.js†L5798-L5828】</li>
+      <li><strong>Телеметрия за <code>kv.list</code></strong> – изпращайте събраните данни към Dashboard и показвайте предупреждение в админ панела, ако <code>listClients</code> генерира твърде много изброявания.【F:worker.js†L2640-L2668】【F:worker.js†L5843-L5878】</li>
+    </ul>
+  </section>
+  <footer>Поддръжано от екипа на MyBody.Best &middot; Последна актуализация: <time datetime="2024-01-01">2024</time></footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- добавена е нова страница `docs/kv-request-overview.html` с матрица на всички KV заявки от потребителските, администраторските и споделените потоци
- описани са cron/automation процесите, най-натоварените сценарии и препоръки за оптимизация на KV достъпите

## Testing
- npm run lint
- npm test *(частично, спряно след поредица от OOM и фейлиращи сценарийни тестове)*

------
https://chatgpt.com/codex/tasks/task_e_68d497441a54832682777b2219797b88