### PR TITLE
Handle target macro fix timeouts

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -433,9 +433,15 @@ const resolveTargetMacrosWithPrompt = async ({
       `Корекционен prompt за макро таргети - опит ${attempt}`,
       { checkpoint: attempt === 1, reason: 'target-macros-fix' }
     );
-    lastRawResponse = await callModelRef.current(planModelName, prompt, env, {
-      temperature: 0.05,
-      maxTokens: 1200
+    lastRawResponse = await callModelWithTimeout({
+      model: planModelName,
+      prompt,
+      env,
+      options: {
+        temperature: 0.05,
+        maxTokens: 1200
+      },
+      timeoutMs: resolvePlanCallTimeoutMs(env)
     });
 
     const candidateMacros = finalizeTargetMacros(extractTargetMacrosFromAny(lastRawResponse));


### PR DESCRIPTION
## Summary
- call resolveTargetMacrosWithPrompt via callModelWithTimeout so Cloudflare requests receive abort signals
- keep runTargetMacroFix logging while letting AbortError propagate and be recorded in user metadata
- add a Jest scenario that mocks a slow Cloudflare AI call and verifies the timeout records the processing error

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6907e8434f848326bd73bfbfe0cb82e0