### PR TITLE
Add dashboard macro recalculation fallback

### DIFF
--- a/tests/dashboardDataMacros.test.js
+++ b/tests/dashboardDataMacros.test.js
@@ -1,0 +1,108 @@
+import { jest } from '@jest/globals';
+
+const workerModule = await import('../worker.js');
+
+function createTestEnv(userId, finalPlan) {
+  const kvData = new Map();
+
+  kvData.set(`${userId}_initial_answers`, JSON.stringify({ name: 'Клиент', goal: 'Форма' }));
+  kvData.set(`${userId}_final_plan`, JSON.stringify(finalPlan));
+  kvData.set(`plan_status_${userId}`, 'ready');
+  kvData.set(`${userId}_current_status`, '{}');
+  kvData.set(`${userId}_profile`, '{}');
+  kvData.set(`${userId}_welcome_seen`, 'true');
+
+  const userMetadataKv = {
+    get: jest.fn(async (key) => (kvData.has(key) ? kvData.get(key) : null)),
+    put: jest.fn(async (key, value) => {
+      kvData.set(key, value);
+    }),
+    list: jest.fn(async () => ({ keys: [] }))
+  };
+
+  const env = {
+    USER_METADATA_KV: userMetadataKv,
+    RESOURCES_KV: {
+      get: jest.fn(async () => '{}')
+    }
+  };
+
+  return { env, kvData };
+}
+
+describe('handleDashboardDataRequest - макроси', () => {
+  test('преизчислява липсващи макроси от менюто и ги записва', async () => {
+    const userId = 'dashboard-macros-user';
+    const finalPlan = {
+      caloriesMacros: null,
+      week1Menu: {
+        monday: [
+          {
+            macros: {
+              protein_grams: 60,
+              carbs_grams: 90,
+              fat_grams: 20,
+              fiber_grams: 10
+            }
+          },
+          {
+            macros: {
+              protein_grams: 60,
+              carbs_grams: 90,
+              fat_grams: 35,
+              fiber_grams: 8
+            }
+          }
+        ]
+      }
+    };
+
+    const { env, kvData } = createTestEnv(userId, finalPlan);
+    const request = { url: `https://example.com/api/dashboard-data?userId=${userId}&recalcMacros=1` };
+
+    const response = await workerModule.handleDashboardDataRequest(request, env);
+
+    expect(response.success).toBe(true);
+    expect(response.planData?.caloriesMacros).toEqual(
+      expect.objectContaining({
+        calories: 1731,
+        protein_grams: 120,
+        carbs_grams: 180,
+        fat_grams: 55,
+        fiber_grams: 18,
+        protein_percent: 28,
+        carbs_percent: 42,
+        fat_percent: 29,
+        fiber_percent: 2
+      })
+    );
+
+    const savedPlanRaw = kvData.get(`${userId}_final_plan`);
+    expect(savedPlanRaw).toBeTruthy();
+    const savedPlan = JSON.parse(savedPlanRaw);
+    expect(savedPlan.caloriesMacros).toEqual(response.planData.caloriesMacros);
+
+    const saveCall = env.USER_METADATA_KV.put.mock.calls.find(([key]) => key === `${userId}_final_plan`);
+    expect(saveCall).toBeDefined();
+  });
+
+  test('връща грешка, когато менюто не позволява преизчисление', async () => {
+    const userId = 'dashboard-macros-missing';
+    const finalPlan = {
+      caloriesMacros: null,
+      week1Menu: {}
+    };
+
+    const { env } = createTestEnv(userId, finalPlan);
+    const request = { url: `https://example.com/api/dashboard-data?userId=${userId}&recalcMacros=1` };
+
+    const response = await workerModule.handleDashboardDataRequest(request, env);
+
+    expect(response.success).toBe(false);
+    expect(response.message).toBe(
+      'Планът няма макроси и автоматичното преизчисление се провали. Моля, регенерирайте плана.'
+    );
+    expect(env.USER_METADATA_KV.put.mock.calls.find(([key]) => key === `${userId}_final_plan`)).toBeUndefined();
+  });
+});
+

