### PR TITLE
Stop getAdminQueries requests

### DIFF
--- a/js/__tests__/adminQueriesPolling.test.js
+++ b/js/__tests__/adminQueriesPolling.test.js
@@ -79,7 +79,7 @@ describe('admin query polling behaviour', () => {
     expect(intervalValue).toBe(24 * 60 * 60000);
   });
 
-  test('спира, когато разделът е скрит, и възобновява с незабавна проверка', async () => {
+  test('спира таймера, когато разделът е скрит, без да изпраща заявки', async () => {
     const timeoutSpy = jest.spyOn(global, 'setTimeout');
     const clearSpy = jest.spyOn(global, 'clearTimeout');
     startAdminQueriesPolling({ intervalMinutes: 60 });
@@ -93,29 +93,28 @@ describe('admin query polling behaviour', () => {
     setVisibility('visible');
     expect(timeoutSpy).toHaveBeenCalledTimes(1);
     await Promise.resolve();
-    expect(global.fetch).toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  test('отварянето на чата прави незабавна проверка', async () => {
+  test('отварянето на чата не изпраща заявка, когато polling е изключен', async () => {
     global.fetch.mockClear();
     selectors.chatWidget.classList.remove('visible');
     toggleChatWidget();
     await Promise.resolve();
-    expect(global.fetch).toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  test('не изпраща повторна заявка преди да изтече интервалът (24 часа)', async () => {
+  test('polling не изпраща заявки към бекенда', async () => {
     jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00Z'));
     await checkAdminQueries('test-user');
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).not.toHaveBeenCalled();
 
-    global.fetch.mockClear();
     await checkAdminQueries('test-user');
     expect(global.fetch).not.toHaveBeenCalled();
 
     jest.setSystemTime(new Date('2025-01-02T00:01:00Z'));
     await checkAdminQueries('test-user');
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).not.toHaveBeenCalled();
     jest.useRealTimers();
   });
 });

--- a/js/__tests__/adminSendTests.test.js
+++ b/js/__tests__/adminSendTests.test.js
@@ -21,7 +21,8 @@ describe('sendTestEmail and admin query', () => {
     jest.unstable_mockModule('../config.js', () => ({
       apiEndpoints: {
         sendTestEmail: '/api/sendTestEmail',
-        addAdminQuery: '/api/addAdminQuery'
+        addAdminQuery: '/api/addAdminQuery',
+        peekAdminQueries: '/api/peekAdminQueries'
       }
     }));
     mod = await import('../admin.js');
@@ -116,6 +117,7 @@ describe('sendTestEmail and admin query', () => {
       body: JSON.stringify({ userId: 'u123', message: 'Hi there' })
     }));
     expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenNthCalledWith(2, '/api/peekAdminQueries?userId=u123');
     expect(document.getElementById('newQueryText').value).toBe('');
     expect(result).toBe(true);
   });

--- a/js/admin.js
+++ b/js/admin.js
@@ -1459,10 +1459,11 @@ if (profileForm) {
     });
 }
 
-async function loadQueries(markRead = false) {
+async function loadQueries(_markRead = false) {
     if (!currentUserId) return;
     try {
-        const endpoint = markRead ? apiEndpoints.getAdminQueries : apiEndpoints.peekAdminQueries;
+        const endpoint = apiEndpoints.peekAdminQueries;
+        if (!endpoint) return;
         const resp = await fetch(`${endpoint}?userId=${currentUserId}`);
         const data = await resp.json();
         if (queriesList) queriesList.innerHTML = '';

--- a/js/app.js
+++ b/js/app.js
@@ -6,6 +6,7 @@ const MINUTES_IN_DAY = 24 * 60;
 const MILLISECONDS_IN_MINUTE = 60 * 1000;
 const ADMIN_QUERY_POLL_INTERVAL_MS_DEFAULT = MINUTES_IN_DAY * MILLISECONDS_IN_MINUTE; // 24 часа
 const ADMIN_QUERY_MINIMUM_INTERVAL_MS = ADMIN_QUERY_POLL_INTERVAL_MS_DEFAULT;
+const ADMIN_QUERIES_POLLING_ENABLED = false; // Временно спираме заявки към getAdminQueries
 const ADMIN_QUERY_LAST_FETCH_STORAGE_KEY = 'lastAdminQueriesFetchTs';
 const ADMIN_QUERY_LAST_FETCH_SESSION_KEY = 'lastAdminQueriesFetchTsSession';
 const lastAdminQueriesFetchMemory = new Map();
@@ -127,7 +128,7 @@ function persistAdminQueryFetchTs(userId, value) {
 }
 
 export async function checkAdminQueries(userId) {
-    if (!userId) return;
+    if (!userId || !ADMIN_QUERIES_POLLING_ENABLED) return;
     const now = Date.now();
     const interval = Math.max(adminQueriesIntervalMs, ADMIN_QUERY_MINIMUM_INTERVAL_MS);
     if (userId !== lastAdminQueriesFetchUserId) {


### PR DESCRIPTION
## Summary
- disable automatic admin query polling so the frontend no longer calls the getAdminQueries endpoint
- switch the admin dashboard query loader to the peek endpoint to avoid marking messages as read while still listing them
- update the admin query polling and admin send tests to reflect the disabled polling and new endpoint usage

## Testing
- npm run lint
- sh scripts/test.sh js/__tests__/adminQueriesPolling.test.js js/__tests__/adminSendTests.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d51a01b86c8326bb8f285a085b70aa