### PR TITLE
Нормализация на макроси и подобрен fallback

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -79,6 +79,25 @@ test('calculateCurrentMacros използва mealMacrosIndex като fallback'
   expect(result).toEqual({ calories: 320, protein: 30, carbs: 25, fat: 12, fiber: 6 });
 });
 
+test('calculateCurrentMacros нормализира макроси с *_g и *_kcal полета', () => {
+  const planMenu = {
+    monday: [
+      {
+        macros: {
+          calories_kcal: '320',
+          protein_g: '30',
+          carbs_g: '25',
+          fat_g: '12',
+          fiber_g: '6'
+        }
+      }
+    ]
+  };
+  const completionStatus = { monday_0: true };
+  const result = calculateCurrentMacros(planMenu, completionStatus, []);
+  expect(result).toEqual({ calories: 320, protein: 30, carbs: 25, fat: 12, fiber: 6 });
+});
+
 test('calculatePlanMacros sums macros for day menu', () => {
   const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   const dayMenu = [


### PR DESCRIPTION
## Summary
- разширих mapGramFields с алиаси за макро полета и добавих проверка за липсващи стойности
- позволих calculatePlanMacros/calculateCurrentMacros да падат обратно към mealMacrosIndex при непълен payload
- добавих unit тест за calculateCurrentMacros с *_g/*_kcal макроси

## Testing
- `npm run lint` (warnings only)
- `npm test` (неуспешно: недостиг на памет и предварително падащи тестове)


------
https://chatgpt.com/codex/tasks/task_e_68dc67812bac8326b548438396c83458