### PR TITLE
Fix macro card data fallbacks and dashboard threshold sync

### DIFF
--- a/js/__tests__/macroThreshold.test.js
+++ b/js/__tests__/macroThreshold.test.js
@@ -29,6 +29,7 @@ test('buildMacroCardUrl appends user threshold', async () => {
     planHasRecContent: false,
     todaysExtraMeals: [],
     loadCurrentIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn(),
     currentUserId: 'u1',
     todaysPlanMacros: {
       calories: 0,
@@ -42,10 +43,74 @@ test('buildMacroCardUrl appends user threshold', async () => {
       fiber_percent: 0
     },
     recalculateCurrentIntakeMacros: jest.fn(),
-    resetAppState: jest.fn()
+    resetAppState: jest.fn(),
+    ensureFreshDailyIntake: jest.fn()
   }));
   jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
   const { setMacroExceedThreshold, buildMacroCardUrl } = await import('../populateUI.js');
   setMacroExceedThreshold(1.05);
   expect(buildMacroCardUrl()).toBe('macroAnalyticsCardStandalone.html?threshold=1.05');
+});
+
+test('setMacroExceedThreshold обновява атрибута на съществуващата карта', async () => {
+  jest.resetModules();
+  document.body.innerHTML = '<div id="macroAnalyticsCardContainer"><macro-analytics-card exceed-threshold="1.15"></macro-analytics-card></div>';
+  const container = document.getElementById('macroAnalyticsCardContainer');
+  const card = container.querySelector('macro-analytics-card');
+  jest.unstable_mockModule('../config.js', () => ({
+    standaloneMacroUrl: 'macroAnalyticsCardStandalone.html',
+    generateId: () => 'id',
+    apiEndpoints: {}
+  }));
+  jest.unstable_mockModule('../uiElements.js', () => ({
+    selectors: { macroAnalyticsCardContainer: container },
+    trackerInfoTexts: {},
+    detailedMetricInfoTexts: {}
+  }));
+  jest.unstable_mockModule('../uiHandlers.js', () => ({ showToast: jest.fn() }));
+  jest.unstable_mockModule('../macroUtils.js', () => ({
+    getNutrientOverride: jest.fn(),
+    addMealMacros: jest.fn(),
+    scaleMacros: jest.fn(),
+    calculateMacroPercents: jest.fn(() => ({ protein_percent: 0, carbs_percent: 0, fat_percent: 0, fiber_percent: 0 })),
+    calculatePlanMacros: jest.fn()
+  }));
+  jest.unstable_mockModule('../eventListeners.js', () => ({
+    ensureMacroAnalyticsElement: jest.fn(() => {
+      card.setData = jest.fn();
+      return card;
+    }),
+    setupStaticEventListeners: jest.fn(),
+    setupDynamicEventListeners: jest.fn(),
+    initializeCollapsibleCards: jest.fn()
+  }));
+  jest.unstable_mockModule('../app.js', () => ({
+    fullDashboardData: {},
+    todaysMealCompletionStatus: {},
+    currentIntakeMacros: {},
+    planHasRecContent: false,
+    todaysExtraMeals: [],
+    loadCurrentIntake: jest.fn(),
+    updateMacrosAndAnalytics: jest.fn(),
+    currentUserId: 'u1',
+    todaysPlanMacros: {
+      calories: 0,
+      protein: 0,
+      carbs: 0,
+      fat: 0,
+      fiber: 0,
+      protein_percent: 0,
+      carbs_percent: 0,
+      fat_percent: 0,
+      fiber_percent: 0
+    },
+    recalculateCurrentIntakeMacros: jest.fn(),
+    resetAppState: jest.fn(),
+    ensureFreshDailyIntake: jest.fn()
+  }));
+  jest.unstable_mockModule('../chartLoader.js', () => ({ ensureChart: jest.fn() }));
+  const { setMacroExceedThreshold } = await import('../populateUI.js');
+  expect(card.getAttribute('exceed-threshold')).toBe('1.15');
+  setMacroExceedThreshold(1.25);
+  expect(card.getAttribute('exceed-threshold')).toBe('1.25');
 });

--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -63,6 +63,22 @@ test('calculateCurrentMacros скалира macros по grams', () => {
   expect(result).toEqual({ calories: 100, protein: 5, carbs: 10, fat: 5, fiber: 2.5 });
 });
 
+test('calculateCurrentMacros използва mealMacrosIndex като fallback', () => {
+  const planMenu = { monday: [{ meal_name: 'Домашно ястие' }] };
+  const completionStatus = { monday_0: true };
+  const mealMacrosIndex = {
+    monday_0: {
+      calories: 320,
+      protein_grams: 30,
+      carbs_grams: 25,
+      fat_grams: 12,
+      fiber_grams: 6
+    }
+  };
+  const result = calculateCurrentMacros(planMenu, completionStatus, [], false, mealMacrosIndex);
+  expect(result).toEqual({ calories: 320, protein: 30, carbs: 25, fat: 12, fiber: 6 });
+});
+
 test('calculatePlanMacros sums macros for day menu', () => {
   const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   const dayMenu = [
@@ -100,6 +116,31 @@ test('calculatePlanMacros използва наличното поле macros', 
     carbs_percent: 46,
     fat_percent: 31,
     fiber_percent: 4
+  });
+});
+
+test('calculatePlanMacros използва mealMacrosIndex при липсващи макроси', () => {
+  const dayMenu = [{ meal_name: 'Домашна супа' }];
+  const mealMacrosIndex = {
+    monday_0: {
+      calories: 280,
+      protein_grams: 18,
+      carbs_grams: 32,
+      fat_grams: 9,
+      fiber_grams: 4
+    }
+  };
+  const result = calculatePlanMacros(dayMenu, true, true, mealMacrosIndex, 'monday');
+  expect(result).toMatchObject({
+    calories: 280,
+    protein: 18,
+    carbs: 32,
+    fat: 9,
+    fiber: 4,
+    protein_percent: expect.any(Number),
+    carbs_percent: expect.any(Number),
+    fat_percent: expect.any(Number),
+    fiber_percent: expect.any(Number)
   });
 });
 

