### PR TITLE
Fix macro fallback when indexed values are missing

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -161,6 +161,22 @@ test('calculateCurrentMacros използва camelCase recipeKey преди fal
   registerNutrientOverrides({});
 });
 
+test('calculateCurrentMacros премахва липсващи макроси, за да използва каталожен fallback', () => {
+  registerNutrientOverrides({});
+  const planMenu = {
+    monday: [
+      {
+        recipeKey: 'z-01',
+        macros: {}
+      }
+    ]
+  };
+  const completionStatus = { monday_0: true };
+  const result = calculateCurrentMacros(planMenu, completionStatus, [], false, {});
+  expect(result).toEqual({ calories: 300, protein: 27, carbs: 30, fat: 8, fiber: 0 });
+  registerNutrientOverrides({});
+});
+
 test('normalizeMacros парсира стойности със съответните единици', () => {
   const normalized = normalizeMacros({
     calories: '320 kcal',


### PR DESCRIPTION
## Summary
- preserve the list of unresolved macro keys when merging indexed data with normalized values
- drop unresolved macro fields before passing meals to addMealMacros so the catalog fallback repopulates them
- add a regression test to ensure empty macros with an available recipeKey pull catalog nutrition

## Testing
- npm run lint
- npm test *(fails: Node heap OOM while running js/__tests__/populateUI.test.js)*
- NODE_OPTIONS=--experimental-vm-modules npx jest --runTestsByPath js/__tests__/macroUtils.test.js

------
https://chatgpt.com/codex/tasks/task_e_6900139dc2608326a1083a173650c2e8