### PR TITLE
Обработка на camelCase идентификатори при извличане на макроси

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -119,6 +119,22 @@ test('calculateCurrentMacros намира макроси по recipeKey и им�
   registerNutrientOverrides({});
 });
 
+test('calculateCurrentMacros използва camelCase recipeKey преди fallback опции', () => {
+  registerNutrientOverrides({});
+  const planMenu = {
+    monday: [
+      {
+        meal_name: 'Персонализирано без артикули',
+        recipeKey: 'z-01'
+      }
+    ]
+  };
+  const completionStatus = { monday_0: true };
+  const result = calculateCurrentMacros(planMenu, completionStatus, []);
+  expect(result).toEqual({ calories: 300, protein: 27, carbs: 30, fat: 8, fiber: 0 });
+  registerNutrientOverrides({});
+});
+
 test('normalizeMacros парсира стойности със съответните единици', () => {
   const normalized = normalizeMacros({
     calories: '320 kcal',


### PR DESCRIPTION
## Summary
- добавих приоритизирано разпознаване на camelCase суфикси Id/Name/Key при събиране на кандидати за макро индекс и избегнах повторно добавяне
- разширих unit тестовете на macroUtils с кейс за meal без items, който разчита изцяло на recipeKey

## Testing
- npm run lint
- npm test *(проваля се поради `FATAL ERROR: Reached heap limit` в средата на суитата)*
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand js/__tests__/macroUtils.test.js

------
https://chatgpt.com/codex/tasks/task_e_68febe203200832689024c5880763a17