### PR TITLE
Handle missing macros without index fallback

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -193,6 +193,14 @@ test('calculateCurrentMacros използва каталожен fallback при
   registerNutrientOverrides({});
 });
 
+test('addMealMacros използва каталожен fallback при празни макроси и липсващ индекс', () => {
+  registerNutrientOverrides({});
+  const acc = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
+  addMealMacros({ recipeKey: 'z-01', macros: {} }, acc);
+  expect(acc).toEqual({ calories: 300, protein: 27, carbs: 30, fat: 8, fiber: 0 });
+  registerNutrientOverrides({});
+});
+
 test('normalizeMacros парсира стойности със съответните единици', () => {
   const normalized = normalizeMacros({
     calories: '320 kcal',

--- a/js/macroUtils.js
+++ b/js/macroUtils.js
@@ -713,12 +713,14 @@ export function calculateCurrentMacros(
       }
       const indexed = key ? getIndexedMacros(key, grams) : null;
       const merged = mergeNormalizedWithIndexed(normalized, indexed, grams);
-      const missingKeys = Array.isArray(merged.__missingMacroKeys) ? merged.__missingMacroKeys : [];
-      const shouldDropMissing = !indexed && missingKeys.length > 0;
+      const normalizedMissingKeys = Array.isArray(normalized.__missingMacroKeys)
+        ? normalized.__missingMacroKeys
+        : [];
+      const shouldDropMissing = !indexed && normalizedMissingKeys.length > 0;
       const { grams: mergedGrams, ...restValues } = merged;
       const macroValues = { ...restValues };
       if (shouldDropMissing) {
-        missingKeys.forEach((macroKey) => {
+        normalizedMissingKeys.forEach((macroKey) => {
           delete macroValues[macroKey];
         });
       }
@@ -728,7 +730,7 @@ export function calculateCurrentMacros(
         ...(mergedGrams != null ? { grams: mergedGrams } : {})
       };
       if (shouldDropMissing) {
-        missingKeys.forEach((macroKey) => {
+        normalizedMissingKeys.forEach((macroKey) => {
           delete prepared[macroKey];
         });
       }
@@ -740,13 +742,13 @@ export function calculateCurrentMacros(
       }
       const mergedMacros = { ...(meal.macros || {}) };
       if (shouldDropMissing) {
-        missingKeys.forEach((macroKey) => {
+        normalizedMissingKeys.forEach((macroKey) => {
           delete mergedMacros[macroKey];
         });
       }
       prepared.macros = { ...mergedMacros, ...macroValues };
       if (shouldDropMissing) {
-        missingKeys.forEach((macroKey) => {
+        normalizedMissingKeys.forEach((macroKey) => {
           delete prepared.macros[macroKey];
         });
       }


### PR DESCRIPTION
## Summary
- drop normalized missing macro keys from prepared payloads when no indexed fallback is available so catalog lookups can trigger
- add a regression test covering addMealMacros fallback behaviour with empty macros and recipeKey

## Testing
- npm run lint (fails: existing warnings across repository)
- npm test (fails: multiple suites fail or abort due to out-of-memory and pre-existing expectation mismatches)

------
https://chatgpt.com/codex/tasks/task_e_69001f56f2b883269c49a24858ddae45