### PR TITLE
Throttle admin queries fetch to once per day

### DIFF
--- a/js/__tests__/adminQueriesPolling.test.js
+++ b/js/__tests__/adminQueriesPolling.test.js
@@ -24,7 +24,7 @@ function setVisibility(state) {
 
 describe('admin query polling behaviour', () => {
   beforeEach(() => {
-    localStorage.removeItem('adminQueryPollMinutes');
+    localStorage.clear();
     visibilityState = 'visible';
     selectors.chatMessages = document.createElement('div');
     selectors.chatWidget = document.createElement('div');
@@ -101,9 +101,9 @@ describe('admin query polling behaviour', () => {
     expect(global.fetch).toHaveBeenCalled();
   });
 
-  test('не изпраща повторна заявка преди да изтече интервалът без force', async () => {
+  test('не изпраща повторна заявка преди да изтече интервалът (24 часа)', async () => {
     jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00Z'));
-    await checkAdminQueries('test-user', { force: true });
+    await checkAdminQueries('test-user');
     expect(global.fetch).toHaveBeenCalledTimes(1);
 
     global.fetch.mockClear();

--- a/js/chat.js
+++ b/js/chat.js
@@ -34,7 +34,7 @@ export function toggleChatWidget(skipInit = false) {
             scrollToChatBottom();
         }
         if (currentUserId) {
-            void checkAdminQueries(currentUserId, { force: true });
+            void checkAdminQueries(currentUserId);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a persisted 24-hour throttle for admin query polling and stop using force refreshes
- load the cached timestamp when (re)starting polling and keep chat checks within the same guard
- align the admin query polling tests with the new behaviour

## Testing
- npm run lint
- NODE_OPTIONS=--max-old-space-size=4096 npm test *(fails: multiple pre-existing suites and OOM in test runner)*

------
https://chatgpt.com/codex/tasks/task_e_68d4abcf4b6083269198a1b4b74e60db