--- a/js/app.js
+++ b/js/app.js
@@ -502,7 +502,9 @@ export function loadCurrentIntake(status = null, extraMeals = null) {
         currentIntakeMacros = calculateCurrentMacros(
             fullDashboardData.planData?.week1Menu || {},
             status,
-            extraMeals
+            extraMeals,
+            false,
+            fullDashboardData.planData?.mealMacrosIndex || null
         );
     } catch (err) {
         console.error('Error loading current intake:', err);
@@ -515,7 +517,9 @@ export function recalculateCurrentIntakeMacros() {
         currentIntakeMacros = calculateCurrentMacros(
             fullDashboardData.planData?.week1Menu || {},
             todaysMealCompletionStatus,
-            todaysExtraMeals
+            todaysExtraMeals,
+            false,
+            fullDashboardData.planData?.mealMacrosIndex || null
         );
     } catch (err) {
         console.error('Error recalculating current intake:', err);
@@ -554,7 +558,13 @@ export async function loadDashboardData() {
             const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
             const currentDayKey = dayNames[new Date().getDay()];
             const dayMenu = fullDashboardData.planData?.week1Menu?.[currentDayKey] || [];
-            todaysPlanMacros = calculatePlanMacros(dayMenu, true, true);
+            todaysPlanMacros = calculatePlanMacros(
+                dayMenu,
+                true,
+                true,
+                fullDashboardData.planData?.mealMacrosIndex || null,
+                currentDayKey
+            );
             loadCurrentIntake();
             chatHistory = []; // Reset chat history for test user on reload
 
@@ -622,7 +632,13 @@ export async function loadDashboardData() {
         const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
         const currentDayKey = dayNames[new Date().getDay()];
         const dayMenu = fullDashboardData.planData?.week1Menu?.[currentDayKey] || [];
-        todaysPlanMacros = calculatePlanMacros(dayMenu, true, true);
+        todaysPlanMacros = calculatePlanMacros(
+            dayMenu,
+            true,
+            true,
+            fullDashboardData.planData?.mealMacrosIndex || null,
+            currentDayKey
+        );
         loadCurrentIntake();
         await populateDashboardMacros(fullDashboardData.planData?.caloriesMacros);
 

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -61,10 +61,13 @@ async function acknowledgeAiUpdate() {
 
 export function ensureMacroAnalyticsElement() {
     let el = selectors.macroAnalyticsCardContainer?.querySelector('macro-analytics-card');
+    const threshold = String(macroExceedThreshold);
     if (!el) {
         el = document.createElement('macro-analytics-card');
-        el.setAttribute('exceed-threshold', String(macroExceedThreshold));
+        el.setAttribute('exceed-threshold', threshold);
         selectors.macroAnalyticsCardContainer.appendChild(el);
+    } else if (el.getAttribute('exceed-threshold') !== threshold) {
+        el.setAttribute('exceed-threshold', threshold);
     }
     macroChartInstance?.resize();
     progressChartInstance?.resize();

--- a/js/populateUI.js
+++ b/js/populateUI.js
@@ -21,6 +21,10 @@ export function setMacroExceedThreshold(val) {
     } else {
         macroExceedThreshold = 1.15;
     }
+    const card = selectors.macroAnalyticsCardContainer?.querySelector('macro-analytics-card');
+    if (card) {
+        card.setAttribute('exceed-threshold', String(macroExceedThreshold));
+    }
 }
 
 export function buildMacroCardUrl() {
@@ -637,7 +641,16 @@ function populateDashboardDailyPlan(week1Menu, dailyLogs, recipeData) {
     if (selectors.dailyPlanTitle) selectors.dailyPlanTitle.innerHTML = `<svg class="icon"><use href="#icon-calendar"></use></svg> Меню (${capitalizeFirstLetter(todayTitle)})`;
 
     const dailyPlanData = safeGet(week1Menu, currentDayKey, []);
-    Object.assign(todaysPlanMacros, calculatePlanMacros(dailyPlanData, true, true));
+    Object.assign(
+        todaysPlanMacros,
+        calculatePlanMacros(
+            dailyPlanData,
+            true,
+            true,
+            fullDashboardData?.planData?.mealMacrosIndex || null,
+            currentDayKey
+        )
+    );
 
     populateDashboardMacros();
 


### PR DESCRIPTION
## Summary
- use planData.mealMacrosIndex when inline meal macros are missing so plan and current sums work for legacy menus
- propagate the meal macro index through dashboard loaders and tests, and keep the macro analytics card threshold attribute in sync when it changes
- extend extra meal autofill with override fallbacks, formatting, and existing measure listeners to cover additional UI paths

## Testing
- npm run lint
- NODE_OPTIONS="--max-old-space-size=4096 --experimental-vm-modules" npx jest --runInBand js/__tests__/extraMealAutofill.test.js
- NODE_OPTIONS="--max-old-space-size=4096 --experimental-vm-modules" npx jest --runInBand js/__tests__/macroThreshold.test.js
- npm test *(fails: JavaScript heap out of memory even after rerun)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d2f52dec832689209656a75aa297