### PR TITLE
Improve macro resolution fallbacks and indexing

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -97,6 +97,32 @@ test('calculateCurrentMacros използва mealMacrosIndex като fallback'
   expect(result).toEqual({ calories: 320, protein: 30, carbs: 25, fat: 12, fiber: 6 });
 });
 
+test('calculateCurrentMacros запазва индекс макроси при съвпадение с каталога', () => {
+  const planMenu = {
+    monday: [
+      {
+        meal_name: 'Протеинов шейк',
+        macros: {
+          calories: 220
+        }
+      }
+    ]
+  };
+  const completionStatus = { monday_0: true };
+  const mealMacrosIndex = {
+    monday_0: {
+      calories: 220,
+      protein_grams: 18,
+      carbs_grams: 12,
+      fat_grams: 9,
+      fiber_grams: 4
+    }
+  };
+
+  const result = calculateCurrentMacros(planMenu, completionStatus, [], false, mealMacrosIndex);
+  expect(result).toEqual({ calories: 220, protein: 18, carbs: 12, fat: 9, fiber: 4 });
+});
+
 test('calculateCurrentMacros намира макроси по recipeKey и имена на продукти', () => {
   registerNutrientOverrides({});
   const planMenu = {


### PR DESCRIPTION
## Summary
- track and propagate `__providedMacroKeys` when normalizing or merging macro payloads so we know which values originate from the user
- refine `resolveMacros` to combine provided, indexed, and catalog macros without overwriting indexed data and to mark `__preferGivenCalories` only when true user input exists
- copy provided-key metadata through plan/current macro aggregation helpers
- add a regression test ensuring indexed macro data wins over catalog values when names collide

## Testing
- npm run lint
- npm test -- js/__tests__/macroUtils.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fed5186ae48326a33b18060b6dcad0