--- a/worker.js
+++ b/worker.js
@@ -1379,6 +1379,76 @@ async function handleAnalysisStatusRequest(request, env) {
 // ------------- END FUNCTION: handleAnalysisStatusRequest -------------
 
 // ------------- START FUNCTION: handleDashboardDataRequest -------------
+function recalculatePlanMacrosFromMenu(plan = {}) {
+    if (!plan || typeof plan !== 'object') {
+        return null;
+    }
+    const { week1Menu, mealMacrosIndex } = plan;
+    if (!week1Menu || typeof week1Menu !== 'object') {
+        return null;
+    }
+
+    const totals = { protein: 0, carbs: 0, fat: 0, fiber: 0, alcohol: 0 };
+    let hasContributingMeal = false;
+
+    for (const [dayKey, meals] of Object.entries(week1Menu)) {
+        if (!Array.isArray(meals)) continue;
+        meals.forEach((meal, mealIndex) => {
+            const source = meal?.macros ?? mealMacrosIndex?.[`${dayKey}_${mealIndex}`] ?? meal;
+            const normalized = normalizePlanCaloriesMacros(source, { roundValues: false });
+            if (!normalized) return;
+            totals.protein += normalized.protein_grams || 0;
+            totals.carbs += normalized.carbs_grams || 0;
+            totals.fat += normalized.fat_grams || 0;
+            totals.fiber += normalized.fiber_grams || 0;
+            totals.alcohol += normalized.alcohol_grams || 0;
+            hasContributingMeal = true;
+        });
+    }
+
+    if (!hasContributingMeal) {
+        return null;
+    }
+
+    const totalCalories =
+        totals.protein * 4 +
+        totals.carbs * 4 +
+        totals.fat * 9 +
+        totals.fiber * 2 +
+        totals.alcohol * 7;
+
+    if (!(totalCalories > 0)) {
+        return null;
+    }
+
+    const calories = Math.round(totalCalories);
+    const result = {
+        calories,
+        protein_grams: Math.round(totals.protein),
+        carbs_grams: Math.round(totals.carbs),
+        fat_grams: Math.round(totals.fat),
+        fiber_grams: Math.round(totals.fiber)
+    };
+
+    if (totals.alcohol > 0) {
+        result.alcohol_grams = Math.round(totals.alcohol);
+    }
+
+    const percentDenominator = totalCalories > 0 ? totalCalories : 0;
+    const toPercent = (grams, kcalPerGram) =>
+        percentDenominator > 0 ? Math.round((grams * kcalPerGram * 100) / percentDenominator) : 0;
+
+    result.protein_percent = toPercent(totals.protein, 4);
+    result.carbs_percent = toPercent(totals.carbs, 4);
+    result.fat_percent = toPercent(totals.fat, 9);
+    result.fiber_percent = toPercent(totals.fiber, 2);
+    if (totals.alcohol > 0) {
+        result.alcohol_percent = toPercent(totals.alcohol, 7);
+    }
+
+    return result;
+}
+
 async function handleDashboardDataRequest(request, env) {
     const url = new URL(request.url);
     const userId = url.searchParams.get('userId');
@@ -1497,25 +1567,43 @@ async function handleDashboardDataRequest(request, env) {
         }
         const shouldRecalcMacros = url.searchParams.get('recalcMacros') === '1';
         const originalMacrosSnapshot = finalPlan.caloriesMacros ? JSON.stringify(finalPlan.caloriesMacros) : null;
-        const macroResult = ensurePlanCaloriesMacros(finalPlan, { allowAggregation: shouldRecalcMacros });
+        const macroNormalization = ensurePlanCaloriesMacros(finalPlan, { allowAggregation: false });
+        let macrosStatus = macroNormalization.status;
         let shouldPersistFinalPlan = false;
-        if (macroResult.status === 'missing') {
-            console.error(`DASHBOARD_DATA (${userId}): Missing caloriesMacros in final plan${shouldRecalcMacros ? ' и неуспешно fallback преизчисление.' : '.'}`);
-            return {
-                ...baseResponse,
-                success: false,
-                message: shouldRecalcMacros
-                    ? 'Планът няма макроси и автоматичното преизчисление се провали. Моля, регенерирайте плана.'
-                    : 'Планът няма макроси; изисква се повторно генериране',
-                statusHint: 500,
-                planData: null,
-                analytics: null
-            };
+
+        if (macrosStatus === 'missing') {
+            if (shouldRecalcMacros) {
+                const recalculated = recalculatePlanMacrosFromMenu(finalPlan);
+                if (recalculated) {
+                    finalPlan.caloriesMacros = recalculated;
+                    macrosStatus = 'recalculated';
+                    shouldPersistFinalPlan = true;
+                    console.warn(`DASHBOARD_DATA (${userId}): caloriesMacros were recalculated from menu data on-demand.`);
+                } else {
+                    console.error(`DASHBOARD_DATA (${userId}): Неуспешно преизчисление на макросите от менюто.`);
+                    return {
+                        ...baseResponse,
+                        success: false,
+                        message: 'Планът няма макроси и автоматичното преизчисление се провали. Моля, регенерирайте плана.',
+                        statusHint: 500,
+                        planData: null,
+                        analytics: null
+                    };
+                }
+            } else {
+                console.error(`DASHBOARD_DATA (${userId}): Missing caloriesMacros in final plan.`);
+                return {
+                    ...baseResponse,
+                    success: false,
+                    message: 'Планът няма макроси; изисква се повторно генериране',
+                    statusHint: 500,
+                    planData: null,
+                    analytics: null
+                };
+            }
         }
-        if (macroResult.status === 'recalculated') {
-            shouldPersistFinalPlan = true;
-            console.warn(`DASHBOARD_DATA (${userId}): caloriesMacros were recalculated from menu data on-demand.`);
-        } else if (macroResult.status === 'normalized') {
+
+        if (macrosStatus === 'normalized') {
             const normalizedSnapshot = finalPlan.caloriesMacros ? JSON.stringify(finalPlan.caloriesMacros) : null;
             if (normalizedSnapshot !== originalMacrosSnapshot) {
                 shouldPersistFinalPlan = true;


### PR DESCRIPTION
## Summary
- add a recalculatePlanMacrosFromMenu helper to rebuild plan macros from the stored weekly menu when needed
- ensure handleDashboardDataRequest persists normalized or freshly recalculated macros so follow-up requests reuse them
- cover the recalculation path with a focused Jest suite, including failure when the menu cannot provide macros

## Testing
- npm run lint
- NODE_OPTIONS=--experimental-vm-modules npx --no-install jest --runInBand tests/dashboardDataMacros.test.js
- npm test *(fails: existing suites hit OOM and unrelated assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68e5af46dbd88326a4e7637650c57d48