### PR TITLE
Добави alias за липсващи макроси

### DIFF
--- a/js/__tests__/macroUtils.test.js
+++ b/js/__tests__/macroUtils.test.js
@@ -97,6 +97,21 @@ test('calculateCurrentMacros използва mealMacrosIndex като fallback'
   expect(result).toEqual({ calories: 320, protein: 30, carbs: 25, fat: 12, fiber: 6 });
 });
 
+test('calculateCurrentMacros използва alias за липсващо каталожно ястие', () => {
+  registerNutrientOverrides({});
+  const planMenu = {
+    monday: [
+      {
+        recipeKey: 'dinner_salad_fish'
+      }
+    ]
+  };
+  const completionStatus = { monday_0: true };
+  const result = calculateCurrentMacros(planMenu, completionStatus, []);
+  expect(result).toEqual({ calories: 400, protein: 35, carbs: 10, fat: 24, fiber: 0 });
+  registerNutrientOverrides({});
+});
+
 test('calculateCurrentMacros запазва индекс макроси при съвпадение с каталога', () => {
   const planMenu = {
     monday: [


### PR DESCRIPTION
## Summary
- добавих ограничена таблица `RECIPE_MACRO_ALIASES` за проблемните recipeKey/meal_name стойности
- нормализирах fallback логиката в `resolveFallbackMacrosFromMeal`, като проверявам alias-ите и форматирам каталожните макроси през споделени помощници
- добавих unit тест, който доказва, че alias за `dinner_salad_fish` връща коректните макроси

## Testing
- npm run lint
- npm test -- js/__tests__/macroUtils.test.js

------
https://chatgpt.com/codex/tasks/task_e_6900248dbf548326a04c558e7cf97e08