### PR TITLE
Add separate admin query mark-read endpoint

### DIFF
--- a/js/__tests__/adminSendTests.test.js
+++ b/js/__tests__/adminSendTests.test.js
@@ -22,7 +22,8 @@ describe('sendTestEmail and admin query', () => {
       apiEndpoints: {
         sendTestEmail: '/api/sendTestEmail',
         addAdminQuery: '/api/addAdminQuery',
-        peekAdminQueries: '/api/peekAdminQueries'
+        peekAdminQueries: '/api/peekAdminQueries',
+        markAdminQueriesRead: '/api/markAdminQueriesRead'
       }
     }));
     mod = await import('../admin.js');
@@ -120,6 +121,29 @@ describe('sendTestEmail and admin query', () => {
     expect(global.fetch).toHaveBeenNthCalledWith(2, '/api/peekAdminQueries?userId=u123');
     expect(document.getElementById('newQueryText').value).toBe('');
     expect(result).toBe(true);
+  });
+
+  test('loadQueries marks entries as read when requested', async () => {
+    mod.setCurrentUserId('u123');
+    const queriesResponse = {
+      ok: true,
+      json: async () => ({ success: true, queries: [{ message: 'One', ts: Date.now() }] })
+    };
+    const markResponse = {
+      ok: true,
+      json: async () => ({ success: true, markedCount: 1 })
+    };
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(queriesResponse)
+      .mockResolvedValueOnce(markResponse);
+    await mod.loadQueries(true);
+    expect(global.fetch).toHaveBeenNthCalledWith(1, '/api/peekAdminQueries?userId=u123');
+    expect(global.fetch).toHaveBeenNthCalledWith(2, '/api/markAdminQueriesRead', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: 'u123' })
+    }));
+    expect(document.querySelectorAll('#queriesList li')).toHaveLength(1);
   });
 
   test('sendAdminQuery alerts on failure', async () => {

--- a/js/admin.js
+++ b/js/admin.js
@@ -1474,6 +1474,21 @@ async function loadQueries(_markRead = false) {
                 li.textContent = q.message;
                 queriesList?.appendChild(li);
             });
+            if (_markRead && apiEndpoints.markAdminQueriesRead) {
+                try {
+                    const markResp = await fetch(apiEndpoints.markAdminQueriesRead, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ userId: currentUserId })
+                    });
+                    const markData = await markResp.json().catch(() => ({}));
+                    if (!markResp.ok || !markData.success) {
+                        console.error('Error marking queries as read:', markData.message || markResp.statusText);
+                    }
+                } catch (markErr) {
+                    console.error('Error marking queries as read:', markErr);
+                }
+            }
         }
     } catch (err) {
         console.error('Error loading queries:', err);

--- a/js/config.js
+++ b/js/config.js
@@ -42,6 +42,7 @@ export const apiEndpoints = {
     addAdminQuery: `${workerBaseUrl}/api/addAdminQuery`,
     getAdminQueries: `${workerBaseUrl}/api/getAdminQueries`,
     peekAdminQueries: `${workerBaseUrl}/api/peekAdminQueries`,
+    markAdminQueriesRead: `${workerBaseUrl}/api/markAdminQueriesRead`,
     addClientReply: `${workerBaseUrl}/api/addClientReply`,
     getClientReplies: `${workerBaseUrl}/api/getClientReplies`,
     peekClientReplies: `${workerBaseUrl}/api/peekClientReplies`,

--- a/worker.js
+++ b/worker.js
@@ -671,6 +671,8 @@ export default {
                 responseBody = await handleDeleteClientRequest(request, env);
             } else if (method === 'POST' && path === '/api/addAdminQuery') {
                 responseBody = await handleAddAdminQueryRequest(request, env);
+            } else if (method === 'POST' && path === '/api/markAdminQueriesRead') {
+                responseBody = await handleMarkAdminQueriesReadRequest(request, env);
             } else if (method === 'GET' && path === '/api/getAdminQueries') {
                 responseBody = await handleGetAdminQueriesRequest(request, env);
             } else if (method === 'GET' && path === '/api/peekAdminQueries') {
@@ -2877,6 +2879,22 @@ async function handleAddAdminQueryRequest(request, env) {
 const ADMIN_QUERIES_MIN_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const ADMIN_QUERIES_LAST_FETCH_SUFFIX = '_admin_queries_last_fetch';
 
+async function markAdminQueriesAsRead(env, userId, arr, now) {
+    const key = `${userId}_admin_queries`;
+    let markedCount = 0;
+    for (const entry of arr) {
+        if (!entry?.read) {
+            entry.read = true;
+            markedCount += 1;
+        }
+    }
+    if (markedCount > 0) {
+        await env.USER_METADATA_KV.put(key, JSON.stringify(arr));
+    }
+    await env.USER_METADATA_KV.put(`${userId}${ADMIN_QUERIES_LAST_FETCH_SUFFIX}`, String(now));
+    return markedCount;
+}
+
 // ------------- START FUNCTION: handleGetAdminQueriesRequest -------------
 async function handleGetAdminQueriesRequest(request, env, peek = false) {
     try {
@@ -2894,7 +2912,7 @@ async function handleGetAdminQueriesRequest(request, env, peek = false) {
                 lastFetchTs = parsed;
             }
         }
-        const unread = arr.filter(q => !q.read);
+        const unread = arr.filter(q => !q?.read).map(q => ({ ...q }));
         if (!peek && lastFetchTs > 0) {
             const hasNewSinceLast = unread.some(entry => {
                 const ts = typeof entry?.ts === 'number' ? entry.ts : Number(entry?.ts) || 0;
@@ -2909,12 +2927,8 @@ async function handleGetAdminQueriesRequest(request, env, peek = false) {
                 };
             }
         }
-        if (unread.length > 0 && !peek) {
-            arr.forEach(q => { q.read = true; });
-            await env.USER_METADATA_KV.put(key, JSON.stringify(arr));
-        }
         if (!peek) {
-            await env.USER_METADATA_KV.put(`${userId}${ADMIN_QUERIES_LAST_FETCH_SUFFIX}`, String(now));
+            await markAdminQueriesAsRead(env, userId, arr, now);
         }
         return { success: true, queries: unread };
     } catch (error) {
@@ -2923,6 +2937,28 @@ async function handleGetAdminQueriesRequest(request, env, peek = false) {
     }
 }
 // ------------- END FUNCTION: handleGetAdminQueriesRequest -------------
+
+// ------------- START FUNCTION: handleMarkAdminQueriesReadRequest -------------
+async function handleMarkAdminQueriesReadRequest(request, env) {
+    try {
+        let body;
+        try {
+            body = await request.json();
+        } catch {
+            return { success: false, message: 'Невалидни данни.', statusHint: 400 };
+        }
+        const { userId } = body || {};
+        if (!userId) return { success: false, message: 'Липсва userId.', statusHint: 400 };
+        const key = `${userId}_admin_queries`;
+        const arr = safeParseJson(await env.USER_METADATA_KV.get(key), []);
+        const markedCount = await markAdminQueriesAsRead(env, userId, arr, Date.now());
+        return { success: true, markedCount };
+    } catch (error) {
+        console.error('Error in handleMarkAdminQueriesReadRequest:', error.message, error.stack);
+        return { success: false, message: 'Грешка при маркиране на запитванията.', statusHint: 500 };
+    }
+}
+// ------------- END FUNCTION: handleMarkAdminQueriesReadRequest -------------
 
 // ------------- START FUNCTION: handleAddClientReplyRequest -------------
 async function handleAddClientReplyRequest(request, env) {
@@ -5917,4 +5953,4 @@ async function _maybeSendKvListTelemetry(env) {
 }
 // ------------- END BLOCK: kv list telemetry -------------
 // ------------- INSERTION POINT: EndOfFile -------------
-export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRegeneratePlanRequest, handleCheckPlanPrerequisitesRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleDashboardDataRequest, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handlePeekAdminNotificationsRequest, handleDeleteClientRequest, handleAddAdminQueryRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleDeleteAiPreset, handleTestAiModelRequest, handleContactFormRequest, handleGetContactRequestsRequest, handleValidateIndexesRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleLoginRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, setCallModelImplementation, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, sendAnalysisLinkEmail, sendContactEmail, getEmailConfig, getUserLogDates, calculateAnalyticsIndexes, handleListUserKvRequest, rebuildUserKvIndex, handleUpdateKvRequest, handleLogRequest, handlePlanLogRequest, setPlanStatus, resetAiPresetIndexCache, _withKvListCounting, _maybeSendKvListTelemetry, getMaxChatHistoryMessages, summarizeAndTrimChatHistory, getCachedResource, clearResourceCache };
+export { processSingleUserPlan, handleLogExtraMealRequest, handleGetProfileRequest, handleUpdateProfileRequest, handleUpdatePlanRequest, handleRegeneratePlanRequest, handleCheckPlanPrerequisitesRequest, handleRequestPasswordReset, handlePerformPasswordReset, shouldTriggerAutomatedFeedbackChat, processPendingUserEvents, handleDashboardDataRequest, handleRecordFeedbackChatRequest, handleSubmitFeedbackRequest, handleGetAchievementsRequest, handleGeneratePraiseRequest, handleAnalyzeInitialAnswers, handleGetInitialAnalysisRequest, handleReAnalyzeQuestionnaireRequest, handleAnalysisStatusRequest, createUserEvent, handleUploadTestResult, handleUploadIrisDiag, handleAiHelperRequest, handleAnalyzeImageRequest, handleRunImageModelRequest, handleListClientsRequest, handlePeekAdminNotificationsRequest, handleDeleteClientRequest, handleAddAdminQueryRequest, handleMarkAdminQueriesReadRequest, handleGetAdminQueriesRequest, handleAddClientReplyRequest, handleGetClientRepliesRequest, handleGetFeedbackMessagesRequest, handleGetPlanModificationPrompt, handleGetAiConfig, handleSetAiConfig, handleListAiPresets, handleGetAiPreset, handleSaveAiPreset, handleDeleteAiPreset, handleTestAiModelRequest, handleContactFormRequest, handleGetContactRequestsRequest, handleValidateIndexesRequest, handleSendTestEmailRequest, handleGetMaintenanceMode, handleSetMaintenanceMode, handleRegisterRequest, handleRegisterDemoRequest, handleLoginRequest, handleSubmitQuestionnaire, handleSubmitDemoQuestionnaire, callCfAi, callModel, setCallModelImplementation, callGeminiVisionAPI, handlePrincipleAdjustment, createFallbackPrincipleSummary, createPlanUpdateSummary, createUserConcernsSummary, evaluatePlanChange, handleChatRequest, populatePrompt, createPraiseReplacements, buildCfImagePayload, sendAnalysisLinkEmail, sendContactEmail, getEmailConfig, getUserLogDates, calculateAnalyticsIndexes, handleListUserKvRequest, rebuildUserKvIndex, handleUpdateKvRequest, handleLogRequest, handlePlanLogRequest, setPlanStatus, resetAiPresetIndexCache, _withKvListCounting, _maybeSendKvListTelemetry, getMaxChatHistoryMessages, summarizeAndTrimChatHistory, getCachedResource, clearResourceCache };


### PR DESCRIPTION
## Summary
- add a dedicated endpoint for marking admin queries as read and refactor the shared logic
- trigger the new mark-read call from the admin UI without fetching the payload twice
- cover the new behaviour with an adminSend test that checks the mark-read request

## Testing
- npm run lint
- npm test *(fails: extraMealAutofill tests expect seeded macro data; unrelated to this change)*
- npm test -- js/__tests__/adminSendTests.test.js


------
https://chatgpt.com/codex/tasks/task_e_68d5bf5b833483269570267b0ac8f164