### PR TITLE
Ensure plan persistence validates macros via shared helper

### DIFF
--- a/js/__tests__/updatePlanData.test.js
+++ b/js/__tests__/updatePlanData.test.js
@@ -1,20 +1,82 @@
 import { jest } from '@jest/globals';
-import { handleUpdatePlanRequest } from '../../worker.js';
+import { handleUpdatePlanRequest, setCallModelImplementation } from '../../worker.js';
 
 describe('handleUpdatePlanRequest', () => {
+  afterEach(() => {
+    setCallModelImplementation(null);
+    jest.clearAllMocks();
+  });
+
   test('stores plan data with flat macros', async () => {
-    const env = { USER_METADATA_KV: { put: jest.fn() } };
+    const env = {
+      USER_METADATA_KV: {
+        put: jest.fn().mockResolvedValue(),
+        get: jest.fn().mockResolvedValue(null),
+        delete: jest.fn().mockResolvedValue()
+      }
+    };
     const planData = {
       week: 1,
-      caloriesMacros: { calories: 2000, fiber_percent: 10, fiber_grams: 30 }
+      caloriesMacros: {
+        calories: 2000,
+        protein_grams: 140,
+        carbs_grams: 220,
+        fat_grams: 60,
+        fiber_percent: 10,
+        fiber_grams: 30
+      },
+      generationMetadata: { errors: [] }
     };
     const request = { json: async () => ({ userId: 'u1', planData }) };
     const res = await handleUpdatePlanRequest(request, env);
-    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith('u1_final_plan', JSON.stringify(planData));
+    const planCall = env.USER_METADATA_KV.put.mock.calls.find(([key]) => key === 'u1_final_plan');
+    expect(planCall).toBeDefined();
+    const storedPlan = JSON.parse(planCall[1]);
+    expect(storedPlan.caloriesMacros).toEqual(planData.caloriesMacros);
     expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
       'u1_analysis_macros',
       JSON.stringify({ status: 'final', data: planData.caloriesMacros })
     );
     expect(res.success).toBe(true);
+  });
+
+  test('does not overwrite plan when macros remain incomplete', async () => {
+    const env = {
+      USER_METADATA_KV: {
+        put: jest.fn().mockResolvedValue(),
+        get: jest.fn().mockResolvedValue('[]'),
+        delete: jest.fn().mockResolvedValue()
+      },
+      RESOURCES_KV: {
+        get: jest.fn().mockImplementation(async (key) =>
+          key === 'model_plan_generation' ? 'gpt-test' : null
+        )
+      },
+      OPENAI_API_KEY: 'test-key'
+    };
+    const incompletePlan = {
+      caloriesMacros: { calories: 1800 },
+      week1Menu: {
+        day1: [
+          { meal_name: 'Закуска', description: 'примерно меню без макроси' }
+        ]
+      },
+      generationMetadata: { errors: [] }
+    };
+    const request = { json: async () => ({ userId: 'u2', planData: incompletePlan }) };
+    const modelMock = jest.fn().mockResolvedValue(JSON.stringify({ caloriesMacros: {} }));
+    setCallModelImplementation(modelMock);
+
+    const res = await handleUpdatePlanRequest(request, env);
+
+    const finalPlanCall = env.USER_METADATA_KV.put.mock.calls.find(([key]) => key === 'u2_final_plan');
+    expect(finalPlanCall).toBeUndefined();
+    expect(res.success).toBe(false);
+    expect(res.statusHint).toBe(422);
+    expect(env.USER_METADATA_KV.put).toHaveBeenCalledWith(
+      'u2_plan_update_incident',
+      expect.any(String)
+    );
+    expect(modelMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- extract a reusable enforcement helper that validates macronutrients and runs AI correction retries before plans are stored
- reuse the shared validation in both automated plan generation and manual handleUpdatePlanRequest flows, logging incidents when recovery fails
- expand updatePlanData tests to cover the new validation workflow and guard against overwriting existing plans when gaps remain

## Testing
- npm run lint
- npm test *(fails: JavaScript heap out of memory in this environment)*
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runTestsByPath js/__tests__/updatePlanData.test.js
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runTestsByPath tests/processSingleUserPlan.spec.js

------
https://chatgpt.com/codex/tasks/task_e_6902c79daa788326a854555210aa6826