### PR TITLE
Adjust default addLog handler for macro plan enforcement

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -4538,7 +4538,11 @@ async function enforceCompletePlanBeforePersist({
     env,
     planModelName,
     basePrompt,
-    addLog = async () => {},
+    addLog = async (...args) => {
+        if (args.length) {
+            return;
+        }
+    },
     maxAttempts = PLAN_MACRO_RETRY_LIMIT,
     retryArtifactKey = null
 }) {


### PR DESCRIPTION
## Summary
- allow enforceCompletePlanBeforePersist to accept addLog parameters by defaulting to an async handler that safely ignores inputs

## Testing
- npm run lint
- NODE_OPTIONS=--max_old_space_size=4096 npm test *(fails: JavaScript heap out of memory in populateUI.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6905678e0fb08326b82dccac5be348c5