### PR TITLE
Tweak goal card and recommendations heading styling

### DIFF
--- a/css/dashboard_panel_styles.css
+++ b/css/dashboard_panel_styles.css
@@ -690,9 +690,14 @@ body.vivid-theme .tracker .metric-rating .rating-value {
 
 /* Подобрения за goalCard визуализация */
 #goalCard {
-  background: linear-gradient(135deg, var(--card-bg) 0%, color-mix(in srgb, var(--card-bg) 90%, var(--primary-color)) 100%);
-  border: 2px solid color-mix(in srgb, var(--primary-color) 30%, transparent);
-  transition: all 0.3s ease;
+  background: linear-gradient(
+    145deg,
+    var(--card-bg) 0%,
+    color-mix(in srgb, var(--card-bg) 90%, var(--surface-background)) 100%
+  );
+  border: 1px solid var(--border-color-soft);
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
   position: relative;
   overflow: hidden;
 }
@@ -700,33 +705,33 @@ body.vivid-theme .tracker .metric-rating .rating-value {
 #goalCard::before {
   content: '';
   position: absolute;
-  top: -50%;
-  right: -50%;
-  width: 200%;
-  height: 200%;
-  background: radial-gradient(circle, color-mix(in srgb, var(--primary-color) 15%, transparent) 0%, transparent 70%);
+  top: -10%;
+  right: -10%;
+  width: 130%;
+  height: 130%;
+  background: radial-gradient(circle, color-mix(in srgb, var(--primary-color) 8%, transparent) 0%, transparent 60%);
   pointer-events: none;
-  opacity: 0.5;
+  opacity: 0.35;
 }
 
 #goalCard:hover {
-  transform: translateY(-3px);
-  box-shadow: var(--shadow-lg);
-  border-color: var(--primary-color);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+  border-color: color-mix(in srgb, var(--primary-color) 35%, var(--border-color-soft));
 }
 
 #goalCard h4 {
   position: relative;
   z-index: 1;
-  font-weight: 700;
-  color: var(--primary-color);
+  font-weight: 600;
+  color: var(--text-color-secondary);
 }
 
 #goalCard .index-value {
   position: relative;
   z-index: 1;
-  font-size: 1.4rem;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  font-size: 1.2rem;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
 /* Подобрена анимация за tracker елементи */

--- a/css/recommendations_panel_styles.css
+++ b/css/recommendations_panel_styles.css
@@ -1,17 +1,34 @@
 /* --- 6.4. Таб "Препоръки" - Стилизиране на картите като кутийки --- */
-.recommendation-section { 
-  margin-bottom: var(--space-xl); 
+#recs-panel h2 {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--surface-background);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color-soft);
+  box-shadow: var(--shadow-sm);
+}
+
+.recommendation-section {
+  margin-top: var(--space-md);
+  margin-bottom: var(--space-xl);
 }
 .recommendation-section > h3 {
-  font-size: clamp(1.35rem, 3.2vw, 1.75rem); 
+  font-size: clamp(1.35rem, 3.2vw, 1.75rem);
   border-bottom: 3px solid var(--primary-color);
-  padding-bottom: var(--space-md); 
+  padding: var(--space-md);
   margin-bottom: var(--space-lg);
   display: flex;
   align-items: center;
   gap: var(--space-sm);
   color: var(--primary-color);
   font-weight: 700;
+  background: var(--surface-background);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color-soft);
+  box-shadow: var(--shadow-sm);
 }
 .recommendation-section .card {
   margin-bottom: var(--space-lg);


### PR DESCRIPTION
## Summary
- soften the goal card background, border, and typography so it aligns with other index cards
- add padded headers in the Recommendations tab to better separate h2/h3 content on mobile

## Testing
- npm run lint *(warnings about unused variables in existing tests)*
- npm test *(failures in existing processSingleUserPlan and extraMealForm specs; unchanged by this PR)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69212d6d59548326947b05f351f84ca1)