### PR TITLE
Fix Cloudflare AI request signal handling and add timeout test

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -6836,11 +6836,9 @@ async function callCfAi(model, payload, env, options = {}) {
             'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json'
         },
-        body: JSON.stringify(payload)
+        body: JSON.stringify(payload),
+        signal: options.signal
     };
-    if (signal !== undefined) {
-        fetchOptions.signal = signal;
-    }
     let resp;
     try {
         resp = await fetch(url, fetchOptions);


### PR DESCRIPTION
## Summary
- ensure the Cloudflare AI helper always issues HTTP requests with the provided AbortSignal so timeout controllers can cancel the fetch
- add a processSingleUserPlan test that simulates a slow Cloudflare AI response and verifies the timeout aborts cleanly

## Testing
- npm run lint
- npm test *(fails: multiple suites exhaust the heap and some pre-existing UI tests fail due to missing exports)*

------
https://chatgpt.com/codex/tasks/task_e_6906b25cc3c08326ac11cc3d42b3c7b1