### PR TITLE
Handle missing macro fields when meal index is absent

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -177,6 +177,22 @@ test('calculateCurrentMacros премахва липсващи макроси, �
   registerNutrientOverrides({});
 });
 
+test('calculateCurrentMacros използва каталожен fallback при липсващ mealMacrosIndex', () => {
+  registerNutrientOverrides({});
+  const planMenu = {
+    monday: [
+      {
+        recipeKey: 'z-01',
+        macros: {}
+      }
+    ]
+  };
+  const completionStatus = { monday_0: true };
+  const result = calculateCurrentMacros(planMenu, completionStatus, [], false, null);
+  expect(result).toEqual({ calories: 300, protein: 27, carbs: 30, fat: 8, fiber: 0 });
+  registerNutrientOverrides({});
+});
+
 test('normalizeMacros парсира стойности със съответните единици', () => {
   const normalized = normalizeMacros({
     calories: '320 kcal',

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -713,13 +713,13 @@ export function calculateCurrentMacros(
       }
       const indexed = key ? getIndexedMacros(key, grams) : null;
       const merged = mergeNormalizedWithIndexed(normalized, indexed, grams);
+      const missingKeys = Array.isArray(merged.__missingMacroKeys) ? merged.__missingMacroKeys : [];
+      const shouldDropMissing = !indexed && missingKeys.length > 0;
       const { grams: mergedGrams, ...restValues } = merged;
       const macroValues = { ...restValues };
-      const missingKeys = Array.isArray(merged.__missingMacroKeys) ? merged.__missingMacroKeys : [];
-      const shouldDropMissing = missingKeys.length > 0;
       if (shouldDropMissing) {
-        missingKeys.forEach((key) => {
-          delete macroValues[key];
+        missingKeys.forEach((macroKey) => {
+          delete macroValues[macroKey];
         });
       }
       const prepared = {
@@ -727,6 +727,11 @@ export function calculateCurrentMacros(
         ...macroValues,
         ...(mergedGrams != null ? { grams: mergedGrams } : {})
       };
+      if (shouldDropMissing) {
+        missingKeys.forEach((macroKey) => {
+          delete prepared[macroKey];
+        });
+      }
       if (Array.isArray(merged.__providedMacroKeys)) {
         Object.defineProperty(prepared, '__providedMacroKeys', {
           value: merged.__providedMacroKeys,
@@ -735,11 +740,16 @@ export function calculateCurrentMacros(
       }
       const mergedMacros = { ...(meal.macros || {}) };
       if (shouldDropMissing) {
-        missingKeys.forEach((key) => {
-          delete mergedMacros[key];
+        missingKeys.forEach((macroKey) => {
+          delete mergedMacros[macroKey];
         });
       }
       prepared.macros = { ...mergedMacros, ...macroValues };
+      if (shouldDropMissing) {
+        missingKeys.forEach((macroKey) => {
+          delete prepared.macros[macroKey];
+        });
+      }
       Object.defineProperty(prepared, '__preferGivenCalories', {
         value: true,
         enumerable: false


### PR DESCRIPTION
## Summary
- prevent prepareMeal from carrying zeroed macro fields when no indexed macros are available so fallback lookup can run
- clean prepared macro payloads before calling addMealMacros to trigger resolveFallbackMacrosFromMeal
- add regression test ensuring catalog macros are used when meal macros and mealMacrosIndex are empty

## Testing
- npm run lint
- npm test *(fails: JavaScript heap out of memory; macroUtils suite finished successfully before the failure)*

------
https://chatgpt.com/codex/tasks/task_e_69001a5a42a08326a4ba101911f280f0