### PR TITLE
Allow partial macro index fallbacks

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -222,6 +222,36 @@ test('calculatePlanMacros използва mealMacrosIndex при липсващ
   });
 });
 
+test('calculatePlanMacros комбинира частични потребителски и индекс макроси', () => {
+  const dayMenu = [
+    {
+      meal_name: 'Комбинирано ястие',
+      macros: {
+        calories: 200,
+        protein_grams: 20
+      }
+    }
+  ];
+  const mealMacrosIndex = {
+    monday_0: {
+      carbs_grams: 30,
+      fat_grams: 10
+    }
+  };
+  const result = calculatePlanMacros(dayMenu, true, false, mealMacrosIndex, 'monday');
+  expect(result).toMatchObject({
+    calories: 200,
+    protein: 20,
+    carbs: 30,
+    fat: 10,
+    fiber: 0,
+    protein_percent: 40,
+    carbs_percent: 60,
+    fat_percent: 45,
+    fiber_percent: 0
+  });
+});
+
 test('addMealMacros и removeMealMacros актуализират и clamp-ват акумулатора', () => {
   const acc = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
   const meal = { calories: 280, protein_grams: 20, carbs_grams: 30, fat_grams: 10, fiber_grams: 5 };

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -423,7 +423,6 @@ export function calculatePlanMacros(
     const indexed = mealMacrosIndex[key];
     if (!indexed || typeof indexed !== 'object') return null;
     const normalized = normalizeMacros(indexed);
-    if (hasMissingCoreMacros(normalized)) return null;
     const result = { ...normalized };
     if (hasValue(indexed.grams)) {
       const parsedGrams = parseNumericValue(indexed.grams);
@@ -497,7 +496,6 @@ export function calculateCurrentMacros(
     const indexed = mealMacrosIndex[key];
     if (!indexed || typeof indexed !== 'object') return null;
     const normalized = normalizeMacros(indexed);
-    if (hasMissingCoreMacros(normalized)) return null;
     const result = { ...normalized };
     const resolvedGrams = grams ?? indexed.grams;
     if (resolvedGrams != null) result.grams = resolvedGrams;


### PR DESCRIPTION
## Summary
- keep normalized indexed macros even when some fields are missing so they can still merge into plan totals
- add a regression test that exercises mixed user/index macro data for planned meals

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddb37cd6a48326993775899c7e6956