### PR TITLE
Normalize plan macro placeholder handling

### DIFF
--- a/tests/processSingleUserPlan.spec.js
+++ b/tests/processSingleUserPlan.spec.js
@@ -236,11 +236,17 @@ describe('processSingleUserPlan - буфериран лог', () => {
     const promptArgument = callModelMock.mock.calls[0][1];
     expect(promptArgument).toContain('1900');
     expect(promptArgument).toContain('145');
+    expect(promptArgument).toContain('30%');
+    expect(promptArgument).toContain('45%');
+    expect(promptArgument).toContain('25%');
+    expect(promptArgument).toContain('28 г');
     expect(promptArgument).toContain('Емоционален профил');
     expect(promptArgument).toContain('Mindful Eating');
     expect(promptArgument).toContain('"goal":"Подобряване на формата"');
     expect(promptArgument).not.toContain('%%TARGET_CALORIES%%');
     expect(promptArgument).not.toMatch(/%%TARGET_[A-Z_]+%%/);
+    expect(promptArgument).not.toContain('%%TARGET_PROTEIN_G%%');
+    expect(promptArgument).not.toContain('%%TARGET_PROTEIN_P%%');
     expect(promptArgument).not.toContain('%%DOMINANT_PSYCHO_PROFILE%%');
     expect(promptArgument).not.toContain('%%USER_ANSWERS_JSON%%');
   });


### PR DESCRIPTION
## Summary
- extend the target macro placeholder mapping to cover both gram and percent aliases and reuse them when generating replacements
- update `processSingleUserPlan` to cache KV lookups, merge macro sources safely, and replace any leftover placeholders with safe defaults before populating the prompt
- adjust the unit test to assert that the generated prompt contains concrete macro values instead of unresolved placeholders

## Testing
- `npm run lint`
- `npm test` *(fails with Node.js OOM while iterating through all Jest suites)*
- `NODE_OPTIONS='--experimental-vm-modules' node_modules/.bin/jest --runTestsByPath tests/processSingleUserPlan.spec.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_690015ed2ac88326a2809101929214ea