### PR TITLE
Handle partial meal macros with fallback

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -27,11 +27,11 @@ test('calculateCurrentMacros sums macros from completed meals and extras', () =>
   expect(result).toEqual({ calories: 848, protein: 67, carbs: 48, fat: 42, fiber: 5 });
 });
 
-  test('calculateCurrentMacros използва meal.macros и overrides', () => {
-    registerNutrientOverrides({
-      'override meal': { calories: 56, protein: 5, carbs: 5, fat: 2, fiber: 1 }
-    });
-    const planMenu = {
+test('calculateCurrentMacros използва meal.macros и overrides', () => {
+  registerNutrientOverrides({
+    'override meal': { calories: 56, protein: 5, carbs: 5, fat: 2, fiber: 1 }
+  });
+  const planMenu = {
       monday: [
         { meal_name: 'Override Meal' },
         { macros: { calories: 159, protein_grams: 10, carbs_grams: 20, fat_grams: 5, fiber_grams: 3 } }
@@ -39,9 +39,27 @@ test('calculateCurrentMacros sums macros from completed meals and extras', () =>
     };
     const completionStatus = { monday_0: true, monday_1: true };
     const result = calculateCurrentMacros(planMenu, completionStatus, []);
-    expect(result).toEqual({ calories: 215, protein: 15, carbs: 25, fat: 7, fiber: 4 });
-    registerNutrientOverrides({});
-  });
+  expect(result).toEqual({ calories: 215, protein: 15, carbs: 25, fat: 7, fiber: 4 });
+  registerNutrientOverrides({});
+});
+
+test('calculateCurrentMacros комбинира частични макроси без индекс', () => {
+  const planMenu = {
+    monday: [
+      {
+        macros: {
+          calories: 420,
+          protein_grams: 32,
+          carbs_grams: 45,
+          fat_grams: 12
+        }
+      }
+    ]
+  };
+  const completionStatus = { monday_0: true };
+  const result = calculateCurrentMacros(planMenu, completionStatus, []);
+  expect(result).toEqual({ calories: 420, protein: 32, carbs: 45, fat: 12, fiber: 0 });
+});
 
 test('calculateCurrentMacros скалира macros по grams', () => {
   const planMenu = {


### PR DESCRIPTION
## Summary
- propagate nested `macros` fields into meal objects and preserve provided calorie values when normalizing
- merge user-specified partial macros with indexed values before aggregating plan and current totals
- add coverage ensuring `calculateCurrentMacros` respects partial macro payloads without relying on indices

## Testing
- NODE_OPTIONS=--experimental-vm-modules npx jest js/__tests__/macroUtils.test.js
- NODE_OPTIONS=--experimental-vm-modules npx jest js/__tests__/loadCurrentIntake.test.js
- npm run lint
- NODE_OPTIONS=--max-old-space-size=8192 npm test *(fails: existing suites such as saveAiConfig.test.js and populateDashboardMacros.noSetData.test.js require ensureFreshDailyIntake export)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9dac24c48326851c78fe7b7f2e6b