### PR TITLE
Handle meals missing fiber macros gracefully

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -79,6 +79,19 @@ test('calculateCurrentMacros използва mealMacrosIndex като fallback'
   expect(result).toEqual({ calories: 320, protein: 30, carbs: 25, fat: 12, fiber: 6 });
 });
 
+test('calculateCurrentMacros приема макроси без fiber без fallback към 0', () => {
+  const planMenu = {
+    monday: [
+      {
+        macros: { calories: 290, protein_grams: 20, carbs_grams: 30, fat_grams: 10 }
+      }
+    ]
+  };
+  const completionStatus = { monday_0: true };
+  const result = calculateCurrentMacros(planMenu, completionStatus, []);
+  expect(result).toEqual({ calories: 290, protein: 20, carbs: 30, fat: 10, fiber: 0 });
+});
+
 test('normalizeMacros парсира стойности със съответните единици', () => {
   const normalized = normalizeMacros({
     calories: '320 kcal',


### PR DESCRIPTION
## Summary
- flatten nested `meal.macros` payloads so fallback normalization can see core macro fields
- treat macro payloads that only miss fiber as valid in plan and current macro aggregation
- add a regression test ensuring meals without fiber macros contribute non-zero totals

## Testing
- npm test -- js/__tests__/macroUtils.test.js
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9d9570308326a7be41969b578731