### PR TITLE
Fix notification timestamp normalization

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -2723,7 +2723,11 @@ async function handlePeekAdminNotificationsRequest(request, env) {
 
             const normalizeEntry = (input, tsKey = 'ts') => {
                 if (!input || typeof input !== 'object') return null;
-                const { message = '', rating = null, timestamp, ts, [tsKey]: keyedTs } = /** @type {NotificationEntry} */ (input);
+                const source = /** @type {NotificationEntry & Record<string, unknown>} */ (input);
+                const { message = '', rating = null, timestamp, ts } = source;
+                const keyedTs = typeof tsKey === 'string' && tsKey in source
+                    ? /** @type {string | number | null | undefined} */ (source[tsKey])
+                    : undefined;
                 return { message, rating, ts: keyedTs ?? timestamp ?? ts ?? null };
             };
 


### PR DESCRIPTION
## Summary
- guard notification normalization in `worker.js` with a typed record so we can safely read dynamic timestamp keys without triggering TypeScript errors

## Testing
- npm run lint
- npm test *(fails: numerous existing suites error and several runs hit OOM even with `--max-old-space-size=4096`)*

------
https://chatgpt.com/codex/tasks/task_e_68d4acbb1e148326a00dbbbe35a486e6