### PR TITLE
Add meal macro index persistence and guard missing macros

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -5,11 +5,41 @@ import { calculateCurrentMacros, addMealMacros, removeMealMacros, registerNutrie
 test('calculateCurrentMacros sums macros from completed meals and extras', () => {
   const planMenu = {
     monday: [
-      { id: 'z-01', meal_name: 'Протеинов шейк' },
-      { id: 'o-01', meal_name: 'Печено пилешко с ориз/картофи и салата' }
+      {
+        id: 'z-01',
+        meal_name: 'Протеинов шейк',
+        macros: {
+          calories: 510,
+          protein_grams: 40,
+          carbs_grams: 20,
+          fat_grams: 30,
+          fiber_grams: 0
+        }
+      },
+      {
+        id: 'o-01',
+        meal_name: 'Печено пилешко с ориз/картофи и салата',
+        macros: {
+          calories: 420,
+          protein_grams: 28,
+          carbs_grams: 45,
+          fat_grams: 15,
+          fiber_grams: 5
+        }
+      }
     ],
     tuesday: [
-      { id: 'o-02', meal_name: 'Телешки кюфтета със салата' }
+      {
+        id: 'o-02',
+        meal_name: 'Телешки кюфтета със салата',
+        macros: {
+          calories: 250,
+          protein_grams: 22,
+          carbs_grams: 18,
+          fat_grams: 10,
+          fiber_grams: 0
+        }
+      }
     ]
   };
 
@@ -24,7 +54,7 @@ test('calculateCurrentMacros sums macros from completed meals and extras', () =>
   ];
 
   const result = calculateCurrentMacros(planMenu, completionStatus, extraMeals);
-  expect(result).toEqual({ calories: 848, protein: 67, carbs: 48, fat: 42, fiber: 5 });
+  expect(result).toEqual({ calories: 828, protein: 67, carbs: 48, fat: 42, fiber: 5 });
 });
 
   test('calculateCurrentMacros използва meal.macros и overrides', () => {
@@ -77,6 +107,18 @@ test('calculateCurrentMacros използва mealMacrosIndex като fallback'
   };
   const result = calculateCurrentMacros(planMenu, completionStatus, [], false, mealMacrosIndex);
   expect(result).toEqual({ calories: 320, protein: 30, carbs: 25, fat: 12, fiber: 6 });
+});
+
+test('calculateCurrentMacros пропуска хранения без макроси и индекс', () => {
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const planMenu = { monday: [{ meal_name: 'Без данни' }] };
+  const completionStatus = { monday_0: true };
+  const result = calculateCurrentMacros(planMenu, completionStatus, [], false, null);
+  expect(result).toEqual({ calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 });
+  expect(warnSpy).toHaveBeenCalledWith(
+    expect.stringContaining("[macroUtils] Missing macros for 'Без данни'")
+  );
+  warnSpy.mockRestore();
 });
 
 test('calculatePlanMacros sums macros for day menu', () => {

--- a/js/app.js
+++ b/js/app.js
@@ -71,6 +71,87 @@ function normalizeText(input) {
     return String(input);
 }
 
+const MACRO_FIELD_MAP = {
+    calories: ['calories', 'calories_kcal', 'cal', 'kcal'],
+    protein_grams: ['protein_grams', 'protein', 'protein_g'],
+    carbs_grams: ['carbs_grams', 'carbs', 'carbohydrates', 'carbs_g'],
+    fat_grams: ['fat_grams', 'fat', 'fats', 'fat_g'],
+    fiber_grams: ['fiber_grams', 'fiber', 'fibers', 'fiber_g'],
+    alcohol_grams: ['alcohol_grams', 'alcohol', 'alcohol_g']
+};
+
+const MACRO_GRAM_FIELDS = ['grams', 'serving_grams', 'portion_grams'];
+
+function parseMacroNumber(value) {
+    if (value === null || value === undefined) return null;
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+    }
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) return null;
+        const normalized = trimmed.replace(/,/g, '.');
+        const match = normalized.match(/-?\d+(?:\.\d+)?/);
+        if (!match) return null;
+        const parsed = parseFloat(match[0]);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+}
+
+function pickMacroValue(source, fields = []) {
+    if (!source || typeof source !== 'object') return null;
+    for (const key of fields) {
+        if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+        const parsed = parseMacroNumber(source[key]);
+        if (parsed !== null) return parsed;
+    }
+    return null;
+}
+
+function extractMealMacroForIndex(meal) {
+    if (!meal || typeof meal !== 'object') return null;
+    const macrosSource = meal.macros && typeof meal.macros === 'object' ? meal.macros : meal;
+    const normalized = {};
+    for (const [targetKey, candidates] of Object.entries(MACRO_FIELD_MAP)) {
+        const value = pickMacroValue(macrosSource, candidates);
+        if (value !== null) {
+            normalized[targetKey] = value;
+        }
+    }
+    const grams = pickMacroValue(meal, MACRO_GRAM_FIELDS);
+    if (grams !== null) {
+        normalized.grams = grams;
+    }
+    return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function buildMealMacrosIndex(planData = {}) {
+    const menu = planData?.week1Menu;
+    if (!menu || typeof menu !== 'object') return null;
+    const index = {};
+    let count = 0;
+    for (const [day, meals] of Object.entries(menu)) {
+        if (!Array.isArray(meals)) continue;
+        meals.forEach((meal, idx) => {
+            const entry = extractMealMacroForIndex(meal);
+            if (!entry) return;
+            index[`${day}_${idx}`] = entry;
+            count += 1;
+        });
+    }
+    return count > 0 ? index : null;
+}
+
+function ensurePlanHasMealMacrosIndex(planData) {
+    if (!planData || typeof planData !== 'object') return;
+    const existing = planData.mealMacrosIndex;
+    const needsBuild = !existing || typeof existing !== 'object' || Object.keys(existing).length === 0;
+    if (!needsBuild) return;
+    const rebuilt = buildMealMacrosIndex(planData);
+    planData.mealMacrosIndex = rebuilt || null;
+}
+
 function tryGetStorageItem(storage, key) {
     if (!storage) return null;
     try {
@@ -320,6 +401,13 @@ function createTestData() {
             week1Menu: {
                 monday: [{
                     meal_name: "Закуска",
+                    macros: {
+                        calories: 320,
+                        protein_grams: 20,
+                        carbs_grams: 35,
+                        fat_grams: 10,
+                        fiber_grams: 5
+                    },
                     items: [
                         { name: "Овесена каша", grams: "50г" },
                         { name: "Банан", grams: "1 бр." }
@@ -481,6 +569,7 @@ async function initializeApp() {
 export function loadCurrentIntake(status = null, extraMeals = null) {
     try {
         ensureFreshDailyIntake();
+        ensurePlanHasMealMacrosIndex(fullDashboardData?.planData);
         currentIntakeMacros = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
 
         const todayStr = getLocalDate();
@@ -514,6 +603,7 @@ export function loadCurrentIntake(status = null, extraMeals = null) {
 export function recalculateCurrentIntakeMacros() {
     try {
         ensureFreshDailyIntake();
+        ensurePlanHasMealMacrosIndex(fullDashboardData?.planData);
         currentIntakeMacros = calculateCurrentMacros(
             fullDashboardData.planData?.week1Menu || {},
             todaysMealCompletionStatus,
@@ -553,6 +643,7 @@ export async function loadDashboardData() {
             const data = createTestData();
             debugLog("Using test data for development:", data);
             fullDashboardData = data;
+            ensurePlanHasMealMacrosIndex(fullDashboardData?.planData);
             setMacroExceedThreshold(data.macroExceedThreshold);
             fullDashboardData.dailyLogs = normalizeDailyLogs(fullDashboardData.dailyLogs);
             const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
@@ -618,6 +709,7 @@ export async function loadDashboardData() {
 
         debugLog("Data received from worker:", data);
         fullDashboardData = data;
+        ensurePlanHasMealMacrosIndex(fullDashboardData?.planData);
         setMacroExceedThreshold(data.macroExceedThreshold);
         // chatHistory = []; // Do not reset chat history on normal data load, only for test user or logout
 

--- a/worker.js
+++ b/worker.js
@@ -141,6 +141,71 @@ function clearResourceCache(keys) {
   }
 }
 
+function parseMacroNumber(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string') {
+    const cleaned = value.trim();
+    if (!cleaned) return null;
+    const normalized = cleaned.replace(/,/g, '.');
+    const match = normalized.match(/-?\d+(?:\.\d+)?/);
+    if (!match) return null;
+    const parsed = parseFloat(match[0]);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function pickMacroValue(source, candidates = []) {
+  if (!source || typeof source !== 'object') return null;
+  for (const key of candidates) {
+    if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+    const parsed = parseMacroNumber(source[key]);
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
+function extractMealMacroEntry(meal) {
+  if (!meal || typeof meal !== 'object') return null;
+  const macrosSource = meal.macros && typeof meal.macros === 'object' ? meal.macros : meal;
+  const normalized = {};
+  const calories = pickMacroValue(macrosSource, ['calories', 'calories_kcal', 'cal', 'kcal']);
+  if (calories !== null) normalized.calories = calories;
+  const protein = pickMacroValue(macrosSource, ['protein_grams', 'protein', 'protein_g']);
+  if (protein !== null) normalized.protein_grams = protein;
+  const carbs = pickMacroValue(macrosSource, ['carbs_grams', 'carbs', 'carbohydrates', 'carbs_g']);
+  if (carbs !== null) normalized.carbs_grams = carbs;
+  const fat = pickMacroValue(macrosSource, ['fat_grams', 'fat', 'fats', 'fat_g']);
+  if (fat !== null) normalized.fat_grams = fat;
+  const fiber = pickMacroValue(macrosSource, ['fiber_grams', 'fiber', 'fibers', 'fiber_g']);
+  if (fiber !== null) normalized.fiber_grams = fiber;
+  const alcohol = pickMacroValue(macrosSource, ['alcohol_grams', 'alcohol', 'alcohol_g']);
+  if (alcohol !== null) normalized.alcohol_grams = alcohol;
+  const grams = pickMacroValue(meal, ['grams', 'serving_grams', 'portion_grams']);
+  if (grams !== null) normalized.grams = grams;
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function buildMealMacrosIndexFromPlan(plan) {
+  const menu = plan?.week1Menu;
+  if (!menu || typeof menu !== 'object') return null;
+  const index = {};
+  let count = 0;
+  for (const [day, meals] of Object.entries(menu)) {
+    if (!Array.isArray(meals)) continue;
+    meals.forEach((meal, idx) => {
+      const entry = extractMealMacroEntry(meal);
+      if (!entry) return;
+      index[`${day}_${idx}`] = entry;
+      count += 1;
+    });
+  }
+  return count > 0 ? index : null;
+}
+
 const WELCOME_SUBJECT = 'Добре дошъл в MyBody!';
 const WELCOME_BODY_TEMPLATE = `<!DOCTYPE html>
 <html lang="bg">
@@ -1964,6 +2029,12 @@ async function handleUpdatePlanRequest(request, env) {
         if (!planData || typeof planData !== 'object') {
             return { success: false, message: 'Невалидни данни за плана.', statusHint: 400 };
         }
+        const rebuiltIndex = buildMealMacrosIndexFromPlan(planData);
+        if (rebuiltIndex) {
+            planData.mealMacrosIndex = rebuiltIndex;
+        } else if (!planData.mealMacrosIndex || typeof planData.mealMacrosIndex !== 'object') {
+            planData.mealMacrosIndex = null;
+        }
         await env.USER_METADATA_KV.put(`${userId}_final_plan`, JSON.stringify(planData));
         const macrosRecord = {
             status: 'final',
@@ -3480,7 +3551,7 @@ async function processSingleUserPlan(userId, env) {
         }
         console.log(`PROCESS_USER_PLAN (${userId}): Processing for email: ${initialAnswers.email || 'N/A'}`);
         await addLog('Подготовка на модела');
-        const planBuilder = { profileSummary: null, caloriesMacros: null, week1Menu: null, principlesWeek2_4: [], additionalGuidelines: [], hydrationCookingSupplements: null, allowedForbiddenFoods: {}, psychologicalGuidance: null, detailedTargets: null, generationMetadata: { timestamp: '', modelUsed: null, errors: [] } };
+        const planBuilder = { profileSummary: null, caloriesMacros: null, week1Menu: null, mealMacrosIndex: null, principlesWeek2_4: [], additionalGuidelines: [], hydrationCookingSupplements: null, allowedForbiddenFoods: {}, psychologicalGuidance: null, detailedTargets: null, generationMetadata: { timestamp: '', modelUsed: null, errors: [] } };
         const [ questionsJsonString, baseDietModelContent, allowedMealCombinationsContent, eatingPsychologyContent, recipeDataStr, geminiApiKey, openaiApiKey, planModelName, unifiedPromptTemplate ] = await Promise.all([
             env.RESOURCES_KV.get('question_definitions'),
             env.RESOURCES_KV.get('base_diet_model'),
@@ -3663,6 +3734,13 @@ async function processSingleUserPlan(userId, env) {
             };
             if (planBuilder.caloriesMacros) {
                 ensureFiber(planBuilder.caloriesMacros);
+            }
+            if (!planBuilder.mealMacrosIndex || typeof planBuilder.mealMacrosIndex !== 'object') {
+                planBuilder.mealMacrosIndex = null;
+            }
+            const rebuiltIndex = buildMealMacrosIndexFromPlan(planBuilder);
+            if (rebuiltIndex) {
+                planBuilder.mealMacrosIndex = rebuiltIndex;
             }
             if (generationMetadata && Array.isArray(generationMetadata.errors)) planBuilder.generationMetadata.errors.push(...generationMetadata.errors);
             await addLog('Планът е генериран', { checkpoint: true, reason: 'plan-generated' });


### PR DESCRIPTION
## Summary
- build and persist a mealMacrosIndex when generating or manually updating plans in the worker
- rebuild missing meal macro indexes on the client before calculating current intake and skip meals without any macro source
- expand macro utility tests to cover the new warning behaviour and updated fixtures

## Testing
- npm run lint
- NODE_OPTIONS=--experimental-vm-modules npx jest js/__tests__/macroUtils.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dc6078bafc8326853f2d00b0488581